### PR TITLE
feat: mass subtitle sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-  Provider priority · OpenSubtitles.org web scraper · AI translation via OpenRouter (300+ LLMs) · API key encryption · batch translation · advanced table filters · security hardening · Python 3.14 · navy + amber dark theme
+  Provider priority · OpenSubtitles.org web scraper · AI translation via OpenRouter (300+ LLMs) · API key encryption · batch translation · mass subtitle sync · advanced table filters · security hardening · Python 3.14 · navy + amber dark theme
 </p>
 
 ---
@@ -47,6 +47,15 @@ Upstream has Google Translate, Gemini, and Lingarr. Bazarr+ adds **OpenRouter** 
 - **Three-button unsaved changes modal**: Save & Leave, Discard, or Keep Editing (upstream only has Leave/Stay)
 - **Navy + amber dark theme**: custom color palette from `#121125` (navy black) to `#fff8e1` (cream), with amber brand accents (`#e68a00` to `#b36b00`)
 - **Audio language display** as blue badges in all table views
+
+### Mass Subtitle Sync
+Upstream lets you sync subtitles one at a time, or per-series via Mass Edit. But there's no way to sync your entire library at once. This has been [requested for years](https://bazarr.featureupvote.com/suggestions/191692/mass-sync-all-subtitles) (249 votes), but upstream rejected it as "won't happen," saying "Bazarr isn't a batch tool."
+
+Bazarr+ adds two entry points for bulk sync:
+- **System Tasks page**: a "Mass Sync All Subtitles" task with a Run button that syncs every subtitle in your library
+- **Mass Edit pages**: a "Sync Subtitles" button for both Movies and Series editors, so you can select specific items and sync their subtitles in bulk
+
+Both use the existing ffsubsync engine. Already-synced subtitles are skipped by default (with a force re-sync option). Configurable max offset, Golden-Section Search, and framerate correction settings.
 
 ### Security Hardening
 8 areas upstream doesn't address:
@@ -100,6 +109,7 @@ docker pull ghcr.io/lavx/ai-subtitle-translator:latest
 | **API Key Encryption** | ❌ Not available | ✅ AES-256-GCM encryption for keys in transit |
 | **Translate from Missing Menu** | ❌ Not available | ✅ Action menu on missing subs with source language picker |
 | **Batch Translation** | ❌ Not available | ✅ Translate entire series/libraries from Wanted pages |
+| **Mass Subtitle Sync** | ❌ [Rejected](https://bazarr.featureupvote.com/suggestions/191692/mass-sync-all-subtitles) (249 votes) | ✅ Bulk sync from Tasks page or Mass Edit, skips already-synced |
 | **Dedicated Translator Settings** | ❌ Not available | ✅ 4-zone page with pricing, cost estimates, status panel |
 | **Security Hardening** | MD5, no CSRF/SSRF/rate limiting | ✅ PBKDF2 (600k iter), CSRF, SSRF, brute-force, 4 more |
 | **Audio Language Display** | ❌ Not shown in tables | ✅ Badges in all table views |

--- a/bazarr/api/subtitles/__init__.py
+++ b/bazarr/api/subtitles/__init__.py
@@ -3,10 +3,12 @@
 from .subtitles import api_ns_subtitles
 from .subtitles_info import api_ns_subtitles_info
 from .batch_translate import api_ns_batch_translate
+from .batch_sync import api_ns_batch_sync
 
 
 api_ns_list_subtitles = [
     api_ns_subtitles,
     api_ns_subtitles_info,
     api_ns_batch_translate,
+    api_ns_batch_sync,
 ]

--- a/bazarr/api/subtitles/batch_sync.py
+++ b/bazarr/api/subtitles/batch_sync.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+
+import logging
+from flask_restx import Resource, Namespace, fields
+
+from subtitles.mass_sync import mass_sync_subtitles
+from ..utils import authenticate
+
+logger = logging.getLogger(__name__)
+
+api_ns_batch_sync = Namespace('BatchSync', description='Batch sync subtitles')
+
+
+@api_ns_batch_sync.route('subtitles/sync/batch')
+class BatchSync(Resource):
+    post_item_model = api_ns_batch_sync.model('BatchSyncItem', {
+        'type': fields.String(required=True, description='Type: "episode", "movie", or "series"'),
+        'sonarrSeriesId': fields.Integer(description='Sonarr Series ID'),
+        'sonarrEpisodeId': fields.Integer(description='Sonarr Episode ID'),
+        'radarrId': fields.Integer(description='Radarr Movie ID'),
+    })
+
+    post_options_model = api_ns_batch_sync.model('BatchSyncOptions', {
+        'max_offset_seconds': fields.Integer(default=60, description='Maximum offset in seconds'),
+        'no_fix_framerate': fields.Boolean(default=True, description='Skip framerate correction'),
+        'gss': fields.Boolean(default=True, description='Use Golden-Section Search'),
+        'force_resync': fields.Boolean(default=False, description='Re-sync already synced subtitles'),
+    })
+
+    post_request_model = api_ns_batch_sync.model('BatchSyncRequest', {
+        'items': fields.List(fields.Nested(post_item_model), required=True),
+        'options': fields.Nested(post_options_model),
+    })
+
+    post_response_model = api_ns_batch_sync.model('BatchSyncResponse', {
+        'queued': fields.Integer(description='Number of sync jobs queued'),
+        'skipped': fields.Integer(description='Number of subtitles skipped'),
+        'errors': fields.List(fields.String(), description='Error messages'),
+    })
+
+    @authenticate
+    @api_ns_batch_sync.doc(body=post_request_model)
+    @api_ns_batch_sync.response(200, 'Success', post_response_model)
+    @api_ns_batch_sync.response(400, 'Bad Request')
+    @api_ns_batch_sync.response(401, 'Not Authenticated')
+    def post(self):
+        """Queue batch sync jobs for multiple items"""
+        from flask import request
+        data = request.get_json()
+
+        if not data or 'items' not in data:
+            return {'error': 'No items provided'}, 400
+
+        items = data.get('items', [])
+        if not items:
+            return {'error': 'Empty items list'}, 400
+
+        options = data.get('options', {})
+
+        result = mass_sync_subtitles(items=items, options=options, job_id='batch_sync_api')
+        if result is None:
+            return {'error': 'Mass sync failed'}, 500
+
+        return result, 200

--- a/bazarr/app/scheduler.py
+++ b/bazarr/app/scheduler.py
@@ -25,6 +25,7 @@ from subtitles.indexer.movies import movies_full_scan_subtitles
 from subtitles.indexer.series import series_full_scan_subtitles
 from subtitles.wanted import wanted_search_missing_subtitles_series, wanted_search_missing_subtitles_movies
 from subtitles.upgrade import upgrade_subtitles
+from subtitles.mass_sync import mass_sync_subtitles
 from utilities.cache import cache_maintenance
 from utilities.health import check_health
 from utilities.backup import backup_to_zip
@@ -108,6 +109,7 @@ class Scheduler:
         self.__update_bazarr_task()
         self.__search_wanted_subtitles_task()
         self.__upgrade_subtitles_task()
+        self.__mass_sync_task()
         self.__randomize_interval_task()
         self.__automatic_backup()
         if args.no_tasks:
@@ -315,6 +317,12 @@ class Scheduler:
                 upgrade_subtitles, 'interval', hours=int(settings.general.upgrade_frequency), max_instances=1,
                 coalesce=True, misfire_grace_time=15, id='upgrade_subtitles',
                 name='Upgrade Previously Downloaded Subtitles', replace_existing=True)
+
+    def __mass_sync_task(self):
+        self.aps_scheduler.add_job(
+            mass_sync_subtitles, 'cron', year=in_a_century(), max_instances=1,
+            coalesce=True, misfire_grace_time=15, id='mass_sync_subtitles',
+            name='Mass Sync All Subtitles', replace_existing=True)
 
     def __randomize_interval_task(self):
         for job in self.aps_scheduler.get_jobs():

--- a/bazarr/subtitles/mass_sync.py
+++ b/bazarr/subtitles/mass_sync.py
@@ -1,0 +1,270 @@
+# coding=utf-8
+
+import ast
+import logging
+import os
+
+from app.config import settings
+from app.database import TableEpisodes, TableMovies, TableHistory, TableHistoryMovie, TableShows, database, select
+from app.jobs_queue import jobs_queue
+from utilities.path_mappings import path_mappings
+from utilities.video_analyzer import languages_from_colon_seperated_string
+
+logger = logging.getLogger(__name__)
+
+
+def _get_synced_episode_paths():
+    """Get set of subtitle paths that have been synced (action=5) from episode history."""
+    results = database.execute(
+        select(TableHistory.subtitles_path)
+        .where(TableHistory.action == 5)
+    ).all()
+    return {r.subtitles_path for r in results if r.subtitles_path}
+
+
+def _get_synced_movie_paths():
+    """Get set of subtitle paths that have been synced (action=5) from movie history."""
+    results = database.execute(
+        select(TableHistoryMovie.subtitles_path)
+        .where(TableHistoryMovie.action == 5)
+    ).all()
+    return {r.subtitles_path for r in results if r.subtitles_path}
+
+
+def _parse_subtitles_column(subtitles_raw):
+    """Parse the subtitles TEXT column into a list of (lang_string, path) tuples."""
+    if not subtitles_raw:
+        return []
+    try:
+        parsed = ast.literal_eval(subtitles_raw)
+        return [(entry[0], entry[1]) for entry in parsed if len(entry) >= 2 and entry[1]]
+    except (ValueError, SyntaxError):
+        return []
+
+
+def _process_episodes(series_ids=None, episode_ids=None, options=None, force_resync=False):
+    """Queue sync jobs for episode subtitles."""
+    options = options or {}
+    max_offset = str(options.get('max_offset_seconds', settings.subsync.max_offset_seconds))
+    gss = options.get('gss', settings.subsync.gss)
+    no_fix_framerate = options.get('no_fix_framerate', settings.subsync.no_fix_framerate)
+
+    query = select(
+        TableEpisodes.sonarrEpisodeId,
+        TableEpisodes.sonarrSeriesId,
+        TableEpisodes.path,
+        TableEpisodes.subtitles,
+    )
+
+    from sqlalchemy import or_
+    filters = []
+    if episode_ids:
+        filters.append(TableEpisodes.sonarrEpisodeId.in_(episode_ids))
+    if series_ids:
+        filters.append(TableEpisodes.sonarrSeriesId.in_(series_ids))
+    if filters:
+        query = query.where(or_(*filters))
+
+    episodes = database.execute(query).all()
+
+    synced_paths = set() if force_resync else _get_synced_episode_paths()
+    queued = 0
+    skipped = 0
+    errors = []
+
+    for ep in episodes:
+        subtitles = _parse_subtitles_column(ep.subtitles)
+        video_path = path_mappings.path_replace(ep.path)
+
+        for lang_string, sub_path in subtitles:
+            lang_info = languages_from_colon_seperated_string(lang_string)
+
+            if lang_info['forced']:
+                skipped += 1
+                continue
+
+            mapped_sub_path = path_mappings.path_replace(sub_path)
+            if not os.path.isfile(mapped_sub_path):
+                skipped += 1
+                continue
+
+            reversed_path = path_mappings.path_replace_reverse(mapped_sub_path)
+            if not force_resync and reversed_path in synced_paths:
+                skipped += 1
+                continue
+
+            try:
+                jobs_queue.feed_jobs_pending_queue(
+                    job_name=f"Mass Syncing {os.path.basename(mapped_sub_path)}",
+                    module='subtitles.sync',
+                    func='sync_subtitles',
+                    kwargs={
+                        'video_path': video_path,
+                        'srt_path': mapped_sub_path,
+                        'srt_lang': lang_string.split(':')[0],
+                        'forced': lang_info['forced'],
+                        'hi': lang_info['hi'],
+                        'percent_score': 0,
+                        'sonarr_series_id': ep.sonarrSeriesId,
+                        'sonarr_episode_id': ep.sonarrEpisodeId,
+                        'radarr_id': None,
+                        'max_offset_seconds': max_offset,
+                        'no_fix_framerate': no_fix_framerate,
+                        'gss': gss,
+                        'force_sync': True,
+                    }
+                )
+                queued += 1
+            except Exception as e:
+                logger.error(f'Error queuing sync for {sub_path}: {e}')
+                errors.append(str(e))
+                skipped += 1
+
+    return queued, skipped, errors
+
+
+def _process_movies(movie_ids=None, options=None, force_resync=False):
+    """Queue sync jobs for movie subtitles."""
+    options = options or {}
+    max_offset = str(options.get('max_offset_seconds', settings.subsync.max_offset_seconds))
+    gss = options.get('gss', settings.subsync.gss)
+    no_fix_framerate = options.get('no_fix_framerate', settings.subsync.no_fix_framerate)
+
+    query = select(
+        TableMovies.radarrId,
+        TableMovies.path,
+        TableMovies.subtitles,
+    )
+
+    if movie_ids:
+        query = query.where(TableMovies.radarrId.in_(movie_ids))
+
+    movies = database.execute(query).all()
+
+    synced_paths = set() if force_resync else _get_synced_movie_paths()
+    queued = 0
+    skipped = 0
+    errors = []
+
+    for movie in movies:
+        subtitles = _parse_subtitles_column(movie.subtitles)
+        video_path = path_mappings.path_replace_movie(movie.path)
+
+        for lang_string, sub_path in subtitles:
+            lang_info = languages_from_colon_seperated_string(lang_string)
+
+            if lang_info['forced']:
+                skipped += 1
+                continue
+
+            mapped_sub_path = path_mappings.path_replace_movie(sub_path)
+            if not os.path.isfile(mapped_sub_path):
+                skipped += 1
+                continue
+
+            reversed_path = path_mappings.path_replace_reverse_movie(mapped_sub_path)
+            if not force_resync and reversed_path in synced_paths:
+                skipped += 1
+                continue
+
+            try:
+                jobs_queue.feed_jobs_pending_queue(
+                    job_name=f"Mass Syncing {os.path.basename(mapped_sub_path)}",
+                    module='subtitles.sync',
+                    func='sync_subtitles',
+                    kwargs={
+                        'video_path': video_path,
+                        'srt_path': mapped_sub_path,
+                        'srt_lang': lang_string.split(':')[0],
+                        'forced': lang_info['forced'],
+                        'hi': lang_info['hi'],
+                        'percent_score': 0,
+                        'sonarr_series_id': None,
+                        'sonarr_episode_id': None,
+                        'radarr_id': movie.radarrId,
+                        'max_offset_seconds': max_offset,
+                        'no_fix_framerate': no_fix_framerate,
+                        'gss': gss,
+                        'force_sync': True,
+                    }
+                )
+                queued += 1
+            except Exception as e:
+                logger.error(f'Error queuing sync for {sub_path}: {e}')
+                errors.append(str(e))
+                skipped += 1
+
+    return queued, skipped, errors
+
+
+def mass_sync_subtitles(items=None, options=None, job_id=None):
+    """Main entry point for mass subtitle sync.
+
+    Args:
+        items: List of dicts with 'type' and IDs. If None, syncs entire library.
+        options: Dict with max_offset_seconds, gss, no_fix_framerate, force_resync.
+        job_id: Job ID for scheduled task tracking.
+    """
+    if not job_id and items is None:
+        jobs_queue.add_job_from_function("Mass Syncing All Subtitles", is_progress=False)
+        return
+
+    options = options or {}
+    force_resync = options.get('force_resync', False)
+
+    total_queued = 0
+    total_skipped = 0
+    all_errors = []
+
+    if items is None:
+        # Sync entire library
+        logger.info('BAZARR starting mass sync for all subtitles')
+        if settings.general.use_sonarr:
+            q, s, e = _process_episodes(options=options, force_resync=force_resync)
+            total_queued += q
+            total_skipped += s
+            all_errors.extend(e)
+
+        if settings.general.use_radarr:
+            q, s, e = _process_movies(options=options, force_resync=force_resync)
+            total_queued += q
+            total_skipped += s
+            all_errors.extend(e)
+    else:
+        # Sync specific items
+        series_ids = []
+        episode_ids = []
+        movie_ids = []
+
+        for item in items:
+            item_type = item.get('type')
+            if item_type == 'series':
+                series_ids.append(item.get('sonarrSeriesId'))
+            elif item_type == 'episode':
+                episode_ids.append(item.get('sonarrEpisodeId'))
+            elif item_type == 'movie':
+                movie_ids.append(item.get('radarrId'))
+
+        if series_ids or episode_ids:
+            q, s, e = _process_episodes(
+                series_ids=series_ids or None,
+                episode_ids=episode_ids or None,
+                options=options,
+                force_resync=force_resync,
+            )
+            total_queued += q
+            total_skipped += s
+            all_errors.extend(e)
+
+        if movie_ids:
+            q, s, e = _process_movies(
+                movie_ids=movie_ids,
+                options=options,
+                force_resync=force_resync,
+            )
+            total_queued += q
+            total_skipped += s
+            all_errors.extend(e)
+
+    logger.info(f'BAZARR mass sync complete: {total_queued} queued, {total_skipped} skipped, {len(all_errors)} errors')
+    return {'queued': total_queued, 'skipped': total_skipped, 'errors': all_errors}

--- a/frontend/src/apis/hooks/subtitles.ts
+++ b/frontend/src/apis/hooks/subtitles.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { QueryKeys } from "@/apis/queries/keys";
 import api from "@/apis/raw";
-import { BatchTranslateItem } from "@/apis/raw/subtitles";
+import { BatchTranslateItem, BatchSyncItem, BatchSyncOptions } from "@/apis/raw/subtitles";
 
 export function useSubtitleAction() {
   const client = useQueryClient();
@@ -200,6 +200,26 @@ export function useBatchTranslate() {
       // Also invalidate translator jobs to show new jobs
       void client.invalidateQueries({
         queryKey: [QueryKeys.Translator],
+      });
+    },
+  });
+}
+
+export function useBatchSync() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationKey: [QueryKeys.Subtitles, "batch-sync"],
+    mutationFn: (params: { items: BatchSyncItem[]; options: BatchSyncOptions }) =>
+      api.subtitles.batchSync(params.items, params.options),
+    onSuccess: () => {
+      void client.invalidateQueries({
+        queryKey: [QueryKeys.Series],
+      });
+      void client.invalidateQueries({
+        queryKey: [QueryKeys.Movies],
+      });
+      void client.invalidateQueries({
+        queryKey: [QueryKeys.History],
       });
     },
   });

--- a/frontend/src/apis/raw/subtitles.ts
+++ b/frontend/src/apis/raw/subtitles.ts
@@ -18,6 +18,26 @@ export interface BatchTranslateResponse {
   errors: string[];
 }
 
+export interface BatchSyncItem {
+  type: "episode" | "movie" | "series";
+  sonarrSeriesId?: number;
+  sonarrEpisodeId?: number;
+  radarrId?: number;
+}
+
+export interface BatchSyncOptions {
+  max_offset_seconds: number;
+  no_fix_framerate: boolean;
+  gss: boolean;
+  force_resync: boolean;
+}
+
+export interface BatchSyncResponse {
+  queued: number;
+  skipped: number;
+  errors: string[];
+}
+
 class SubtitlesApi extends BaseApi {
   constructor() {
     super("/subtitles");
@@ -62,6 +82,17 @@ class SubtitlesApi extends BaseApi {
     const response = await this.postRaw<BatchTranslateResponse>(
       "/translate/batch",
       { items },
+    );
+    return response.data;
+  }
+
+  async batchSync(
+    items: BatchSyncItem[],
+    options: BatchSyncOptions,
+  ): Promise<BatchSyncResponse> {
+    const response = await this.postRaw<BatchSyncResponse>(
+      "/sync/batch",
+      { items, options },
     );
     return response.data;
   }

--- a/frontend/src/components/forms/MassSyncForm.tsx
+++ b/frontend/src/components/forms/MassSyncForm.tsx
@@ -1,0 +1,117 @@
+import { FunctionComponent } from "react";
+import {
+  Button,
+  Checkbox,
+  Divider,
+  Group,
+  NumberInput,
+  Stack,
+  Text,
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { notifications } from "@mantine/notifications";
+import { useBatchSync, useSystemSettings } from "@/apis/hooks";
+import {
+  BatchSyncItem,
+  BatchSyncOptions,
+} from "@/apis/raw/subtitles";
+import { useModals, withModal } from "@/modules/modals";
+
+interface MassSyncFormProps {
+  items: BatchSyncItem[];
+}
+
+const MassSyncForm: FunctionComponent<MassSyncFormProps> = ({ items }) => {
+  const { data: settings } = useSystemSettings();
+  const { mutateAsync, isPending } = useBatchSync();
+  const modals = useModals();
+
+  const form = useForm<BatchSyncOptions>({
+    initialValues: {
+      max_offset_seconds: settings?.subsync.max_offset_seconds ?? 60,
+      no_fix_framerate: settings?.subsync.no_fix_framerate ?? true,
+      gss: settings?.subsync.gss ?? true,
+      force_resync: false,
+    },
+  });
+
+  const handleSubmit = form.onSubmit(async (values) => {
+    if (items.length >= 100) {
+      const confirmed = window.confirm(
+        `This will sync subtitles for ${items.length} items. This may take a while. Continue?`,
+      );
+      if (!confirmed) return;
+    }
+
+    try {
+      const result = await mutateAsync({ items, options: values });
+
+      notifications.show({
+        title: "Mass Sync Queued",
+        message: `Queued: ${result.queued}, Skipped: ${result.skipped}${result.errors.length > 0 ? `, Errors: ${result.errors.length}` : ""}`,
+        color: result.errors.length > 0 ? "yellow" : "green",
+      });
+
+      modals.closeSelf();
+    } catch (error) {
+      notifications.show({
+        title: "Mass Sync Failed",
+        message: String(error),
+        color: "red",
+      });
+    }
+  });
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Stack>
+        <Text size="sm">
+          Sync subtitles for <strong>{items.length}</strong> selected item(s).
+          Subtitles will be synchronized using the video audio track as
+          reference.
+        </Text>
+
+        <NumberInput
+          label="Max Offset Seconds"
+          min={1}
+          max={600}
+          {...form.getInputProps("max_offset_seconds")}
+        />
+
+        <Checkbox
+          label="Golden-Section Search"
+          {...form.getInputProps("gss", { type: "checkbox" })}
+        />
+
+        <Checkbox
+          label="No Fix Framerate"
+          {...form.getInputProps("no_fix_framerate", { type: "checkbox" })}
+        />
+
+        <Checkbox
+          label="Force Re-sync"
+          description="Re-sync subtitles that have already been synced"
+          {...form.getInputProps("force_resync", { type: "checkbox" })}
+        />
+
+        <Divider />
+
+        <Group justify="apart">
+          <Button variant="default" onClick={() => modals.closeSelf()}>
+            Cancel
+          </Button>
+          <Button type="submit" loading={isPending} disabled={items.length === 0}>
+            Sync {items.length} Item(s)
+          </Button>
+        </Group>
+      </Stack>
+    </form>
+  );
+};
+
+export const MassSyncModal = withModal(MassSyncForm, "mass-sync", {
+  title: "Mass Sync Subtitles",
+  size: "md",
+});
+
+export default MassSyncForm;

--- a/frontend/src/pages/Movies/Editor.tsx
+++ b/frontend/src/pages/Movies/Editor.tsx
@@ -1,19 +1,44 @@
-import { FunctionComponent, useMemo } from "react";
+import { FunctionComponent, useCallback, useMemo } from "react";
+import { faSync } from "@fortawesome/free-solid-svg-icons";
 import { Checkbox } from "@mantine/core";
 import { useDocumentTitle } from "@mantine/hooks";
 import { ColumnDef } from "@tanstack/react-table";
 import { useMovieModification, useMovies } from "@/apis/hooks";
 import { useInstanceName } from "@/apis/hooks/site";
+import { BatchSyncItem } from "@/apis/raw/subtitles";
+import { Toolbox } from "@/components";
 import { QueryOverlay } from "@/components/async";
 import { AudioList } from "@/components/bazarr";
 import LanguageProfileName from "@/components/bazarr/LanguageProfile";
+import { MassSyncModal } from "@/components/forms/MassSyncForm";
+import { useModals } from "@/modules/modals";
 import MassEditor from "@/pages/views/MassEditor";
 
 const MovieMassEditor: FunctionComponent = () => {
   const query = useMovies();
   const mutation = useMovieModification();
+  const modals = useModals();
 
   useDocumentTitle(`Movies - ${useInstanceName()} (Mass Editor)`);
+
+  const toolbarExtras = useCallback(
+    (selections: Item.Movie[]) => (
+      <Toolbox.Button
+        icon={faSync}
+        disabled={selections.length === 0}
+        onClick={() => {
+          const items: BatchSyncItem[] = selections.map((s) => ({
+            type: "movie" as const,
+            radarrId: s.radarrId,
+          }));
+          modals.openContextModal(MassSyncModal, { items });
+        }}
+      >
+        Sync Subtitles
+      </Toolbox.Button>
+    ),
+    [modals],
+  );
 
   const columns = useMemo<ColumnDef<Item.Movie>[]>(
     () => [
@@ -76,6 +101,7 @@ const MovieMassEditor: FunctionComponent = () => {
         columns={columns}
         data={query.data ?? []}
         mutation={mutation}
+        toolbarExtras={toolbarExtras}
       ></MassEditor>
     </QueryOverlay>
   );

--- a/frontend/src/pages/Series/Editor.tsx
+++ b/frontend/src/pages/Series/Editor.tsx
@@ -1,17 +1,23 @@
-import { FunctionComponent, useMemo } from "react";
+import { FunctionComponent, useCallback, useMemo } from "react";
+import { faSync } from "@fortawesome/free-solid-svg-icons";
 import { Checkbox } from "@mantine/core";
 import { useDocumentTitle } from "@mantine/hooks";
 import { ColumnDef } from "@tanstack/react-table";
 import { useSeries, useSeriesModification } from "@/apis/hooks";
 import { useInstanceName } from "@/apis/hooks/site";
+import { BatchSyncItem } from "@/apis/raw/subtitles";
+import { Toolbox } from "@/components";
 import { QueryOverlay } from "@/components/async";
 import { AudioList } from "@/components/bazarr";
 import LanguageProfileName from "@/components/bazarr/LanguageProfile";
+import { MassSyncModal } from "@/components/forms/MassSyncForm";
+import { useModals } from "@/modules/modals";
 import MassEditor from "@/pages/views/MassEditor";
 
 const SeriesMassEditor: FunctionComponent = () => {
   const query = useSeries();
   const mutation = useSeriesModification();
+  const modals = useModals();
 
   const columns = useMemo<ColumnDef<Item.Series>[]>(
     () => [
@@ -70,12 +76,32 @@ const SeriesMassEditor: FunctionComponent = () => {
 
   useDocumentTitle(`Series - ${useInstanceName()} (Mass Editor)`);
 
+  const toolbarExtras = useCallback(
+    (selections: Item.Series[]) => (
+      <Toolbox.Button
+        icon={faSync}
+        disabled={selections.length === 0}
+        onClick={() => {
+          const items: BatchSyncItem[] = selections.map((s) => ({
+            type: "series" as const,
+            sonarrSeriesId: s.sonarrSeriesId,
+          }));
+          modals.openContextModal(MassSyncModal, { items });
+        }}
+      >
+        Sync Subtitles
+      </Toolbox.Button>
+    ),
+    [modals],
+  );
+
   return (
     <QueryOverlay result={query}>
       <MassEditor
         columns={columns}
         data={query.data ?? []}
         mutation={mutation}
+        toolbarExtras={toolbarExtras}
       ></MassEditor>
     </QueryOverlay>
   );

--- a/frontend/src/pages/views/MassEditor.tsx
+++ b/frontend/src/pages/views/MassEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { ReactNode, useCallback, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { Box, Container, useCombobox } from "@mantine/core";
 import { faCheck, faUndo } from "@fortawesome/free-solid-svg-icons";
@@ -14,10 +14,11 @@ interface MassEditorProps<T extends Item.Base = Item.Base> {
   columns: ColumnDef<T>[];
   data: T[];
   mutation: UseMutationResult<void, unknown, FormType.ModifyItem>;
+  toolbarExtras?: (selections: T[]) => ReactNode;
 }
 
 function MassEditor<T extends Item.Base>(props: MassEditorProps<T>) {
-  const { columns, data: raw, mutation } = props;
+  const { columns, data: raw, mutation, toolbarExtras } = props;
 
   const [selections, setSelections] = useState<T[]>([]);
   const [dirties, setDirties] = useState<T[]>([]);
@@ -119,6 +120,7 @@ function MassEditor<T extends Item.Base>(props: MassEditorProps<T>) {
   return (
     <Container fluid px={0}>
       <Toolbox>
+        {toolbarExtras && <Box>{toolbarExtras(selections)}</Box>}
         <Box>
           <GroupedSelector
             onClick={() => combobox.openDropdown()}

--- a/tests/bazarr/test_mass_sync.py
+++ b/tests/bazarr/test_mass_sync.py
@@ -1,0 +1,591 @@
+# coding=utf-8
+
+import pytest
+from unittest.mock import patch, MagicMock, call
+
+
+class TestParseSubtitlesColumn:
+    """Test _parse_subtitles_column function."""
+
+    def test_empty_input(self):
+        from bazarr.subtitles.mass_sync import _parse_subtitles_column
+        assert _parse_subtitles_column(None) == []
+        assert _parse_subtitles_column('') == []
+
+    def test_valid_subtitles(self):
+        from bazarr.subtitles.mass_sync import _parse_subtitles_column
+        raw = "[['en', '/path/to/sub.srt'], ['fr:forced', '/path/to/sub.fr.srt']]"
+        result = _parse_subtitles_column(raw)
+        assert len(result) == 2
+        assert result[0] == ('en', '/path/to/sub.srt')
+        assert result[1] == ('fr:forced', '/path/to/sub.fr.srt')
+
+    def test_skips_entries_without_path(self):
+        from bazarr.subtitles.mass_sync import _parse_subtitles_column
+        raw = "[['en', '/path/to/sub.srt'], ['fr', '']]"
+        result = _parse_subtitles_column(raw)
+        assert len(result) == 1
+        assert result[0] == ('en', '/path/to/sub.srt')
+
+    def test_skips_entries_with_none_path(self):
+        from bazarr.subtitles.mass_sync import _parse_subtitles_column
+        raw = "[['en', '/path/to/sub.srt'], ['fr', None]]"
+        result = _parse_subtitles_column(raw)
+        assert len(result) == 1
+
+    def test_invalid_syntax(self):
+        from bazarr.subtitles.mass_sync import _parse_subtitles_column
+        assert _parse_subtitles_column('not valid python') == []
+
+    def test_short_entries(self):
+        from bazarr.subtitles.mass_sync import _parse_subtitles_column
+        raw = "[['en']]"
+        result = _parse_subtitles_column(raw)
+        assert len(result) == 0
+
+
+class TestMassSyncSubtitles:
+    """Test mass_sync_subtitles entry point."""
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    def test_schedules_job_when_no_job_id_and_no_items(self, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        result = mass_sync_subtitles(items=None, options=None, job_id=None)
+        mock_jobs_queue.add_job_from_function.assert_called_once_with(
+            "Mass Syncing All Subtitles", is_progress=False
+        )
+        assert result is None
+
+    @patch('bazarr.subtitles.mass_sync._process_movies')
+    @patch('bazarr.subtitles.mass_sync._process_episodes')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_syncs_entire_library_when_no_items(self, mock_settings, mock_proc_ep, mock_proc_mov):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        mock_settings.general.use_sonarr = True
+        mock_settings.general.use_radarr = True
+        mock_proc_ep.return_value = (5, 2, [])
+        mock_proc_mov.return_value = (3, 1, [])
+
+        result = mass_sync_subtitles(items=None, options={}, job_id='test')
+        assert result == {'queued': 8, 'skipped': 3, 'errors': []}
+        mock_proc_ep.assert_called_once()
+        mock_proc_mov.assert_called_once()
+
+    @patch('bazarr.subtitles.mass_sync._process_movies')
+    @patch('bazarr.subtitles.mass_sync._process_episodes')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_skips_sonarr_when_disabled(self, mock_settings, mock_proc_ep, mock_proc_mov):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        mock_settings.general.use_sonarr = False
+        mock_settings.general.use_radarr = True
+        mock_proc_mov.return_value = (1, 0, [])
+
+        result = mass_sync_subtitles(items=None, options={}, job_id='test')
+        mock_proc_ep.assert_not_called()
+        mock_proc_mov.assert_called_once()
+        assert result['queued'] == 1
+
+    @patch('bazarr.subtitles.mass_sync._process_movies')
+    @patch('bazarr.subtitles.mass_sync._process_episodes')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_skips_radarr_when_disabled(self, mock_settings, mock_proc_ep, mock_proc_mov):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        mock_settings.general.use_sonarr = True
+        mock_settings.general.use_radarr = False
+        mock_proc_ep.return_value = (2, 0, [])
+
+        result = mass_sync_subtitles(items=None, options={}, job_id='test')
+        mock_proc_mov.assert_not_called()
+        mock_proc_ep.assert_called_once()
+        assert result['queued'] == 2
+
+    @patch('bazarr.subtitles.mass_sync._process_movies')
+    @patch('bazarr.subtitles.mass_sync._process_episodes')
+    def test_routes_items_by_type(self, mock_proc_ep, mock_proc_mov):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        mock_proc_ep.return_value = (2, 0, [])
+        mock_proc_mov.return_value = (1, 0, [])
+
+        items = [
+            {'type': 'series', 'sonarrSeriesId': 1},
+            {'type': 'movie', 'radarrId': 10},
+            {'type': 'episode', 'sonarrEpisodeId': 100},
+        ]
+        result = mass_sync_subtitles(items=items, options={}, job_id='test')
+
+        mock_proc_ep.assert_called_once()
+        call_kwargs = mock_proc_ep.call_args
+        assert call_kwargs[1]['series_ids'] == [1]
+        assert call_kwargs[1]['episode_ids'] == [100]
+
+        mock_proc_mov.assert_called_once()
+        call_kwargs = mock_proc_mov.call_args
+        assert call_kwargs[1]['movie_ids'] == [10]
+
+        assert result['queued'] == 3
+
+    @patch('bazarr.subtitles.mass_sync._process_movies')
+    @patch('bazarr.subtitles.mass_sync._process_episodes')
+    def test_passes_force_resync_option(self, mock_proc_ep, mock_proc_mov):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        mock_proc_ep.return_value = (0, 0, [])
+
+        items = [{'type': 'series', 'sonarrSeriesId': 1}]
+        mass_sync_subtitles(items=items, options={'force_resync': True}, job_id='test')
+
+        call_kwargs = mock_proc_ep.call_args
+        assert call_kwargs[1]['force_resync'] is True
+
+    @patch('bazarr.subtitles.mass_sync._process_movies')
+    @patch('bazarr.subtitles.mass_sync._process_episodes')
+    def test_aggregates_errors(self, mock_proc_ep, mock_proc_mov):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        mock_proc_ep.return_value = (1, 0, ['error1'])
+        mock_proc_mov.return_value = (1, 0, ['error2'])
+
+        items = [
+            {'type': 'series', 'sonarrSeriesId': 1},
+            {'type': 'movie', 'radarrId': 1},
+        ]
+        result = mass_sync_subtitles(items=items, options={}, job_id='test')
+        assert result['errors'] == ['error1', 'error2']
+
+    @patch('bazarr.subtitles.mass_sync._process_movies')
+    @patch('bazarr.subtitles.mass_sync._process_episodes')
+    def test_only_episodes_no_movies_called_for_series_items(self, mock_proc_ep, mock_proc_mov):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        mock_proc_ep.return_value = (1, 0, [])
+
+        items = [{'type': 'series', 'sonarrSeriesId': 5}]
+        result = mass_sync_subtitles(items=items, options={}, job_id='test')
+
+        mock_proc_ep.assert_called_once()
+        mock_proc_mov.assert_not_called()
+        assert result['queued'] == 1
+
+    @patch('bazarr.subtitles.mass_sync._process_movies')
+    @patch('bazarr.subtitles.mass_sync._process_episodes')
+    def test_unknown_item_type_is_ignored(self, mock_proc_ep, mock_proc_mov):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+
+        items = [{'type': 'unknown', 'id': 99}]
+        result = mass_sync_subtitles(items=items, options={}, job_id='test')
+
+        mock_proc_ep.assert_not_called()
+        mock_proc_mov.assert_not_called()
+        assert result == {'queued': 0, 'skipped': 0, 'errors': []}
+
+
+class TestProcessEpisodes:
+    """Test _process_episodes function."""
+
+    def _make_episode(self, ep_id=1, series_id=10, path='/video/ep1.mkv',
+                      subtitles="[['en', '/subs/ep1.en.srt']]"):
+        ep = MagicMock()
+        ep.sonarrEpisodeId = ep_id
+        ep.sonarrSeriesId = series_id
+        ep.path = path
+        ep.subtitles = subtitles
+        return ep
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
+    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.path_mappings')
+    @patch('bazarr.subtitles.mass_sync._get_synced_episode_paths', return_value=set())
+    @patch('bazarr.subtitles.mass_sync.database')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_queues_sync_for_valid_subtitle(self, mock_settings, mock_db, mock_synced,
+                                             mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import _process_episodes
+
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_path_map.path_replace.side_effect = lambda x: x
+        mock_path_map.path_replace_reverse.side_effect = lambda x: x
+        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
+
+        episode = self._make_episode()
+        mock_db.execute.return_value.all.return_value = [episode]
+
+        queued, skipped, errors = _process_episodes(episode_ids=[1])
+
+        assert queued == 1
+        assert skipped == 0
+        assert errors == []
+        mock_jobs_queue.feed_jobs_pending_queue.assert_called_once()
+        kwargs = mock_jobs_queue.feed_jobs_pending_queue.call_args[1]['kwargs']
+        assert kwargs['srt_path'] == '/subs/ep1.en.srt'
+        assert kwargs['force_sync'] is True
+        assert kwargs['percent_score'] == 0
+        assert kwargs['sonarr_episode_id'] == 1
+        assert kwargs['sonarr_series_id'] == 10
+        assert kwargs['radarr_id'] is None
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
+    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.path_mappings')
+    @patch('bazarr.subtitles.mass_sync._get_synced_episode_paths', return_value=set())
+    @patch('bazarr.subtitles.mass_sync.database')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_skips_forced_subtitles(self, mock_settings, mock_db, mock_synced,
+                                     mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import _process_episodes
+
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_path_map.path_replace.side_effect = lambda x: x
+        mock_lang.return_value = {'language': 'en', 'forced': True, 'hi': False}
+
+        episode = self._make_episode(subtitles="[['en:forced', '/subs/ep1.en.forced.srt']]")
+        mock_db.execute.return_value.all.return_value = [episode]
+
+        queued, skipped, errors = _process_episodes(episode_ids=[1])
+
+        assert queued == 0
+        assert skipped == 1
+        mock_jobs_queue.feed_jobs_pending_queue.assert_not_called()
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
+    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=False)
+    @patch('bazarr.subtitles.mass_sync.path_mappings')
+    @patch('bazarr.subtitles.mass_sync._get_synced_episode_paths', return_value=set())
+    @patch('bazarr.subtitles.mass_sync.database')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_skips_missing_files(self, mock_settings, mock_db, mock_synced,
+                                  mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import _process_episodes
+
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_path_map.path_replace.side_effect = lambda x: x
+        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
+
+        episode = self._make_episode()
+        mock_db.execute.return_value.all.return_value = [episode]
+
+        queued, skipped, errors = _process_episodes(episode_ids=[1])
+
+        assert queued == 0
+        assert skipped == 1
+        mock_jobs_queue.feed_jobs_pending_queue.assert_not_called()
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
+    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.path_mappings')
+    @patch('bazarr.subtitles.mass_sync._get_synced_episode_paths')
+    @patch('bazarr.subtitles.mass_sync.database')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_skips_already_synced(self, mock_settings, mock_db, mock_synced,
+                                   mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import _process_episodes
+
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_path_map.path_replace.side_effect = lambda x: x
+        mock_path_map.path_replace_reverse.side_effect = lambda x: x
+        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
+        mock_synced.return_value = {'/subs/ep1.en.srt'}
+
+        episode = self._make_episode()
+        mock_db.execute.return_value.all.return_value = [episode]
+
+        queued, skipped, errors = _process_episodes(episode_ids=[1])
+
+        assert queued == 0
+        assert skipped == 1
+        mock_jobs_queue.feed_jobs_pending_queue.assert_not_called()
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
+    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.path_mappings')
+    @patch('bazarr.subtitles.mass_sync._get_synced_episode_paths')
+    @patch('bazarr.subtitles.mass_sync.database')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_force_resync_ignores_history(self, mock_settings, mock_db, mock_synced,
+                                           mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import _process_episodes
+
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_path_map.path_replace.side_effect = lambda x: x
+        mock_path_map.path_replace_reverse.side_effect = lambda x: x
+        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
+
+        episode = self._make_episode()
+        mock_db.execute.return_value.all.return_value = [episode]
+
+        queued, skipped, errors = _process_episodes(episode_ids=[1], force_resync=True)
+
+        assert queued == 1
+        mock_synced.assert_not_called()
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
+    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.path_mappings')
+    @patch('bazarr.subtitles.mass_sync._get_synced_episode_paths', return_value=set())
+    @patch('bazarr.subtitles.mass_sync.database')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_options_override_settings(self, mock_settings, mock_db, mock_synced,
+                                        mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import _process_episodes
+
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = False
+        mock_path_map.path_replace.side_effect = lambda x: x
+        mock_path_map.path_replace_reverse.side_effect = lambda x: x
+        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
+
+        episode = self._make_episode()
+        mock_db.execute.return_value.all.return_value = [episode]
+
+        options = {'max_offset_seconds': 120, 'gss': False, 'no_fix_framerate': True}
+        _process_episodes(episode_ids=[1], options=options)
+
+        kwargs = mock_jobs_queue.feed_jobs_pending_queue.call_args[1]['kwargs']
+        assert kwargs['max_offset_seconds'] == '120'
+        assert kwargs['gss'] is False
+        assert kwargs['no_fix_framerate'] is True
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
+    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.path_mappings')
+    @patch('bazarr.subtitles.mass_sync._get_synced_episode_paths', return_value=set())
+    @patch('bazarr.subtitles.mass_sync.database')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_queue_exception_adds_to_errors(self, mock_settings, mock_db, mock_synced,
+                                             mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import _process_episodes
+
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_path_map.path_replace.side_effect = lambda x: x
+        mock_path_map.path_replace_reverse.side_effect = lambda x: x
+        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
+        mock_jobs_queue.feed_jobs_pending_queue.side_effect = RuntimeError("queue full")
+
+        episode = self._make_episode()
+        mock_db.execute.return_value.all.return_value = [episode]
+
+        queued, skipped, errors = _process_episodes(episode_ids=[1])
+
+        assert queued == 0
+        assert skipped == 1
+        assert len(errors) == 1
+        assert 'queue full' in errors[0]
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
+    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.path_mappings')
+    @patch('bazarr.subtitles.mass_sync._get_synced_episode_paths', return_value=set())
+    @patch('bazarr.subtitles.mass_sync.database')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_multiple_subtitles_per_episode(self, mock_settings, mock_db, mock_synced,
+                                             mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import _process_episodes
+
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_path_map.path_replace.side_effect = lambda x: x
+        mock_path_map.path_replace_reverse.side_effect = lambda x: x
+        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
+
+        episode = self._make_episode(
+            subtitles="[['en', '/subs/ep1.en.srt'], ['fr', '/subs/ep1.fr.srt']]"
+        )
+        mock_db.execute.return_value.all.return_value = [episode]
+
+        queued, skipped, errors = _process_episodes(episode_ids=[1])
+
+        assert queued == 2
+        assert mock_jobs_queue.feed_jobs_pending_queue.call_count == 2
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
+    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.path_mappings')
+    @patch('bazarr.subtitles.mass_sync._get_synced_episode_paths', return_value=set())
+    @patch('bazarr.subtitles.mass_sync.database')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_no_subtitles_returns_zero_counts(self, mock_settings, mock_db, mock_synced,
+                                               mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import _process_episodes
+
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_path_map.path_replace.side_effect = lambda x: x
+
+        episode = self._make_episode(subtitles="[]")
+        mock_db.execute.return_value.all.return_value = [episode]
+
+        queued, skipped, errors = _process_episodes(episode_ids=[1])
+
+        assert queued == 0
+        assert skipped == 0
+        assert errors == []
+        mock_jobs_queue.feed_jobs_pending_queue.assert_not_called()
+
+
+class TestProcessMovies:
+    """Test _process_movies function."""
+
+    def _make_movie(self, radarr_id=10, path='/video/movie.mkv',
+                    subtitles="[['en', '/subs/movie.en.srt']]"):
+        movie = MagicMock()
+        movie.radarrId = radarr_id
+        movie.path = path
+        movie.subtitles = subtitles
+        return movie
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
+    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.path_mappings')
+    @patch('bazarr.subtitles.mass_sync._get_synced_movie_paths', return_value=set())
+    @patch('bazarr.subtitles.mass_sync.database')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_queues_sync_for_valid_subtitle(self, mock_settings, mock_db, mock_synced,
+                                             mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import _process_movies
+
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_path_map.path_replace_movie.side_effect = lambda x: x
+        mock_path_map.path_replace_reverse_movie.side_effect = lambda x: x
+        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
+
+        movie = self._make_movie()
+        mock_db.execute.return_value.all.return_value = [movie]
+
+        queued, skipped, errors = _process_movies(movie_ids=[10])
+
+        assert queued == 1
+        assert skipped == 0
+        assert errors == []
+        mock_jobs_queue.feed_jobs_pending_queue.assert_called_once()
+        kwargs = mock_jobs_queue.feed_jobs_pending_queue.call_args[1]['kwargs']
+        assert kwargs['srt_path'] == '/subs/movie.en.srt'
+        assert kwargs['radarr_id'] == 10
+        assert kwargs['sonarr_series_id'] is None
+        assert kwargs['sonarr_episode_id'] is None
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
+    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.path_mappings')
+    @patch('bazarr.subtitles.mass_sync._get_synced_movie_paths', return_value=set())
+    @patch('bazarr.subtitles.mass_sync.database')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_skips_forced_subtitles(self, mock_settings, mock_db, mock_synced,
+                                     mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import _process_movies
+
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_path_map.path_replace_movie.side_effect = lambda x: x
+        mock_lang.return_value = {'language': 'en', 'forced': True, 'hi': False}
+
+        movie = self._make_movie(subtitles="[['en:forced', '/subs/movie.en.forced.srt']]")
+        mock_db.execute.return_value.all.return_value = [movie]
+
+        queued, skipped, errors = _process_movies(movie_ids=[10])
+
+        assert queued == 0
+        assert skipped == 1
+        mock_jobs_queue.feed_jobs_pending_queue.assert_not_called()
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
+    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=False)
+    @patch('bazarr.subtitles.mass_sync.path_mappings')
+    @patch('bazarr.subtitles.mass_sync._get_synced_movie_paths', return_value=set())
+    @patch('bazarr.subtitles.mass_sync.database')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_skips_missing_files(self, mock_settings, mock_db, mock_synced,
+                                  mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import _process_movies
+
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_path_map.path_replace_movie.side_effect = lambda x: x
+        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
+
+        movie = self._make_movie()
+        mock_db.execute.return_value.all.return_value = [movie]
+
+        queued, skipped, errors = _process_movies(movie_ids=[10])
+
+        assert queued == 0
+        assert skipped == 1
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
+    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.path_mappings')
+    @patch('bazarr.subtitles.mass_sync._get_synced_movie_paths')
+    @patch('bazarr.subtitles.mass_sync.database')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_skips_already_synced(self, mock_settings, mock_db, mock_synced,
+                                   mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import _process_movies
+
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_path_map.path_replace_movie.side_effect = lambda x: x
+        mock_path_map.path_replace_reverse_movie.side_effect = lambda x: x
+        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
+        mock_synced.return_value = {'/subs/movie.en.srt'}
+
+        movie = self._make_movie()
+        mock_db.execute.return_value.all.return_value = [movie]
+
+        queued, skipped, errors = _process_movies(movie_ids=[10])
+
+        assert queued == 0
+        assert skipped == 1
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
+    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.path_mappings')
+    @patch('bazarr.subtitles.mass_sync._get_synced_movie_paths')
+    @patch('bazarr.subtitles.mass_sync.database')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_force_resync_ignores_history(self, mock_settings, mock_db, mock_synced,
+                                           mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import _process_movies
+
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_path_map.path_replace_movie.side_effect = lambda x: x
+        mock_path_map.path_replace_reverse_movie.side_effect = lambda x: x
+        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
+
+        movie = self._make_movie()
+        mock_db.execute.return_value.all.return_value = [movie]
+
+        queued, skipped, errors = _process_movies(movie_ids=[10], force_resync=True)
+
+        assert queued == 1
+        mock_synced.assert_not_called()


### PR DESCRIPTION
## Summary

- Add bulk subtitle synchronization, a feature upstream rejected (249 votes, "won't happen")
- Two entry points: "Mass Sync All Subtitles" task on System Tasks page, and "Sync Subtitles" button in Movies/Series Mass Edit pages
- Uses existing ffsubsync engine, skips already-synced subtitles by default with force re-sync option
- New `POST /subtitles/sync/batch` API endpoint accepting movie/series/episode IDs
- Configurable max offset, Golden-Section Search, and framerate correction

## Test plan

- [ ] 29 backend tests pass (`pytest tests/bazarr/test_mass_sync.py`)
- [ ] Frontend builds with zero TypeScript errors
- [ ] "Mass Sync All Subtitles" appears on System Tasks page with Run button
- [ ] Movies Mass Edit shows "Sync Subtitles" button when rows selected
- [ ] Series Mass Edit shows "Sync Subtitles" button when rows selected
- [ ] Modal opens with sync options (max offset, GSS, framerate, force re-sync)
- [ ] Batch sync API returns queued/skipped/errors counts