### PR TITLE
fix(security): enforce CSRF state validation in Plex OAuth

### DIFF
--- a/bazarr/api/plex/oauth.py
+++ b/bazarr/api/plex/oauth.py
@@ -318,11 +318,11 @@ class PlexPinCheck(Resource):
             if not cached_pin:
                 raise PlexPinExpiredError("PIN not found or expired")
 
-            if state_param:
-                stored_state = cached_pin.get('state_token')
-                if not stored_state or not get_token_manager().validate_state_token(state_param, stored_state):
+            stored_state = cached_pin.get('state_token')
+            if stored_state:
+                if not state_param or not get_token_manager().validate_state_token(state_param, stored_state):
                     logger.warning(f"CSRF state validation failed for PIN {pin_id}")
-                    return abort(403, "CSRF state validation failed")
+                    abort(403, "Request validation failed")
 
             headers = {
                 'Accept': 'application/json',

--- a/bazarr/api/plex/oauth.py
+++ b/bazarr/api/plex/oauth.py
@@ -322,6 +322,7 @@ class PlexPinCheck(Resource):
                 stored_state = cached_pin.get('state_token')
                 if not stored_state or not get_token_manager().validate_state_token(state_param, stored_state):
                     logger.warning(f"CSRF state validation failed for PIN {pin_id}")
+                    return abort(403, "CSRF state validation failed")
 
             headers = {
                 'Accept': 'application/json',

--- a/frontend/src/apis/hooks/plex.ts
+++ b/frontend/src/apis/hooks/plex.ts
@@ -70,6 +70,7 @@ export const usePlexPinMutation = () => {
 
 export const usePlexPinCheckQuery = (
   pinId: string | null,
+  state: string | null,
   enabled: boolean,
   refetchInterval: number | false,
 ) => {
@@ -77,7 +78,7 @@ export const usePlexPinCheckQuery = (
     queryKey: [QueryKeys.Plex, "pinCheck", pinId],
     queryFn: () => {
       if (!pinId) throw new Error("Pin ID is required");
-      return api.plex.checkPin(pinId);
+      return api.plex.checkPin(pinId, state ?? undefined);
     },
     enabled: enabled && !!pinId,
     retry: false,

--- a/frontend/src/apis/raw/plex.ts
+++ b/frontend/src/apis/raw/plex.ts
@@ -11,10 +11,10 @@ class NewPlexApi extends BaseApi {
     return response.data;
   }
 
-  async checkPin(pinId: string) {
-    // TODO: Can this be replaced with params instead of passing a variable in the path?
+  async checkPin(pinId: string, state?: string) {
     const response = await this.get<DataWrapper<Plex.PinCheckResult>>(
       `/oauth/pin/${pinId}/check`,
+      state ? { state } : undefined,
     );
 
     return response.data;

--- a/frontend/src/pages/Settings/Plex/AuthSection.tsx
+++ b/frontend/src/pages/Settings/Plex/AuthSection.tsx
@@ -29,6 +29,7 @@ const AuthSection = () => {
 
   const { data: pinData } = usePlexPinCheckQuery(
     pin?.pinId ?? null,
+    pin?.state ?? null,
     isPolling,
     pin?.pinId ? PLEX_AUTH_CONFIG.POLLING_INTERVAL_MS : false,
   );

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -269,6 +269,7 @@ declare namespace Plex {
     pinId: string;
     code: string;
     clientId: string;
+    state: string;
     authUrl: string;
   }
 


### PR DESCRIPTION
## Summary
- The Plex OAuth PIN check endpoint logged CSRF validation failures but continued processing
- Now returns `abort(403)` when state token validation fails

## Severity
**Low** — requires valid PIN ID that expires quickly, limited impact

## Test plan
- [ ] Verify Plex OAuth flow still works with valid state tokens
- [ ] Verify invalid/missing state tokens are rejected with 403