### PR TITLE
fix(ci): workflow issues from audit

### DIFF
--- a/.github/workflows/build-docker-manual.yml
+++ b/.github/workflows/build-docker-manual.yml
@@ -173,7 +173,7 @@ jobs:
   # Build and Push Bazarr Image
   # ==========================================================================
   build-and-push:
-    needs: [build-frontend]
+    needs: [build-frontend, build-scraper]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-scraper.yml
+++ b/.github/workflows/build-scraper.yml
@@ -172,65 +172,15 @@ jobs:
           echo "${TAGS}" | tr ',' '\n' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
-      - name: Generate Dockerfile with Python version
-        run: |
-          cd opensubtitles-scraper
-          
-          # Create a modified Dockerfile with the selected Python version
-          cat > Dockerfile.build << EOF
-          # Generated Dockerfile with Python ${{ steps.version.outputs.python_version }}
-          FROM python:${{ steps.version.outputs.python_version }}-slim
-          
-          # Set working directory
-          WORKDIR /app
-          
-          # Install system dependencies
-          RUN apt-get update && apt-get install -y \\
-              gcc \\
-              && rm -rf /var/lib/apt/lists/*
-          
-          # Set environment variables
-          ENV PYTHONDONTWRITEBYTECODE=1 \\
-              PYTHONUNBUFFERED=1
-          EOF
-          
-          # Add JIT env var if enabled
-          if [ "${{ inputs.enable_jit }}" == "true" ]; then
-            echo 'ENV PYTHON_JIT=1' >> Dockerfile.build
-          fi
-          
-          cat >> Dockerfile.build << 'EOF'
-          
-          # Copy requirements file
-          COPY requirements.txt .
-          
-          # Install Python dependencies
-          RUN pip install --no-cache-dir --upgrade pip && \
-              pip install --no-cache-dir -r requirements.txt
-          
-          # Copy application code
-          COPY . .
-          
-          # Expose port 8000
-          EXPOSE 8000
-          
-          # Health check
-          HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-              CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
-          
-          # Run the application
-          CMD ["python", "main.py"]
-          EOF
-          
-          cat Dockerfile.build
-
       - name: Build and Push Scraper Image
         id: push
         uses: docker/build-push-action@v6
         with:
           context: ./opensubtitles-scraper
-          file: ./opensubtitles-scraper/Dockerfile.build
+          file: ./opensubtitles-scraper/Dockerfile
           platforms: ${{ inputs.platforms }}
+          build-args: |
+            PYTHON_JIT=${{ inputs.enable_jit == true && '1' || '0' }}
           push: true
           tags: ${{ steps.version.outputs.tags }}
           labels: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - libs/**
       - custom_libs/**
       - migrations/**
+      - opensubtitles-scraper/**
       - bazarr.py
       - requirements.txt
       - dev-requirements.txt
@@ -90,7 +91,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install UI
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v4
         with:
           name: ${{ env.UI_ARTIFACT_NAME }}
           path: "${{ env.UI_DIRECTORY }}/build"


### PR DESCRIPTION
## Summary
Fixes from CI workflow audit:

| # | Severity | Fix |
|---|---|---|
| 1-2 | HIGH | `build-scraper.yml`: use real Dockerfile instead of generated one with broken leading whitespace |
| 9 | HIGH | `ci.yml`: fix `download-artifact@v5` to `@v4` to match `upload-artifact@v4` |
| 10 | MEDIUM | `ci.yml`: add `opensubtitles-scraper/**` to paths trigger |
| 7 | MEDIUM | `build-docker-manual.yml`: add `build-scraper` to `build-and-push.needs` |

## Test plan
- [ ] CI pipeline passes on PR
- [ ] Manual scraper build workflow succeeds
- [ ] Manual docker build waits for scraper before pushing bazarr image