### PR TITLE
feat: read-only subtitle viewer (Phase 0)

### DIFF
--- a/bazarr/api/subtitles/__init__.py
+++ b/bazarr/api/subtitles/__init__.py
@@ -3,10 +3,12 @@
 from .subtitles import api_ns_subtitles
 from .subtitles_info import api_ns_subtitles_info
 from .batch import api_ns_batch
+from .content import api_ns_subtitle_content
 
 
 api_ns_list_subtitles = [
     api_ns_subtitles,
     api_ns_subtitles_info,
     api_ns_batch,
+    api_ns_subtitle_content,
 ]

--- a/bazarr/api/subtitles/content.py
+++ b/bazarr/api/subtitles/content.py
@@ -1,0 +1,208 @@
+# coding=utf-8
+
+import ast
+import hashlib
+import os
+
+from flask import make_response, jsonify, request
+from flask_restx import Resource, Namespace
+
+from app.database import TableEpisodes, TableMovies, database, select
+from utilities.path_mappings import path_mappings
+
+from ..utils import authenticate
+
+api_ns_subtitle_content = Namespace('SubtitleContent', description='Read subtitle file content')
+
+MAX_FILE_SIZE = 5 * 1024 * 1024  # 5 MB
+
+SUBTITLE_EXTENSIONS = {
+    '.srt', '.ass', '.ssa', '.sub', '.idx', '.sup',
+    '.vtt', '.dfxp', '.ttml', '.smi', '.mpl', '.txt',
+}
+
+FORMAT_MAP = {
+    '.srt': 'srt',
+    '.ass': 'ass',
+    '.ssa': 'ssa',
+    '.vtt': 'vtt',
+    '.sub': 'sub',
+    '.dfxp': 'dfxp',
+    '.ttml': 'ttml',
+    '.smi': 'smi',
+    '.mpl': 'mpl',
+    '.txt': 'txt',
+}
+
+
+def resolve_subtitle_path(media_type, media_id, language_code):
+    """Resolve a subtitle file path from a media ID and language code.
+
+    language_code can be like "en", "hu", "en:hi", "en:forced".
+    Matches against the language field in the subtitles array.
+
+    Returns (path, language) on success, or (message, status_code) on failure.
+    """
+    if media_type == 'episode':
+        row = database.execute(
+            select(TableEpisodes.subtitles, TableEpisodes.path)
+            .where(TableEpisodes.sonarrEpisodeId == media_id)
+        ).first()
+    elif media_type == 'movie':
+        row = database.execute(
+            select(TableMovies.subtitles, TableMovies.path)
+            .where(TableMovies.radarrId == media_id)
+        ).first()
+    else:
+        return 'Invalid media type', 400
+
+    if not row:
+        return 'Media not found', 404
+
+    raw_subtitles = row.subtitles
+    if not raw_subtitles:
+        return 'No subtitles found for this media', 404
+
+    try:
+        subtitles_list = ast.literal_eval(raw_subtitles)
+    except (ValueError, SyntaxError):
+        return 'Failed to parse subtitles data', 500
+
+    if not isinstance(subtitles_list, list):
+        return 'Invalid subtitles data', 500
+
+    # Find the subtitle entry matching the language code
+    entry = None
+    for item in subtitles_list:
+        if isinstance(item, list) and len(item) >= 2 and item[0] == language_code:
+            # Must have a file path (not an embedded track)
+            if item[1] and isinstance(item[1], str) and len(item[1]) > 0:
+                entry = item
+                break
+
+    if entry is None:
+        return f'No subtitle found for language "{language_code}"', 404
+
+    language = entry[0]
+    subtitle_path = entry[1]
+
+    if media_type == 'episode':
+        subtitle_path = path_mappings.path_replace(subtitle_path)
+    else:
+        subtitle_path = path_mappings.path_replace_movie(subtitle_path)
+
+    ext = os.path.splitext(subtitle_path)[1].lower()
+    if ext not in SUBTITLE_EXTENSIONS:
+        return f'File does not have a recognized subtitle extension: {ext}', 400
+
+    if not os.path.isfile(subtitle_path):
+        return 'Subtitle file not found on disk', 404
+
+    return subtitle_path, language
+
+
+def read_subtitle_file(path):
+    """Read a subtitle file and detect its encoding.
+
+    Returns (content_str, encoding) on success.
+    Raises ValueError if the file exceeds MAX_FILE_SIZE.
+    """
+    file_size = os.path.getsize(path)
+    if file_size > MAX_FILE_SIZE:
+        raise ValueError(f'Subtitle file too large ({file_size} bytes, max {MAX_FILE_SIZE})')
+
+    with open(path, 'rb') as f:
+        raw = f.read()
+
+    # BOM detection
+    if raw.startswith(b'\xef\xbb\xbf'):
+        return raw[3:].decode('utf-8'), 'utf-8-sig'
+    if raw.startswith(b'\xff\xfe'):
+        return raw[2:].decode('utf-16-le'), 'utf-16-le'
+    if raw.startswith(b'\xfe\xff'):
+        return raw[2:].decode('utf-16-be'), 'utf-16-be'
+
+    # Try UTF-8
+    try:
+        return raw.decode('utf-8'), 'utf-8'
+    except UnicodeDecodeError:
+        pass
+
+    # charset_normalizer
+    try:
+        import charset_normalizer
+        result = charset_normalizer.from_bytes(raw).best()
+        if result is not None:
+            return str(result), result.encoding
+    except Exception:
+        pass
+
+    # Fallback
+    return raw.decode('cp1252', errors='replace'), 'cp1252'
+
+
+def detect_subtitle_format(path):
+    """Map a subtitle file extension to a format string."""
+    ext = os.path.splitext(path)[1].lower()
+    return FORMAT_MAP.get(ext, 'unknown')
+
+
+def generate_etag(path):
+    """Generate an ETag from file mtime and size."""
+    stat = os.stat(path)
+    tag_input = f"{stat.st_mtime_ns}:{stat.st_size}"
+    return hashlib.md5(tag_input.encode()).hexdigest()
+
+
+def _get_subtitle_content(media_type, media_id, language_code):
+    """Shared handler for episode and movie subtitle content."""
+    result = resolve_subtitle_path(media_type, media_id, language_code)
+
+    # Error tuple
+    if isinstance(result[1], int):
+        return result[0], result[1]
+
+    subtitle_path, language = result
+
+    etag = generate_etag(subtitle_path)
+
+    # ETag-based caching
+    if_none_match = request.headers.get('If-None-Match')
+    if if_none_match and if_none_match.strip('"') == etag:
+        return '', 304
+
+    try:
+        content, encoding = read_subtitle_file(subtitle_path)
+    except ValueError as e:
+        return str(e), 413
+
+    stat = os.stat(subtitle_path)
+    fmt = detect_subtitle_format(subtitle_path)
+
+    response = make_response(jsonify({
+        'content': content,
+        'encoding': encoding,
+        'format': fmt,
+        'language': language,
+        'size': stat.st_size,
+        'lastModified': stat.st_mtime,
+    }))
+
+    response.headers['ETag'] = f'"{etag}"'
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+
+    return response
+
+
+@api_ns_subtitle_content.route('episodes/<int:sonarrEpisodeId>/subtitles/<language>/content')
+class EpisodeSubtitleContent(Resource):
+    @authenticate
+    def get(self, sonarrEpisodeId, language):
+        return _get_subtitle_content('episode', sonarrEpisodeId, language)
+
+
+@api_ns_subtitle_content.route('movies/<int:radarrId>/subtitles/<language>/content')
+class MovieSubtitleContent(Resource):
+    @authenticate
+    def get(self, radarrId, language):
+        return _get_subtitle_content('movie', radarrId, language)

--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -87,6 +87,8 @@ else:
     def set_sqlite_pragma(dbapi_connection, connection_record):
         cursor = dbapi_connection.cursor()
         cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA busy_timeout=5000")
         cursor.close()
 
 session_factory = sessionmaker(bind=engine)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@mantine/notifications": "^8.3.9",
         "@tanstack/react-query": "^5.64.1",
         "@tanstack/react-table": "^8.19.2",
+        "@tanstack/react-virtual": "^3.13.23",
         "axios": "^1.8.2",
         "braces": "^3.0.3",
         "react": "^19.2.3",
@@ -3900,6 +3901,23 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
+      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.23"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@tanstack/table-core": {
       "version": "8.19.2",
       "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.19.2.tgz",
@@ -3908,6 +3926,16 @@
       "engines": {
         "node": ">=12"
       },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@mantine/notifications": "^8.3.9",
     "@tanstack/react-query": "^5.64.1",
     "@tanstack/react-table": "^8.19.2",
+    "@tanstack/react-virtual": "^3.13.23",
     "axios": "^1.8.2",
     "braces": "^3.0.3",
     "react": "^19.2.3",

--- a/frontend/src/Router/index.tsx
+++ b/frontend/src/Router/index.tsx
@@ -57,6 +57,7 @@ const HistoryStats = lazy(
   () => import("@/pages/History/Statistics/HistoryStats"),
 );
 const SystemStatusView = lazy(() => import("@/pages/System/Status"));
+const SubtitleEditor = lazy(() => import("@/pages/SubtitleEditor"));
 
 function useRoutes(): CustomRouteObject[] {
   const { data } = useBadges();
@@ -289,6 +290,15 @@ function useRoutes(): CustomRouteObject[] {
                 element: <SystemAnnouncementsView></SystemAnnouncementsView>,
               },
             ],
+          },
+          {
+            path: "subtitles/preview/:mediaType/:mediaId/:language",
+            hidden: true,
+            element: (
+              <Lazy>
+                <SubtitleEditor></SubtitleEditor>
+              </Lazy>
+            ),
           },
           {
             path: "*",

--- a/frontend/src/apis/hooks/subtitles.ts
+++ b/frontend/src/apis/hooks/subtitles.ts
@@ -216,3 +216,21 @@ export function useBatchAction() {
     },
   });
 }
+
+export function useSubtitleContent(
+  mediaType: string | undefined,
+  mediaId: number | undefined,
+  language: string | undefined,
+) {
+  return useQuery({
+    queryKey: [QueryKeys.Subtitles, "content", mediaType, mediaId, language],
+    queryFn: () => {
+      if (!mediaType || mediaId === undefined || !language) {
+        throw new Error("Missing parameters");
+      }
+      return api.subtitles.getContent(mediaType, mediaId, language);
+    },
+    enabled: !!mediaType && mediaId !== undefined && !!language,
+    staleTime: 5 * 60 * 1000, // 5 min, not Infinity - subtitle files can change
+  });
+}

--- a/frontend/src/apis/raw/subtitles.ts
+++ b/frontend/src/apis/raw/subtitles.ts
@@ -1,4 +1,14 @@
 import BaseApi from "./base";
+import client from "./client";
+
+export interface SubtitleContentResponse {
+  content: string;
+  encoding: string;
+  format: string;
+  language: string;
+  size: number;
+  lastModified: number;
+}
 
 export type BatchAction =
   | "sync"
@@ -91,6 +101,13 @@ class SubtitlesApi extends BaseApi {
       "/upgradable",
     );
     return response;
+  }
+
+  async getContent(mediaType: string, mediaId: number, language: string) {
+    const base = mediaType === "episode" ? "episodes" : "movies";
+    const url = `/${base}/${mediaId}/subtitles/${encodeURIComponent(language)}/content`;
+    const response = await client.axios.get<SubtitleContentResponse>(url);
+    return response.data;
   }
 }
 

--- a/frontend/src/components/SubtitleToolsMenu.tsx
+++ b/frontend/src/components/SubtitleToolsMenu.tsx
@@ -5,6 +5,7 @@ import {
   faCode,
   faDeaf,
   faExchangeAlt,
+  faEye,
   faFaceGrinStars,
   faFilm,
   faImage,
@@ -115,7 +116,7 @@ interface Props {
   selections: FormType.ModifySubtitle[];
   children?: ReactElement;
   menu?: Omit<MenuProps, "children">;
-  onAction?: (action: "delete" | "search") => void;
+  onAction?: (action: "delete" | "search" | "view") => void;
   // For missing subtitle translation
   missingLanguage?: Subtitle;
   translationSources?: Subtitle[];
@@ -221,6 +222,15 @@ const SubtitleToolsMenu: FunctionComponent<Props> = ({
             No source subtitles to translate from
           </Menu.Item>
         )}
+        <Menu.Item
+          disabled={selections.length === 0 || onAction === undefined}
+          leftSection={<FontAwesomeIcon icon={faEye}></FontAwesomeIcon>}
+          onClick={() => {
+            onAction?.("view");
+          }}
+        >
+          View
+        </Menu.Item>
         <Menu.Item
           disabled={selections.length !== 0 || onAction === undefined}
           leftSection={<FontAwesomeIcon icon={faSearch}></FontAwesomeIcon>}

--- a/frontend/src/pages/Episodes/components.tsx
+++ b/frontend/src/pages/Episodes/components.tsx
@@ -1,9 +1,17 @@
 import { FunctionComponent, useMemo, useState } from "react";
+import { useNavigate } from "react-router";
 import { Badge, MantineColor, Tooltip } from "@mantine/core";
 import { useEpisodeSubtitleModification } from "@/apis/hooks";
 import Language from "@/components/bazarr/Language";
 import SubtitleToolsMenu from "@/components/SubtitleToolsMenu";
 import { toPython } from "@/utilities";
+
+function buildLanguageKey(sub: Subtitle): string {
+  let key = sub.code2;
+  if (sub.hi) key += ":hi";
+  if (sub.forced) key += ":forced";
+  return key;
+}
 
 interface Props {
   seriesId: number;
@@ -20,6 +28,7 @@ export const Subtitle: FunctionComponent<Props> = ({
   subtitle,
   availableSubtitles,
 }) => {
+  const navigate = useNavigate();
   const { remove, download } = useEpisodeSubtitleModification();
 
   const [opened, setOpen] = useState(false);
@@ -82,7 +91,9 @@ export const Subtitle: FunctionComponent<Props> = ({
       mediaId={episodeId}
       mediaType="episode"
       onAction={async (action) => {
-        if (action === "search") {
+        if (action === "view") {
+          navigate(`/subtitles/preview/episode/${episodeId}/${encodeURIComponent(buildLanguageKey(subtitle))}`);
+        } else if (action === "search") {
           await download.mutateAsync({
             seriesId,
             episodeId,

--- a/frontend/src/pages/Episodes/table.tsx
+++ b/frontend/src/pages/Episodes/table.tsx
@@ -87,12 +87,12 @@ const Table = forwardRef<TableInstance<Item.Episode> | null, Props>(
             ></Subtitle>
           ));
 
-          let rawSubtitles = episode.subtitles;
+          let filteredSubtitles = episode.subtitles;
           if (onlyDesired) {
-            rawSubtitles = filterSubtitleBy(rawSubtitles, profileItems);
+            filteredSubtitles = filterSubtitleBy(filteredSubtitles, profileItems);
           }
 
-          const subtitles = rawSubtitles.map((val, idx) => (
+          const subtitles = filteredSubtitles.map((val, idx) => (
             <Subtitle
               key={BuildKey(idx, val.code2, "valid")}
               seriesId={seriesId}

--- a/frontend/src/pages/Movies/Details/table.tsx
+++ b/frontend/src/pages/Movies/Details/table.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, useMemo } from "react";
+import { useNavigate } from "react-router";
 import { Badge, Text, TextProps } from "@mantine/core";
 import { faEllipsis } from "@fortawesome/free-solid-svg-icons";
 import { ColumnDef } from "@tanstack/react-table";
@@ -28,6 +29,13 @@ function isSubtitleMissing(path: string | undefined | null) {
   return path === missingText;
 }
 
+function buildLanguageKey(sub: Subtitle): string {
+  let key = sub.code2;
+  if (sub.hi) key += ":hi";
+  if (sub.forced) key += ":forced";
+  return key;
+}
+
 const Table: FunctionComponent<Props> = ({ movie, profile }) => {
   const onlyDesired = useShowOnlyDesired();
 
@@ -40,6 +48,8 @@ const Table: FunctionComponent<Props> = ({ movie, profile }) => {
     () => (movie?.subtitles ?? []).filter((s) => s.path && !isSubtitleTrack(s.path)),
     [movie?.subtitles],
   );
+
+  const navigate = useNavigate();
 
   const CodeCell = React.memo(({ item }: { item: Subtitle }) => {
     const { code2, path, hi, forced } = item;
@@ -100,7 +110,9 @@ const Table: FunctionComponent<Props> = ({ movie, profile }) => {
       <SubtitleToolsMenu
         selections={selections}
         onAction={async (action) => {
-          if (action === "delete" && path) {
+          if (action === "view") {
+            navigate(`/subtitles/preview/movie/${radarrId}/${encodeURIComponent(buildLanguageKey(item))}`);
+          } else if (action === "delete" && path) {
             await remove.mutateAsync({
               radarrId,
               form: {
@@ -110,8 +122,6 @@ const Table: FunctionComponent<Props> = ({ movie, profile }) => {
                 path,
               },
             });
-          } else if (action === "search") {
-            throw new Error("This shouldn't happen, please report the bug");
           }
         }}
       >
@@ -189,12 +199,12 @@ const Table: FunctionComponent<Props> = ({ movie, profile }) => {
         path: missingText,
       })) ?? [];
 
-    let rawSubtitles = movie?.subtitles ?? [];
+    let subtitles = movie?.subtitles ?? [];
     if (onlyDesired) {
-      rawSubtitles = filterSubtitleBy(rawSubtitles, profileItems);
+      subtitles = filterSubtitleBy(subtitles, profileItems);
     }
 
-    return [...rawSubtitles, ...missing];
+    return [...subtitles, ...missing];
   }, [movie, onlyDesired, profileItems]);
 
   return (

--- a/frontend/src/pages/SubtitleEditor/CueTable.tsx
+++ b/frontend/src/pages/SubtitleEditor/CueTable.tsx
@@ -1,0 +1,391 @@
+import { Fragment, ReactNode, useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import type { Cue } from "./types";
+
+function formatTimestamp(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const millis = ms % 1000;
+
+  return (
+    String(hours).padStart(2, "0") +
+    ":" +
+    String(minutes).padStart(2, "0") +
+    ":" +
+    String(seconds).padStart(2, "0") +
+    "." +
+    String(millis).padStart(3, "0")
+  );
+}
+
+function formatDuration(ms: number): string {
+  const seconds = ms / 1000;
+  if (Number.isInteger(seconds)) {
+    return seconds + ".0s";
+  }
+  return parseFloat(seconds.toFixed(1)) + "s";
+}
+
+// Tag colors by type
+// Badge color categories
+const TAG_COLORS: Record<string, { bg: string; text: string }> = {
+  // HTML style tags
+  i: { bg: "rgba(139, 92, 246, 0.2)", text: "#a78bfa" },
+  b: { bg: "rgba(251, 146, 60, 0.2)", text: "#fb923c" },
+  u: { bg: "rgba(52, 211, 153, 0.2)", text: "#34d399" },
+  font: { bg: "rgba(96, 165, 250, 0.2)", text: "#60a5fa" },
+  s: { bg: "rgba(248, 113, 113, 0.2)", text: "#f87171" },
+  // ASS categories
+  pos: { bg: "rgba(251, 191, 36, 0.2)", text: "#fbbf24" },
+  align: { bg: "rgba(251, 191, 36, 0.2)", text: "#fbbf24" },
+  effect: { bg: "rgba(168, 85, 247, 0.2)", text: "#a855f7" },
+  color: { bg: "rgba(96, 165, 250, 0.2)", text: "#60a5fa" },
+  font_ass: { bg: "rgba(96, 165, 250, 0.2)", text: "#60a5fa" },
+};
+
+const DEFAULT_TAG_COLOR = { bg: "rgba(148, 163, 184, 0.15)", text: "#94a3b8" };
+
+function tagBadgeStyle(colorKey: string): React.CSSProperties {
+  const colors = TAG_COLORS[colorKey] ?? DEFAULT_TAG_COLOR;
+  return {
+    display: "inline-block",
+    fontSize: "0.6rem",
+    fontFamily: "monospace",
+    fontWeight: 600,
+    lineHeight: 1,
+    padding: "2px 5px",
+    borderRadius: "3px",
+    backgroundColor: colors.bg,
+    color: colors.text,
+    verticalAlign: "middle",
+    marginInline: "1px",
+  };
+}
+
+/**
+ * Categorize an ASS override tag block like {\an8} or {\pos(320,50)\fad(1200,0)}
+ * into a readable badge label and color category.
+ */
+function parseAssTagBlock(block: string): { label: string; colorKey: string } {
+  // Remove the outer braces
+  const inner = block.slice(1, -1);
+
+  // Common ASS tags and their human-readable labels
+  const patterns: [RegExp, string, string][] = [
+    // Alignment: \an1-\an9, \a1-\a11
+    [/^\\an(\d)$/, "align-$1", "align"],
+    [/^\\a(\d+)$/, "align-$1", "align"],
+    // Position
+    [/\\pos\([^)]+\)/, "pos", "pos"],
+    // Move
+    [/\\move\([^)]+\)/, "move", "pos"],
+    // Origin
+    [/\\org\([^)]+\)/, "org", "pos"],
+    // Fade
+    [/\\fad\([^)]+\)/, "fade", "effect"],
+    [/\\fade\([^)]+\)/, "fade", "effect"],
+    // Blur
+    [/\\be\d/, "blur", "effect"],
+    [/\\blur[\d.]/, "blur", "effect"],
+    // Border/shadow
+    [/\\bord[\d.]/, "border", "effect"],
+    [/\\shad[\d.]/, "shadow", "effect"],
+    // Rotation
+    [/\\fr[xyz]?[\d.-]/, "rotate", "effect"],
+    // Scale
+    [/\\fsc[xy][\d.]/, "scale", "effect"],
+    // Color
+    [/\\1?c&H/, "color", "color"],
+    [/\\2c&H/, "color2", "color"],
+    [/\\3c&H/, "border-color", "color"],
+    [/\\4c&H/, "shadow-color", "color"],
+    // Alpha
+    [/\\alpha/, "alpha", "effect"],
+    [/\\[1234]a&H/, "alpha", "effect"],
+    // Font
+    [/\\fn/, "font", "font_ass"],
+    [/\\fs[\d.]/, "size", "font_ass"],
+    // Bold/italic in ASS
+    [/\\b[01]/, "bold", "b"],
+    [/\\i[01]/, "italic", "i"],
+    [/\\u[01]/, "underline", "u"],
+    [/\\s[01]/, "strike", "s"],
+    // Karaoke
+    [/\\k[fo]?\d/, "karaoke", "effect"],
+    // Clip
+    [/\\i?clip\(/, "clip", "effect"],
+    // Drawing
+    [/\\p[01]/, "drawing", "effect"],
+    // Letter spacing
+    [/\\fsp[\d.-]/, "spacing", "font_ass"],
+    // Encoding
+    [/\\fe\d/, "encoding", "font_ass"],
+    // Animated transform
+    [/\\t\(/, "animate", "effect"],
+    // Wrap
+    [/\\q\d/, "wrap", "align"],
+    // Reset
+    [/\\r/, "reset", "effect"],
+  ];
+
+  // Try to match known tags
+  const labels: string[] = [];
+  let colorKey = "effect";
+
+  for (const [pattern, label, category] of patterns) {
+    if (pattern.test(inner)) {
+      labels.push(label.replace("$1", inner.match(/\d+/)?.[0] ?? ""));
+      colorKey = category;
+    }
+  }
+
+  if (labels.length > 0) {
+    return { label: labels.join(" "), colorKey };
+  }
+
+  // Fallback: show the raw content, abbreviated
+  const abbreviated = inner.length > 12 ? inner.slice(0, 12) + ".." : inner;
+  return { label: abbreviated, colorKey: "effect" };
+}
+
+/**
+ * Renders cue text with formatting tags shown as small colored badges.
+ * Handles both HTML tags (<i>, <b>, <font>) and ASS override tags ({\an8}, {\pos}).
+ */
+function renderStyledText(text: string): ReactNode {
+  // Match HTML tags and ASS override tag blocks
+  // HTML: <i>, </i>, <b>, </b>, <font color=...>, etc.
+  // ASS: {\an8}, {\pos(320,50)}, {\fad(1200,0)\be1}, etc.
+  const tagPattern = /<\/?([a-zA-Z]+)(?:\s[^>]*)?>|\{\\[^}]+\}/g;
+  const parts: ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+
+  while ((match = tagPattern.exec(text)) !== null) {
+    // Text before the tag
+    if (match.index > lastIndex) {
+      parts.push(
+        <Fragment key={key++}>{text.slice(lastIndex, match.index)}</Fragment>,
+      );
+    }
+
+    const fullMatch = match[0];
+
+    if (fullMatch.startsWith("{\\")) {
+      // ASS override tag block
+      const { label, colorKey } = parseAssTagBlock(fullMatch);
+      parts.push(
+        <span key={key++} style={tagBadgeStyle(colorKey)}>
+          {label}
+        </span>,
+      );
+    } else {
+      // HTML tag
+      const tagName = match[1].toLowerCase();
+      const isClosing = fullMatch.startsWith("</");
+      parts.push(
+        <span key={key++} style={tagBadgeStyle(tagName)}>
+          {isClosing ? `/${tagName}` : tagName}
+        </span>,
+      );
+    }
+
+    lastIndex = match.index + fullMatch.length;
+  }
+
+  // Remaining text after last tag
+  if (lastIndex < text.length) {
+    parts.push(<Fragment key={key++}>{text.slice(lastIndex)}</Fragment>);
+  }
+
+  return parts.length > 0 ? parts : text;
+}
+
+const gridTemplate = "56px 140px 140px 72px 1fr";
+
+const headerStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: gridTemplate,
+  position: "sticky",
+  top: 0,
+  zIndex: 1,
+  backgroundColor: "var(--mantine-color-body)",
+  borderBottom: "2px solid var(--mantine-color-default-border)",
+  fontWeight: 700,
+  fontSize: "0.7rem",
+  textTransform: "uppercase",
+  letterSpacing: "0.8px",
+  color: "var(--mantine-color-dimmed)",
+};
+
+const headerCellStyle: React.CSSProperties = {
+  padding: "10px 12px",
+};
+
+const rowBaseStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: gridTemplate,
+  alignItems: "start",
+  borderBottom: "1px solid rgba(255, 255, 255, 0.04)",
+  transition: "background-color 0.1s ease",
+};
+
+const cellStyle: React.CSSProperties = {
+  padding: "10px 12px",
+  fontSize: "0.85rem",
+  lineHeight: 1.5,
+};
+
+const monoStyle: React.CSSProperties = {
+  ...cellStyle,
+  fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
+  fontSize: "0.8rem",
+  color: "var(--mantine-color-yellow-4)",
+  letterSpacing: "-0.2px",
+};
+
+const durationStyle: React.CSSProperties = {
+  ...cellStyle,
+  fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
+  fontSize: "0.8rem",
+  color: "var(--mantine-color-dimmed)",
+  textAlign: "center",
+};
+
+const textCellStyle: React.CSSProperties = {
+  ...cellStyle,
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+  color: "var(--mantine-color-text)",
+};
+
+const indexCellStyle: React.CSSProperties = {
+  ...cellStyle,
+  color: "var(--mantine-color-dimmed)",
+  fontSize: "0.75rem",
+  textAlign: "right",
+  fontFamily: "monospace",
+  paddingRight: "16px",
+};
+
+const COLUMNS = ["#", "START", "END", "DURATION", "TEXT"] as const;
+
+interface CueTableProps {
+  cues: Cue[];
+}
+
+export default function CueTable({ cues }: CueTableProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const virtualizer = useVirtualizer({
+    count: cues.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 48,
+    overscan: 10,
+  });
+
+  return (
+    <div
+      role="grid"
+      aria-label="Subtitle cues"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        flex: 1,
+        minHeight: 0,
+        overflow: "hidden",
+        border: "1px solid var(--mantine-color-default-border)",
+        borderRadius: "var(--mantine-radius-md)",
+        backgroundColor: "var(--mantine-color-body)",
+      }}
+    >
+      <div role="row" style={headerStyle}>
+        {COLUMNS.map((col) => (
+          <div
+            key={col}
+            role="columnheader"
+            style={{
+              ...headerCellStyle,
+              textAlign: col === "#" ? "right" : col === "DURATION" ? "center" : undefined,
+              paddingRight: col === "#" ? "16px" : undefined,
+            }}
+          >
+            {col}
+          </div>
+        ))}
+      </div>
+
+      <div
+        ref={scrollRef}
+        style={{
+          flex: 1,
+          overflow: "auto",
+          minHeight: 0,
+        }}
+      >
+        <div
+          style={{
+            height: virtualizer.getTotalSize(),
+            position: "relative",
+            width: "100%",
+          }}
+        >
+          {virtualizer.getVirtualItems().map((virtualRow) => {
+            const cue = cues[virtualRow.index];
+            const isOdd = virtualRow.index % 2 === 1;
+
+            return (
+              <div
+                key={cue.id}
+                role="row"
+                data-index={virtualRow.index}
+                ref={virtualizer.measureElement}
+                style={{
+                  ...rowBaseStyle,
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  transform: `translateY(${virtualRow.start}px)`,
+                  backgroundColor: isOdd
+                    ? "rgba(255, 255, 255, 0.02)"
+                    : "transparent",
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor =
+                    "rgba(255, 255, 255, 0.05)";
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = isOdd
+                    ? "rgba(255, 255, 255, 0.02)"
+                    : "transparent";
+                }}
+              >
+                <div role="gridcell" style={indexCellStyle}>
+                  {virtualRow.index + 1}
+                </div>
+                <div role="gridcell" style={monoStyle}>
+                  {formatTimestamp(cue.startMs)}
+                </div>
+                <div role="gridcell" style={monoStyle}>
+                  {formatTimestamp(cue.endMs)}
+                </div>
+                <div role="gridcell" style={durationStyle}>
+                  {formatDuration(cue.endMs - cue.startMs)}
+                </div>
+                <div role="gridcell" style={textCellStyle}>
+                  {renderStyledText(cue.text)}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { formatTimestamp, formatDuration };

--- a/frontend/src/pages/SubtitleEditor/__tests__/parsers.test.ts
+++ b/frontend/src/pages/SubtitleEditor/__tests__/parsers.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getParser } from "../parsers";
+
+// Mock crypto.randomUUID since it may not be available in test env
+beforeEach(() => {
+  let counter = 0;
+  vi.stubGlobal("crypto", {
+    randomUUID: () => `test-uuid-${++counter}`,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 1: SRT
+// ---------------------------------------------------------------------------
+describe("SRT parser", () => {
+  const parser = getParser("srt");
+
+  it("parses a basic SRT file with 2 cues", () => {
+    const input = [
+      "1",
+      "00:00:01,000 --> 00:00:02,500",
+      "Hello world",
+      "",
+      "2",
+      "00:01:00,000 --> 00:01:03,400",
+      "Second cue",
+    ].join("\n");
+
+    const result = parser.parse(input);
+    expect(result.cues).toHaveLength(2);
+
+    expect(result.cues[0].startMs).toBe(1000);
+    expect(result.cues[0].endMs).toBe(2500);
+    expect(result.cues[0].text).toBe("Hello world");
+
+    expect(result.cues[1].startMs).toBe(60000);
+    expect(result.cues[1].endMs).toBe(63400);
+    expect(result.cues[1].text).toBe("Second cue");
+
+    expect(result.metadata.format).toBe("srt");
+  });
+
+  it("returns 0 cues for empty input", () => {
+    const result = parser.parse("");
+    expect(result.cues).toHaveLength(0);
+  });
+
+  it("handles multiline cue text", () => {
+    const input = [
+      "1",
+      "00:00:01,000 --> 00:00:04,000",
+      "Line one",
+      "Line two",
+      "Line three",
+    ].join("\n");
+
+    const result = parser.parse(input);
+    expect(result.cues).toHaveLength(1);
+    expect(result.cues[0].text).toBe("Line one\nLine two\nLine three");
+  });
+
+  it("handles Windows line endings (\\r\\n)", () => {
+    const input =
+      "1\r\n00:00:01,000 --> 00:00:02,000\r\nHello\r\n\r\n2\r\n00:00:03,000 --> 00:00:04,000\r\nWorld";
+
+    const result = parser.parse(input);
+    expect(result.cues).toHaveLength(2);
+    expect(result.cues[0].text).toBe("Hello");
+    expect(result.cues[1].text).toBe("World");
+  });
+
+  it("handles BOM prefix", () => {
+    const input =
+      "\uFEFF1\n00:00:01,000 --> 00:00:02,000\nWith BOM";
+
+    const result = parser.parse(input);
+    expect(result.cues).toHaveLength(1);
+    expect(result.cues[0].text).toBe("With BOM");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 1: ASS/SSA
+// ---------------------------------------------------------------------------
+describe("ASS parser", () => {
+  const parser = getParser("ass");
+
+  const minimalASS = [
+    "[Script Info]",
+    "Title: Test Script",
+    "ScriptType: v4.00+",
+    "",
+    "[V4+ Styles]",
+    "Format: Name, Fontname, Fontsize",
+    "Style: Default,Arial,20",
+    "",
+    "[Events]",
+    "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text",
+    "Dialogue: 0,0:00:01.00,0:00:04.00,Default,,0000,0000,0000,,Hello world",
+    "Dialogue: 0,0:01:00.50,0:01:03.00,Default,,0000,0000,0000,,{\\b1}Bold text{\\b0}\\NSecond line",
+  ].join("\n");
+
+  it("parses a minimal ASS file with Script Info, Styles, and Dialogue", () => {
+    const result = parser.parse(minimalASS);
+    expect(result.metadata.format).toBe("ass");
+    expect(result.metadata.title).toBe("Test Script");
+    expect(result.cues).toHaveLength(2);
+
+    expect(result.cues[0].startMs).toBe(1000);
+    expect(result.cues[0].endMs).toBe(4000);
+    expect(result.cues[0].text).toBe("Hello world");
+  });
+
+  it("preserves the full original Dialogue line in rawText", () => {
+    const result = parser.parse(minimalASS);
+    expect(result.cues[1].rawText).toBe(
+      "Dialogue: 0,0:01:00.50,0:01:03.00,Default,,0000,0000,0000,,{\\b1}Bold text{\\b0}\\NSecond line",
+    );
+  });
+
+  it("strips override tags and converts \\N to newlines in text", () => {
+    const result = parser.parse(minimalASS);
+    expect(result.cues[1].text).toBe("Bold text\nSecond line");
+  });
+
+  it("includes header sections in metadata.rawHeader", () => {
+    const result = parser.parse(minimalASS);
+    const rawHeader = result.metadata.rawHeader as string;
+    expect(rawHeader).toContain("[Script Info]");
+    expect(rawHeader).toContain("[V4+ Styles]");
+    expect(rawHeader).not.toContain("[Events]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 1: VTT
+// ---------------------------------------------------------------------------
+describe("VTT parser", () => {
+  const parser = getParser("vtt");
+
+  it("parses with WEBVTT header", () => {
+    const input = [
+      "WEBVTT",
+      "",
+      "00:00:01.000 --> 00:00:04.000",
+      "Hello world",
+      "",
+      "00:01:00.000 --> 00:01:03.500",
+      "Second cue",
+    ].join("\n");
+
+    const result = parser.parse(input);
+    expect(result.metadata.format).toBe("vtt");
+    expect(result.cues).toHaveLength(2);
+
+    expect(result.cues[0].startMs).toBe(1000);
+    expect(result.cues[0].endMs).toBe(4000);
+    expect(result.cues[0].text).toBe("Hello world");
+
+    expect(result.cues[1].startMs).toBe(60000);
+    expect(result.cues[1].endMs).toBe(63500);
+    expect(result.cues[1].text).toBe("Second cue");
+  });
+
+  it("handles optional cue identifiers", () => {
+    const input = [
+      "WEBVTT",
+      "",
+      "intro",
+      "00:00:01.000 --> 00:00:04.000",
+      "With identifier",
+    ].join("\n");
+
+    const result = parser.parse(input);
+    expect(result.cues).toHaveLength(1);
+    expect(result.cues[0].text).toBe("With identifier");
+  });
+
+  it("handles position/alignment settings in timestamp line", () => {
+    const input = [
+      "WEBVTT",
+      "",
+      "00:00:01.000 --> 00:00:04.000 position:10% align:start",
+      "Positioned cue",
+    ].join("\n");
+
+    const result = parser.parse(input);
+    expect(result.cues).toHaveLength(1);
+    expect(result.cues[0].startMs).toBe(1000);
+    expect(result.cues[0].endMs).toBe(4000);
+    expect(result.cues[0].text).toBe("Positioned cue");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 2: SUB (MicroDVD)
+// ---------------------------------------------------------------------------
+describe("SUB parser", () => {
+  it("parses frame-based lines and converts to ms at 23.976fps", () => {
+    const parser = getParser("sub");
+    const input = "{0}{100}Hello";
+
+    const result = parser.parse(input);
+    expect(result.cues).toHaveLength(1);
+    expect(result.metadata.format).toBe("sub");
+
+    // 0 frames = 0ms, 100 frames at 23.976fps = Math.round((100/23.976)*1000)
+    expect(result.cues[0].startMs).toBe(0);
+    expect(result.cues[0].endMs).toBe(Math.round((100 / 23.976) * 1000));
+    expect(result.cues[0].text).toBe("Hello");
+    expect(result.cues[0].rawText).toBe("{0}{100}Hello");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 2: SMI
+// ---------------------------------------------------------------------------
+describe("SMI parser", () => {
+  it("parses SYNC-based content", () => {
+    const parser = getParser("smi");
+    const input = [
+      "<SAMI>",
+      "<BODY>",
+      '<SYNC Start=1000>Hello',
+      '<SYNC Start=4000>&nbsp;',
+      "</BODY>",
+      "</SAMI>",
+    ].join("\n");
+
+    const result = parser.parse(input);
+    expect(result.metadata.format).toBe("smi");
+    expect(result.cues).toHaveLength(1);
+    expect(result.cues[0].startMs).toBe(1000);
+    expect(result.cues[0].endMs).toBe(4000);
+    expect(result.cues[0].text).toBe("Hello");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 2: TXT (TMPlayer)
+// ---------------------------------------------------------------------------
+describe("TXT parser", () => {
+  it("parses TMPlayer format", () => {
+    const parser = getParser("txt");
+    const input = ["00:01:00:Hello", "00:02:00:World"].join("\n");
+
+    const result = parser.parse(input);
+    expect(result.metadata.format).toBe("txt");
+    expect(result.cues).toHaveLength(2);
+
+    expect(result.cues[0].startMs).toBe(60000);
+    // End time adjusted to next cue's start
+    expect(result.cues[0].endMs).toBe(120000);
+    expect(result.cues[0].text).toBe("Hello");
+
+    expect(result.cues[1].startMs).toBe(120000);
+    // Last cue gets startMs + 3000
+    expect(result.cues[1].endMs).toBe(123000);
+    expect(result.cues[1].text).toBe("World");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tier 2: MPL
+// ---------------------------------------------------------------------------
+describe("MPL parser", () => {
+  it("parses decisecond-based lines and converts to ms", () => {
+    const parser = getParser("mpl");
+    const input = "[100][200]Hello";
+
+    const result = parser.parse(input);
+    expect(result.metadata.format).toBe("mpl");
+    expect(result.cues).toHaveLength(1);
+
+    // 100 deciseconds = 10000ms, 200 deciseconds = 20000ms
+    expect(result.cues[0].startMs).toBe(10000);
+    expect(result.cues[0].endMs).toBe(20000);
+    expect(result.cues[0].text).toBe("Hello");
+    expect(result.cues[0].rawText).toBe("[100][200]Hello");
+  });
+});

--- a/frontend/src/pages/SubtitleEditor/index.tsx
+++ b/frontend/src/pages/SubtitleEditor/index.tsx
@@ -1,0 +1,108 @@
+import { useMemo } from "react";
+import { useParams } from "react-router";
+import {
+  Breadcrumbs,
+  Anchor,
+  Text,
+  Alert,
+  Badge,
+  Group,
+  Stack,
+  Center,
+  Loader,
+} from "@mantine/core";
+import { useSubtitleContent } from "@/apis/hooks/subtitles";
+import { getParser } from "./parsers";
+import CueTable from "./CueTable";
+import type { SubtitleFormat, ParseResult } from "./types";
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return bytes + " B";
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB";
+  return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+}
+
+export default function SubtitleEditor() {
+  const { mediaType, mediaId, language } = useParams();
+
+  const { data, isLoading, error } = useSubtitleContent(
+    mediaType,
+    mediaId ? Number(mediaId) : undefined,
+    language,
+  );
+
+  const parseResult = useMemo<ParseResult | null>(() => {
+    if (!data) return null;
+    try {
+      return getParser(data.format as SubtitleFormat).parse(data.content);
+    } catch {
+      return null;
+    }
+  }, [data]);
+
+  if (isLoading) {
+    return (
+      <Center style={{ height: "100%" }}>
+        <Loader />
+      </Center>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert color="red" title="Error" m="md">
+        {error.message || "Failed to load subtitle content"}
+      </Alert>
+    );
+  }
+
+  if (data && !parseResult) {
+    return (
+      <Alert color="red" title="Parse Error" m="md">
+        Failed to parse subtitle file
+      </Alert>
+    );
+  }
+
+  if (!data || !parseResult) {
+    return null;
+  }
+
+  const listPath =
+    mediaType === "episode" || mediaType === "series" ? "/series" : "/movies";
+  const listLabel =
+    mediaType === "episode" || mediaType === "series" ? "Series" : "Movies";
+
+  return (
+    <Stack gap="sm" style={{ height: "100%", padding: "0" }}>
+      <Group justify="space-between" px="md" pt="xs">
+        <Breadcrumbs>
+          <Anchor href={listPath}>{listLabel}</Anchor>
+          <Text>Subtitle Viewer</Text>
+        </Breadcrumbs>
+        <Group gap="xs">
+          <Badge variant="light" size="sm">
+            {data.format.toUpperCase()}
+          </Badge>
+          {data.language && (
+            <Badge variant="light" color="teal" size="sm">
+              {data.language}
+            </Badge>
+          )}
+          <Badge variant="outline" color="gray" size="sm">
+            {data.encoding}
+          </Badge>
+          <Text size="xs" c="dimmed">
+            {parseResult.cues.length} cues
+          </Text>
+          <Text size="xs" c="dimmed">
+            {formatFileSize(data.size)}
+          </Text>
+        </Group>
+      </Group>
+      <div style={{ flex: 1, minHeight: 0, display: "flex", padding: "0 var(--mantine-spacing-md) var(--mantine-spacing-md)" }}>
+        <CueTable cues={parseResult.cues} />
+      </div>
+    </Stack>
+  );
+}

--- a/frontend/src/pages/SubtitleEditor/parsers/ass.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/ass.ts
@@ -1,0 +1,146 @@
+import type { ParseResult, Cue } from "../types";
+import type { SubtitleParser } from "./index";
+
+function parseTimestamp(raw: string): number {
+  // H:MM:SS.cc (centiseconds)
+  const match = raw.trim().match(/^(\d+):(\d+):(\d+)\.(\d+)$/);
+  if (!match) return 0;
+  const [, h, m, s, cs] = match;
+  return (
+    parseInt(h, 10) * 3600000 +
+    parseInt(m, 10) * 60000 +
+    parseInt(s, 10) * 1000 +
+    parseInt(cs.padEnd(2, "0").slice(0, 2), 10) * 10
+  );
+}
+
+function stripOverrideTags(text: string): string {
+  // Remove {...} override blocks
+  return text.replace(/\{[^}]*\}/g, "");
+}
+
+function assTextToDisplay(text: string): string {
+  let clean = stripOverrideTags(text);
+  // \N and \n both become newlines for display
+  clean = clean.replace(/\\N/g, "\n").replace(/\\n/g, "\n");
+  return clean;
+}
+
+export const assParser: SubtitleParser = {
+  parse(content: string): ParseResult {
+    const text = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+
+    if (!text.trim()) {
+      return { metadata: { format: "ass" }, cues: [] };
+    }
+
+    // Determine format variant
+    const isSSA = !text.includes("[V4+ Styles]") && text.includes("[V4 Styles]");
+    const format = isSSA ? "ssa" : "ass";
+
+    // Split into sections
+    const sections: Record<string, string> = {};
+    let currentSection = "";
+    const lines = text.split("\n");
+
+    for (const line of lines) {
+      const sectionMatch = line.match(/^\[([^\]]+)\]/);
+      if (sectionMatch) {
+        currentSection = sectionMatch[1];
+        sections[currentSection] = "";
+      } else if (currentSection) {
+        sections[currentSection] += line + "\n";
+      }
+    }
+
+    // Build rawHeader from everything before [Events]
+    const eventsIdx = text.indexOf("[Events]");
+    const rawHeader = eventsIdx >= 0 ? text.slice(0, eventsIdx) : text;
+
+    // Extract title from Script Info
+    let title: string | undefined;
+    const scriptInfo = sections["Script Info"] ?? "";
+    const titleMatch = scriptInfo.match(/^Title:\s*(.+)$/m);
+    if (titleMatch) {
+      title = titleMatch[1].trim();
+    }
+
+    // Extract styles
+    const stylesKey = isSSA ? "V4 Styles" : "V4+ Styles";
+    const styles = sections[stylesKey]?.trim() || undefined;
+
+    // Parse events
+    const eventsText = sections["Events"] ?? "";
+    const eventsLines = eventsText.split("\n").filter((l) => l.trim());
+
+    // Find Format line to determine column order
+    const formatLine = eventsLines.find((l) =>
+      l.trim().startsWith("Format:"),
+    );
+    let formatColumns: string[] = [];
+    if (formatLine) {
+      formatColumns = formatLine
+        .replace(/^Format:\s*/, "")
+        .split(",")
+        .map((c) => c.trim());
+    }
+
+    const textColIdx = formatColumns.findIndex(
+      (c) => c.toLowerCase() === "text",
+    );
+    const startColIdx = formatColumns.findIndex(
+      (c) => c.toLowerCase() === "start",
+    );
+    const endColIdx = formatColumns.findIndex(
+      (c) => c.toLowerCase() === "end",
+    );
+
+    const cues: Cue[] = [];
+
+    for (const line of eventsLines) {
+      if (!line.trim().startsWith("Dialogue:")) continue;
+
+      const afterPrefix = line.replace(/^Dialogue:\s*/, "");
+      // Split only up to (columns - 1) commas, because the Text field can contain commas
+      const maxSplits = formatColumns.length - 1;
+      const parts: string[] = [];
+      let remaining = afterPrefix;
+      for (let i = 0; i < maxSplits; i++) {
+        const commaIdx = remaining.indexOf(",");
+        if (commaIdx === -1) break;
+        parts.push(remaining.slice(0, commaIdx).trim());
+        remaining = remaining.slice(commaIdx + 1);
+      }
+      parts.push(remaining); // The rest is the Text column (or last column)
+
+      const rawCueText =
+        textColIdx >= 0 && textColIdx < parts.length
+          ? parts[textColIdx]
+          : parts[parts.length - 1];
+      const startStr =
+        startColIdx >= 0 && startColIdx < parts.length
+          ? parts[startColIdx]
+          : "";
+      const endStr =
+        endColIdx >= 0 && endColIdx < parts.length ? parts[endColIdx] : "";
+
+      cues.push({
+        id: crypto.randomUUID(),
+        startMs: parseTimestamp(startStr),
+        endMs: parseTimestamp(endStr),
+        text: assTextToDisplay(rawCueText),
+        rawText: line,
+      });
+    }
+
+    return {
+      metadata: {
+        format,
+        title,
+        styles,
+        rawHeader: rawHeader.trimEnd(),
+      },
+      cues,
+    };
+  },
+};

--- a/frontend/src/pages/SubtitleEditor/parsers/index.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/index.ts
@@ -1,0 +1,46 @@
+import type { ParseResult, SubtitleFormat } from "../types";
+import { srtParser } from "./srt";
+import { assParser } from "./ass";
+import { vttParser } from "./vtt";
+import { subParser } from "./sub";
+import { smiParser } from "./smi";
+import { txtParser } from "./txt";
+import { mplParser } from "./mpl";
+
+export interface SubtitleParser {
+  parse(content: string): ParseResult;
+}
+
+const parsers: Record<SubtitleFormat, SubtitleParser> = {
+  srt: srtParser,
+  ass: assParser,
+  ssa: assParser,
+  vtt: vttParser,
+  sub: subParser,
+  smi: smiParser,
+  txt: txtParser,
+  mpl: mplParser,
+};
+
+export function getParser(format: SubtitleFormat): SubtitleParser {
+  return parsers[format];
+}
+
+const extensionMap: Record<string, SubtitleFormat> = {
+  ".srt": "srt",
+  ".ass": "ass",
+  ".ssa": "ssa",
+  ".vtt": "vtt",
+  ".sub": "sub",
+  ".smi": "smi",
+  ".sami": "smi",
+  ".txt": "txt",
+  ".mpl": "mpl",
+};
+
+export function detectFormat(filename: string): SubtitleFormat {
+  const dot = filename.lastIndexOf(".");
+  if (dot === -1) return "srt";
+  const ext = filename.slice(dot).toLowerCase();
+  return extensionMap[ext] ?? "srt";
+}

--- a/frontend/src/pages/SubtitleEditor/parsers/mpl.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/mpl.ts
@@ -1,0 +1,36 @@
+import type { ParseResult } from "../types";
+import type { SubtitleParser } from "./index";
+
+export const mplParser: SubtitleParser = {
+  parse(content: string): ParseResult {
+    const text = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+
+    if (!text.trim()) {
+      return { metadata: { format: "mpl" }, cues: [] };
+    }
+
+    const lines = text.split("\n").filter((l) => l.trim());
+    const cues = [];
+    // MPL2 format: [start_ds][end_ds]text
+    // ds = deciseconds (1/10 second)
+    const pattern = /^\[(\d+)\]\[(\d+)\](.*)$/;
+
+    for (const line of lines) {
+      const match = line.match(pattern);
+      if (!match) continue;
+
+      const [, startDs, endDs, rawText] = match;
+      const displayText = rawText.replace(/\|/g, "\n");
+
+      cues.push({
+        id: crypto.randomUUID(),
+        startMs: parseInt(startDs, 10) * 100,
+        endMs: parseInt(endDs, 10) * 100,
+        text: displayText,
+        rawText: line,
+      });
+    }
+
+    return { metadata: { format: "mpl" }, cues };
+  },
+};

--- a/frontend/src/pages/SubtitleEditor/parsers/smi.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/smi.ts
@@ -1,0 +1,79 @@
+import type { ParseResult } from "../types";
+import type { SubtitleParser } from "./index";
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&amp;/gi, "&")
+    .trim();
+}
+
+export const smiParser: SubtitleParser = {
+  parse(content: string): ParseResult {
+    const text = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+
+    if (!text.trim()) {
+      return { metadata: { format: "smi" }, cues: [] };
+    }
+
+    // Find all SYNC tags with their start times and collect text between them
+    const syncPattern = /<SYNC\s+Start\s*=\s*(\d+)\s*>/gi;
+    const syncs: { startMs: number; index: number }[] = [];
+    let match: RegExpExecArray | null;
+
+    while ((match = syncPattern.exec(text)) !== null) {
+      syncs.push({
+        startMs: parseInt(match[1], 10),
+        index: match.index + match[0].length,
+      });
+    }
+
+    // Extract title if present
+    let title: string | undefined;
+    const titleMatch = text.match(/<TITLE[^>]*>([\s\S]*?)<\/TITLE>/i);
+    if (titleMatch) {
+      title = stripHtml(titleMatch[1]);
+    }
+
+    const cues = [];
+
+    for (let i = 0; i < syncs.length; i++) {
+      const start = syncs[i];
+      // Get text from after this SYNC tag to the start of the next SYNC tag (or end of text)
+      const nextSyncPattern = /<SYNC\s/i;
+      const remainingText = text.slice(start.index);
+      const nextSyncMatch = remainingText.match(nextSyncPattern);
+      const segment = nextSyncMatch
+        ? remainingText.slice(0, nextSyncMatch.index)
+        : remainingText;
+      const displayText = stripHtml(segment);
+
+      // Skip empty/whitespace-only cues (often used as "clear" markers)
+      if (!displayText || displayText === "&nbsp;" || !displayText.trim()) {
+        continue;
+      }
+
+      const endMs =
+        i + 1 < syncs.length ? syncs[i + 1].startMs : start.startMs + 3000;
+
+      cues.push({
+        id: crypto.randomUUID(),
+        startMs: start.startMs,
+        endMs,
+        text: displayText,
+      });
+    }
+
+    return {
+      metadata: {
+        format: "smi",
+        title,
+      },
+      cues,
+    };
+  },
+};

--- a/frontend/src/pages/SubtitleEditor/parsers/srt.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/srt.ts
@@ -1,0 +1,61 @@
+import type { ParseResult } from "../types";
+import type { SubtitleParser } from "./index";
+
+function parseTimestamp(raw: string): number {
+  // HH:MM:SS,mmm or HH:MM:SS.mmm
+  const match = raw.trim().match(/^(\d+):(\d+):(\d+)[,.](\d+)$/);
+  if (!match) return 0;
+  const [, h, m, s, ms] = match;
+  return (
+    parseInt(h, 10) * 3600000 +
+    parseInt(m, 10) * 60000 +
+    parseInt(s, 10) * 1000 +
+    parseInt(ms.padEnd(3, "0").slice(0, 3), 10)
+  );
+}
+
+export const srtParser: SubtitleParser = {
+  parse(content: string): ParseResult {
+    // Normalize: strip BOM, normalize line endings
+    const text = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+
+    if (!text.trim()) {
+      return { metadata: { format: "srt" }, cues: [] };
+    }
+
+    const blocks = text.split(/\n\n+/).filter((b) => b.trim());
+    const cues = [];
+
+    for (const block of blocks) {
+      const lines = block.trim().split("\n");
+      if (lines.length < 2) continue;
+
+      // Find the timestamp line. It could be line 0 (missing sequence number)
+      // or line 1 (normal case).
+      let tsLineIdx = -1;
+      for (let i = 0; i < Math.min(lines.length, 2); i++) {
+        if (lines[i].includes("-->")) {
+          tsLineIdx = i;
+          break;
+        }
+      }
+      if (tsLineIdx === -1) continue;
+
+      const tsParts = lines[tsLineIdx].split("-->");
+      if (tsParts.length < 2) continue;
+
+      const startMs = parseTimestamp(tsParts[0]);
+      const endMs = parseTimestamp(tsParts[1].trim().split(/\s/)[0]);
+      const cueText = lines.slice(tsLineIdx + 1).join("\n");
+
+      cues.push({
+        id: crypto.randomUUID(),
+        startMs,
+        endMs,
+        text: cueText,
+      });
+    }
+
+    return { metadata: { format: "srt" }, cues };
+  },
+};

--- a/frontend/src/pages/SubtitleEditor/parsers/sub.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/sub.ts
@@ -1,0 +1,39 @@
+import type { ParseResult } from "../types";
+import type { SubtitleParser } from "./index";
+
+const DEFAULT_FPS = 23.976;
+
+function framesToMs(frame: number, fps: number): number {
+  return Math.round((frame / fps) * 1000);
+}
+
+export const subParser: SubtitleParser = {
+  parse(content: string): ParseResult {
+    const text = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+
+    if (!text.trim()) {
+      return { metadata: { format: "sub" }, cues: [] };
+    }
+
+    const lines = text.split("\n").filter((l) => l.trim());
+    const cues = [];
+
+    for (const line of lines) {
+      const match = line.match(/^\{(\d+)\}\{(\d+)\}(.*)$/);
+      if (!match) continue;
+
+      const [, startFrame, endFrame, rawText] = match;
+      const displayText = rawText.replace(/\|/g, "\n");
+
+      cues.push({
+        id: crypto.randomUUID(),
+        startMs: framesToMs(parseInt(startFrame, 10), DEFAULT_FPS),
+        endMs: framesToMs(parseInt(endFrame, 10), DEFAULT_FPS),
+        text: displayText,
+        rawText: line,
+      });
+    }
+
+    return { metadata: { format: "sub" }, cues };
+  },
+};

--- a/frontend/src/pages/SubtitleEditor/parsers/txt.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/txt.ts
@@ -1,0 +1,80 @@
+import type { ParseResult } from "../types";
+import type { SubtitleParser } from "./index";
+
+function parseTimestampToMs(h: string, m: string, s: string): number {
+  return (
+    parseInt(h, 10) * 3600000 +
+    parseInt(m, 10) * 60000 +
+    parseInt(s, 10) * 1000
+  );
+}
+
+export const txtParser: SubtitleParser = {
+  parse(content: string): ParseResult {
+    const text = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+
+    if (!text.trim()) {
+      return { metadata: { format: "txt" }, cues: [] };
+    }
+
+    const lines = text.split("\n").filter((l) => l.trim());
+    const cues = [];
+
+    // Try TMPlayer format: HH:MM:SS:text or HH:MM:SS=text
+    const tmPlayerPattern = /^(\d+):(\d+):(\d+)[:=](.+)$/;
+    let isTmPlayer = false;
+
+    // Check first non-empty line to detect format
+    if (lines.length > 0 && tmPlayerPattern.test(lines[0])) {
+      isTmPlayer = true;
+    }
+
+    if (isTmPlayer) {
+      for (const line of lines) {
+        const match = line.match(tmPlayerPattern);
+        if (!match) continue;
+
+        const [, h, m, s, cueText] = match;
+        const startMs = parseTimestampToMs(h, m, s);
+        const displayText = cueText.replace(/\|/g, "\n");
+
+        cues.push({
+          id: crypto.randomUUID(),
+          startMs,
+          endMs: startMs + 3000,
+          text: displayText,
+        });
+      }
+
+      // Adjust end times: each cue ends when the next one starts
+      for (let i = 0; i < cues.length - 1; i++) {
+        cues[i].endMs = cues[i + 1].startMs;
+      }
+    } else {
+      // Try simple numbered format: N HH:MM:SS text
+      const numberedPattern = /^(\d+)\s+(\d+):(\d+):(\d+)\s+(.+)$/;
+
+      for (const line of lines) {
+        const match = line.match(numberedPattern);
+        if (!match) continue;
+
+        const [, , h, m, s, cueText] = match;
+        const startMs = parseTimestampToMs(h, m, s);
+
+        cues.push({
+          id: crypto.randomUUID(),
+          startMs,
+          endMs: startMs + 3000,
+          text: cueText,
+        });
+      }
+
+      // Adjust end times
+      for (let i = 0; i < cues.length - 1; i++) {
+        cues[i].endMs = cues[i + 1].startMs;
+      }
+    }
+
+    return { metadata: { format: "txt" }, cues };
+  },
+};

--- a/frontend/src/pages/SubtitleEditor/parsers/vtt.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/vtt.ts
@@ -1,0 +1,128 @@
+import type { ParseResult } from "../types";
+import type { SubtitleParser } from "./index";
+
+function parseTimestamp(raw: string): number {
+  // HH:MM:SS.mmm or MM:SS.mmm
+  const match = raw.trim().match(/^(?:(\d+):)?(\d+):(\d+)\.(\d+)$/);
+  if (!match) return 0;
+  const [, h, m, s, ms] = match;
+  return (
+    (parseInt(h ?? "0", 10)) * 3600000 +
+    parseInt(m, 10) * 60000 +
+    parseInt(s, 10) * 1000 +
+    parseInt(ms.padEnd(3, "0").slice(0, 3), 10)
+  );
+}
+
+export const vttParser: SubtitleParser = {
+  parse(content: string): ParseResult {
+    const text = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+
+    if (!text.trim()) {
+      return { metadata: { format: "vtt" }, cues: [] };
+    }
+
+    const lines = text.split("\n");
+
+    // Verify WEBVTT header
+    if (!lines[0].trim().startsWith("WEBVTT")) {
+      return { metadata: { format: "vtt" }, cues: [] };
+    }
+
+    // Collect header metadata (STYLE, REGION blocks, NOTE blocks before first cue)
+    let rawHeader = "";
+    let i = 0;
+
+    // Skip WEBVTT line and any following header text
+    rawHeader += lines[i] + "\n";
+    i++;
+
+    // Collect everything before the first cue as header
+    // A cue starts with a timestamp line containing -->
+    const headerLines: string[] = [lines[0]];
+    let foundFirstCue = false;
+    for (i = 1; i < lines.length; i++) {
+      if (lines[i].includes("-->")) {
+        // Check if previous non-empty line was a cue identifier
+        foundFirstCue = true;
+        // Remove the cue ID line if it was added to header
+        const lastNonEmpty = headerLines.length - 1;
+        if (
+          lastNonEmpty >= 0 &&
+          headerLines[lastNonEmpty].trim() &&
+          !headerLines[lastNonEmpty].includes("-->") &&
+          !headerLines[lastNonEmpty].startsWith("STYLE") &&
+          !headerLines[lastNonEmpty].startsWith("REGION") &&
+          !headerLines[lastNonEmpty].startsWith("NOTE")
+        ) {
+          headerLines.pop();
+        }
+        break;
+      }
+      headerLines.push(lines[i]);
+    }
+
+    rawHeader = headerLines.join("\n").trimEnd();
+
+    // Parse cue blocks
+    const cues = [];
+    const blocks = text.split(/\n\n+/);
+
+    for (const block of blocks) {
+      const blockLines = block.trim().split("\n");
+      if (blockLines.length < 2) continue;
+
+      // Find the timestamp line
+      let tsLineIdx = -1;
+      for (let j = 0; j < blockLines.length; j++) {
+        if (blockLines[j].includes("-->")) {
+          tsLineIdx = j;
+          break;
+        }
+      }
+      if (tsLineIdx === -1) continue;
+
+      const tsLine = blockLines[tsLineIdx];
+      // Split on --> but the right side may have positioning info
+      const arrowIdx = tsLine.indexOf("-->");
+      const leftTs = tsLine.slice(0, arrowIdx).trim();
+      const rightPart = tsLine.slice(arrowIdx + 3).trim();
+      // The end timestamp is the first token; the rest are settings
+      const rightTokens = rightPart.split(/\s+/);
+      const rightTs = rightTokens[0];
+
+      const startMs = parseTimestamp(leftTs);
+      const endMs = parseTimestamp(rightTs);
+      const cueText = blockLines.slice(tsLineIdx + 1).join("\n");
+
+      if (!cueText.trim() && startMs === 0 && endMs === 0) continue;
+
+      cues.push({
+        id: crypto.randomUUID(),
+        startMs,
+        endMs,
+        text: cueText,
+      });
+    }
+
+    // Extract styles from header
+    let styles: string | undefined;
+    if (foundFirstCue) {
+      const styleMatch = rawHeader.match(
+        /STYLE\s*\n([\s\S]*?)(?:\n\n|$)/,
+      );
+      if (styleMatch) {
+        styles = styleMatch[1].trim();
+      }
+    }
+
+    return {
+      metadata: {
+        format: "vtt",
+        styles: styles || undefined,
+        rawHeader,
+      },
+      cues,
+    };
+  },
+};

--- a/frontend/src/pages/SubtitleEditor/types.ts
+++ b/frontend/src/pages/SubtitleEditor/types.ts
@@ -1,0 +1,39 @@
+export type SubtitleFormat =
+  | "srt"
+  | "ass"
+  | "ssa"
+  | "vtt"
+  | "sub"
+  | "smi"
+  | "txt"
+  | "mpl";
+
+export interface Cue {
+  id: string;
+  startMs: number;
+  endMs: number;
+  text: string;
+  rawText?: string;
+  formatMetadata?: unknown;
+}
+
+export interface SubtitleMetadata {
+  format: SubtitleFormat;
+  title?: string;
+  styles?: unknown;
+  rawHeader?: string;
+}
+
+export interface ParseResult {
+  metadata: SubtitleMetadata;
+  cues: Cue[];
+}
+
+export interface SubtitleContentResponse {
+  content: string;
+  encoding: string;
+  format: string;
+  language: string;
+  size: number;
+  lastModified: number;
+}


### PR DESCRIPTION
## Summary

- New dedicated page for viewing subtitle file contents at `/subtitles/preview/:mediaType/:mediaId/:language`
- Supports all 8 subtitle formats: SRT, ASS/SSA, VTT, SUB, SMI, TXT, MPL
- Virtualized cue table handles 2000+ cues smoothly
- HTML tags (`<i>`, `<b>`, `<font>`) and ASS override tags (`{\an8}`, `{\pos}`, `{\fad}`, etc.) rendered as colored badges
- Backend resolves paths from media IDs (no raw filesystem paths), with charset detection and ETag caching
- Language-based routing (stable across subtitle re-indexing)
- "View" menu item added to subtitle tools menu on both series and movie detail pages
- SQLite WAL mode enabled for concurrent read/write support

This is Phase 0 of the subtitle editor feature. Future phases will add editing, video preview, timeline, and waveform visualization.

## Test plan

- [x] Navigate to a series episode detail page, hover a subtitle badge, click "View" from the menu
- [x] Navigate to a movie detail page, click "..." on a subtitle, click "View"
- [x] Verify SRT files with HTML tags show colored badges (not raw `<i>` text)
- [x] Verify SRT files with ASS tags like `{\an8}` show yellow "align-8" badges
- [x] Test with a large subtitle file (400+ cues), verify smooth scrolling
- [x] Test with multiple subtitle languages on same media, verify correct content for each