### PR TITLE
fix(config): handle provider priorities as JSON strings

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -3,6 +3,7 @@
 import hashlib
 import os
 import ast
+import json
 import logging
 import re
 import secrets
@@ -710,6 +711,13 @@ def save_settings(settings_items):
             value = True
         elif value == 'false':
             value = False
+
+        # Handle JSON strings for dict settings
+        if settings_keys[-1] == 'provider_priorities' and isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except ValueError:
+                pass
 
         if key in ['settings-general-use_embedded_subs', 'settings-general-ignore_pgs_subs',
                    'settings-general-ignore_vobsub_subs', 'settings-general-ignore_ass_subs']:

--- a/bazarr/subtitles/tools/translate/batch.py
+++ b/bazarr/subtitles/tools/translate/batch.py
@@ -10,7 +10,7 @@ from subtitles.tools.translate.main import translate_subtitles_file
 
 logger = logging.getLogger(__name__)
 
-def process_episode_translation(item, source_language, target_language, forced, hi, subtitle_path):
+def process_episode_translation(item, source_language, target_language, forced, hi, subtitle_path, job_id=None):
     """Process a single episode for translation in background"""
     sonarr_series_id = item.get('sonarrSeriesId')
     sonarr_episode_id = item.get('sonarrEpisodeId')
@@ -66,7 +66,7 @@ def process_episode_translation(item, source_language, target_language, forced, 
         logger.error(f'Translation failed for episode {sonarr_episode_id}: {e}')
         return False
 
-def process_movie_translation(item, source_language, target_language, forced, hi, subtitle_path):
+def process_movie_translation(item, source_language, target_language, forced, hi, subtitle_path, job_id=None):
     """Process a single movie for translation in background"""
     radarr_id = item.get('radarrId')
 

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -468,7 +468,7 @@ class SZProviderPool(ProviderPool):
                 continue
 
             # Search this provider
-            provider_subtitles = self.list_subtitles_provider(name, video, languages)
+            provider_subtitles = SZProviderPool.list_subtitles_provider(self, name, video, languages)
 
             if provider_subtitles is None:
                 logger.info('Discarding provider %s', name)

--- a/dev_event_handler.py
+++ b/dev_event_handler.py
@@ -1,0 +1,19 @@
+# coding=utf-8
+
+from .app import socketio
+
+
+def event_stream(type, action="update", payload=None):
+    """
+        :param type: The type of element.
+        :type type: str
+        :param action: The action type of element from update and delete.
+        :type action: str
+        :param payload: The payload to send, can be anything
+    """
+
+    try:
+        payload = int(payload)
+    except (ValueError, TypeError):
+        pass
+    socketio.emit("data", {"type": type, "action": action, "payload": payload})

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,1 +1,1 @@
-export const GithubRepoRoot = "https://github.com/morpheus65535/bazarr";
+export const GithubRepoRoot = "https://github.com/LavX/bazarr";

--- a/frontend/src/pages/Settings/Providers/components.tsx
+++ b/frontend/src/pages/Settings/Providers/components.tsx
@@ -241,7 +241,8 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
         if (settings?.general?.provider_priorities?.[payload.key]) {
           const priorities = { ...settings.general.provider_priorities };
           delete priorities[payload.key];
-          changes["settings-general-provider_priorities"] = priorities;
+          changes["settings-general-provider_priorities"] =
+            JSON.stringify(priorities);
         }
 
         onChangeRef.current(changes);
@@ -275,7 +276,8 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
             ...(settings?.general?.provider_priorities ?? {}),
           };
           priorities[info.key] = priority;
-          changes["settings-general-provider_priorities"] = priorities;
+          changes["settings-general-provider_priorities"] =
+            JSON.stringify(priorities);
           delete changes[priorityKey];
         }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -38,6 +38,7 @@ export default defineConfig(({ mode, command }) => {
       VitePWA({
         workbox: {
           globIgnores: ["index.html"],
+          navigateFallback: null,
         },
         registerType: "autoUpdate",
         includeAssets: [

--- a/master_event_handler.py
+++ b/master_event_handler.py
@@ -1,0 +1,31 @@
+# coding=utf-8
+
+from .app import socketio
+
+
+def event_stream(type, action="update", payload=None):
+    """
+        :param type: The type of element.
+        :type type: str
+        :param action: The action type of element from update and delete.
+        :type action: str
+        :param payload: The payload to send, can be anything
+    """
+
+    try:
+        payload = int(payload)
+    except (ValueError, TypeError):
+        pass
+    socketio.emit("data", {"type": type, "action": action, "payload": payload})
+
+
+def show_message(msg):
+    event_stream(type="message", payload=msg)
+
+
+def show_progress(id, header, name, value, count):
+    event_stream(type="progress", payload={"id": id, "header": header, "name": name, "value": value, "count": count})
+
+
+def hide_progress(id):
+    event_stream(type="progress", action="delete", payload=id)


### PR DESCRIPTION
- Add JSON parsing for provider_priorities in config save handler
- Stringify provider_priorities when submitting from frontend UI
- Add optional job_id parameter to translation batch functions
- Fix explicit method call in SZProviderPool.list_subtitles_provider
- Update repository reference to LavX/bazarr fork

This fixes an issue where provider priorities dictionary settings weren't being properly serialized/deserialized between the frontend and backend, causing data type mismatches when saving provider configurations.