### PR TITLE
fix(ci): skip_scraper, Dockerfile ARGs, and config default

### DIFF
--- a/.github/workflows/build-docker-manual.yml
+++ b/.github/workflows/build-docker-manual.yml
@@ -174,6 +174,7 @@ jobs:
   # ==========================================================================
   build-and-push:
     needs: [build-frontend, build-scraper]
+    if: ${{ !cancelled() && needs.build-frontend.result == 'success' && (needs.build-scraper.result == 'success' || needs.build-scraper.result == 'skipped') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-scraper.yml
+++ b/.github/workflows/build-scraper.yml
@@ -180,6 +180,7 @@ jobs:
           file: ./opensubtitles-scraper/Dockerfile
           platforms: ${{ inputs.platforms }}
           build-args: |
+            PYTHON_VERSION=${{ steps.version.outputs.python_version }}
             PYTHON_JIT=${{ inputs.enable_jit == true && '1' || '0' }}
           push: true
           tags: ${{ steps.version.outputs.tags }}

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -308,9 +308,9 @@ validators = [
     Validator('opensubtitles.ssl', must_exist=True, default=False, is_type_of=bool),
     Validator('opensubtitles.timeout', must_exist=True, default=15, is_type_of=int, gte=1),
     Validator('opensubtitles.skip_wrong_fps', must_exist=True, default=False, is_type_of=bool),
-    # Web scraper mode - can be enabled via OPENSUBTITLES_USE_WEB_SCRAPER=true environment variable
+    # Web scraper mode - enabled by default, can be disabled via OPENSUBTITLES_USE_WEB_SCRAPER=false
     Validator('opensubtitles.use_web_scraper', must_exist=True,
-              default=os.environ.get('OPENSUBTITLES_USE_WEB_SCRAPER', 'false').lower() in ('true', '1', 'yes'),
+              default=os.environ.get('OPENSUBTITLES_USE_WEB_SCRAPER', 'true').lower() in ('true', '1', 'yes'),
               is_type_of=bool),
     # Scraper URL - can be set via OPENSUBTITLES_SCRAPER_URL environment variable
     Validator('opensubtitles.scraper_service_url', must_exist=True,


### PR DESCRIPTION
## Summary
Fixes confirmed by Codex review + 3 specialized agents:

| Priority | Fix |
|---|---|
| P1 | `build-and-push` now runs even when `skip_scraper=true` (was silently skipping entire Bazarr build) |
| P2 | Scraper Dockerfile now accepts `PYTHON_VERSION` and `PYTHON_JIT` build args (were hardcoded, making workflow inputs theater) |
| P2 | Added `curl` to scraper image (needed for healthchecks) |
| P2 | `OPENSUBTITLES_USE_WEB_SCRAPER` default changed from `false` to `true` (code now matches README) |

## Test plan
- [ ] Manual workflow with `skip_scraper=true` still builds Bazarr image
- [ ] Manual workflow with `python_version=3.12` builds correct Python version
- [ ] Fresh deploy without `OPENSUBTITLES_USE_WEB_SCRAPER` env var enables scraper by default