### PR TITLE
fix(security): upgrade password hashing from MD5 to PBKDF2-SHA256

### DIFF
--- a/bazarr/api/system/account.py
+++ b/bazarr/api/system/account.py
@@ -6,7 +6,7 @@ from flask import session, request
 from flask_restx import Resource, Namespace, reqparse
 
 from app.config import settings
-from utilities.helper import check_credentials
+from utilities.helper import check_credentials, needs_password_upgrade, upgrade_password_hash
 
 api_ns_system_account = Namespace('System Account', description='Login or logout from Bazarr UI')
 
@@ -15,7 +15,8 @@ api_ns_system_account = Namespace('System Account', description='Login or logout
 @api_ns_system_account.route('system/account')
 class SystemAccount(Resource):
     post_request_parser = reqparse.RequestParser()
-    post_request_parser.add_argument('action', type=str, required=True, help='Action from ["login", "logout"]')
+    post_request_parser.add_argument('action', type=str, required=True,
+                                     help='Action from ["login", "logout", "upgrade_hash"]')
     post_request_parser.add_argument('username', type=str, required=False, help='Bazarr username')
     post_request_parser.add_argument('password', type=str, required=False, help='Bazarr password')
 
@@ -37,6 +38,8 @@ class SystemAccount(Resource):
             password = args.get('password')
             if check_credentials(username, password, request):
                 session['logged_in'] = True
+                if needs_password_upgrade():
+                    return {'upgrade_hash': True}, 200
                 return '', 204
             else:
                 session['logged_in'] = False
@@ -48,5 +51,13 @@ class SystemAccount(Resource):
                 session.clear()
                 gc.collect()
                 return '', 204
+        elif action == 'upgrade_hash':
+            username = args.get('username')
+            password = args.get('password')
+            if check_credentials(username, password, request, log_success=False):
+                upgrade_password_hash(password)
+                return '', 204
+            else:
+                return 'Authentication failed', 403
 
         return 'Unknown action', 400

--- a/bazarr/api/system/account.py
+++ b/bazarr/api/system/account.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import gc
+import secrets
 
 from flask import session, request
 from flask_restx import Resource, Namespace, reqparse
@@ -39,7 +40,10 @@ class SystemAccount(Resource):
             if check_credentials(username, password, request):
                 session['logged_in'] = True
                 if needs_password_upgrade():
-                    return {'upgrade_hash': True}, 200
+                    # Store password in session for upgrade (server-side only, never sent to client)
+                    session['_pw_for_upgrade'] = password
+                    session['_upgrade_token'] = secrets.token_urlsafe(16)
+                    return {'upgrade_hash': True, 'upgrade_token': session['_upgrade_token']}, 200
                 return '', 204
             else:
                 session['logged_in'] = False
@@ -52,12 +56,15 @@ class SystemAccount(Resource):
                 gc.collect()
                 return '', 204
         elif action == 'upgrade_hash':
-            username = args.get('username')
-            password = args.get('password')
-            if check_credentials(username, password, request, log_success=False):
-                upgrade_password_hash(password)
-                return '', 204
-            else:
-                return 'Authentication failed', 403
+            # Verify upgrade token from session (no password re-transmission)
+            token = args.get('password')  # reuse password field for token
+            stored_token = session.get('_upgrade_token')
+            stored_pw = session.get('_pw_for_upgrade')
+            if not stored_token or not stored_pw or token != stored_token:
+                return 'Invalid or expired upgrade token', 403
+            upgrade_password_hash(stored_pw)
+            session.pop('_pw_for_upgrade', None)
+            session.pop('_upgrade_token', None)
+            return '', 204
 
         return 'Unknown action', 400

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -752,7 +752,8 @@ def save_settings(settings_items):
 
         if key == 'settings-auth-password':
             if value != settings.auth.password and value is not None:
-                value = hashlib.md5(f"{value}".encode('utf-8')).hexdigest()
+                from utilities.helper import hash_password
+                value = hash_password(value)
 
         if key == 'settings-general-debug':
             configure_debug = True

--- a/bazarr/utilities/helper.py
+++ b/bazarr/utilities/helper.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import os
+import hmac
 import logging
 import hashlib
 
@@ -10,19 +11,56 @@ from bs4 import UnicodeDammit
 from app.config import settings
 
 
+def hash_password(pw):
+    salt = os.urandom(16)
+    hashed = hashlib.pbkdf2_hmac('sha256', f"{pw}".encode('utf-8'), salt, 150000)
+    return 'pbkdf2:' + salt.hex() + ':' + hashed.hex()
+
+
+def _is_legacy_md5(stored_hash):
+    return not stored_hash.startswith('pbkdf2:')
+
+
+def _verify_password(pw, stored_hash):
+    if stored_hash.startswith('pbkdf2:'):
+        _, salt_hex, hash_hex = stored_hash.split(':', 2)
+        salt = bytes.fromhex(salt_hex)
+        expected = bytes.fromhex(hash_hex)
+        actual = hashlib.pbkdf2_hmac('sha256', f"{pw}".encode('utf-8'), salt, 150000)
+        return hmac.compare_digest(actual, expected)
+    else:
+        return hmac.compare_digest(
+            hashlib.md5(f"{pw}".encode('utf-8')).hexdigest(),
+            stored_hash
+        )
+
+
+def upgrade_password_hash(pw):
+    new_hash = hash_password(pw)
+    settings.auth.password = new_hash
+    from app.config import write_config
+    write_config()
+    logging.info('Upgraded password hash from MD5 to PBKDF2-SHA256')
+
+
 def check_credentials(user, pw, request, log_success=True):
     forwarded_for_ip_addr = request.environ.get('HTTP_X_FORWARDED_FOR')
     real_ip_addr = request.environ.get('HTTP_X_REAL_IP')
     ip_addr = forwarded_for_ip_addr or real_ip_addr or request.remote_addr
     username = settings.auth.username
     password = settings.auth.password
-    if hashlib.md5(f"{pw}".encode('utf-8')).hexdigest() == password and user == username:
+    if user == username and _verify_password(pw, password):
         if log_success:
             logging.info(f'Successful authentication from {ip_addr} for user {user}')
         return True
     else:
         logging.info(f'Failed authentication from {ip_addr} for user {user}')
         return False
+
+
+def needs_password_upgrade():
+    password = settings.auth.password
+    return bool(password) and _is_legacy_md5(password)
 
 
 def get_subtitle_destination_folder():

--- a/bazarr/utilities/helper.py
+++ b/bazarr/utilities/helper.py
@@ -11,9 +11,12 @@ from bs4 import UnicodeDammit
 from app.config import settings
 
 
+PBKDF2_ITERATIONS = 600_000
+
+
 def hash_password(pw):
     salt = os.urandom(16)
-    hashed = hashlib.pbkdf2_hmac('sha256', f"{pw}".encode('utf-8'), salt, 150000)
+    hashed = hashlib.pbkdf2_hmac('sha256', f"{pw}".encode('utf-8'), salt, PBKDF2_ITERATIONS)
     return 'pbkdf2:' + salt.hex() + ':' + hashed.hex()
 
 
@@ -26,7 +29,7 @@ def _verify_password(pw, stored_hash):
         _, salt_hex, hash_hex = stored_hash.split(':', 2)
         salt = bytes.fromhex(salt_hex)
         expected = bytes.fromhex(hash_hex)
-        actual = hashlib.pbkdf2_hmac('sha256', f"{pw}".encode('utf-8'), salt, 150000)
+        actual = hashlib.pbkdf2_hmac('sha256', f"{pw}".encode('utf-8'), salt, PBKDF2_ITERATIONS)
         return hmac.compare_digest(actual, expected)
     else:
         return hmac.compare_digest(
@@ -37,10 +40,16 @@ def _verify_password(pw, stored_hash):
 
 def upgrade_password_hash(pw):
     new_hash = hash_password(pw)
+    old_hash = settings.auth.password
     settings.auth.password = new_hash
-    from app.config import write_config
-    write_config()
-    logging.info('Upgraded password hash from MD5 to PBKDF2-SHA256')
+    try:
+        from app.config import write_config
+        write_config()
+        logging.info('Upgraded password hash from MD5 to PBKDF2-SHA256')
+    except Exception:
+        settings.auth.password = old_hash
+        logging.exception('Failed to persist password hash upgrade, reverted to previous hash')
+        raise
 
 
 def check_credentials(user, pw, request, log_success=True):

--- a/bazarr/utilities/helper.py
+++ b/bazarr/utilities/helper.py
@@ -26,9 +26,13 @@ def _is_legacy_md5(stored_hash):
 
 def _verify_password(pw, stored_hash):
     if stored_hash.startswith('pbkdf2:'):
-        _, salt_hex, hash_hex = stored_hash.split(':', 2)
-        salt = bytes.fromhex(salt_hex)
-        expected = bytes.fromhex(hash_hex)
+        try:
+            _, salt_hex, hash_hex = stored_hash.split(':', 2)
+            salt = bytes.fromhex(salt_hex)
+            expected = bytes.fromhex(hash_hex)
+        except (ValueError, TypeError):
+            logging.error('Corrupted PBKDF2 password hash in config. Re-set your password in settings.')
+            return False
         actual = hashlib.pbkdf2_hmac('sha256', f"{pw}".encode('utf-8'), salt, PBKDF2_ITERATIONS)
         return hmac.compare_digest(actual, expected)
     else:

--- a/frontend/src/App/index.tsx
+++ b/frontend/src/App/index.tsx
@@ -1,8 +1,9 @@
-import { FunctionComponent, useEffect, useState } from "react";
+import { FunctionComponent, useCallback, useEffect, useState } from "react";
 import { Outlet, useNavigate } from "react-router";
-import { AppShell } from "@mantine/core";
+import { AppShell, Button, Group, Modal, Stack, Text } from "@mantine/core";
 import { useWindowEvent } from "@mantine/hooks";
 import { showNotification } from "@mantine/notifications";
+import api from "@/apis/raw";
 import AppNavbar from "@/App/Navbar";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import NavbarProvider from "@/contexts/Navbar";
@@ -35,6 +36,9 @@ const App: FunctionComponent = () => {
     setOnline(detail.online);
   });
 
+  const [upgradeModalOpen, setUpgradeModalOpen] = useState(false);
+  const [upgrading, setUpgrading] = useState(false);
+
   useEffect(() => {
     if (Environment.hasUpdate) {
       showNotification(
@@ -44,6 +48,42 @@ const App: FunctionComponent = () => {
         ),
       );
     }
+  }, []);
+
+  useEffect(() => {
+    const pending = sessionStorage.getItem("password_upgrade_pending");
+    if (pending) {
+      setUpgradeModalOpen(true);
+    }
+  }, []);
+
+  const handleUpgradeAccept = useCallback(async () => {
+    const raw = sessionStorage.getItem("password_upgrade_pending");
+    if (!raw) return;
+    setUpgrading(true);
+    try {
+      const { username, password } = JSON.parse(raw);
+      await api.system.upgradePasswordHash(username, password);
+      showNotification(
+        notification.info(
+          "Password upgraded",
+          "Your password hash has been upgraded to PBKDF2-SHA256",
+        ),
+      );
+    } catch {
+      showNotification(
+        notification.warn("Upgrade failed", "Could not upgrade password hash"),
+      );
+    } finally {
+      sessionStorage.removeItem("password_upgrade_pending");
+      setUpgradeModalOpen(false);
+      setUpgrading(false);
+    }
+  }, []);
+
+  const handleUpgradeDecline = useCallback(() => {
+    sessionStorage.removeItem("password_upgrade_pending");
+    setUpgradeModalOpen(false);
   }, []);
 
   if (criticalError !== null) {
@@ -69,6 +109,31 @@ const App: FunctionComponent = () => {
               <Outlet></Outlet>
             </AppShell.Main>
           </AppShell>
+          <Modal
+            opened={upgradeModalOpen}
+            onClose={handleUpgradeDecline}
+            title="Upgrade Password Security"
+            centered
+          >
+            <Stack>
+              <Text size="sm">
+                Your password is currently stored using a weak MD5 hash.
+                Would you like to upgrade to PBKDF2-SHA256 for better security?
+              </Text>
+              <Text size="xs" c="dimmed">
+                Note: After upgrading, reverting to upstream Bazarr will require
+                resetting your password via the config file.
+              </Text>
+              <Group justify="flex-end">
+                <Button variant="default" onClick={handleUpgradeDecline}>
+                  Not now
+                </Button>
+                <Button onClick={handleUpgradeAccept} loading={upgrading}>
+                  Upgrade
+                </Button>
+              </Group>
+            </Stack>
+          </Modal>
         </OnlineProvider>
       </NavbarProvider>
     </ErrorBoundary>

--- a/frontend/src/App/index.tsx
+++ b/frontend/src/App/index.tsx
@@ -51,19 +51,18 @@ const App: FunctionComponent = () => {
   }, []);
 
   useEffect(() => {
-    const pending = sessionStorage.getItem("password_upgrade_pending");
-    if (pending) {
+    const token = sessionStorage.getItem("password_upgrade_token");
+    if (token) {
       setUpgradeModalOpen(true);
     }
   }, []);
 
   const handleUpgradeAccept = useCallback(async () => {
-    const raw = sessionStorage.getItem("password_upgrade_pending");
-    if (!raw) return;
+    const token = sessionStorage.getItem("password_upgrade_token");
+    if (!token) return;
     setUpgrading(true);
     try {
-      const { username, password } = JSON.parse(raw);
-      await api.system.upgradePasswordHash(username, password);
+      await api.system.upgradePasswordHash(token);
       showNotification(
         notification.info(
           "Password upgraded",
@@ -75,14 +74,14 @@ const App: FunctionComponent = () => {
         notification.warn("Upgrade failed", "Could not upgrade password hash"),
       );
     } finally {
-      sessionStorage.removeItem("password_upgrade_pending");
+      sessionStorage.removeItem("password_upgrade_token");
       setUpgradeModalOpen(false);
       setUpgrading(false);
     }
   }, []);
 
   const handleUpgradeDecline = useCallback(() => {
-    sessionStorage.removeItem("password_upgrade_pending");
+    sessionStorage.removeItem("password_upgrade_token");
     setUpgradeModalOpen(false);
   }, []);
 

--- a/frontend/src/apis/hooks/system.ts
+++ b/frontend/src/apis/hooks/system.ts
@@ -274,7 +274,14 @@ export function useSystem() {
     mutationFn: (param: { username: string; password: string }) =>
       api.system.login(param.username, param.password),
 
-    onSuccess: () => {
+    onSuccess: (data, variables) => {
+      if (data && typeof data === "object" && "upgrade_hash" in data && data.upgrade_hash) {
+        // Store credentials temporarily for upgrade prompt
+        sessionStorage.setItem("password_upgrade_pending", JSON.stringify({
+          username: variables.username,
+          password: variables.password,
+        }));
+      }
       // TODO: Hard-coded value
       window.location.replace(Environment.baseUrl);
     },

--- a/frontend/src/apis/hooks/system.ts
+++ b/frontend/src/apis/hooks/system.ts
@@ -274,13 +274,10 @@ export function useSystem() {
     mutationFn: (param: { username: string; password: string }) =>
       api.system.login(param.username, param.password),
 
-    onSuccess: (data, variables) => {
-      if (data && typeof data === "object" && "upgrade_hash" in data && data.upgrade_hash) {
-        // Store credentials temporarily for upgrade prompt
-        sessionStorage.setItem("password_upgrade_pending", JSON.stringify({
-          username: variables.username,
-          password: variables.password,
-        }));
+    onSuccess: (data) => {
+      if (data && typeof data === "object" && "upgrade_token" in data && data.upgrade_token) {
+        // Store opaque token (not password) for upgrade prompt
+        sessionStorage.setItem("password_upgrade_token", data.upgrade_token);
       }
       // TODO: Hard-coded value
       window.location.replace(Environment.baseUrl);

--- a/frontend/src/apis/raw/system.ts
+++ b/frontend/src/apis/raw/system.ts
@@ -10,7 +10,16 @@ class SystemApi extends BaseApi {
   }
 
   async login(username: string, password: string) {
-    await this.post("/account", { username, password }, { action: "login" });
+    const response = await this.post<{ upgrade_hash?: boolean }>(
+      "/account",
+      { username, password },
+      { action: "login" },
+    );
+    return response;
+  }
+
+  async upgradePasswordHash(username: string, password: string) {
+    await this.post("/account", { username, password }, { action: "upgrade_hash" });
   }
 
   async logout() {

--- a/frontend/src/apis/raw/system.ts
+++ b/frontend/src/apis/raw/system.ts
@@ -10,16 +10,15 @@ class SystemApi extends BaseApi {
   }
 
   async login(username: string, password: string) {
-    const response = await this.post<{ upgrade_hash?: boolean }>(
-      "/account",
-      { username, password },
-      { action: "login" },
-    );
-    return response;
+    const response = await this.post<{
+      upgrade_hash?: boolean;
+      upgrade_token?: string;
+    }>("/account", { username, password }, { action: "login" });
+    return response.data;
   }
 
-  async upgradePasswordHash(username: string, password: string) {
-    await this.post("/account", { username, password }, { action: "upgrade_hash" });
+  async upgradePasswordHash(upgradeToken: string) {
+    await this.post("/account", { password: upgradeToken }, { action: "upgrade_hash" });
   }
 
   async logout() {


### PR DESCRIPTION
## Summary
- Replace unsalted MD5 with PBKDF2-SHA256 (150k iterations, 16-byte random salt)
- Timing-safe comparison via `hmac.compare_digest()`
- Legacy MD5 hashes (upstream format) always accepted for backward compatibility
- After login with MD5 hash, a UI modal prompts user to upgrade
- User can decline; prompt reappears on next login
- New passwords via settings UI always use PBKDF2
- Upstream bazarr users can migrate seamlessly

## Files changed
- `bazarr/utilities/helper.py` — PBKDF2 hashing, verification, migration
- `bazarr/app/config.py` — use `hash_password()` when saving new passwords
- `bazarr/api/system/account.py` — return upgrade hint + upgrade_hash action
- `frontend/src/apis/raw/system.ts` — login response type + upgrade API
- `frontend/src/apis/hooks/system.ts` — store upgrade pending flag
- `frontend/src/App/index.tsx` — upgrade prompt modal

## Severity
**Medium** — MD5 is cryptographically broken; upgrade path is non-destructive

## Test plan
- [ ] Login with existing MD5 password works
- [ ] Upgrade prompt appears after MD5 login
- [ ] Accepting upgrade re-hashes to PBKDF2
- [ ] Subsequent logins use PBKDF2 (no prompt)
- [ ] Declining upgrade allows login, prompt reappears next time
- [ ] Setting new password via UI uses PBKDF2