### PR TITLE
fix(security): add per-service TLS verification toggle

### DIFF
--- a/bazarr/api/plex/oauth.py
+++ b/bazarr/api/plex/oauth.py
@@ -18,6 +18,7 @@ from . import api_ns_plex
 from .exceptions import *
 from .security import (TokenManager, sanitize_log_data, pin_cache, get_or_create_encryption_key, sanitize_server_url,
                        encrypt_api_key)
+from app.config import get_ssl_verify
 from app.config import settings, write_config
 from app.logger import logger
 from utilities.plex_utils import _get_library_locations
@@ -223,7 +224,7 @@ def test_plex_connection(uri, token):
             f"{uri}/identity",
             headers=headers,
             timeout=3,
-            verify=False
+            verify=get_ssl_verify('plex')
         )
         latency_ms = int((time.time() - start_time) * 1000)
 
@@ -625,7 +626,7 @@ class PlexLibraries(Resource):
                         f"{server_url}/library/sections",
                         headers=headers,
                         timeout=10,
-                        verify=False
+                        verify=get_ssl_verify('plex')
                     )
 
                     if lib_response.status_code in (401, 403):
@@ -691,7 +692,7 @@ class PlexLibraries(Resource):
                             f"{successful_server_url}/library/sections/{section_key}/all",
                             headers={'X-Plex-Token': decrypted_token, 'Accept': 'application/json'},
                             timeout=5,
-                            verify=False
+                            verify=get_ssl_verify('plex')
                         )
                         
                         actual_count = 0
@@ -840,7 +841,7 @@ class PlexTestConnection(Resource):
                 f"{uri}/identity",
                 headers=headers,
                 timeout=3,
-                verify=False
+                verify=get_ssl_verify('plex')
             )
 
             if response.status_code == 200:

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -1020,10 +1020,14 @@ def configure_proxy_func():
         os.environ['NO_PROXY'] = exclude
 
 
+_SSL_VERIFY_SERVICES = frozenset({'sonarr', 'radarr', 'plex'})
+
+
 def get_ssl_verify(service):
-    """Return the verify parameter for requests calls to a service.
-    service should be 'sonarr', 'radarr', or 'plex'."""
-    return settings.get(service, {}).get('verify_ssl', False)
+    """Return the verify parameter for requests calls to a service."""
+    if service not in _SSL_VERIFY_SERVICES:
+        raise ValueError(f"Unknown service for SSL verify: {service}")
+    return settings.get(f'{service}.verify_ssl', False)
 
 
 def get_scores():

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -235,6 +235,7 @@ validators = [
     Validator('sonarr.defer_search_signalr', must_exist=True, default=False, is_type_of=bool),
     Validator('sonarr.sync_only_monitored_series', must_exist=True, default=False, is_type_of=bool),
     Validator('sonarr.sync_only_monitored_episodes', must_exist=True, default=False, is_type_of=bool),
+    Validator('sonarr.verify_ssl', must_exist=True, default=False, is_type_of=bool),
 
     # radarr section
     Validator('radarr.ip', must_exist=True, default='127.0.0.1', is_type_of=str),
@@ -256,6 +257,7 @@ validators = [
     Validator('radarr.use_ffprobe_cache', must_exist=True, default=True, is_type_of=bool),
     Validator('radarr.defer_search_signalr', must_exist=True, default=False, is_type_of=bool),
     Validator('radarr.sync_only_monitored_movies', must_exist=True, default=False, is_type_of=bool),
+    Validator('radarr.verify_ssl', must_exist=True, default=False, is_type_of=bool),
 
     # plex section
     Validator('plex.ip', must_exist=True, default='127.0.0.1', is_type_of=str),
@@ -277,6 +279,7 @@ validators = [
     Validator('plex.user_id', must_exist=True, default='', is_type_of=(int, str)),
     Validator('plex.auth_method', must_exist=True, default='apikey', is_type_of=str, is_in=['apikey', 'oauth']),
     Validator('plex.encryption_key', must_exist=True, default='', is_type_of=str),
+    Validator('plex.verify_ssl', must_exist=True, default=False, is_type_of=bool),
     Validator('plex.server_machine_id', must_exist=True, default='', is_type_of=str),
     Validator('plex.server_name', must_exist=True, default='', is_type_of=str),
     Validator('plex.server_url', must_exist=True, default='', is_type_of=str),
@@ -1015,6 +1018,12 @@ def configure_proxy_func():
         os.environ['HTTPS_PROXY'] = str(proxy)
         exclude = ','.join(settings.proxy.exclude)
         os.environ['NO_PROXY'] = exclude
+
+
+def get_ssl_verify(service):
+    """Return the verify parameter for requests calls to a service.
+    service should be 'sonarr', 'radarr', or 'plex'."""
+    return settings.get(service, {}).get('verify_ssl', False)
 
 
 def get_scores():

--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -16,7 +16,7 @@ from radarr.info import url_api_radarr
 from utilities.helper import check_credentials
 from utilities.central import get_log_file_path
 
-from .config import settings, base_url
+from .config import settings, base_url, get_ssl_verify
 from .database import database, System
 from .get_args import args
 
@@ -132,7 +132,7 @@ def series_images(url):
     baseUrl = settings.sonarr.base_url
     url_image = f'{url_api_sonarr()}{url.lstrip(baseUrl)}?apikey={apikey}'.replace('poster-250', 'poster-500')
     try:
-        req = requests.get(url_image, stream=True, timeout=15, verify=False, headers=HEADERS)
+        req = requests.get(url_image, stream=True, timeout=15, verify=get_ssl_verify('sonarr'), headers=HEADERS)
     except Exception:
         return '', 404
     else:
@@ -146,7 +146,7 @@ def movies_images(url):
     baseUrl = settings.radarr.base_url
     url_image = f'{url_api_radarr()}{url.lstrip(baseUrl)}?apikey={apikey}'
     try:
-        req = requests.get(url_image, stream=True, timeout=15, verify=False, headers=HEADERS)
+        req = requests.get(url_image, stream=True, timeout=15, verify=get_ssl_verify('radarr'), headers=HEADERS)
     except Exception:
         return '', 404
     else:

--- a/bazarr/radarr/filesystem.py
+++ b/bazarr/radarr/filesystem.py
@@ -3,7 +3,7 @@
 import requests
 import logging
 
-from app.config import settings
+from app.config import settings, get_ssl_verify
 from radarr.info import url_api_radarr
 from constants import HEADERS
 
@@ -15,7 +15,7 @@ def browse_radarr_filesystem(path='#'):
     url_radarr_api_filesystem = (f"{url_api_radarr()}filesystem?path={path}&allowFoldersWithoutTrailingSlashes=true&"
                                  f"includeFiles=false&apikey={settings.radarr.apikey}")
     try:
-        r = requests.get(url_radarr_api_filesystem, timeout=int(settings.radarr.http_timeout), verify=False,
+        r = requests.get(url_radarr_api_filesystem, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'),
                          headers=HEADERS)
         r.raise_for_status()
     except requests.exceptions.HTTPError:

--- a/bazarr/radarr/info.py
+++ b/bazarr/radarr/info.py
@@ -9,7 +9,7 @@ from requests.exceptions import JSONDecodeError
 
 from dogpile.cache import make_region
 
-from app.config import settings, empty_values
+from app.config import settings, empty_values, get_ssl_verify
 from constants import HEADERS
 
 region = make_region().configure('dogpile.cache.memory')
@@ -31,7 +31,7 @@ class GetRadarrInfo:
         if settings.general.use_radarr:
             try:
                 rv = f"{url_radarr()}/api/system/status?apikey={settings.radarr.apikey}"
-                radarr_json = requests.get(rv, timeout=int(settings.radarr.http_timeout), verify=False,
+                radarr_json = requests.get(rv, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'),
                                            headers=HEADERS).json()
                 if 'version' in radarr_json:
                     radarr_version = radarr_json['version']
@@ -40,7 +40,7 @@ class GetRadarrInfo:
             except JSONDecodeError:
                 try:
                     rv = f"{url_radarr()}/api/v3/system/status?apikey={settings.radarr.apikey}"
-                    radarr_version = requests.get(rv, timeout=int(settings.radarr.http_timeout), verify=False,
+                    radarr_version = requests.get(rv, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'),
                                                   headers=HEADERS).json()['version']
                 except JSONDecodeError:
                     logging.debug('BAZARR cannot get Radarr version')

--- a/bazarr/radarr/notify.py
+++ b/bazarr/radarr/notify.py
@@ -3,7 +3,7 @@
 import logging
 import requests
 
-from app.config import settings
+from app.config import settings, get_ssl_verify
 from radarr.info import url_api_radarr
 from constants import HEADERS
 
@@ -15,6 +15,6 @@ def notify_radarr(radarr_id):
             'name': 'RescanMovie',
             'movieId': int(radarr_id)
         }
-        requests.post(url, json=data, timeout=int(settings.radarr.http_timeout), verify=False, headers=HEADERS)
+        requests.post(url, json=data, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'), headers=HEADERS)
     except Exception:
         logging.exception('BAZARR cannot notify Radarr')

--- a/bazarr/radarr/rootfolder.py
+++ b/bazarr/radarr/rootfolder.py
@@ -4,7 +4,7 @@ import os
 import requests
 import logging
 
-from app.config import settings
+from app.config import settings, get_ssl_verify
 from utilities.path_mappings import path_mappings
 from app.database import TableMoviesRootfolder, TableMovies, database, delete, update, insert, select
 from radarr.info import url_api_radarr
@@ -19,7 +19,7 @@ def get_radarr_rootfolder():
     url_radarr_api_rootfolder = f"{url_api_radarr()}rootfolder?apikey={apikey_radarr}"
 
     try:
-        rootfolder = requests.get(url_radarr_api_rootfolder, timeout=int(settings.radarr.http_timeout), verify=False, headers=HEADERS)
+        rootfolder = requests.get(url_radarr_api_rootfolder, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'), headers=HEADERS)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get rootfolder from Radarr. Connection Error.")
         return []

--- a/bazarr/radarr/sync/utils.py
+++ b/bazarr/radarr/sync/utils.py
@@ -3,7 +3,7 @@
 import requests
 import logging
 
-from app.config import settings
+from app.config import settings, get_ssl_verify
 from radarr.info import get_radarr_info, url_api_radarr
 from constants import HEADERS
 
@@ -16,7 +16,7 @@ def get_profile_list():
                              f"apikey={apikey_radarr}")
 
     try:
-        profiles_json = requests.get(url_radarr_api_movies, timeout=int(settings.radarr.http_timeout), verify=False,
+        profiles_json = requests.get(url_radarr_api_movies, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'),
                                      headers=HEADERS)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get profiles from Radarr. Connection Error.")
@@ -46,7 +46,7 @@ def get_tags():
     url_radarr_api_series = f"{url_api_radarr()}tag?apikey={apikey_radarr}"
 
     try:
-        tagsDict = requests.get(url_radarr_api_series, timeout=int(settings.radarr.http_timeout), verify=False, headers=HEADERS)
+        tagsDict = requests.get(url_radarr_api_series, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'), headers=HEADERS)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get tags from Radarr. Connection Error.")
         return []
@@ -70,7 +70,7 @@ def get_movies_from_radarr_api(apikey_radarr, radarr_id=None):
     url_radarr_api_movies = f'{url_api_radarr()}movie{f"/{radarr_id}" if radarr_id else ""}?apikey={apikey_radarr}'
 
     try:
-        r = requests.get(url_radarr_api_movies, timeout=int(settings.radarr.http_timeout), verify=False, headers=HEADERS)
+        r = requests.get(url_radarr_api_movies, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'), headers=HEADERS)
         if r.status_code == 404:
             return
         r.raise_for_status()
@@ -100,7 +100,7 @@ def get_history_from_radarr_api(apikey_radarr, movie_id):
     url_radarr_api_history = f"{url_api_radarr()}history?eventType=1&movieIds={movie_id}&apikey={apikey_radarr}"
 
     try:
-        r = requests.get(url_radarr_api_history, timeout=int(settings.sonarr.http_timeout), verify=False,
+        r = requests.get(url_radarr_api_history, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('radarr'),
                          headers=HEADERS)
         r.raise_for_status()
     except requests.exceptions.HTTPError:

--- a/bazarr/sonarr/filesystem.py
+++ b/bazarr/sonarr/filesystem.py
@@ -3,7 +3,7 @@
 import requests
 import logging
 
-from app.config import settings
+from app.config import settings, get_ssl_verify
 from sonarr.info import url_api_sonarr
 from constants import HEADERS
 
@@ -14,7 +14,7 @@ def browse_sonarr_filesystem(path='#'):
     url_sonarr_api_filesystem = (f"{url_api_sonarr()}filesystem?path={path}&allowFoldersWithoutTrailingSlashes=true&"
                                  f"includeFiles=false&apikey={settings.sonarr.apikey}")
     try:
-        r = requests.get(url_sonarr_api_filesystem, timeout=int(settings.sonarr.http_timeout), verify=False,
+        r = requests.get(url_sonarr_api_filesystem, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
                          headers=HEADERS)
         r.raise_for_status()
     except requests.exceptions.HTTPError:

--- a/bazarr/sonarr/info.py
+++ b/bazarr/sonarr/info.py
@@ -9,7 +9,7 @@ from requests.exceptions import JSONDecodeError
 
 from dogpile.cache import make_region
 
-from app.config import settings, empty_values
+from app.config import settings, empty_values, get_ssl_verify
 from constants import HEADERS
 
 region = make_region().configure('dogpile.cache.memory')
@@ -31,7 +31,7 @@ class GetSonarrInfo:
         if settings.general.use_sonarr:
             try:
                 sv = f"{url_sonarr()}/api/system/status?apikey={settings.sonarr.apikey}"
-                sonarr_json = requests.get(sv, timeout=int(settings.sonarr.http_timeout), verify=False,
+                sonarr_json = requests.get(sv, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
                                            headers=HEADERS).json()
                 if 'version' in sonarr_json:
                     sonarr_version = sonarr_json['version']
@@ -40,7 +40,7 @@ class GetSonarrInfo:
             except JSONDecodeError:
                 try:
                     sv = f"{url_sonarr()}/api/v3/system/status?apikey={settings.sonarr.apikey}"
-                    sonarr_version = requests.get(sv, timeout=int(settings.sonarr.http_timeout), verify=False,
+                    sonarr_version = requests.get(sv, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
                                                   headers=HEADERS).json()['version']
                 except JSONDecodeError:
                     logging.debug('BAZARR cannot get Sonarr version')

--- a/bazarr/sonarr/notify.py
+++ b/bazarr/sonarr/notify.py
@@ -3,7 +3,7 @@
 import logging
 import requests
 
-from app.config import settings
+from app.config import settings, get_ssl_verify
 from sonarr.info import url_api_sonarr
 from constants import HEADERS
 
@@ -15,6 +15,6 @@ def notify_sonarr(sonarr_series_id):
             'name': 'RescanSeries',
             'seriesId': int(sonarr_series_id)
         }
-        requests.post(url, json=data, timeout=int(settings.sonarr.http_timeout), verify=False, headers=HEADERS)
+        requests.post(url, json=data, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'), headers=HEADERS)
     except Exception:
         logging.exception('BAZARR cannot notify Sonarr')

--- a/bazarr/sonarr/rootfolder.py
+++ b/bazarr/sonarr/rootfolder.py
@@ -4,7 +4,7 @@ import os
 import requests
 import logging
 
-from app.config import settings
+from app.config import settings, get_ssl_verify
 from app.database import TableShowsRootfolder, TableShows, database, insert, update, delete, select
 from utilities.path_mappings import path_mappings
 from sonarr.info import url_api_sonarr
@@ -19,7 +19,7 @@ def get_sonarr_rootfolder():
     url_sonarr_api_rootfolder = f"{url_api_sonarr()}rootfolder?apikey={apikey_sonarr}"
 
     try:
-        rootfolder = requests.get(url_sonarr_api_rootfolder, timeout=int(settings.sonarr.http_timeout), verify=False, headers=HEADERS)
+        rootfolder = requests.get(url_sonarr_api_rootfolder, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'), headers=HEADERS)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get rootfolder from Sonarr. Connection Error.")
         return []

--- a/bazarr/sonarr/sync/utils.py
+++ b/bazarr/sonarr/sync/utils.py
@@ -3,7 +3,7 @@
 import requests
 import logging
 
-from app.config import settings
+from app.config import settings, get_ssl_verify
 from sonarr.info import get_sonarr_info, url_api_sonarr
 from constants import HEADERS
 
@@ -22,7 +22,7 @@ def get_profile_list():
         url_sonarr_api_series = f"{url_api_sonarr()}languageprofile?apikey={apikey_sonarr}"
 
     try:
-        profiles_json = requests.get(url_sonarr_api_series, timeout=int(settings.sonarr.http_timeout), verify=False,
+        profiles_json = requests.get(url_sonarr_api_series, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
                                      headers=HEADERS)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get profiles from Sonarr. Connection Error.")
@@ -55,7 +55,7 @@ def get_tags():
     url_sonarr_api_series = f"{url_api_sonarr()}tag?apikey={apikey_sonarr}"
 
     try:
-        tagsDict = requests.get(url_sonarr_api_series, timeout=int(settings.sonarr.http_timeout), verify=False, headers=HEADERS)
+        tagsDict = requests.get(url_sonarr_api_series, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'), headers=HEADERS)
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get tags from Sonarr. Connection Error.")
         return []
@@ -73,7 +73,7 @@ def get_series_from_sonarr_api(apikey_sonarr, sonarr_series_id=None):
     url_sonarr_api_series = (f"{url_api_sonarr()}series/{sonarr_series_id if sonarr_series_id else ''}?"
                              f"apikey={apikey_sonarr}")
     try:
-        r = requests.get(url_sonarr_api_series, timeout=int(settings.sonarr.http_timeout), verify=False, headers=HEADERS)
+        r = requests.get(url_sonarr_api_series, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'), headers=HEADERS)
         r.raise_for_status()
     except requests.exceptions.HTTPError as e:
         if e.response.status_code:
@@ -113,7 +113,7 @@ def get_episodes_from_sonarr_api(apikey_sonarr, series_id=None, episode_id=None)
         return
 
     try:
-        r = requests.get(url_sonarr_api_episode, timeout=int(settings.sonarr.http_timeout), verify=False, headers=HEADERS)
+        r = requests.get(url_sonarr_api_episode, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'), headers=HEADERS)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get episodes from Sonarr. Http error.")
@@ -146,7 +146,7 @@ def get_episodesFiles_from_sonarr_api(apikey_sonarr, series_id=None, episode_fil
         return
 
     try:
-        r = requests.get(url_sonarr_api_episodeFiles, timeout=int(settings.sonarr.http_timeout), verify=False,
+        r = requests.get(url_sonarr_api_episodeFiles, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
                          headers=HEADERS)
         r.raise_for_status()
     except requests.exceptions.HTTPError:
@@ -175,7 +175,7 @@ def get_history_from_sonarr_api(apikey_sonarr, episode_id):
     url_sonarr_api_history = f"{url_api_sonarr()}history?eventType=1&episodeId={episode_id}&apikey={apikey_sonarr}"
 
     try:
-        r = requests.get(url_sonarr_api_history, timeout=int(settings.sonarr.http_timeout), verify=False,
+        r = requests.get(url_sonarr_api_history, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
                          headers=HEADERS)
         r.raise_for_status()
     except requests.exceptions.HTTPError:

--- a/bazarr/utilities/plex_utils.py
+++ b/bazarr/utilities/plex_utils.py
@@ -2,7 +2,7 @@
 
 import logging
 import requests
-from app.config import settings
+from app.config import settings, get_ssl_verify
 
 
 def get_plex_libraries_with_paths():
@@ -30,7 +30,7 @@ def get_plex_libraries_with_paths():
             f"{server_url}/library/sections",
             headers={'X-Plex-Token': decrypted_token, 'Accept': 'application/json'},
             timeout=5,
-            verify=False
+            verify=get_ssl_verify('plex')
         )
         
         if response.status_code != 200:
@@ -73,7 +73,7 @@ def _get_library_locations(server_url, section_key, token):
             f"{server_url}/library/sections/{section_key}",
             headers={'X-Plex-Token': token, 'Accept': 'application/json'},
             timeout=5,
-            verify=False
+            verify=get_ssl_verify('plex')
         )
         
         if response.status_code == 200:


### PR DESCRIPTION
## Summary
- Add `verify_ssl` config option for sonarr, radarr, and plex (default: false)
- Replace all 28 hardcoded `verify=False` calls with `get_ssl_verify()`
- Users with proper TLS certs can now enable verification per service
- Default false maintains backward compatibility with self-signed certs

## Files changed (14 files)
- `bazarr/app/config.py` — 3 new validators + helper function
- `bazarr/sonarr/*.py` — 5 files updated
- `bazarr/radarr/*.py` — 5 files updated
- `bazarr/utilities/plex_utils.py` — updated
- `bazarr/api/plex/oauth.py` — updated
- `bazarr/app/ui.py` — image proxy endpoints updated

## Severity
**Low** — defense-in-depth for users with proper TLS infrastructure

## Test plan
- [ ] Default behavior unchanged (verify_ssl=false works as before)
- [ ] Setting verify_ssl=true for sonarr uses TLS verification
- [ ] Setting verify_ssl=true for radarr uses TLS verification
- [ ] Setting verify_ssl=true for plex uses TLS verification