### PR TITLE
fix: translation job failure handling and status ring colors

### DIFF
--- a/bazarr/subtitles/tools/translate/batch.py
+++ b/bazarr/subtitles/tools/translate/batch.py
@@ -56,7 +56,7 @@ def process_episode_translation(item, source_language, target_language, forced, 
 
     # Queue translation
     try:
-        result = translate_subtitles_file(
+        translate_subtitles_file(
             video_path=video_path,
             source_srt_file=source_subtitle_path,
             from_lang=source_language,
@@ -69,14 +69,12 @@ def process_episode_translation(item, source_language, target_language, forced, 
             radarr_id=None,
             job_id=job_id
         )
-        if result is not False:
-            # Re-index subtitles so Bazarr's DB knows about the new translated file
-            store_subtitles(path_mappings.path_replace_reverse(video_path), video_path)
-            # Notify frontend to refresh
-            event_stream(type='series', payload=sonarr_series_id)
-            event_stream(type='episode', payload=sonarr_episode_id)
-            return True
-        return False
+        # Re-index subtitles so Bazarr's DB knows about the new translated file
+        store_subtitles(path_mappings.path_replace_reverse(video_path), video_path)
+        # Notify frontend to refresh series and episode views
+        event_stream(type='series', payload=sonarr_series_id)
+        event_stream(type='episode', payload=sonarr_episode_id)
+        return True
     except Exception as e:
         logger.error(f'Translation failed for episode {sonarr_episode_id}: {e}')
         return False
@@ -119,7 +117,7 @@ def process_movie_translation(item, source_language, target_language, forced, hi
 
     # Queue translation
     try:
-        result = translate_subtitles_file(
+        translate_subtitles_file(
             video_path=video_path,
             source_srt_file=source_subtitle_path,
             from_lang=source_language,
@@ -132,13 +130,11 @@ def process_movie_translation(item, source_language, target_language, forced, hi
             radarr_id=radarr_id,
             job_id=job_id
         )
-        if result is not False:
-            # Re-index subtitles so Bazarr's DB knows about the new translated file
-            store_subtitles_movie(path_mappings.path_replace_reverse_movie(video_path), video_path)
-            # Notify frontend to refresh
-            event_stream(type='movie', payload=radarr_id)
-            return True
-        return False
+        # Re-index subtitles so Bazarr's DB knows about the new translated file
+        store_subtitles_movie(path_mappings.path_replace_reverse_movie(video_path), video_path)
+        # Notify frontend to refresh movie view
+        event_stream(type='movie', payload=radarr_id)
+        return True
     except Exception as e:
         logger.error(f'Translation failed for movie {radarr_id}: {e}')
         return False

--- a/bazarr/subtitles/tools/translate/main.py
+++ b/bazarr/subtitles/tools/translate/main.py
@@ -22,6 +22,7 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
                                          is_progress=True)
         return
 
+    translator_label = settings.translator.translator_type.replace("_", " ").title()
     try:
         logging.debug(f'Translation request: video={video_path}, source={source_srt_file}, from={from_lang}, to={to_lang}')
 
@@ -30,7 +31,6 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
 
         logging.debug(f'BAZARR is translating in {lang_obj} this subtitles {source_srt_file}')
 
-        # get the destination path if the subtitles are alongside the video
         dest_srt_file_if_alongside_video = get_subtitle_path(
             video_path,
             language=lang_obj if isinstance(lang_obj, Language) else lang_obj.subzero_language(),
@@ -39,8 +39,6 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
             hi_tag=hi
         )
 
-        # get the real destination path taking into account if the user set up Bazarr to store external subtitles in
-        #  a custom folder or relative folder
         dest_srt_file = get_external_subtitles_path(
             file=video_path,
             subtitle=os.path.basename(dest_srt_file_if_alongside_video)
@@ -69,13 +67,17 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
         logging.debug(f'Created translator instance: {translator.__class__.__name__}')
         result = translator.translate(job_id=job_id)
         logging.debug(f'BAZARR saved translated subtitles to {dest_srt_file}')
+
+        jobs_queue.update_job_name(
+            job_id=job_id,
+            new_job_name=f'Translated from {from_lang.upper()} to {to_lang.upper()} using {translator_label}'
+        )
         return result
 
     except Exception as e:
         logging.error(f'Translation failed: {str(e)}', exc_info=True)
-        return False
-
-    finally:
-        jobs_queue.update_job_name(job_id=job_id,
-                                   new_job_name=f'Translated from {from_lang.upper()} to {to_lang.upper()} using '
-                                                f'{settings.translator.translator_type.replace("_", " ").title()}')
+        jobs_queue.update_job_name(
+            job_id=job_id,
+            new_job_name=f'Translation failed: {from_lang.upper()} to {to_lang.upper()} using {translator_label}'
+        )
+        raise

--- a/frontend/src/App/NotificationDrawer.tsx
+++ b/frontend/src/App/NotificationDrawer.tsx
@@ -282,7 +282,12 @@ const NotificationDrawer: FunctionComponent<NotificationDrawerProps> = ({
                                                       job.progress_max) *
                                                     100
                                                   : 0,
-                                            color: "brand",
+                                            color:
+                                              status === "completed"
+                                                ? "green"
+                                                : status === "failed"
+                                                  ? "red"
+                                                  : "brand",
                                           },
                                         ]}
                                         label={
@@ -294,6 +299,13 @@ const NotificationDrawer: FunctionComponent<NotificationDrawerProps> = ({
                                                 : "9px"
                                             }
                                             fw={700}
+                                            c={
+                                              status === "completed"
+                                                ? "green"
+                                                : status === "failed"
+                                                  ? "red"
+                                                  : undefined
+                                            }
                                           >
                                             {status === "completed" &&
                                             job.progress_max == 0 &&


### PR DESCRIPTION
## Summary
Three fixes from the screenshot feedback:

### 1. Failed jobs now marked as failed
- `translate_subtitles_file()` re-raises exceptions instead of catching and returning `False`
- The job queue catches the exception and marks the job as `failed`
- Job name shows `Translation failed: EN to HU using...` instead of `Translated from...`

### 2. Directory rescan after translation
- `store_subtitles()` / `store_subtitles_movie()` run after successful translation
- `event_stream` notifies frontend to refresh the series/episode/movie view
- UI updates automatically without manual refresh

### 3. Status ring colors
- **Completed**: green ring + green percentage text
- **Failed**: red ring + red percentage text  
- **Running**: brand color with pulse animation (unchanged)

## Test plan
- [ ] Trigger a translation that will fail (e.g., no API credits) — verify it shows in Failed section with red ring
- [ ] Trigger a successful translation — verify green ring and UI refreshes automatically
- [ ] Running jobs still show brand color with pulse