### PR TITLE
fix(subtitle-editor): fallback cue id for non-secure contexts

### DIFF
--- a/frontend/src/pages/SubtitleEditor/parsers/ass.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/ass.ts
@@ -1,5 +1,6 @@
 import type { Cue, ParseResult } from "@/pages/SubtitleEditor/types";
 import type { SubtitleParser } from "./index";
+import { cueId } from "./uuid";
 
 function parseTimestamp(raw: string): number {
   // H:MM:SS.cc (centiseconds)
@@ -122,7 +123,7 @@ export const assParser: SubtitleParser = {
         endColIdx >= 0 && endColIdx < parts.length ? parts[endColIdx] : "";
 
       cues.push({
-        id: crypto.randomUUID(),
+        id: cueId(),
         startMs: parseTimestamp(startStr),
         endMs: parseTimestamp(endStr),
         text: assTextToDisplay(rawCueText),

--- a/frontend/src/pages/SubtitleEditor/parsers/mpl.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/mpl.ts
@@ -1,5 +1,6 @@
 import type { ParseResult } from "@/pages/SubtitleEditor/types";
 import type { SubtitleParser } from "./index";
+import { cueId } from "./uuid";
 
 export const mplParser: SubtitleParser = {
   parse(content: string): ParseResult {
@@ -23,7 +24,7 @@ export const mplParser: SubtitleParser = {
       const displayText = rawText.replace(/\|/g, "\n");
 
       cues.push({
-        id: crypto.randomUUID(),
+        id: cueId(),
         startMs: parseInt(startDs, 10) * 100,
         endMs: parseInt(endDs, 10) * 100,
         text: displayText,

--- a/frontend/src/pages/SubtitleEditor/parsers/smi.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/smi.ts
@@ -1,5 +1,6 @@
 import type { ParseResult } from "@/pages/SubtitleEditor/types";
 import type { SubtitleParser } from "./index";
+import { cueId } from "./uuid";
 
 function stripHtml(html: string): string {
   let result = html.replace(/<br\s*\/?>/gi, "\n");
@@ -66,7 +67,7 @@ export const smiParser: SubtitleParser = {
         i + 1 < syncs.length ? syncs[i + 1].startMs : start.startMs + 3000;
 
       cues.push({
-        id: crypto.randomUUID(),
+        id: cueId(),
         startMs: start.startMs,
         endMs,
         text: displayText,

--- a/frontend/src/pages/SubtitleEditor/parsers/srt.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/srt.ts
@@ -1,5 +1,6 @@
 import type { ParseResult } from "@/pages/SubtitleEditor/types";
 import type { SubtitleParser } from "./index";
+import { cueId } from "./uuid";
 
 function parseTimestamp(raw: string): number {
   // HH:MM:SS,mmm or HH:MM:SS.mmm
@@ -49,7 +50,7 @@ export const srtParser: SubtitleParser = {
       const cueText = lines.slice(tsLineIdx + 1).join("\n");
 
       cues.push({
-        id: crypto.randomUUID(),
+        id: cueId(),
         startMs,
         endMs,
         text: cueText,

--- a/frontend/src/pages/SubtitleEditor/parsers/sub.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/sub.ts
@@ -1,5 +1,6 @@
 import type { ParseResult } from "@/pages/SubtitleEditor/types";
 import type { SubtitleParser } from "./index";
+import { cueId } from "./uuid";
 
 const DEFAULT_FPS = 23.976;
 
@@ -26,7 +27,7 @@ export const subParser: SubtitleParser = {
       const displayText = rawText.replace(/\|/g, "\n");
 
       cues.push({
-        id: crypto.randomUUID(),
+        id: cueId(),
         startMs: framesToMs(parseInt(startFrame, 10), DEFAULT_FPS),
         endMs: framesToMs(parseInt(endFrame, 10), DEFAULT_FPS),
         text: displayText,

--- a/frontend/src/pages/SubtitleEditor/parsers/txt.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/txt.ts
@@ -1,5 +1,6 @@
 import type { ParseResult } from "@/pages/SubtitleEditor/types";
 import type { SubtitleParser } from "./index";
+import { cueId } from "./uuid";
 
 function parseTimestampToMs(h: string, m: string, s: string): number {
   return (
@@ -37,7 +38,7 @@ export const txtParser: SubtitleParser = {
         const displayText = cueText.replace(/\|/g, "\n");
 
         cues.push({
-          id: crypto.randomUUID(),
+          id: cueId(),
           startMs,
           endMs: startMs + 3000,
           text: displayText,
@@ -60,7 +61,7 @@ export const txtParser: SubtitleParser = {
         const startMs = parseTimestampToMs(h, m, s);
 
         cues.push({
-          id: crypto.randomUUID(),
+          id: cueId(),
           startMs,
           endMs: startMs + 3000,
           text: cueText,

--- a/frontend/src/pages/SubtitleEditor/parsers/uuid.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/uuid.ts
@@ -1,0 +1,17 @@
+let counter = 0;
+
+// crypto.randomUUID() is only defined in secure contexts (HTTPS, localhost,
+// 127.0.0.1). On plain-http LAN origins like http://192.168.x.x it is
+// undefined and calling it throws TypeError, which breaks the subtitle parsers.
+export function cueId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function" &&
+    (window.isSecureContext ||
+      location.hostname === "localhost" ||
+      location.hostname === "127.0.0.1")
+  ) {
+    return crypto.randomUUID();
+  }
+  return `cue-${Date.now()}-${counter++}`;
+}

--- a/frontend/src/pages/SubtitleEditor/parsers/vtt.ts
+++ b/frontend/src/pages/SubtitleEditor/parsers/vtt.ts
@@ -1,5 +1,6 @@
 import type { ParseResult } from "@/pages/SubtitleEditor/types";
 import type { SubtitleParser } from "./index";
+import { cueId } from "./uuid";
 
 function parseTimestamp(raw: string): number {
   // HH:MM:SS.mmm or MM:SS.mmm
@@ -98,7 +99,7 @@ export const vttParser: SubtitleParser = {
       if (!cueText.trim() && startMs === 0 && endMs === 0) continue;
 
       cues.push({
-        id: crypto.randomUUID(),
+        id: cueId(),
         startMs,
         endMs,
         text: cueText,


### PR DESCRIPTION
## Summary
- `crypto.randomUUID()` is only defined on secure origins (HTTPS, localhost, 127.0.0.1). On plain-http LAN origins like `http://192.168.x.x` it is undefined, so every subtitle parser threw `TypeError` and the editor rendered the generic "Failed to parse subtitle file" error.
- Adds `parsers/uuid.ts` with a `cueId()` helper that prefers `crypto.randomUUID()` when available and otherwise returns a `cue-<timestamp>-<counter>` id. IDs only need to be unique within a single parse run since they feed React list keys.
- Replaces all 8 `crypto.randomUUID()` call sites across `ass/mpl/smi/srt/sub/txt/vtt.ts`.

## Test plan
- [x] `npm run check:ts` clean
- [x] `npm run check` (0 errors, existing warnings unchanged)
- [x] `npm run check:fmt` clean
- [x] `npm test -- --run` (424 passed / 3 skipped)
- [x] `npm run build` successful
- [x] Deployed image to LAN test server; verify subtitle editor now parses on `http://192.168.x.x:6767`