### PR TITLE
fix(security): block SSRF to cloud metadata via /test proxy

### DIFF
--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -1,13 +1,15 @@
 # coding=utf-8
 
 import os
+import ipaddress
+import socket
 import requests
 import mimetypes
 
 from flask import (request, abort, render_template, Response, session, send_file, stream_with_context, Blueprint,
                    redirect)
 from functools import wraps
-from urllib.parse import unquote
+from urllib.parse import unquote, urlparse
 
 from constants import HEADERS
 from literals import FILE_LOG
@@ -175,6 +177,25 @@ def swaggerui_static(filename):
         return send_file(fullpath)
 
 
+def _is_safe_url(url_str):
+    """Block requests to cloud metadata endpoints and link-local addresses."""
+    try:
+        parsed = urlparse(url_str)
+        hostname = parsed.hostname
+        if not hostname:
+            return False
+        addrs = socket.getaddrinfo(hostname, None)
+        for _, _, _, _, sockaddr in addrs:
+            ip = ipaddress.ip_address(sockaddr[0])
+            if ip.is_loopback or ip.is_link_local or ip.is_private:
+                # Allow private IPs (LAN) but block link-local (169.254.x.x / cloud metadata)
+                if ip.is_link_local:
+                    return False
+        return True
+    except (socket.gaierror, ValueError):
+        return True  # Let requests handle DNS failures
+
+
 @check_login
 @ui_bp.route('/test', methods=['GET'])
 @ui_bp.route('/test/<protocol>/<path:url>', methods=['GET'])
@@ -182,6 +203,8 @@ def proxy(protocol, url):
     if protocol.lower() not in ['http', 'https']:
         return dict(status=False, error='Unsupported protocol', code=0)
     url = f'{protocol}://{unquote(url)}'
+    if not _is_safe_url(url):
+        return dict(status=False, error='Request to link-local or metadata addresses is not allowed', code=0)
     params = request.args
     try:
         result = requests.get(url, params, allow_redirects=False, verify=False, timeout=5, headers=HEADERS)

--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -177,23 +177,23 @@ def swaggerui_static(filename):
         return send_file(fullpath)
 
 
-def _is_safe_url(url_str):
-    """Block requests to cloud metadata endpoints and link-local addresses."""
-    try:
-        parsed = urlparse(url_str)
-        hostname = parsed.hostname
-        if not hostname:
-            return False
-        addrs = socket.getaddrinfo(hostname, None)
-        for _, _, _, _, sockaddr in addrs:
-            ip = ipaddress.ip_address(sockaddr[0])
-            if ip.is_loopback or ip.is_link_local or ip.is_private:
-                # Allow private IPs (LAN) but block link-local (169.254.x.x / cloud metadata)
-                if ip.is_link_local:
-                    return False
-        return True
-    except (socket.gaierror, ValueError):
-        return True  # Let requests handle DNS failures
+def _resolve_and_validate(url_str):
+    """Resolve DNS once and validate all resolved IPs are safe.
+    Returns (resolved_ip, hostname, parsed) or raises ValueError."""
+    parsed = urlparse(url_str)
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("No hostname in URL")
+    port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+    addrs = socket.getaddrinfo(hostname, port)
+    if not addrs:
+        raise ValueError("DNS resolution returned no results")
+    for _, _, _, _, sockaddr in addrs:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if ip.is_link_local or ip.is_loopback:
+            raise ValueError(f"Blocked address: {ip}")
+    # Return first resolved IP for pinning
+    return addrs[0][4][0], hostname, parsed
 
 
 @check_login
@@ -203,11 +203,19 @@ def proxy(protocol, url):
     if protocol.lower() not in ['http', 'https']:
         return dict(status=False, error='Unsupported protocol', code=0)
     url = f'{protocol}://{unquote(url)}'
-    if not _is_safe_url(url):
-        return dict(status=False, error='Request to link-local or metadata addresses is not allowed', code=0)
+    try:
+        resolved_ip, hostname, parsed = _resolve_and_validate(url)
+    except (ValueError, socket.gaierror) as e:
+        return dict(status=False, error=f'Request blocked: {e}', code=0)
+    # Pin request to resolved IP to prevent DNS rebinding
+    port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+    pinned_netloc = f'{resolved_ip}:{port}'
+    pinned_url = parsed._replace(netloc=pinned_netloc).geturl()
+    pinned_headers = dict(HEADERS)
+    pinned_headers['Host'] = hostname
     params = request.args
     try:
-        result = requests.get(url, params, allow_redirects=False, verify=False, timeout=5, headers=HEADERS)
+        result = requests.get(pinned_url, params, allow_redirects=False, verify=False, timeout=5, headers=pinned_headers)
     except Exception as e:
         return dict(status=False, error=repr(e))
     else:

--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -178,7 +178,7 @@ def swaggerui_static(filename):
 
 
 def _resolve_and_validate(url_str):
-    """Resolve DNS once and validate all resolved IPs are safe.
+    """Resolve DNS once and validate resolved IPs. Pick a safe address to pin to.
     Returns (resolved_ip, hostname, parsed) or raises ValueError."""
     parsed = urlparse(url_str)
     hostname = parsed.hostname
@@ -188,12 +188,17 @@ def _resolve_and_validate(url_str):
     addrs = socket.getaddrinfo(hostname, port)
     if not addrs:
         raise ValueError("DNS resolution returned no results")
+    # Find a safe (non-link-local, non-loopback) address to pin to.
+    # Dual-stack hosts may resolve to both private LAN and link-local IPv6.
+    safe_ip = None
     for _, _, _, _, sockaddr in addrs:
         ip = ipaddress.ip_address(sockaddr[0])
-        if ip.is_link_local or ip.is_loopback:
-            raise ValueError(f"Blocked address: {ip}")
-    # Return first resolved IP for pinning
-    return addrs[0][4][0], hostname, parsed
+        if not ip.is_link_local and not ip.is_loopback:
+            if safe_ip is None:
+                safe_ip = sockaddr[0]
+    if safe_ip is None:
+        raise ValueError("All resolved addresses are link-local or loopback")
+    return safe_ip, hostname, parsed
 
 
 @check_login


### PR DESCRIPTION
## Summary
- Add URL validation to block requests to link-local addresses (169.254.x.x / cloud metadata)
- Private LAN IPs still allowed (needed for Sonarr/Radarr/Plex connectivity testing)
- DNS resolution checked before request to catch hostname-based metadata access

## Severity
**Medium** — prevents cloud metadata endpoint access via authenticated proxy

## Test plan
- [ ] Testing Sonarr/Radarr/Plex connectivity still works (private LAN IPs)
- [ ] Requests to 169.254.169.254 are blocked
- [ ] Requests to normal external URLs still work