### PR TITLE
fix: provider code bugs from post-fix audit

### DIFF
--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -398,7 +398,7 @@ def _handle_mgb(name, exception, ids, language):
 
     if ids:
         if exception.media_type == "series":
-            if 'sonarrSeriesId' in ids and 'sonarrEpsiodeId' in ids:
+            if 'sonarrSeriesId' in ids and 'sonarrEpisodeId' in ids:
                 blacklist_log(ids['sonarrSeriesId'], ids['sonarrEpisodeId'], name, exception.id, language_str)
         else:
             blacklist_log_movie(ids['radarrId'], name, exception.id, language_str)
@@ -412,7 +412,7 @@ def provider_throttle(name, exception, ids=None, language=None):
     cls_name = getattr(cls, "__name__")
     if cls not in VALID_THROTTLE_EXCEPTIONS:
         for valid_cls in VALID_THROTTLE_EXCEPTIONS:
-            if isinstance(cls, valid_cls):
+            if issubclass(cls, valid_cls):
                 cls = valid_cls
 
     throttle_data = provider_throttle_map().get(name, provider_throttle_map()["default"]).get(cls, None) or \

--- a/custom_libs/subliminal_patch/providers/opensubtitles.py
+++ b/custom_libs/subliminal_patch/providers/opensubtitles.py
@@ -138,7 +138,7 @@ class _OpenSubtitlesSubtitle(Subtitle):
             if video.series and sanitize(self.series_name) == sanitize(video.series):
                 matches.add('series')
             # year
-            if video.original_series and self.movie_year is None or video.year and video.year == self.movie_year:
+            if (video.original_series and self.movie_year is None) or (video.year and video.year == self.movie_year):
                 matches.add('year')
             # season
             if video.season and self.series_season == video.season:
@@ -230,7 +230,7 @@ class OpenSubtitlesSubtitle(_OpenSubtitlesSubtitle):
     def get_fps(self):
         try:
             return float(self.fps)
-        except:
+        except (ValueError, TypeError):
             return None
 
     def get_matches(self, video, hearing_impaired=False):
@@ -616,7 +616,7 @@ def checked(fn, raise_api_limit=False):
                 status_code = 506
         else:
             status_code = int(response['status'][:3])
-    except:
+    except Exception:
         status_code = None
 
     if status_code == 401:

--- a/custom_libs/subliminal_patch/providers/opensubtitles_scraper.py
+++ b/custom_libs/subliminal_patch/providers/opensubtitles_scraper.py
@@ -207,11 +207,9 @@ class OpenSubtitlesScraperMixin:
                         if series_match:
                             subtitle.movie_name = series_match.group(1)
                         else:
-                            # Fallback: keep quoted format for series_name property compatibility
-                            # series_name expects '"SeriesName" EpisodeTitle' format
-                            parts = movie_release_name.split()
-                            name = parts[0] if parts else 'Unknown'
-                            subtitle.movie_name = f'"{name}" {" ".join(parts[1:])}'.strip()
+                            # Use release name as-is; series_name property returns
+                            # movie_name directly when quoted format doesn't match
+                            subtitle.movie_name = movie_release_name
                 
                 logger.debug('Found subtitle %r by %s via scraper', subtitle, matched_by)
                 subtitles.append(subtitle)


### PR DESCRIPTION
## Summary
5 bugs found during post-fix verification audit, all confirmed by 3 specialized review agents:

| Severity | Fix | File |
|---|---|---|
| HIGH | `isinstance` -> `issubclass` — exception subclass throttling was silently broken | `get_providers.py:415` |
| HIGH | `sonarrEpsiodeId` typo — series blacklisting was dead code | `get_providers.py:401` |
| MEDIUM | Bare `except:` -> `except Exception:` — was swallowing SystemExit/KeyboardInterrupt | `opensubtitles.py:619,233` |
| LOW | Operator precedence parentheses — clarifies year matching logic | `opensubtitles.py:141` |
| MEDIUM | Fragile quote-wrapping fallback — broke single-token series names | `opensubtitles_scraper.py:209-214` |

## Review
All 3 agents (Code Reviewer, Security Engineer, Code Skeptic) returned **LGTM**.

## Test plan
- [ ] Verify provider throttling works for exception subclasses (e.g., custom TooManyRequests)
- [ ] Verify series subtitle blacklisting triggers correctly
- [ ] Verify single-word series names (Friends, Dexter) match correctly via scraper