### PR TITLE
fix(security): deprecate query string API key authentication

### DIFF
--- a/bazarr/api/utils.py
+++ b/bazarr/api/utils.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import ast
+import hmac
 import logging
 
 from functools import wraps
@@ -17,25 +18,29 @@ None_Keys = ['null', 'undefined', '', None]
 False_Keys = ['False', 'false', '0']
 
 
+def _safe_apikey_compare(provided, expected):
+    if not provided:
+        return False
+    return hmac.compare_digest(str(provided), str(expected))
+
+
 def authenticate(actual_method):
     @wraps(actual_method)
     def wrapper(*args, **kwargs):
         apikey_settings = settings.auth.apikey
-        apikey_header = None
-        if 'X-API-KEY' in request.headers:
-            apikey_header = request.headers['X-API-KEY']
+        apikey_header = request.headers.get('X-API-KEY')
 
-        if apikey_header == apikey_settings:
+        if _safe_apikey_compare(apikey_header, apikey_settings):
             return actual_method(*args, **kwargs)
 
         # Legacy: accept API key from query string or form data with deprecation warning
         apikey_get = request.args.get('apikey')
         apikey_post = request.form.get('apikey')
-        if apikey_settings in [apikey_get, apikey_post]:
+        if _safe_apikey_compare(apikey_get, apikey_settings) or _safe_apikey_compare(apikey_post, apikey_settings):
             logging.warning(
                 'API key passed via query string or form data is deprecated. '
                 'Use the X-API-KEY header instead. '
-                f'Endpoint: {request.method} {request.path}'
+                'Endpoint: %s %s', request.method, request.path
             )
             return actual_method(*args, **kwargs)
 

--- a/bazarr/api/utils.py
+++ b/bazarr/api/utils.py
@@ -34,14 +34,16 @@ def authenticate(actual_method):
             return actual_method(*args, **kwargs)
 
         # Legacy: accept API key from query string or form data with deprecation warning
+        # Suppress warning for webhook endpoints (Plex webhooks use ?apikey= in callback URLs)
         apikey_get = request.args.get('apikey')
         apikey_post = request.form.get('apikey')
         if _safe_apikey_compare(apikey_get, apikey_settings) or _safe_apikey_compare(apikey_post, apikey_settings):
-            logging.warning(
-                'API key passed via query string or form data is deprecated. '
-                'Use the X-API-KEY header instead. '
-                'Endpoint: %s %s', request.method, request.path
-            )
+            if '/webhooks/' not in request.path:
+                logging.warning(
+                    'API key passed via query string or form data is deprecated. '
+                    'Use the X-API-KEY header instead. '
+                    'Endpoint: %s %s', request.method, request.path
+                )
             return actual_method(*args, **kwargs)
 
         return abort(401)

--- a/bazarr/api/utils.py
+++ b/bazarr/api/utils.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import ast
+import logging
 
 from functools import wraps
 from flask import request, abort
@@ -20,13 +21,22 @@ def authenticate(actual_method):
     @wraps(actual_method)
     def wrapper(*args, **kwargs):
         apikey_settings = settings.auth.apikey
-        apikey_get = request.args.get('apikey')
-        apikey_post = request.form.get('apikey')
         apikey_header = None
         if 'X-API-KEY' in request.headers:
             apikey_header = request.headers['X-API-KEY']
 
-        if apikey_settings in [apikey_get, apikey_post, apikey_header]:
+        if apikey_header == apikey_settings:
+            return actual_method(*args, **kwargs)
+
+        # Legacy: accept API key from query string or form data with deprecation warning
+        apikey_get = request.args.get('apikey')
+        apikey_post = request.form.get('apikey')
+        if apikey_settings in [apikey_get, apikey_post]:
+            logging.warning(
+                'API key passed via query string or form data is deprecated. '
+                'Use the X-API-KEY header instead. '
+                f'Endpoint: {request.method} {request.path}'
+            )
             return actual_method(*args, **kwargs)
 
         return abort(401)


### PR DESCRIPTION
## Summary
- Prefer `X-API-KEY` header authentication (checked first)
- Query string and form data API keys still accepted for backward compatibility
- Logs deprecation warning with endpoint path when legacy methods are used
- No breaking changes for existing integrations

## Severity
**Low** — reduces API key exposure in logs, browser history, and Referer headers

## Test plan
- [ ] `X-API-KEY` header auth works without warnings
- [ ] `?apikey=...` still works but logs a deprecation warning
- [ ] Missing API key returns 401
- [ ] Frontend continues working (uses header)