### PR TITLE
fix: process mass sync sequentially in single job

### DIFF
--- a/bazarr/subtitles/mass_sync.py
+++ b/bazarr/subtitles/mass_sync.py
@@ -5,8 +5,9 @@ import logging
 import os
 
 from app.config import settings
-from app.database import TableEpisodes, TableMovies, TableHistory, TableHistoryMovie, TableShows, database, select
+from app.database import TableEpisodes, TableMovies, TableHistory, TableHistoryMovie, database, select
 from app.jobs_queue import jobs_queue
+from subtitles.sync import sync_subtitles
 from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import languages_from_colon_seperated_string
 
@@ -42,8 +43,8 @@ def _parse_subtitles_column(subtitles_raw):
         return []
 
 
-def _process_episodes(series_ids=None, episode_ids=None, options=None, force_resync=False):
-    """Queue sync jobs for episode subtitles."""
+def _collect_episode_items(series_ids=None, episode_ids=None, options=None, force_resync=False):
+    """Collect episode subtitles to sync (without processing them)."""
     options = options or {}
     max_offset = str(options.get('max_offset_seconds', settings.subsync.max_offset_seconds))
     gss = options.get('gss', settings.subsync.gss)
@@ -68,9 +69,8 @@ def _process_episodes(series_ids=None, episode_ids=None, options=None, force_res
     episodes = database.execute(query).all()
 
     synced_paths = set() if force_resync else _get_synced_episode_paths()
-    queued = 0
+    items = []
     skipped = 0
-    errors = []
 
     for ep in episodes:
         subtitles = _parse_subtitles_column(ep.subtitles)
@@ -93,38 +93,25 @@ def _process_episodes(series_ids=None, episode_ids=None, options=None, force_res
                 skipped += 1
                 continue
 
-            try:
-                jobs_queue.feed_jobs_pending_queue(
-                    job_name=f"Mass Syncing {os.path.basename(mapped_sub_path)}",
-                    module='subtitles.sync',
-                    func='sync_subtitles',
-                    kwargs={
-                        'video_path': video_path,
-                        'srt_path': mapped_sub_path,
-                        'srt_lang': lang_string.split(':')[0],
-                        'forced': lang_info['forced'],
-                        'hi': lang_info['hi'],
-                        'percent_score': 0,
-                        'sonarr_series_id': ep.sonarrSeriesId,
-                        'sonarr_episode_id': ep.sonarrEpisodeId,
-                        'radarr_id': None,
-                        'max_offset_seconds': max_offset,
-                        'no_fix_framerate': no_fix_framerate,
-                        'gss': gss,
-                        'force_sync': True,
-                    }
-                )
-                queued += 1
-            except Exception as e:
-                logger.error(f'Error queuing sync for {sub_path}: {e}')
-                errors.append(str(e))
-                skipped += 1
+            items.append({
+                'video_path': video_path,
+                'srt_path': mapped_sub_path,
+                'srt_lang': lang_string.split(':')[0],
+                'forced': lang_info['forced'],
+                'hi': lang_info['hi'],
+                'sonarr_series_id': ep.sonarrSeriesId,
+                'sonarr_episode_id': ep.sonarrEpisodeId,
+                'radarr_id': None,
+                'max_offset_seconds': max_offset,
+                'no_fix_framerate': no_fix_framerate,
+                'gss': gss,
+            })
 
-    return queued, skipped, errors
+    return items, skipped
 
 
-def _process_movies(movie_ids=None, options=None, force_resync=False):
-    """Queue sync jobs for movie subtitles."""
+def _collect_movie_items(movie_ids=None, options=None, force_resync=False):
+    """Collect movie subtitles to sync (without processing them)."""
     options = options or {}
     max_offset = str(options.get('max_offset_seconds', settings.subsync.max_offset_seconds))
     gss = options.get('gss', settings.subsync.gss)
@@ -142,9 +129,8 @@ def _process_movies(movie_ids=None, options=None, force_resync=False):
     movies = database.execute(query).all()
 
     synced_paths = set() if force_resync else _get_synced_movie_paths()
-    queued = 0
+    items = []
     skipped = 0
-    errors = []
 
     for movie in movies:
         subtitles = _parse_subtitles_column(movie.subtitles)
@@ -167,38 +153,29 @@ def _process_movies(movie_ids=None, options=None, force_resync=False):
                 skipped += 1
                 continue
 
-            try:
-                jobs_queue.feed_jobs_pending_queue(
-                    job_name=f"Mass Syncing {os.path.basename(mapped_sub_path)}",
-                    module='subtitles.sync',
-                    func='sync_subtitles',
-                    kwargs={
-                        'video_path': video_path,
-                        'srt_path': mapped_sub_path,
-                        'srt_lang': lang_string.split(':')[0],
-                        'forced': lang_info['forced'],
-                        'hi': lang_info['hi'],
-                        'percent_score': 0,
-                        'sonarr_series_id': None,
-                        'sonarr_episode_id': None,
-                        'radarr_id': movie.radarrId,
-                        'max_offset_seconds': max_offset,
-                        'no_fix_framerate': no_fix_framerate,
-                        'gss': gss,
-                        'force_sync': True,
-                    }
-                )
-                queued += 1
-            except Exception as e:
-                logger.error(f'Error queuing sync for {sub_path}: {e}')
-                errors.append(str(e))
-                skipped += 1
+            items.append({
+                'video_path': video_path,
+                'srt_path': mapped_sub_path,
+                'srt_lang': lang_string.split(':')[0],
+                'forced': lang_info['forced'],
+                'hi': lang_info['hi'],
+                'sonarr_series_id': None,
+                'sonarr_episode_id': None,
+                'radarr_id': movie.radarrId,
+                'max_offset_seconds': max_offset,
+                'no_fix_framerate': no_fix_framerate,
+                'gss': gss,
+            })
 
-    return queued, skipped, errors
+    return items, skipped
 
 
 def mass_sync_subtitles(items=None, options=None, job_id=None):
     """Main entry point for mass subtitle sync.
+
+    Runs as a single job with progress tracking, processing subtitles
+    sequentially. This avoids creating thousands of individual jobs
+    that would overwhelm the frontend polling system.
 
     Args:
         items: List of dicts with 'type' and IDs. If None, syncs entire library.
@@ -206,32 +183,28 @@ def mass_sync_subtitles(items=None, options=None, job_id=None):
         job_id: Job ID for scheduled task tracking.
     """
     if not job_id and items is None:
-        jobs_queue.add_job_from_function("Mass Syncing All Subtitles", is_progress=False)
+        jobs_queue.add_job_from_function("Mass Syncing All Subtitles", is_progress=True)
         return
 
     options = options or {}
     force_resync = options.get('force_resync', False)
 
-    total_queued = 0
+    # Phase 1: Collect all subtitle items to sync
+    all_items = []
     total_skipped = 0
-    all_errors = []
 
     if items is None:
-        # Sync entire library
         logger.info('BAZARR starting mass sync for all subtitles')
         if settings.general.use_sonarr:
-            q, s, e = _process_episodes(options=options, force_resync=force_resync)
-            total_queued += q
-            total_skipped += s
-            all_errors.extend(e)
+            ep_items, ep_skipped = _collect_episode_items(options=options, force_resync=force_resync)
+            all_items.extend(ep_items)
+            total_skipped += ep_skipped
 
         if settings.general.use_radarr:
-            q, s, e = _process_movies(options=options, force_resync=force_resync)
-            total_queued += q
-            total_skipped += s
-            all_errors.extend(e)
+            mov_items, mov_skipped = _collect_movie_items(options=options, force_resync=force_resync)
+            all_items.extend(mov_items)
+            total_skipped += mov_skipped
     else:
-        # Sync specific items
         series_ids = []
         episode_ids = []
         movie_ids = []
@@ -246,25 +219,68 @@ def mass_sync_subtitles(items=None, options=None, job_id=None):
                 movie_ids.append(item.get('radarrId'))
 
         if series_ids or episode_ids:
-            q, s, e = _process_episodes(
+            ep_items, ep_skipped = _collect_episode_items(
                 series_ids=series_ids or None,
                 episode_ids=episode_ids or None,
                 options=options,
                 force_resync=force_resync,
             )
-            total_queued += q
-            total_skipped += s
-            all_errors.extend(e)
+            all_items.extend(ep_items)
+            total_skipped += ep_skipped
 
         if movie_ids:
-            q, s, e = _process_movies(
+            mov_items, mov_skipped = _collect_movie_items(
                 movie_ids=movie_ids,
                 options=options,
                 force_resync=force_resync,
             )
-            total_queued += q
-            total_skipped += s
-            all_errors.extend(e)
+            all_items.extend(mov_items)
+            total_skipped += mov_skipped
 
-    logger.info(f'BAZARR mass sync complete: {total_queued} queued, {total_skipped} skipped, {len(all_errors)} errors')
-    return {'queued': total_queued, 'skipped': total_skipped, 'errors': all_errors}
+    # Phase 2: Process items sequentially within this single job
+    total_count = len(all_items)
+    jobs_queue.update_job_progress(job_id=job_id, progress_max=total_count)
+
+    if total_count == 0:
+        jobs_queue.update_job_progress(job_id=job_id, progress_value='max')
+
+    synced = 0
+    failed = 0
+    all_errors = []
+
+    for i, item in enumerate(all_items, start=1):
+        jobs_queue.update_job_progress(
+            job_id=job_id,
+            progress_value=i,
+            progress_message=f"Syncing {os.path.basename(item['srt_path'])} ({i}/{total_count})"
+        )
+
+        try:
+            result = sync_subtitles(
+                video_path=item['video_path'],
+                srt_path=item['srt_path'],
+                srt_lang=item['srt_lang'],
+                forced=item['forced'],
+                hi=item['hi'],
+                percent_score=0,
+                sonarr_series_id=item['sonarr_series_id'],
+                sonarr_episode_id=item['sonarr_episode_id'],
+                radarr_id=item['radarr_id'],
+                max_offset_seconds=item['max_offset_seconds'],
+                no_fix_framerate=item['no_fix_framerate'],
+                gss=item['gss'],
+                force_sync=True,
+                job_id=job_id,
+            )
+            if result:
+                synced += 1
+            else:
+                failed += 1
+        except Exception as e:
+            logger.error(f'Error syncing {item["srt_path"]}: {e}')
+            all_errors.append(str(e))
+            failed += 1
+
+    jobs_queue.update_job_name(job_id=job_id, new_job_name=f"Mass sync complete: {synced} synced, {total_skipped} skipped")
+    logger.info(f'BAZARR mass sync complete: {synced} synced, {failed} failed, {total_skipped} skipped, {len(all_errors)} errors')
+    return {'queued': synced, 'skipped': total_skipped + failed, 'errors': all_errors}

--- a/tests/bazarr/test_mass_sync.py
+++ b/tests/bazarr/test_mass_sync.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 
-import pytest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 
 
 class TestParseSubtitlesColumn:
@@ -44,140 +43,8 @@ class TestParseSubtitlesColumn:
         assert len(result) == 0
 
 
-class TestMassSyncSubtitles:
-    """Test mass_sync_subtitles entry point."""
-
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
-    def test_schedules_job_when_no_job_id_and_no_items(self, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import mass_sync_subtitles
-        result = mass_sync_subtitles(items=None, options=None, job_id=None)
-        mock_jobs_queue.add_job_from_function.assert_called_once_with(
-            "Mass Syncing All Subtitles", is_progress=False
-        )
-        assert result is None
-
-    @patch('bazarr.subtitles.mass_sync._process_movies')
-    @patch('bazarr.subtitles.mass_sync._process_episodes')
-    @patch('bazarr.subtitles.mass_sync.settings')
-    def test_syncs_entire_library_when_no_items(self, mock_settings, mock_proc_ep, mock_proc_mov):
-        from bazarr.subtitles.mass_sync import mass_sync_subtitles
-        mock_settings.general.use_sonarr = True
-        mock_settings.general.use_radarr = True
-        mock_proc_ep.return_value = (5, 2, [])
-        mock_proc_mov.return_value = (3, 1, [])
-
-        result = mass_sync_subtitles(items=None, options={}, job_id='test')
-        assert result == {'queued': 8, 'skipped': 3, 'errors': []}
-        mock_proc_ep.assert_called_once()
-        mock_proc_mov.assert_called_once()
-
-    @patch('bazarr.subtitles.mass_sync._process_movies')
-    @patch('bazarr.subtitles.mass_sync._process_episodes')
-    @patch('bazarr.subtitles.mass_sync.settings')
-    def test_skips_sonarr_when_disabled(self, mock_settings, mock_proc_ep, mock_proc_mov):
-        from bazarr.subtitles.mass_sync import mass_sync_subtitles
-        mock_settings.general.use_sonarr = False
-        mock_settings.general.use_radarr = True
-        mock_proc_mov.return_value = (1, 0, [])
-
-        result = mass_sync_subtitles(items=None, options={}, job_id='test')
-        mock_proc_ep.assert_not_called()
-        mock_proc_mov.assert_called_once()
-        assert result['queued'] == 1
-
-    @patch('bazarr.subtitles.mass_sync._process_movies')
-    @patch('bazarr.subtitles.mass_sync._process_episodes')
-    @patch('bazarr.subtitles.mass_sync.settings')
-    def test_skips_radarr_when_disabled(self, mock_settings, mock_proc_ep, mock_proc_mov):
-        from bazarr.subtitles.mass_sync import mass_sync_subtitles
-        mock_settings.general.use_sonarr = True
-        mock_settings.general.use_radarr = False
-        mock_proc_ep.return_value = (2, 0, [])
-
-        result = mass_sync_subtitles(items=None, options={}, job_id='test')
-        mock_proc_mov.assert_not_called()
-        mock_proc_ep.assert_called_once()
-        assert result['queued'] == 2
-
-    @patch('bazarr.subtitles.mass_sync._process_movies')
-    @patch('bazarr.subtitles.mass_sync._process_episodes')
-    def test_routes_items_by_type(self, mock_proc_ep, mock_proc_mov):
-        from bazarr.subtitles.mass_sync import mass_sync_subtitles
-        mock_proc_ep.return_value = (2, 0, [])
-        mock_proc_mov.return_value = (1, 0, [])
-
-        items = [
-            {'type': 'series', 'sonarrSeriesId': 1},
-            {'type': 'movie', 'radarrId': 10},
-            {'type': 'episode', 'sonarrEpisodeId': 100},
-        ]
-        result = mass_sync_subtitles(items=items, options={}, job_id='test')
-
-        mock_proc_ep.assert_called_once()
-        call_kwargs = mock_proc_ep.call_args
-        assert call_kwargs[1]['series_ids'] == [1]
-        assert call_kwargs[1]['episode_ids'] == [100]
-
-        mock_proc_mov.assert_called_once()
-        call_kwargs = mock_proc_mov.call_args
-        assert call_kwargs[1]['movie_ids'] == [10]
-
-        assert result['queued'] == 3
-
-    @patch('bazarr.subtitles.mass_sync._process_movies')
-    @patch('bazarr.subtitles.mass_sync._process_episodes')
-    def test_passes_force_resync_option(self, mock_proc_ep, mock_proc_mov):
-        from bazarr.subtitles.mass_sync import mass_sync_subtitles
-        mock_proc_ep.return_value = (0, 0, [])
-
-        items = [{'type': 'series', 'sonarrSeriesId': 1}]
-        mass_sync_subtitles(items=items, options={'force_resync': True}, job_id='test')
-
-        call_kwargs = mock_proc_ep.call_args
-        assert call_kwargs[1]['force_resync'] is True
-
-    @patch('bazarr.subtitles.mass_sync._process_movies')
-    @patch('bazarr.subtitles.mass_sync._process_episodes')
-    def test_aggregates_errors(self, mock_proc_ep, mock_proc_mov):
-        from bazarr.subtitles.mass_sync import mass_sync_subtitles
-        mock_proc_ep.return_value = (1, 0, ['error1'])
-        mock_proc_mov.return_value = (1, 0, ['error2'])
-
-        items = [
-            {'type': 'series', 'sonarrSeriesId': 1},
-            {'type': 'movie', 'radarrId': 1},
-        ]
-        result = mass_sync_subtitles(items=items, options={}, job_id='test')
-        assert result['errors'] == ['error1', 'error2']
-
-    @patch('bazarr.subtitles.mass_sync._process_movies')
-    @patch('bazarr.subtitles.mass_sync._process_episodes')
-    def test_only_episodes_no_movies_called_for_series_items(self, mock_proc_ep, mock_proc_mov):
-        from bazarr.subtitles.mass_sync import mass_sync_subtitles
-        mock_proc_ep.return_value = (1, 0, [])
-
-        items = [{'type': 'series', 'sonarrSeriesId': 5}]
-        result = mass_sync_subtitles(items=items, options={}, job_id='test')
-
-        mock_proc_ep.assert_called_once()
-        mock_proc_mov.assert_not_called()
-        assert result['queued'] == 1
-
-    @patch('bazarr.subtitles.mass_sync._process_movies')
-    @patch('bazarr.subtitles.mass_sync._process_episodes')
-    def test_unknown_item_type_is_ignored(self, mock_proc_ep, mock_proc_mov):
-        from bazarr.subtitles.mass_sync import mass_sync_subtitles
-
-        items = [{'type': 'unknown', 'id': 99}]
-        result = mass_sync_subtitles(items=items, options={}, job_id='test')
-
-        mock_proc_ep.assert_not_called()
-        mock_proc_mov.assert_not_called()
-        assert result == {'queued': 0, 'skipped': 0, 'errors': []}
-
-
-class TestProcessEpisodes:
-    """Test _process_episodes function."""
+class TestCollectEpisodeItems:
+    """Test _collect_episode_items function."""
 
     def _make_episode(self, ep_id=1, series_id=10, path='/video/ep1.mkv',
                       subtitles="[['en', '/subs/ep1.en.srt']]"):
@@ -188,16 +55,15 @@ class TestProcessEpisodes:
         ep.subtitles = subtitles
         return ep
 
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
     @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
     @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
     @patch('bazarr.subtitles.mass_sync.path_mappings')
     @patch('bazarr.subtitles.mass_sync._get_synced_episode_paths', return_value=set())
     @patch('bazarr.subtitles.mass_sync.database')
     @patch('bazarr.subtitles.mass_sync.settings')
-    def test_queues_sync_for_valid_subtitle(self, mock_settings, mock_db, mock_synced,
-                                             mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import _process_episodes
+    def test_collects_valid_subtitle(self, mock_settings, mock_db, mock_synced,
+                                      mock_path_map, mock_isfile, mock_lang):
+        from bazarr.subtitles.mass_sync import _collect_episode_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -209,21 +75,15 @@ class TestProcessEpisodes:
         episode = self._make_episode()
         mock_db.execute.return_value.all.return_value = [episode]
 
-        queued, skipped, errors = _process_episodes(episode_ids=[1])
+        items, skipped = _collect_episode_items(episode_ids=[1])
 
-        assert queued == 1
+        assert len(items) == 1
         assert skipped == 0
-        assert errors == []
-        mock_jobs_queue.feed_jobs_pending_queue.assert_called_once()
-        kwargs = mock_jobs_queue.feed_jobs_pending_queue.call_args[1]['kwargs']
-        assert kwargs['srt_path'] == '/subs/ep1.en.srt'
-        assert kwargs['force_sync'] is True
-        assert kwargs['percent_score'] == 0
-        assert kwargs['sonarr_episode_id'] == 1
-        assert kwargs['sonarr_series_id'] == 10
-        assert kwargs['radarr_id'] is None
+        assert items[0]['srt_path'] == '/subs/ep1.en.srt'
+        assert items[0]['sonarr_episode_id'] == 1
+        assert items[0]['sonarr_series_id'] == 10
+        assert items[0]['radarr_id'] is None
 
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
     @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
     @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
     @patch('bazarr.subtitles.mass_sync.path_mappings')
@@ -231,8 +91,8 @@ class TestProcessEpisodes:
     @patch('bazarr.subtitles.mass_sync.database')
     @patch('bazarr.subtitles.mass_sync.settings')
     def test_skips_forced_subtitles(self, mock_settings, mock_db, mock_synced,
-                                     mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import _process_episodes
+                                     mock_path_map, mock_isfile, mock_lang):
+        from bazarr.subtitles.mass_sync import _collect_episode_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -243,13 +103,11 @@ class TestProcessEpisodes:
         episode = self._make_episode(subtitles="[['en:forced', '/subs/ep1.en.forced.srt']]")
         mock_db.execute.return_value.all.return_value = [episode]
 
-        queued, skipped, errors = _process_episodes(episode_ids=[1])
+        items, skipped = _collect_episode_items(episode_ids=[1])
 
-        assert queued == 0
+        assert len(items) == 0
         assert skipped == 1
-        mock_jobs_queue.feed_jobs_pending_queue.assert_not_called()
 
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
     @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
     @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=False)
     @patch('bazarr.subtitles.mass_sync.path_mappings')
@@ -257,8 +115,8 @@ class TestProcessEpisodes:
     @patch('bazarr.subtitles.mass_sync.database')
     @patch('bazarr.subtitles.mass_sync.settings')
     def test_skips_missing_files(self, mock_settings, mock_db, mock_synced,
-                                  mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import _process_episodes
+                                  mock_path_map, mock_isfile, mock_lang):
+        from bazarr.subtitles.mass_sync import _collect_episode_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -269,13 +127,11 @@ class TestProcessEpisodes:
         episode = self._make_episode()
         mock_db.execute.return_value.all.return_value = [episode]
 
-        queued, skipped, errors = _process_episodes(episode_ids=[1])
+        items, skipped = _collect_episode_items(episode_ids=[1])
 
-        assert queued == 0
+        assert len(items) == 0
         assert skipped == 1
-        mock_jobs_queue.feed_jobs_pending_queue.assert_not_called()
 
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
     @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
     @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
     @patch('bazarr.subtitles.mass_sync.path_mappings')
@@ -283,8 +139,8 @@ class TestProcessEpisodes:
     @patch('bazarr.subtitles.mass_sync.database')
     @patch('bazarr.subtitles.mass_sync.settings')
     def test_skips_already_synced(self, mock_settings, mock_db, mock_synced,
-                                   mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import _process_episodes
+                                   mock_path_map, mock_isfile, mock_lang):
+        from bazarr.subtitles.mass_sync import _collect_episode_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -297,13 +153,11 @@ class TestProcessEpisodes:
         episode = self._make_episode()
         mock_db.execute.return_value.all.return_value = [episode]
 
-        queued, skipped, errors = _process_episodes(episode_ids=[1])
+        items, skipped = _collect_episode_items(episode_ids=[1])
 
-        assert queued == 0
+        assert len(items) == 0
         assert skipped == 1
-        mock_jobs_queue.feed_jobs_pending_queue.assert_not_called()
 
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
     @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
     @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
     @patch('bazarr.subtitles.mass_sync.path_mappings')
@@ -311,8 +165,8 @@ class TestProcessEpisodes:
     @patch('bazarr.subtitles.mass_sync.database')
     @patch('bazarr.subtitles.mass_sync.settings')
     def test_force_resync_ignores_history(self, mock_settings, mock_db, mock_synced,
-                                           mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import _process_episodes
+                                           mock_path_map, mock_isfile, mock_lang):
+        from bazarr.subtitles.mass_sync import _collect_episode_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -324,12 +178,11 @@ class TestProcessEpisodes:
         episode = self._make_episode()
         mock_db.execute.return_value.all.return_value = [episode]
 
-        queued, skipped, errors = _process_episodes(episode_ids=[1], force_resync=True)
+        items, skipped = _collect_episode_items(episode_ids=[1], force_resync=True)
 
-        assert queued == 1
+        assert len(items) == 1
         mock_synced.assert_not_called()
 
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
     @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
     @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
     @patch('bazarr.subtitles.mass_sync.path_mappings')
@@ -337,8 +190,8 @@ class TestProcessEpisodes:
     @patch('bazarr.subtitles.mass_sync.database')
     @patch('bazarr.subtitles.mass_sync.settings')
     def test_options_override_settings(self, mock_settings, mock_db, mock_synced,
-                                        mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import _process_episodes
+                                        mock_path_map, mock_isfile, mock_lang):
+        from bazarr.subtitles.mass_sync import _collect_episode_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -351,43 +204,12 @@ class TestProcessEpisodes:
         mock_db.execute.return_value.all.return_value = [episode]
 
         options = {'max_offset_seconds': 120, 'gss': False, 'no_fix_framerate': True}
-        _process_episodes(episode_ids=[1], options=options)
+        items, _ = _collect_episode_items(episode_ids=[1], options=options)
 
-        kwargs = mock_jobs_queue.feed_jobs_pending_queue.call_args[1]['kwargs']
-        assert kwargs['max_offset_seconds'] == '120'
-        assert kwargs['gss'] is False
-        assert kwargs['no_fix_framerate'] is True
+        assert items[0]['max_offset_seconds'] == '120'
+        assert items[0]['gss'] is False
+        assert items[0]['no_fix_framerate'] is True
 
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
-    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_sync.path_mappings')
-    @patch('bazarr.subtitles.mass_sync._get_synced_episode_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_sync.database')
-    @patch('bazarr.subtitles.mass_sync.settings')
-    def test_queue_exception_adds_to_errors(self, mock_settings, mock_db, mock_synced,
-                                             mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import _process_episodes
-
-        mock_settings.subsync.max_offset_seconds = 60
-        mock_settings.subsync.gss = True
-        mock_settings.subsync.no_fix_framerate = True
-        mock_path_map.path_replace.side_effect = lambda x: x
-        mock_path_map.path_replace_reverse.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
-        mock_jobs_queue.feed_jobs_pending_queue.side_effect = RuntimeError("queue full")
-
-        episode = self._make_episode()
-        mock_db.execute.return_value.all.return_value = [episode]
-
-        queued, skipped, errors = _process_episodes(episode_ids=[1])
-
-        assert queued == 0
-        assert skipped == 1
-        assert len(errors) == 1
-        assert 'queue full' in errors[0]
-
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
     @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
     @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
     @patch('bazarr.subtitles.mass_sync.path_mappings')
@@ -395,8 +217,8 @@ class TestProcessEpisodes:
     @patch('bazarr.subtitles.mass_sync.database')
     @patch('bazarr.subtitles.mass_sync.settings')
     def test_multiple_subtitles_per_episode(self, mock_settings, mock_db, mock_synced,
-                                             mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import _process_episodes
+                                             mock_path_map, mock_isfile, mock_lang):
+        from bazarr.subtitles.mass_sync import _collect_episode_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -410,21 +232,19 @@ class TestProcessEpisodes:
         )
         mock_db.execute.return_value.all.return_value = [episode]
 
-        queued, skipped, errors = _process_episodes(episode_ids=[1])
+        items, skipped = _collect_episode_items(episode_ids=[1])
 
-        assert queued == 2
-        assert mock_jobs_queue.feed_jobs_pending_queue.call_count == 2
+        assert len(items) == 2
 
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
     @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
     @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
     @patch('bazarr.subtitles.mass_sync.path_mappings')
     @patch('bazarr.subtitles.mass_sync._get_synced_episode_paths', return_value=set())
     @patch('bazarr.subtitles.mass_sync.database')
     @patch('bazarr.subtitles.mass_sync.settings')
-    def test_no_subtitles_returns_zero_counts(self, mock_settings, mock_db, mock_synced,
-                                               mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import _process_episodes
+    def test_no_subtitles_returns_empty(self, mock_settings, mock_db, mock_synced,
+                                         mock_path_map, mock_isfile, mock_lang):
+        from bazarr.subtitles.mass_sync import _collect_episode_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -434,16 +254,14 @@ class TestProcessEpisodes:
         episode = self._make_episode(subtitles="[]")
         mock_db.execute.return_value.all.return_value = [episode]
 
-        queued, skipped, errors = _process_episodes(episode_ids=[1])
+        items, skipped = _collect_episode_items(episode_ids=[1])
 
-        assert queued == 0
+        assert len(items) == 0
         assert skipped == 0
-        assert errors == []
-        mock_jobs_queue.feed_jobs_pending_queue.assert_not_called()
 
 
-class TestProcessMovies:
-    """Test _process_movies function."""
+class TestCollectMovieItems:
+    """Test _collect_movie_items function."""
 
     def _make_movie(self, radarr_id=10, path='/video/movie.mkv',
                     subtitles="[['en', '/subs/movie.en.srt']]"):
@@ -453,16 +271,15 @@ class TestProcessMovies:
         movie.subtitles = subtitles
         return movie
 
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
     @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
     @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
     @patch('bazarr.subtitles.mass_sync.path_mappings')
     @patch('bazarr.subtitles.mass_sync._get_synced_movie_paths', return_value=set())
     @patch('bazarr.subtitles.mass_sync.database')
     @patch('bazarr.subtitles.mass_sync.settings')
-    def test_queues_sync_for_valid_subtitle(self, mock_settings, mock_db, mock_synced,
-                                             mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import _process_movies
+    def test_collects_valid_subtitle(self, mock_settings, mock_db, mock_synced,
+                                      mock_path_map, mock_isfile, mock_lang):
+        from bazarr.subtitles.mass_sync import _collect_movie_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -474,97 +291,15 @@ class TestProcessMovies:
         movie = self._make_movie()
         mock_db.execute.return_value.all.return_value = [movie]
 
-        queued, skipped, errors = _process_movies(movie_ids=[10])
+        items, skipped = _collect_movie_items(movie_ids=[10])
 
-        assert queued == 1
+        assert len(items) == 1
         assert skipped == 0
-        assert errors == []
-        mock_jobs_queue.feed_jobs_pending_queue.assert_called_once()
-        kwargs = mock_jobs_queue.feed_jobs_pending_queue.call_args[1]['kwargs']
-        assert kwargs['srt_path'] == '/subs/movie.en.srt'
-        assert kwargs['radarr_id'] == 10
-        assert kwargs['sonarr_series_id'] is None
-        assert kwargs['sonarr_episode_id'] is None
+        assert items[0]['srt_path'] == '/subs/movie.en.srt'
+        assert items[0]['radarr_id'] == 10
+        assert items[0]['sonarr_series_id'] is None
+        assert items[0]['sonarr_episode_id'] is None
 
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
-    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_sync.path_mappings')
-    @patch('bazarr.subtitles.mass_sync._get_synced_movie_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_sync.database')
-    @patch('bazarr.subtitles.mass_sync.settings')
-    def test_skips_forced_subtitles(self, mock_settings, mock_db, mock_synced,
-                                     mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import _process_movies
-
-        mock_settings.subsync.max_offset_seconds = 60
-        mock_settings.subsync.gss = True
-        mock_settings.subsync.no_fix_framerate = True
-        mock_path_map.path_replace_movie.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': True, 'hi': False}
-
-        movie = self._make_movie(subtitles="[['en:forced', '/subs/movie.en.forced.srt']]")
-        mock_db.execute.return_value.all.return_value = [movie]
-
-        queued, skipped, errors = _process_movies(movie_ids=[10])
-
-        assert queued == 0
-        assert skipped == 1
-        mock_jobs_queue.feed_jobs_pending_queue.assert_not_called()
-
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
-    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=False)
-    @patch('bazarr.subtitles.mass_sync.path_mappings')
-    @patch('bazarr.subtitles.mass_sync._get_synced_movie_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_sync.database')
-    @patch('bazarr.subtitles.mass_sync.settings')
-    def test_skips_missing_files(self, mock_settings, mock_db, mock_synced,
-                                  mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import _process_movies
-
-        mock_settings.subsync.max_offset_seconds = 60
-        mock_settings.subsync.gss = True
-        mock_settings.subsync.no_fix_framerate = True
-        mock_path_map.path_replace_movie.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
-
-        movie = self._make_movie()
-        mock_db.execute.return_value.all.return_value = [movie]
-
-        queued, skipped, errors = _process_movies(movie_ids=[10])
-
-        assert queued == 0
-        assert skipped == 1
-
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
-    @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_sync.path_mappings')
-    @patch('bazarr.subtitles.mass_sync._get_synced_movie_paths')
-    @patch('bazarr.subtitles.mass_sync.database')
-    @patch('bazarr.subtitles.mass_sync.settings')
-    def test_skips_already_synced(self, mock_settings, mock_db, mock_synced,
-                                   mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import _process_movies
-
-        mock_settings.subsync.max_offset_seconds = 60
-        mock_settings.subsync.gss = True
-        mock_settings.subsync.no_fix_framerate = True
-        mock_path_map.path_replace_movie.side_effect = lambda x: x
-        mock_path_map.path_replace_reverse_movie.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
-        mock_synced.return_value = {'/subs/movie.en.srt'}
-
-        movie = self._make_movie()
-        mock_db.execute.return_value.all.return_value = [movie]
-
-        queued, skipped, errors = _process_movies(movie_ids=[10])
-
-        assert queued == 0
-        assert skipped == 1
-
-    @patch('bazarr.subtitles.mass_sync.jobs_queue')
     @patch('bazarr.subtitles.mass_sync.languages_from_colon_seperated_string')
     @patch('bazarr.subtitles.mass_sync.os.path.isfile', return_value=True)
     @patch('bazarr.subtitles.mass_sync.path_mappings')
@@ -572,8 +307,8 @@ class TestProcessMovies:
     @patch('bazarr.subtitles.mass_sync.database')
     @patch('bazarr.subtitles.mass_sync.settings')
     def test_force_resync_ignores_history(self, mock_settings, mock_db, mock_synced,
-                                           mock_path_map, mock_isfile, mock_lang, mock_jobs_queue):
-        from bazarr.subtitles.mass_sync import _process_movies
+                                           mock_path_map, mock_isfile, mock_lang):
+        from bazarr.subtitles.mass_sync import _collect_movie_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -585,7 +320,160 @@ class TestProcessMovies:
         movie = self._make_movie()
         mock_db.execute.return_value.all.return_value = [movie]
 
-        queued, skipped, errors = _process_movies(movie_ids=[10], force_resync=True)
+        items, skipped = _collect_movie_items(movie_ids=[10], force_resync=True)
 
-        assert queued == 1
+        assert len(items) == 1
         mock_synced.assert_not_called()
+
+
+class TestMassSyncSubtitles:
+    """Test mass_sync_subtitles entry point."""
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    def test_schedules_job_when_no_job_id_and_no_items(self, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        result = mass_sync_subtitles(items=None, options=None, job_id=None)
+        mock_jobs_queue.add_job_from_function.assert_called_once_with(
+            "Mass Syncing All Subtitles", is_progress=True
+        )
+        assert result is None
+
+    @patch('bazarr.subtitles.mass_sync.sync_subtitles', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync._collect_movie_items')
+    @patch('bazarr.subtitles.mass_sync._collect_episode_items')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_syncs_entire_library(self, mock_settings, mock_collect_ep, mock_collect_mov,
+                                   mock_jobs_queue, mock_sync):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        mock_settings.general.use_sonarr = True
+        mock_settings.general.use_radarr = True
+
+        ep_items = [{'video_path': '/v1.mkv', 'srt_path': '/s1.srt', 'srt_lang': 'en',
+                     'forced': False, 'hi': False, 'sonarr_series_id': 1,
+                     'sonarr_episode_id': 1, 'radarr_id': None,
+                     'max_offset_seconds': '60', 'no_fix_framerate': True, 'gss': True}]
+        mov_items = [{'video_path': '/v2.mkv', 'srt_path': '/s2.srt', 'srt_lang': 'en',
+                      'forced': False, 'hi': False, 'sonarr_series_id': None,
+                      'sonarr_episode_id': None, 'radarr_id': 1,
+                      'max_offset_seconds': '60', 'no_fix_framerate': True, 'gss': True}]
+        mock_collect_ep.return_value = (ep_items, 2)
+        mock_collect_mov.return_value = (mov_items, 1)
+
+        result = mass_sync_subtitles(items=None, options={}, job_id='test')
+
+        assert result['queued'] == 2  # 2 synced successfully
+        assert result['skipped'] == 3  # 2 + 1 from collection phase
+        assert mock_sync.call_count == 2
+
+    @patch('bazarr.subtitles.mass_sync.sync_subtitles', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync._collect_movie_items')
+    @patch('bazarr.subtitles.mass_sync._collect_episode_items')
+    @patch('bazarr.subtitles.mass_sync.settings')
+    def test_skips_sonarr_when_disabled(self, mock_settings, mock_collect_ep, mock_collect_mov,
+                                         mock_jobs_queue, mock_sync):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        mock_settings.general.use_sonarr = False
+        mock_settings.general.use_radarr = True
+        mock_collect_mov.return_value = ([], 0)
+
+        mass_sync_subtitles(items=None, options={}, job_id='test')
+        mock_collect_ep.assert_not_called()
+        mock_collect_mov.assert_called_once()
+
+    @patch('bazarr.subtitles.mass_sync.sync_subtitles', return_value=True)
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync._collect_movie_items')
+    @patch('bazarr.subtitles.mass_sync._collect_episode_items')
+    def test_routes_items_by_type(self, mock_collect_ep, mock_collect_mov,
+                                   mock_jobs_queue, mock_sync):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        mock_collect_ep.return_value = ([], 0)
+        mock_collect_mov.return_value = ([], 0)
+
+        items = [
+            {'type': 'series', 'sonarrSeriesId': 1},
+            {'type': 'movie', 'radarrId': 10},
+            {'type': 'episode', 'sonarrEpisodeId': 100},
+        ]
+        mass_sync_subtitles(items=items, options={}, job_id='test')
+
+        call_kwargs = mock_collect_ep.call_args[1]
+        assert call_kwargs['series_ids'] == [1]
+        assert call_kwargs['episode_ids'] == [100]
+
+        call_kwargs = mock_collect_mov.call_args[1]
+        assert call_kwargs['movie_ids'] == [10]
+
+    @patch('bazarr.subtitles.mass_sync.sync_subtitles')
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync._collect_movie_items')
+    @patch('bazarr.subtitles.mass_sync._collect_episode_items')
+    def test_counts_failed_syncs(self, mock_collect_ep, mock_collect_mov,
+                                  mock_jobs_queue, mock_sync):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        mock_sync.side_effect = [True, False]  # first succeeds, second fails
+        mock_collect_ep.return_value = ([
+            {'video_path': '/v1.mkv', 'srt_path': '/s1.srt', 'srt_lang': 'en',
+             'forced': False, 'hi': False, 'sonarr_series_id': 1,
+             'sonarr_episode_id': 1, 'radarr_id': None,
+             'max_offset_seconds': '60', 'no_fix_framerate': True, 'gss': True},
+            {'video_path': '/v2.mkv', 'srt_path': '/s2.srt', 'srt_lang': 'en',
+             'forced': False, 'hi': False, 'sonarr_series_id': 1,
+             'sonarr_episode_id': 2, 'radarr_id': None,
+             'max_offset_seconds': '60', 'no_fix_framerate': True, 'gss': True},
+        ], 0)
+
+        items = [{'type': 'series', 'sonarrSeriesId': 1}]
+        result = mass_sync_subtitles(items=items, options={}, job_id='test')
+
+        assert result['queued'] == 1  # 1 synced
+        assert result['skipped'] == 1  # 1 failed
+
+    @patch('bazarr.subtitles.mass_sync.sync_subtitles')
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync._collect_movie_items')
+    @patch('bazarr.subtitles.mass_sync._collect_episode_items')
+    def test_handles_sync_exception(self, mock_collect_ep, mock_collect_mov,
+                                     mock_jobs_queue, mock_sync):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        mock_sync.side_effect = RuntimeError("ffsubsync crashed")
+        mock_collect_ep.return_value = ([
+            {'video_path': '/v1.mkv', 'srt_path': '/s1.srt', 'srt_lang': 'en',
+             'forced': False, 'hi': False, 'sonarr_series_id': 1,
+             'sonarr_episode_id': 1, 'radarr_id': None,
+             'max_offset_seconds': '60', 'no_fix_framerate': True, 'gss': True},
+        ], 0)
+
+        items = [{'type': 'series', 'sonarrSeriesId': 1}]
+        result = mass_sync_subtitles(items=items, options={}, job_id='test')
+
+        assert result['queued'] == 0
+        assert len(result['errors']) == 1
+        assert 'ffsubsync crashed' in result['errors'][0]
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync._collect_movie_items')
+    @patch('bazarr.subtitles.mass_sync._collect_episode_items')
+    def test_updates_progress(self, mock_collect_ep, mock_collect_mov, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+        mock_collect_ep.return_value = ([], 0)
+
+        items = [{'type': 'series', 'sonarrSeriesId': 1}]
+        mass_sync_subtitles(items=items, options={}, job_id='test')
+
+        mock_jobs_queue.update_job_progress.assert_called()
+
+    @patch('bazarr.subtitles.mass_sync.jobs_queue')
+    @patch('bazarr.subtitles.mass_sync._collect_movie_items')
+    @patch('bazarr.subtitles.mass_sync._collect_episode_items')
+    def test_unknown_item_type_is_ignored(self, mock_collect_ep, mock_collect_mov, mock_jobs_queue):
+        from bazarr.subtitles.mass_sync import mass_sync_subtitles
+
+        items = [{'type': 'unknown', 'id': 99}]
+        result = mass_sync_subtitles(items=items, options={}, job_id='test')
+
+        mock_collect_ep.assert_not_called()
+        mock_collect_mov.assert_not_called()
+        assert result['queued'] == 0


### PR DESCRIPTION
## Summary

- Fixes browser crash (ERR_INSUFFICIENT_RESOURCES) when mass sync queued 7,500+ individual jobs
- Each job was polled separately via `/api/system/jobs?id=XXXX`, overwhelming the browser
- Now follows the `upgrade_subtitles` pattern: collect all items first, then process sequentially within a single job with progress tracking
- One job, one progress bar, no browser meltdown

## Test plan

- [x] 24 backend tests pass (`pytest tests/bazarr/test_mass_sync.py`)
- [x] Run Mass Sync from System Tasks, verify single job with progress instead of thousands of individual jobs
- [x] No ERR_INSUFFICIENT_RESOURCES errors in browser console