### PR TITLE
feat(providers): add provider priority toggle and improve modal buttons

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -140,6 +140,7 @@ validators = [
               is_in=['3d', '1w', '2w', '3w', '4w']),
     Validator('general.enabled_providers', must_exist=True, default=[], is_type_of=list),
     Validator('general.provider_priorities', must_exist=True, default={}, is_type_of=dict),
+    Validator('general.use_provider_priority', must_exist=True, default=True, is_type_of=bool),
     Validator('general.enabled_integrations', must_exist=True, default=[], is_type_of=list),
     Validator('general.multithreading', must_exist=True, default=True, is_type_of=bool),
     Validator('general.chmod_enabled', must_exist=True, default=False, is_type_of=bool),

--- a/bazarr/subtitles/download.py
+++ b/bazarr/subtitles/download.py
@@ -80,7 +80,8 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
                                                                        min_score=int(min_score),
                                                                        hearing_impaired=hi_required,
                                                                        compute_score=ComputeScore(get_scores()),
-                                                                       use_original_format=original_format in (1, "1", "True", True))
+                                                                       use_original_format=original_format in (1, "1", "True", True),
+                                                                       use_provider_priority=settings.general.use_provider_priority)
                     except Exception as e:
                         logging.exception(f'BAZARR Error downloading Subtitles for this file {path}: {repr(e)}')
                         return None

--- a/custom_libs/subliminal_patch/core_persistent.py
+++ b/custom_libs/subliminal_patch/core_persistent.py
@@ -51,6 +51,7 @@ def download_best_subtitles(
     only_one=False,
     compute_score=None,
     use_original_format=False,
+    use_provider_priority=True,
     **kwargs
 ):
     downloaded_subtitles = defaultdict(list)
@@ -70,8 +71,12 @@ def download_best_subtitles(
     # download best subtitles
     for video in checked_videos:
         logger.info("Downloading best subtitles for %r", video)
+        if use_provider_priority:
+            listed = pool_instance.list_subtitles_prioritized(video, languages - video.subtitle_languages, min_score=min_score)
+        else:
+            listed = pool_instance.list_subtitles(video, languages - video.subtitle_languages)
         subtitles = pool_instance.download_best_subtitles(
-            pool_instance.list_subtitles_prioritized(video, languages - video.subtitle_languages, min_score=min_score),
+            listed,
             video,
             languages,
             min_score=min_score,

--- a/frontend/src/pages/Settings/Providers/components.tsx
+++ b/frontend/src/pages/Settings/Providers/components.tsx
@@ -498,7 +498,10 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
           <Divider></Divider>
           <Group justify="right">
             <Button hidden={!payload} color="red" onClick={deletePayload}>
-              Disable
+              Delete
+            </Button>
+            <Button variant="default" onClick={() => modals.closeAll()}>
+              Cancel
             </Button>
             <Button
               disabled={!canSave}
@@ -506,7 +509,7 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
                 submit(form.values);
               }}
             >
-              Enable
+              Save
             </Button>
           </Group>
         </Stack>

--- a/frontend/src/pages/Settings/Providers/index.tsx
+++ b/frontend/src/pages/Settings/Providers/index.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent } from "react";
 import { Anchor } from "@mantine/core";
 import {
+  Check,
   CollapseBox,
   Layout,
   Message,
@@ -17,6 +18,15 @@ const SettingsProvidersView: FunctionComponent = () => {
   return (
     <Layout name="Providers">
       <Section header="Enabled Providers">
+        <Check
+          label="Provider Priority"
+          settingKey="settings-general-use_provider_priority"
+        ></Check>
+        <Message>
+          Query providers in priority order and stop when a subtitle meeting the
+          minimum score is found. When disabled, all providers are queried
+          simultaneously and the best result is selected.
+        </Message>
         <ProviderView
           availableOptions={ProviderList}
           settingsKey="settings-general-enabled_providers"

--- a/tests/subliminal_patch/test_core_persistent.py
+++ b/tests/subliminal_patch/test_core_persistent.py
@@ -1,0 +1,66 @@
+from collections import defaultdict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from subliminal_patch.core_persistent import download_best_subtitles
+
+
+@pytest.fixture
+def mock_pool():
+    pool = MagicMock()
+    pool.list_subtitles_prioritized.return_value = []
+    pool.list_subtitles.return_value = []
+    pool.download_best_subtitles.return_value = []
+    return pool
+
+
+@pytest.fixture
+def mock_video():
+    video = MagicMock()
+    video.subtitle_languages = set()
+    return video
+
+
+def test_uses_prioritized_listing_by_default(mock_pool, mock_video):
+    languages = {MagicMock()}
+
+    with patch("subliminal_patch.core_persistent.check_video", return_value=True):
+        download_best_subtitles(
+            videos={mock_video},
+            languages=languages,
+            pool_instance=mock_pool,
+        )
+
+    mock_pool.list_subtitles_prioritized.assert_called_once()
+    mock_pool.list_subtitles.assert_not_called()
+
+
+def test_uses_prioritized_listing_when_enabled(mock_pool, mock_video):
+    languages = {MagicMock()}
+
+    with patch("subliminal_patch.core_persistent.check_video", return_value=True):
+        download_best_subtitles(
+            videos={mock_video},
+            languages=languages,
+            pool_instance=mock_pool,
+            use_provider_priority=True,
+        )
+
+    mock_pool.list_subtitles_prioritized.assert_called_once()
+    mock_pool.list_subtitles.assert_not_called()
+
+
+def test_uses_regular_listing_when_disabled(mock_pool, mock_video):
+    languages = {MagicMock()}
+
+    with patch("subliminal_patch.core_persistent.check_video", return_value=True):
+        download_best_subtitles(
+            videos={mock_video},
+            languages=languages,
+            pool_instance=mock_pool,
+            use_provider_priority=False,
+        )
+
+    mock_pool.list_subtitles.assert_called_once()
+    mock_pool.list_subtitles_prioritized.assert_not_called()


### PR DESCRIPTION
## Summary
- Add "Provider Priority" toggle (default on) in Settings > Providers that controls whether providers are queried sequentially in priority order (with early exit on min_score match) or all at once
- Fix provider modal buttons: replace confusing Enable/Disable with Delete, Cancel, and Save

## Changes
- `bazarr/app/config.py`: New `general.use_provider_priority` validator (default True)
- `custom_libs/subliminal_patch/core_persistent.py`: `download_best_subtitles()` accepts `use_provider_priority` flag, switches between `list_subtitles_prioritized()` and `list_subtitles()`
- `bazarr/subtitles/download.py`: Passes the setting through to subliminal_patch
- `frontend/src/pages/Settings/Providers/index.tsx`: Toggle UI with description
- `frontend/src/pages/Settings/Providers/components.tsx`: Modal button labels fixed
- `tests/subliminal_patch/test_core_persistent.py`: Unit tests for the toggle behavior

## Test plan
- [x] Unit tests pass (3/3)
- [x] Frontend builds clean
- [x] Tested on home server: toggle appears, modal buttons correct