### PR TITLE
fix: route individual subtitle mod actions through job queue

### DIFF
--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -11,7 +11,7 @@ from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import subtitles_sync_references
 from subtitles.tools.subsyncer import SubSyncer
 from subtitles.tools.translate.main import translate_subtitles_file
-from subtitles.tools.mods import subtitles_apply_mods
+from subtitles.tools.mods import apply_subtitle_mods
 from subtitles.indexer.series import store_subtitles
 from subtitles.indexer.movies import store_subtitles_movie
 from subtitles.sync import sync_subtitles
@@ -193,11 +193,9 @@ class Subtitles(Resource):
                 except OSError:
                     return 'Unable to edit subtitles file. Check logs.', 409
         else:
-            try:
-                subtitles_apply_mods(language=language, subtitle_path=subtitles_path, mods=[action],
-                                     video_path=video_path)
-            except OSError:
-                return 'Unable to edit subtitles file. Check logs.', 409
+            apply_subtitle_mods(language=language, subtitle_path=subtitles_path, mods=[action],
+                                video_path=video_path, media_type=media_type, media_id=id)
+            return '', 204
 
         # apply chmod if required
         chmod = int(settings.general.chmod, 8) if not sys.platform.startswith(

--- a/bazarr/subtitles/tools/mods.py
+++ b/bazarr/subtitles/tools/mods.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import os
+import sys
 import logging
 
 from subliminal_patch.subtitle import Subtitle
@@ -8,9 +9,91 @@ from subliminal_patch.core import get_subtitle_path
 from subzero.language import Language
 
 from app.config import settings
+from app.jobs_queue import jobs_queue
 from languages.custom_lang import CustomLanguage
 from languages.get_languages import alpha3_from_alpha2
 from subtitles.indexer.utils import get_external_subtitles_path
+
+
+MOD_LABELS = {
+    'remove_HI': 'Remove HI Tags',
+    'remove_tags': 'Remove Style Tags',
+    'OCR_fixes': 'OCR Fixes',
+    'common': 'Common Fixes',
+    'fix_uppercase': 'Fix Uppercase',
+    'reverse_rtl': 'Reverse RTL',
+    'add_color': 'Add Color',
+    'change_frame_rate': 'Change Frame Rate',
+    'adjust_time': 'Adjust Times',
+    'emoji': 'Remove Emoji',
+}
+
+
+def apply_subtitle_mods(language, subtitle_path, mods, video_path,
+                         media_type=None, media_id=None, job_id=None):
+    """Job-aware wrapper for subtitles_apply_mods.
+
+    When called without a job_id, queues the work as a backend job and returns
+    immediately. When called with a job_id (by the job queue consumer), does the
+    actual work and handles post-processing (store_subtitles, event_stream, chmod).
+    """
+    if not job_id:
+        # No local variables can be assigned before add_job_from_function because
+        # it introspects the frame and re-passes all locals as kwargs on re-invocation.
+        jobs_queue.add_job_from_function(
+            (lambda m, p: f'{MOD_LABELS.get(m, m)}: {os.path.basename(p)}')(
+                mods[0] if mods else 'mods', subtitle_path),
+            is_progress=False,
+        )
+        return
+
+    mod_label = MOD_LABELS.get(mods[0], mods[0]) if mods else 'Apply Mods'
+    filename = os.path.basename(subtitle_path)
+
+    try:
+        subtitles_apply_mods(language=language, subtitle_path=subtitle_path,
+                             mods=mods, video_path=video_path)
+    except Exception:
+        jobs_queue.update_job_name(
+            job_id=job_id,
+            new_job_name=f'Failed {mod_label}: {filename}',
+        )
+        raise
+
+    # apply chmod if required
+    chmod = int(settings.general.chmod, 8) if not sys.platform.startswith(
+        'win') and settings.general.chmod_enabled else None
+    if chmod and os.path.exists(subtitle_path):
+        os.chmod(subtitle_path, chmod)
+
+    # re-index subtitles so Bazarr's DB picks up the changes
+    from subtitles.indexer.series import store_subtitles
+    from subtitles.indexer.movies import store_subtitles_movie
+    from app.event_handler import event_stream
+    from utilities.path_mappings import path_mappings
+
+    if media_type == 'episode':
+        store_subtitles(path_mappings.path_replace_reverse(video_path), video_path)
+    elif media_type == 'movie':
+        store_subtitles_movie(path_mappings.path_replace_reverse_movie(video_path), video_path)
+
+    if media_id and media_type:
+        if media_type == 'episode':
+            from app.database import TableEpisodes, database, select
+            metadata = database.execute(
+                select(TableEpisodes.sonarrSeriesId)
+                .where(TableEpisodes.sonarrEpisodeId == media_id)
+            ).first()
+            if metadata:
+                event_stream(type='series', payload=metadata.sonarrSeriesId)
+            event_stream(type='episode', payload=media_id)
+        else:
+            event_stream(type='movie', payload=media_id)
+
+    jobs_queue.update_job_name(
+        job_id=job_id,
+        new_job_name=f'{mod_label}: {filename}',
+    )
 
 
 def subtitles_apply_mods(language, subtitle_path, mods, video_path):


### PR DESCRIPTION
## Summary
- Individual tool actions (Remove HI, OCR Fixes, Common Fixes, etc.) were running synchronously in the PATCH handler and never appeared in the Jobs Manager
- Added `apply_subtitle_mods` wrapper in `mods.py` that queues work via `add_job_from_function`, matching the existing sync/translate pattern
- Post-processing (chmod, store_subtitles, event_stream) now runs inside the job after the mod completes

## Test plan
- [x] Deployed to test server, confirmed all mod tools appear in Jobs Manager
- [x] Verified jobs execute successfully (logs show full lifecycle: pending > running > completed)
- [x] Existing mass_operations tests pass (53/53)
- [x] Verify batch mod operations still work (uses `subtitles_apply_mods` directly, unchanged)