### PR TITLE
feat: add OpenRouter support to translation service options

### DIFF
--- a/frontend/src/components/forms/TranslationForm.tsx
+++ b/frontend/src/components/forms/TranslationForm.tsx
@@ -190,6 +190,12 @@ const TranslationForm: FunctionComponent<Props> = ({
           ...defaultConfig,
           service: "Lingarr",
         };
+      case "openrouter":
+        return {
+          ...defaultConfig,
+          service: "AI Translator",
+          model: ` (${settings?.data?.translator?.openrouter_model || ""})`,
+        };
       default:
         return defaultConfig;
     }


### PR DESCRIPTION
Add OpenRouter as a new translation service option in TranslationForm. The service is labeled as "AI Translator" and displays the configured OpenRouter model from settings. This extends the available translation backends for users to choose from.