### PR TITLE
feat: secure connection to AI Subtitle Translator

### DIFF
--- a/bazarr/api/translator/translator.py
+++ b/bazarr/api/translator/translator.py
@@ -2,6 +2,7 @@
 
 import logging
 import requests
+from flask import request as flask_request
 from flask_restx import Resource, Namespace
 
 from app.config import settings
@@ -199,16 +200,26 @@ class TranslatorTest(Resource):
         responses={200: 'Success', 400: 'Bad Request', 503: 'Service Unavailable'}
     )
     def post(self):
-        """Test connection, encryption, and API key with the translator service"""
-        service_url = get_service_url()
+        """Test connection, encryption, and API key with the translator service.
+
+        Accepts optional JSON body with current (unsaved) form values:
+        - serviceUrl: override saved service URL
+        - apiKey: override saved OpenRouter API key
+        - encryptionKey: override saved encryption key
+        """
+        data = flask_request.get_json(silent=True) or {}
+
+        service_url = data.get("serviceUrl") or get_service_url()
+        if service_url:
+            service_url = service_url.rstrip("/")
         if not service_url:
             return {"error": "AI Subtitle Translator service URL not configured"}, 503
 
-        api_key = settings.translator.openrouter_api_key
+        api_key = data.get("apiKey") or settings.translator.openrouter_api_key
         if not api_key:
             return {"error": "OpenRouter API key not configured"}, 400
 
-        encryption_key = settings.translator.openrouter_encryption_key
+        encryption_key = data.get("encryptionKey") if "encryptionKey" in data else settings.translator.openrouter_encryption_key
         if encryption_key:
             try:
                 from subtitles.tools.translate.services.encryption import encrypt_api_key

--- a/bazarr/api/translator/translator.py
+++ b/bazarr/api/translator/translator.py
@@ -190,3 +190,43 @@ class TranslatorConfig(Resource):
         except Exception as e:
             logger.error(f"Error getting config: {e}")
             return {"error": str(e)}, 500
+
+
+@api_ns_translator.route('translator/test')
+class TranslatorTest(Resource):
+    @authenticate
+    @api_ns_translator.doc(
+        responses={200: 'Success', 400: 'Bad Request', 503: 'Service Unavailable'}
+    )
+    def post(self):
+        """Test connection, encryption, and API key with the translator service"""
+        service_url = get_service_url()
+        if not service_url:
+            return {"error": "AI Subtitle Translator service URL not configured"}, 503
+
+        api_key = settings.translator.openrouter_api_key
+        if not api_key:
+            return {"error": "OpenRouter API key not configured"}, 400
+
+        encryption_key = settings.translator.openrouter_encryption_key
+        if encryption_key:
+            try:
+                from subtitles.tools.translate.services.encryption import encrypt_api_key
+                api_key = encrypt_api_key(api_key, encryption_key)
+            except ValueError as e:
+                return {"error": f"Invalid encryption key: {e}"}, 400
+
+        try:
+            response = requests.post(
+                f"{service_url}/api/v1/test",
+                json={"apiKey": api_key},
+                timeout=10
+            )
+            return response.json(), response.status_code
+        except requests.exceptions.ConnectionError:
+            return {"error": "Cannot connect to AI Subtitle Translator service"}, 503
+        except requests.exceptions.Timeout:
+            return {"error": "Service timeout"}, 503
+        except Exception as e:
+            logger.error(f"Error testing translator: {e}")
+            return {"error": str(e)}, 500

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -212,6 +212,7 @@ validators = [
     Validator('translator.openrouter_reasoning', must_exist=True, default='disabled', is_type_of=str,
               is_in=['disabled', 'low', 'medium', 'high']),
     Validator('translator.openrouter_parallel_batches', must_exist=True, default=4, is_type_of=int, gte=1, lte=8),
+    Validator('translator.openrouter_encryption_key', must_exist=True, default='', is_type_of=str, cast=str),
     Validator('translator.lingarr_token', must_exist=True, default='', is_type_of=str, cast=str),
 
     # sonarr section

--- a/bazarr/subtitles/tools/translate/services/encryption.py
+++ b/bazarr/subtitles/tools/translate/services/encryption.py
@@ -1,0 +1,36 @@
+import base64
+import os
+import re
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+_HEX_64_RE = re.compile(r'^[0-9a-fA-F]{64}$')
+
+
+def validate_encryption_key(key_hex: str) -> bool:
+    """Check if key_hex is a valid 64-character hex string."""
+    return bool(_HEX_64_RE.match(key_hex))
+
+
+def encrypt_api_key(api_key: str, encryption_key_hex: str) -> str:
+    """Encrypt an API key using AES-256-GCM with the shared key.
+
+    Args:
+        api_key: The plaintext OpenRouter API key.
+        encryption_key_hex: 64-char hex string (the shared key).
+
+    Returns:
+        Encrypted string in format "enc:base64data".
+
+    Raises:
+        ValueError: If encryption_key_hex is not a valid 64-char hex string.
+    """
+    if not validate_encryption_key(encryption_key_hex):
+        raise ValueError("Encryption key must be exactly 64 hexadecimal characters")
+
+    key = bytes.fromhex(encryption_key_hex)
+    nonce = os.urandom(12)
+    aesgcm = AESGCM(key)
+    ciphertext = aesgcm.encrypt(nonce, api_key.encode("utf-8"), None)
+    encoded = base64.b64encode(nonce + ciphertext).decode("ascii")
+    return f"enc:{encoded}"

--- a/bazarr/subtitles/tools/translate/services/openrouter_translator.py
+++ b/bazarr/subtitles/tools/translate/services/openrouter_translator.py
@@ -63,6 +63,19 @@ class OpenRouterTranslatorService:
             'effort': reasoning_mode,
         }
 
+    def _get_api_key_value(self):
+        """Get the API key, encrypted if an encryption key is configured."""
+        api_key = settings.translator.openrouter_api_key
+        encryption_key = settings.translator.openrouter_encryption_key
+        if encryption_key:
+            try:
+                from .encryption import encrypt_api_key
+                api_key = encrypt_api_key(api_key, encryption_key)
+            except ValueError as e:
+                logger.error(f'Invalid encryption key: {e}')
+                raise ValueError("Invalid encryption key format. Check your encryption key in Settings.")
+        return api_key
+
     def translate(self, job_id=None):
         try:
             subs = pysubs2.load(self.source_srt_file, encoding='utf-8')
@@ -169,7 +182,7 @@ class OpenRouterTranslatorService:
                 "lines": lines_payload,
                 # Add configuration from Bazarr settings
                 "config": {
-                    "apiKey": settings.translator.openrouter_api_key,
+                    "apiKey": self._get_api_key_value(),
                     "model": settings.translator.openrouter_model,
                     "temperature": settings.translator.openrouter_temperature,
                     "maxConcurrentJobs": settings.translator.openrouter_max_concurrent,

--- a/frontend/src/apis/hooks/translator.ts
+++ b/frontend/src/apis/hooks/translator.ts
@@ -187,11 +187,18 @@ export interface TranslatorTestResponse {
   error?: string;
 }
 
+export interface TranslatorTestParams {
+  serviceUrl?: string;
+  apiKey?: string;
+  encryptionKey?: string;
+}
+
 export function useTestTranslator() {
   return useMutation({
-    mutationFn: async () => {
+    mutationFn: async (params?: TranslatorTestParams) => {
       const response = await client.axios.post<TranslatorTestResponse>(
         "/translator/test",
+        params,
       );
       return response.data;
     },

--- a/frontend/src/apis/hooks/translator.ts
+++ b/frontend/src/apis/hooks/translator.ts
@@ -171,3 +171,29 @@ export function useTranslatorModels(enabled = true) {
     throwOnError: false,
   });
 }
+
+export interface TranslatorTestResponse {
+  encryption?: {
+    status: string;
+    message: string;
+  } | null;
+  apiKey?: {
+    status: string;
+    label: string;
+    limitRemaining: number;
+    usage: number;
+    isFreeTier: boolean;
+  } | null;
+  error?: string;
+}
+
+export function useTestTranslator() {
+  return useMutation({
+    mutationFn: async () => {
+      const response = await client.axios.post<TranslatorTestResponse>(
+        "/translator/test",
+      );
+      return response.data;
+    },
+  });
+}

--- a/frontend/src/pages/Settings/Translator/index.tsx
+++ b/frontend/src/pages/Settings/Translator/index.tsx
@@ -168,21 +168,31 @@ const TestConnectionButton: FunctionComponent = () => {
           });
           return;
         }
-        const parts: string[] = [];
-        if (data.encryption?.status === "ok") {
-          parts.push("Encryption: OK");
+        if (data.encryption) {
+          const encOk = data.encryption.status === "ok";
+          notifications.show({
+            title: encOk ? "Encryption" : "Encryption Failed",
+            message: data.encryption.message,
+            color: encOk ? "green" : "red",
+          });
         }
-        if (data.apiKey?.status === "ok") {
-          parts.push(`API Key: ${data.apiKey.label}`);
-          if (data.apiKey.isFreeTier) {
-            parts.push("(Free tier)");
-          }
+        if (data.apiKey) {
+          const keyOk = data.apiKey.status === "ok";
+          notifications.show({
+            title: keyOk ? "API Key" : "API Key Failed",
+            message: keyOk
+              ? `${data.apiKey.label}${data.apiKey.isFreeTier ? " (Free tier)" : ""}`
+              : "API key validation failed",
+            color: keyOk ? "green" : "red",
+          });
         }
-        notifications.show({
-          title: "Connected",
-          message: parts.join(" | ") || "Connection successful",
-          color: "green",
-        });
+        if (!data.encryption && !data.apiKey) {
+          notifications.show({
+            title: "Connected",
+            message: "Service reachable",
+            color: "green",
+          });
+        }
       },
       onError: () => {
         notifications.show({
@@ -321,16 +331,15 @@ const SettingsTranslatorView: FunctionComponent = () => {
         <Stack gap="md" mt="md">
           {/* Zone 2: Connection Card */}
           <Paper withBorder radius="md" p="md">
-            <SimpleGrid cols={{ base: 1, sm: 2 }}>
+            <SimpleGrid cols={{ base: 1, sm: 3 }}>
               <div>
                 <Text
                   label="Service URL"
                   settingKey="settings-translator-openrouter_url"
                 />
                 <MantineText size="xs" c="dimmed" mt={4}>
-                  URL of the AI Subtitle Translator service.{" "}
                   <Anchor
-                    href="https://github.com/LavX/ai-subtitle-translator"
+                    href="https://github.com/LavX/ai-subtitle-translator/blob/main/docs/BAZARR-SETUP.md"
                     target="_blank"
                     rel="noopener noreferrer"
                     size="xs"
@@ -346,7 +355,6 @@ const SettingsTranslatorView: FunctionComponent = () => {
                   settingKey="settings-translator-openrouter_api_key"
                 />
                 <MantineText size="xs" c="dimmed" mt={4}>
-                  Required for AI translation.{" "}
                   <Anchor
                     href="https://openrouter.ai/keys"
                     target="_blank"
@@ -358,26 +366,25 @@ const SettingsTranslatorView: FunctionComponent = () => {
                   </Anchor>
                 </MantineText>
               </div>
+              <div>
+                <Password
+                  label="Encryption Key (optional)"
+                  settingKey="settings-translator-openrouter_encryption_key"
+                />
+                <MantineText size="xs" c="dimmed" mt={4}>
+                  <Anchor
+                    href="https://github.com/LavX/ai-subtitle-translator/blob/main/docs/BAZARR-SETUP.md#get-your-encryption-key"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    size="xs"
+                    c="yellow.6"
+                  >
+                    How to get your key
+                  </Anchor>
+                </MantineText>
+              </div>
             </SimpleGrid>
-            <div style={{ marginTop: 8 }}>
-              <Password
-                label="Encryption Key (optional)"
-                settingKey="settings-translator-openrouter_encryption_key"
-              />
-              <MantineText size="xs" c="dimmed" mt={4}>
-                Encrypts API keys in transit.{" "}
-                <Anchor
-                  href="https://github.com/LavX/ai-subtitle-translator/blob/main/docs/BAZARR-SETUP.md#get-your-encryption-key"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  size="xs"
-                  c="yellow.6"
-                >
-                  How to get your key
-                </Anchor>
-              </MantineText>
-            </div>
-            <Group mt="xs">
+            <Group mt="xs" justify="flex-end">
               <TestConnectionButton />
             </Group>
           </Paper>

--- a/frontend/src/pages/Settings/Translator/index.tsx
+++ b/frontend/src/pages/Settings/Translator/index.tsx
@@ -155,9 +155,10 @@ const TestConnectionButton: FunctionComponent = () => {
   const testMutation = useTestTranslator();
   const serviceUrl = useSettingValue<string>("settings-translator-openrouter_url");
   const apiKey = useSettingValue<string>("settings-translator-openrouter_api_key");
+  const encryptionKey = useSettingValue<string>("settings-translator-openrouter_encryption_key");
 
   const handleTest = () => {
-    testMutation.mutate(undefined, {
+    testMutation.mutate({ serviceUrl, apiKey, encryptionKey }, {
       onSuccess: (data) => {
         if (data.error) {
           notifications.show({

--- a/frontend/src/pages/Settings/Translator/index.tsx
+++ b/frontend/src/pages/Settings/Translator/index.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   Anchor,
   Badge,
+  Button,
   Group,
   Paper,
   SimpleGrid,
@@ -11,8 +12,10 @@ import {
   Tooltip,
   UnstyledButton,
 } from "@mantine/core";
+import { notifications } from "@mantine/notifications";
 import { faCircleInfo, faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useTestTranslator } from "@/apis/hooks/translator";
 import { TranslatorStatusPanelWithFormContext } from "@/components/TranslatorStatus";
 import {
   Check,
@@ -146,6 +149,61 @@ const ModelDetailsFromSetting: FunctionComponent = () => {
   );
   if (!modelId) return null;
   return <ModelDetailsCard modelId={modelId} reasoningLevel={reasoningLevel ?? "disabled"} />;
+};
+
+const TestConnectionButton: FunctionComponent = () => {
+  const testMutation = useTestTranslator();
+  const serviceUrl = useSettingValue<string>("settings-translator-openrouter_url");
+  const apiKey = useSettingValue<string>("settings-translator-openrouter_api_key");
+
+  const handleTest = () => {
+    testMutation.mutate(undefined, {
+      onSuccess: (data) => {
+        if (data.error) {
+          notifications.show({
+            title: "Connection Failed",
+            message: data.error,
+            color: "red",
+          });
+          return;
+        }
+        const parts: string[] = [];
+        if (data.encryption?.status === "ok") {
+          parts.push("Encryption: OK");
+        }
+        if (data.apiKey?.status === "ok") {
+          parts.push(`API Key: ${data.apiKey.label}`);
+          if (data.apiKey.isFreeTier) {
+            parts.push("(Free tier)");
+          }
+        }
+        notifications.show({
+          title: "Connected",
+          message: parts.join(" | ") || "Connection successful",
+          color: "green",
+        });
+      },
+      onError: () => {
+        notifications.show({
+          title: "Connection Failed",
+          message: "Could not reach the translator service",
+          color: "red",
+        });
+      },
+    });
+  };
+
+  return (
+    <Button
+      variant="default"
+      size="xs"
+      onClick={handleTest}
+      loading={testMutation.isPending}
+      disabled={!serviceUrl || !apiKey}
+    >
+      Test Connection
+    </Button>
+  );
 };
 
 const SettingsTranslatorView: FunctionComponent = () => {
@@ -300,6 +358,27 @@ const SettingsTranslatorView: FunctionComponent = () => {
                 </MantineText>
               </div>
             </SimpleGrid>
+            <div style={{ marginTop: 8 }}>
+              <Password
+                label="Encryption Key (optional)"
+                settingKey="settings-translator-openrouter_encryption_key"
+              />
+              <MantineText size="xs" c="dimmed" mt={4}>
+                Encrypts API keys in transit.{" "}
+                <Anchor
+                  href="https://github.com/LavX/ai-subtitle-translator/blob/main/docs/BAZARR-SETUP.md#get-your-encryption-key"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  size="xs"
+                  c="yellow.6"
+                >
+                  How to get your key
+                </Anchor>
+              </MantineText>
+            </div>
+            <Group mt="xs">
+              <TestConnectionButton />
+            </Group>
           </Paper>
 
           {/* Zone 3: Model & Tuning Card */}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ lxml>=4.3.0
 numpy>=1.12.0,<2.4.0  # prevent segfault on hold hardware caused by new CPU requirements introduced in 2.4.0
 webrtcvad-wheels>=2.0.10
 Pillow>=9.0.0 --only-binary=Pillow
+cryptography>=41.0.0
 pywin32; platform_system == "Windows"

--- a/tests/bazarr/test_encryption.py
+++ b/tests/bazarr/test_encryption.py
@@ -1,11 +1,12 @@
 import base64
+from unittest.mock import patch, MagicMock
 import pytest
 from subtitles.tools.translate.services.encryption import encrypt_api_key, validate_encryption_key
 
 
 class TestValidateEncryptionKey:
     def test_valid_64_hex(self):
-        assert validate_encryption_key("e2c65e79252379c1da0874f9d0928c6194fbc5e5460e3ab4047860560a2aa597") is True
+        assert validate_encryption_key("79866a5b6ef41b78681a7f774f6628fe66c49b0f0c96808cc3f48acbbfe1ac41") is True
 
     def test_empty_string(self):
         assert validate_encryption_key("") is False
@@ -27,7 +28,7 @@ class TestValidateEncryptionKey:
 
 
 class TestEncryptApiKey:
-    KEY_HEX = "e2c65e79252379c1da0874f9d0928c6194fbc5e5460e3ab4047860560a2aa597"
+    KEY_HEX = "79866a5b6ef41b78681a7f774f6628fe66c49b0f0c96808cc3f48acbbfe1ac41"
     API_KEY = "sk-or-v1-test1234567890"
 
     def test_returns_enc_prefix(self):
@@ -65,3 +66,55 @@ class TestEncryptApiKey:
     def test_short_key_raises(self):
         with pytest.raises(ValueError):
             encrypt_api_key(self.API_KEY, "abcd1234")
+
+
+class TestGetApiKeyValue:
+    """Test the _get_api_key_value helper on OpenRouterTranslatorService."""
+
+    KEY_HEX = "79866a5b6ef41b78681a7f774f6628fe66c49b0f0c96808cc3f48acbbfe1ac41"
+    API_KEY = "sk-or-v1-test1234567890"
+
+    def _make_service(self):
+        from subtitles.tools.translate.services.openrouter_translator import OpenRouterTranslatorService
+        return OpenRouterTranslatorService(
+            source_srt_file="", dest_srt_file="", lang_obj=None,
+            to_lang="hun", from_lang="en", media_type="series",
+            video_path="", orig_to_lang="hu", forced=False, hi=False,
+            sonarr_series_id=None, sonarr_episode_id=None, radarr_id=None,
+        )
+
+    @patch("subtitles.tools.translate.services.openrouter_translator.settings")
+    def test_no_encryption_key_returns_plaintext(self, mock_settings):
+        mock_settings.translator.openrouter_api_key = self.API_KEY
+        mock_settings.translator.openrouter_encryption_key = ""
+        svc = self._make_service()
+        result = svc._get_api_key_value()
+        assert result == self.API_KEY
+
+    @patch("subtitles.tools.translate.services.openrouter_translator.settings")
+    def test_with_encryption_key_returns_encrypted(self, mock_settings):
+        mock_settings.translator.openrouter_api_key = self.API_KEY
+        mock_settings.translator.openrouter_encryption_key = self.KEY_HEX
+        svc = self._make_service()
+        result = svc._get_api_key_value()
+        assert result.startswith("enc:")
+
+    @patch("subtitles.tools.translate.services.openrouter_translator.settings")
+    def test_with_encryption_key_roundtrips(self, mock_settings):
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+        mock_settings.translator.openrouter_api_key = self.API_KEY
+        mock_settings.translator.openrouter_encryption_key = self.KEY_HEX
+        svc = self._make_service()
+        result = svc._get_api_key_value()
+        payload = base64.b64decode(result[4:])
+        aesgcm = AESGCM(bytes.fromhex(self.KEY_HEX))
+        decrypted = aesgcm.decrypt(payload[:12], payload[12:], None).decode()
+        assert decrypted == self.API_KEY
+
+    @patch("subtitles.tools.translate.services.openrouter_translator.settings")
+    def test_invalid_encryption_key_raises(self, mock_settings):
+        mock_settings.translator.openrouter_api_key = self.API_KEY
+        mock_settings.translator.openrouter_encryption_key = "not-valid-hex"
+        svc = self._make_service()
+        with pytest.raises(ValueError, match="Invalid encryption key format"):
+            svc._get_api_key_value()

--- a/tests/bazarr/test_encryption.py
+++ b/tests/bazarr/test_encryption.py
@@ -1,0 +1,67 @@
+import base64
+import pytest
+from subtitles.tools.translate.services.encryption import encrypt_api_key, validate_encryption_key
+
+
+class TestValidateEncryptionKey:
+    def test_valid_64_hex(self):
+        assert validate_encryption_key("e2c65e79252379c1da0874f9d0928c6194fbc5e5460e3ab4047860560a2aa597") is True
+
+    def test_empty_string(self):
+        assert validate_encryption_key("") is False
+
+    def test_too_short(self):
+        assert validate_encryption_key("abcd1234") is False
+
+    def test_too_long(self):
+        assert validate_encryption_key("a" * 65) is False
+
+    def test_non_hex_chars(self):
+        assert validate_encryption_key("g" * 64) is False
+
+    def test_uppercase_hex(self):
+        assert validate_encryption_key("A" * 64) is True
+
+    def test_mixed_case_hex(self):
+        assert validate_encryption_key("aAbBcCdD" * 8) is True
+
+
+class TestEncryptApiKey:
+    KEY_HEX = "e2c65e79252379c1da0874f9d0928c6194fbc5e5460e3ab4047860560a2aa597"
+    API_KEY = "sk-or-v1-test1234567890"
+
+    def test_returns_enc_prefix(self):
+        result = encrypt_api_key(self.API_KEY, self.KEY_HEX)
+        assert result.startswith("enc:")
+
+    def test_base64_payload(self):
+        result = encrypt_api_key(self.API_KEY, self.KEY_HEX)
+        payload = result[4:]  # strip "enc:"
+        decoded = base64.b64decode(payload)
+        # 12-byte nonce + ciphertext + 16-byte tag
+        # ciphertext length = len(api_key bytes)
+        assert len(decoded) == 12 + len(self.API_KEY.encode()) + 16
+
+    def test_unique_nonces(self):
+        r1 = encrypt_api_key(self.API_KEY, self.KEY_HEX)
+        r2 = encrypt_api_key(self.API_KEY, self.KEY_HEX)
+        assert r1 != r2  # different nonce each time
+
+    def test_roundtrip_decrypt(self):
+        """Verify we can decrypt what we encrypted."""
+        from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+        encrypted = encrypt_api_key(self.API_KEY, self.KEY_HEX)
+        payload = base64.b64decode(encrypted[4:])
+        nonce = payload[:12]
+        ciphertext = payload[12:]
+        aesgcm = AESGCM(bytes.fromhex(self.KEY_HEX))
+        decrypted = aesgcm.decrypt(nonce, ciphertext, None).decode("utf-8")
+        assert decrypted == self.API_KEY
+
+    def test_invalid_key_raises(self):
+        with pytest.raises(ValueError):
+            encrypt_api_key(self.API_KEY, "not-a-hex-key")
+
+    def test_short_key_raises(self):
+        with pytest.raises(ValueError):
+            encrypt_api_key(self.API_KEY, "abcd1234")


### PR DESCRIPTION
## Summary

- Add AES-256-GCM encryption for OpenRouter API keys sent to the AI Subtitle Translator service
- New encryption key field in Settings (optional, backward compatible)
- Test Connection button validates encryption + API key against the live service
- 17 unit tests covering encryption module and integration

## Changes

- **Backend:** Encryption utility module (`encryption.py`), config validator, `_get_api_key_value()` helper on translator service, `POST /translator/test` endpoint
- **Frontend:** 3-column connection card (URL, API Key, Encryption Key), Test Connection button with separate encryption/API key notifications
- **Dependency:** `cryptography>=41.0.0`

## How it works

1. Translator service generates an AES-256 key on startup
2. User pastes the 64-char hex key into Bazarr settings
3. Bazarr encrypts the OpenRouter API key before every request (`enc:base64data`)
4. Translator decrypts server-side using the shared key
5. Leaving encryption key empty keeps plaintext (backward compatible)

## Test plan

- [x] Test Connection with valid encryption key: green notifications for both encryption and API key
- [x] Test Connection without encryption key: green notification for API key only
- [x] Test Connection with wrong encryption key: red notification with decryption error
- [x] Test Connection with invalid API key: red notification for API key
- [x] Run a translation with encryption enabled: subtitles translate successfully
- [x] Run `python -m pytest tests/bazarr/test_encryption.py -v`: 17/17 pass