### PR TITLE
feat(subdl): anime/pack support behind opt-in anime_mode flag

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -437,6 +437,7 @@ validators = [
 
     # subdl section
     Validator('subdl.api_key', must_exist=True, default='', is_type_of=str, cast=str),
+    Validator('subdl.anime_mode', must_exist=True, default=False, is_type_of=bool),
 
     # turkcealtyaziorg section
     Validator('turkcealtyaziorg.cookies', must_exist=True, default='', is_type_of=str),

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -372,6 +372,7 @@ def get_providers_auth():
         },
         "subdl": {
             'api_key': settings.subdl.api_key,
+            'anime_mode': settings.subdl.anime_mode,
         },
         'turkcealtyaziorg': {
             'cookies': settings.turkcealtyaziorg.cookies,

--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -7,6 +7,7 @@ import io
 from zipfile import ZipFile, is_zipfile
 from urllib.parse import urljoin
 from requests import Session
+from guessit import guessit
 
 from babelfish import language_converters
 from subzero.language import Language
@@ -33,12 +34,14 @@ class SubdlSubtitle(Subtitle):
     hearing_impaired_verifiable = True
 
     def __init__(self, language, forced, hearing_impaired, page_link, download_link, file_id, release_names, uploader,
-                 season=None, episode=None):
+                 season=None, episode=None, absolute_episode=None, is_pack=False):
         super().__init__(language)
         language = Language.rebuild(language, hi=hearing_impaired, forced=forced)
 
         self.season = season
         self.episode = episode
+        self.absolute_episode = absolute_episode
+        self.is_pack = is_pack
         self.releases = release_names
         self.release_info = ', '.join(release_names)
         self.language = language
@@ -64,11 +67,24 @@ class SubdlSubtitle(Subtitle):
             # season
             if video.season == self.season:
                 matches.add('season')
-            # episode
+            elif self.is_pack and self.absolute_episode:
+                # Arc-based season numbering (e.g. subdl's Enies Lobby = S09) differs from
+                # Sonarr's sequential numbering (S11). When a pack is validated via absolute
+                # episode range, trust the match regardless of season number discrepancy.
+                matches.add('season')
+            # episode — match by standard episode, absolute episode, or pack range
             if video.episode == self.episode:
                 matches.add('episode')
-            # imdb
+            elif (getattr(video, 'absolute_episode', None) and
+                  video.absolute_episode == self.episode):
+                matches.add('episode')
+            elif self.is_pack:
+                # Pack was already validated to contain the target episode
+                matches.add('episode')
+            # imdb — IMDB match also confirms the year
             matches.add('series_imdb_id')
+            if video.year:
+                matches.add('year')
         else:
             # title
             matches.add('title')
@@ -77,7 +93,7 @@ class SubdlSubtitle(Subtitle):
             # tmdb 
             matches.add('tmdb_id')
 
-        utils.update_matches(matches, video, self.release_info)
+        utils.update_matches(matches, video, self.releases)
 
         self.matches = matches
 
@@ -157,7 +173,55 @@ class SubdlProvider(ProviderRetryMixin, Provider):
                 amount=retry_amount,
                 retry_timeout=retry_timeout
             )
+
+            # For anime with absolute episode numbering, also search by absolute episode number
+            # so we can find subtitles that are only indexed by absolute number on subdl
+            absolute_episode = getattr(self.video, 'absolute_episode', None)
+            if absolute_episode and absolute_episode != self.video.episode:
+                logger.debug(f'Also searching by absolute episode number: {absolute_episode}')
+                res_absolute = self.retry(
+                    lambda: self.session.get(self.server_url() + 'subtitles',
+                                             params=(('api_key', self.api_key),
+                                                     ('episode_number', absolute_episode),
+                                                     ('film_name', title if not imdb_id else None),
+                                                     ('imdb_id', imdb_id if imdb_id else None),
+                                                     ('languages', langs),
+                                                     ('subs_per_page', 30),
+                                                     ('type', 'tv'),
+                                                     ('comment', 1),
+                                                     ('releases', 1),
+                                                     ('bazarr', 1)),
+                                             timeout=30),
+                    amount=retry_amount,
+                    retry_timeout=retry_timeout
+                )
+            else:
+                res_absolute = None
+
+            # Fallback: search by season only (no episode filter) to catch subtitles that use
+            # split-season / cour-based internal numbering (e.g. Fire Force S3 split into two cours
+            # where episode 25 is stored internally as cour-2 episode 13).
+            # The release name matching in get_matches() will identify the correct episode.
+            logger.debug(f'Also searching by season only (no episode filter) for season {self.video.season}')
+            res_season = self.retry(
+                lambda: self.session.get(self.server_url() + 'subtitles',
+                                         params=(('api_key', self.api_key),
+                                                 ('film_name', title if not imdb_id else None),
+                                                 ('imdb_id', imdb_id if imdb_id else None),
+                                                 ('languages', langs),
+                                                 ('season_number', self.video.season),
+                                                 ('subs_per_page', 30),
+                                                 ('type', 'tv'),
+                                                 ('comment', 1),
+                                                 ('releases', 1),
+                                                 ('bazarr', 1)),
+                                         timeout=30),
+                amount=retry_amount,
+                retry_timeout=retry_timeout
+            )
         else:
+            res_absolute = None
+            res_season = None
             params = {
                        'api_key': self.api_key,
                        'film_name': title if not imdb_id else None,
@@ -226,30 +290,114 @@ class SubdlProvider(ProviderRetryMixin, Provider):
                     return subtitles
                 raise ProviderError(error_msg)
 
-        logger.debug(f"Query returned {len(result['subtitles'])} subtitles")
+        # Merge absolute episode search results if available
+        all_items = list(result.get('subtitles', []))
+        seen_ids = {item['name'] for item in all_items}
 
-        if len(result['subtitles']):
-            for item in result['subtitles']:
-                if (isinstance(self.video, Episode) and
-                        item.get('episode_from', False) != item.get('episode_end', False)):
-                    # ignore season packs
-                    continue
-                else:
-                    subtitle = SubdlSubtitle(
-                        language=Language.fromsubdl(item['language']),
-                        forced=self._is_forced(item),
-                        hearing_impaired=item.get('hi', False) or self._is_hi(item),
-                        page_link=urljoin("https://subdl.com", item.get('subtitlePage', '')),
-                        download_link=item['url'],
-                        file_id=item['name'],
-                        release_names=item.get('releases', []),
-                        uploader=item.get('author', ''),
-                        season=item.get('season', None),
-                        episode=item.get('episode', None),
-                    )
-                    subtitle.get_matches(self.video)
-                    if subtitle.language in languages:  # make sure only desired subtitles variants are returned
-                        subtitles.append(subtitle)
+        if res_absolute and res_absolute.status_code == 200:
+            abs_result = res_absolute.json()
+            if ('success' in abs_result and abs_result['success']) or ('status' in abs_result and abs_result['status']):
+                for item in abs_result.get('subtitles', []):
+                    if item['name'] not in seen_ids:
+                        all_items.append(item)
+                        seen_ids.add(item['name'])
+                logger.debug(f'Absolute episode search added {len(abs_result.get("subtitles", []))} more subtitles')
+
+        if res_season and res_season.status_code == 200:
+            season_result = res_season.json()
+            if ('success' in season_result and season_result['success']) or ('status' in season_result and season_result['status']):
+                added = 0
+                for item in season_result.get('subtitles', []):
+                    if item['name'] not in seen_ids:
+                        all_items.append(item)
+                        seen_ids.add(item['name'])
+                        added += 1
+                logger.debug(f'Season-only search added {added} more subtitles')
+
+        # Last resort: if all season-filtered searches returned nothing, search by title only
+        # (no season/episode filter). This catches anime stored as season 0 on subdl (full series
+        # blocks) where season_number filtering silently excludes all results.
+        if not all_items and isinstance(self.video, Episode):
+            logger.debug('All season-filtered searches returned 0 results, falling back to title-only search')
+            res_title = self.retry(
+                lambda: self.session.get(self.server_url() + 'subtitles',
+                                         params=(('api_key', self.api_key),
+                                                 ('film_name', title if not imdb_id else None),
+                                                 ('imdb_id', imdb_id if imdb_id else None),
+                                                 ('languages', langs),
+                                                 ('subs_per_page', 30),
+                                                 ('type', 'tv'),
+                                                 ('comment', 1),
+                                                 ('releases', 1),
+                                                 ('bazarr', 1)),
+                                         timeout=30),
+                amount=retry_amount,
+                retry_timeout=retry_timeout
+            )
+            if res_title.status_code == 200:
+                title_result = res_title.json()
+                if ('success' in title_result and title_result['success']) or \
+                        ('status' in title_result and title_result['status']):
+                    added = 0
+                    for item in title_result.get('subtitles', []):
+                        if item['name'] not in seen_ids:
+                            all_items.append(item)
+                            seen_ids.add(item['name'])
+                            added += 1
+                    logger.debug(f'Title-only fallback search added {added} subtitles')
+
+        logger.debug(f"Query returned {len(all_items)} subtitles")
+
+        absolute_episode = getattr(self.video, 'absolute_episode', None)
+
+        if len(all_items):
+            for item in all_items:
+                is_pack = False
+                if isinstance(self.video, Episode):
+                    ep_from = item.get('episode_from')
+                    ep_end = item.get('episode_end')
+                    # Fallback: parse episode range from release names when the API
+                    # does not provide episode_from/episode_end fields.
+                    if not (ep_from and ep_end and ep_from != ep_end):
+                        ep_from_parsed, ep_end_parsed = self._parse_episode_range_from_releases(
+                            item.get('releases', [])
+                        )
+                        if ep_from_parsed and ep_end_parsed and ep_from_parsed != ep_end_parsed:
+                            ep_from = ep_from_parsed
+                            ep_end = ep_end_parsed
+                            logger.debug(
+                                f'Parsed episode range {ep_from}-{ep_end} from release names'
+                            )
+                    if ep_from and ep_end and ep_from != ep_end:
+                        # Multi-episode pack: allow if target episode is within range
+                        target_ep = self.video.episode
+                        if absolute_episode:
+                            # Check both standard and absolute episode against the range
+                            if not ((ep_from <= target_ep <= ep_end) or
+                                    (ep_from <= absolute_episode <= ep_end)):
+                                continue
+                        else:
+                            if not (ep_from <= target_ep <= ep_end):
+                                continue
+                        is_pack = True
+
+                subtitle = SubdlSubtitle(
+                    language=Language.fromsubdl(item['language']),
+                    forced=self._is_forced(item),
+                    hearing_impaired=item.get('hi', False) or self._is_hi(item),
+                    page_link=urljoin("https://subdl.com", item.get('subtitlePage', '')),
+                    download_link=item['url'],
+                    file_id=item['name'],
+                    release_names=item.get('releases', []),
+                    uploader=item.get('author', ''),
+                    season=item.get('season', None),
+                    episode=item.get('episode', None),
+                    absolute_episode=absolute_episode,
+                    is_pack=is_pack,
+                )
+                subtitle.get_matches(self.video)
+                if subtitle.language in languages:  # make sure only desired subtitles variants are returned
+                    subtitles.append(subtitle)
 
         return subtitles
 
@@ -286,6 +434,23 @@ class SubdlProvider(ProviderRetryMixin, Provider):
         # nothing match so we consider it as normal subtitles
         return False
 
+    @staticmethod
+    def _parse_episode_range_from_releases(release_names):
+        """Parse episode range (ep_from, ep_end) from release name strings.
+
+        Used as a fallback when the subdl API does not populate episode_from/
+        episode_end for a pack. Guessit expands patterns like 'EP0264-0336'
+        into a list of integers; we extract the first and last as the range.
+
+        Returns (ep_from, ep_end) as ints, or (None, None) if not found.
+        """
+        for name in release_names:
+            guess = guessit(name, {'type': 'episode'})
+            ep = guess.get('episode')
+            if isinstance(ep, list) and len(ep) >= 2:
+                return ep[0], ep[-1]
+        return None, None
+
     def list_subtitles(self, video, languages):
         return self.query(languages, video)
 
@@ -314,11 +479,35 @@ class SubdlProvider(ProviderRetryMixin, Provider):
             archive_stream = io.BytesIO(r.content)
             if is_zipfile(archive_stream):
                 archive = ZipFile(archive_stream)
-                for name in archive.namelist():
-                    # TODO when possible, deal with season pack / multiple files archive
-                    subtitle_content = archive.read(name)
-                    subtitle.content = fix_line_ending(subtitle_content)
-                    return
+                if subtitle.is_pack and self.video and isinstance(self.video, Episode):
+                    # Use smart extraction for packs: match by episode number
+                    target_episode = self.video.episode
+                    absolute_episode = getattr(self.video, 'absolute_episode', None)
+                    content = utils.get_subtitle_from_archive(
+                        archive,
+                        episode=target_episode,
+                        episode_title=getattr(self.video, 'title', None),
+                    )
+                    # Fallback: try absolute episode number
+                    if content is None and absolute_episode:
+                        content = utils.get_subtitle_from_archive(
+                            archive,
+                            episode=absolute_episode,
+                        )
+                    if content is not None:
+                        subtitle.content = content
+                    else:
+                        logger.warning(f'Could not find episode {target_episode} in pack archive {download_link}')
+                        subtitle.content = None
+                else:
+                    # Single episode: prefer subtitle file extensions, fallback to first file
+                    for name in archive.namelist():
+                        if name.endswith(('.srt', '.sub', '.ssa', '.ass')):
+                            subtitle.content = fix_line_ending(archive.read(name))
+                            return
+                    for name in archive.namelist():
+                        subtitle.content = fix_line_ending(archive.read(name))
+                        return
             else:
                 logger.error(f'Could not unzip subtitle from {download_link}')
                 subtitle.content = None

--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -297,23 +297,47 @@ class SubdlProvider(ProviderRetryMixin, Provider):
 
         result = res.json()
 
+        # Whether the primary response reported an empty/error shape. In non-anime-mode
+        # we short-circuit; in anime-mode we fall through so the extra searches can
+        # still contribute results.
+        primary_empty = False
         if ('success' in result and not result['success']) or ('status' in result and not result['status']):
             logger.debug(result)
             if 'error' in result:
                 error_msg = result['error']
                 if "can't find" in error_msg.lower():
-                    logger.debug(f"No subtitles found for {imdb_id or title}: {error_msg}")
-                    return subtitles
-                raise ProviderError(error_msg)
+                    logger.debug(f"No subtitles found (primary) for {imdb_id or title}: {error_msg}")
+                    primary_empty = True
+                else:
+                    raise ProviderError(error_msg)
+            else:
+                primary_empty = True
+
+        if primary_empty and not self.anime_mode:
+            # Original single-call behavior: bail out immediately.
+            return subtitles
 
         # Merge extra search results (only populated when anime_mode enables them).
         # Use .get('name') to skip malformed rows instead of KeyError-ing the whole query.
-        all_items = [i for i in result.get('subtitles', []) if i.get('name')]
+        primary_items = [] if primary_empty else result.get('subtitles', [])
+        all_items = [i for i in primary_items if i.get('name')]
         seen_ids = {item['name'] for item in all_items}
 
         def _merge_extra(response, label):
-            if not response or response.status_code != 200:
+            """Merge an extra anime-mode search response into all_items.
+
+            Propagates throttling and auth errors so the scheduler sees the same
+            failure modes it would see on the primary request. Silently skips
+            only the "empty result" shape, since that is the expected no-op.
+            """
+            if response is None:
                 return
+            if response.status_code == 429:
+                raise APIThrottled(f"Too many requests (subdl {label} search)")
+            if response.status_code == 403:
+                raise ConfigurationError("Invalid API key")
+            if response.status_code != 200:
+                response.raise_for_status()
             data = response.json()
             if not (('success' in data and data['success']) or ('status' in data and data['status'])):
                 return

--- a/custom_libs/subliminal_patch/providers/subdl.py
+++ b/custom_libs/subliminal_patch/providers/subdl.py
@@ -25,6 +25,18 @@ logger = logging.getLogger(__name__)
 retry_amount = 3
 retry_timeout = 5
 
+
+def _coerce_int(value):
+    """Best-effort int coercion; returns None on failure. Subdl's episode_from /
+    episode_end fields are sometimes strings depending on the response shape."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 language_converters.register('subdl = subliminal_patch.converters.subdl:SubdlConverter')
 
 
@@ -110,13 +122,14 @@ class SubdlProvider(ProviderRetryMixin, Provider):
 
     video_types = (Episode, Movie)
 
-    def __init__(self, api_key=None):
+    def __init__(self, api_key=None, anime_mode=False):
         if not api_key:
             raise ConfigurationError('Api_key must be specified')
 
         self.session = Session()
         self.session.headers = {'User-Agent': os.environ.get("SZ_USER_AGENT", "Sub-Zero/2")}
         self.api_key = api_key
+        self.anime_mode = bool(anime_mode)
         self.video = None
         self._started = None
 
@@ -174,18 +187,45 @@ class SubdlProvider(ProviderRetryMixin, Provider):
                 retry_timeout=retry_timeout
             )
 
-            # For anime with absolute episode numbering, also search by absolute episode number
-            # so we can find subtitles that are only indexed by absolute number on subdl
+            # Anime-mode extras: additional searches gated behind settings.subdl.anime_mode
+            # to avoid the 2-4x API call cost on non-anime libraries.
+            res_absolute = None
+            res_season = None
             absolute_episode = getattr(self.video, 'absolute_episode', None)
-            if absolute_episode and absolute_episode != self.video.episode:
-                logger.debug(f'Also searching by absolute episode number: {absolute_episode}')
-                res_absolute = self.retry(
+            if self.anime_mode:
+                # For anime with absolute episode numbering, also search by absolute episode number
+                # so we can find subtitles that are only indexed by absolute number on subdl
+                if absolute_episode and absolute_episode != self.video.episode:
+                    logger.debug(f'Also searching by absolute episode number: {absolute_episode}')
+                    res_absolute = self.retry(
+                        lambda: self.session.get(self.server_url() + 'subtitles',
+                                                 params=(('api_key', self.api_key),
+                                                         ('episode_number', absolute_episode),
+                                                         ('film_name', title if not imdb_id else None),
+                                                         ('imdb_id', imdb_id if imdb_id else None),
+                                                         ('languages', langs),
+                                                         ('subs_per_page', 30),
+                                                         ('type', 'tv'),
+                                                         ('comment', 1),
+                                                         ('releases', 1),
+                                                         ('bazarr', 1)),
+                                                 timeout=30),
+                        amount=retry_amount,
+                        retry_timeout=retry_timeout
+                    )
+
+                # Fallback: search by season only (no episode filter) to catch subtitles that use
+                # split-season / cour-based internal numbering (e.g. Fire Force S3 split into two cours
+                # where episode 25 is stored internally as cour-2 episode 13).
+                # The release name matching in get_matches() will identify the correct episode.
+                logger.debug(f'Also searching by season only (no episode filter) for season {self.video.season}')
+                res_season = self.retry(
                     lambda: self.session.get(self.server_url() + 'subtitles',
                                              params=(('api_key', self.api_key),
-                                                     ('episode_number', absolute_episode),
                                                      ('film_name', title if not imdb_id else None),
                                                      ('imdb_id', imdb_id if imdb_id else None),
                                                      ('languages', langs),
+                                                     ('season_number', self.video.season),
                                                      ('subs_per_page', 30),
                                                      ('type', 'tv'),
                                                      ('comment', 1),
@@ -195,30 +235,6 @@ class SubdlProvider(ProviderRetryMixin, Provider):
                     amount=retry_amount,
                     retry_timeout=retry_timeout
                 )
-            else:
-                res_absolute = None
-
-            # Fallback: search by season only (no episode filter) to catch subtitles that use
-            # split-season / cour-based internal numbering (e.g. Fire Force S3 split into two cours
-            # where episode 25 is stored internally as cour-2 episode 13).
-            # The release name matching in get_matches() will identify the correct episode.
-            logger.debug(f'Also searching by season only (no episode filter) for season {self.video.season}')
-            res_season = self.retry(
-                lambda: self.session.get(self.server_url() + 'subtitles',
-                                         params=(('api_key', self.api_key),
-                                                 ('film_name', title if not imdb_id else None),
-                                                 ('imdb_id', imdb_id if imdb_id else None),
-                                                 ('languages', langs),
-                                                 ('season_number', self.video.season),
-                                                 ('subs_per_page', 30),
-                                                 ('type', 'tv'),
-                                                 ('comment', 1),
-                                                 ('releases', 1),
-                                                 ('bazarr', 1)),
-                                         timeout=30),
-                amount=retry_amount,
-                retry_timeout=retry_timeout
-            )
         else:
             res_absolute = None
             res_season = None
@@ -290,34 +306,34 @@ class SubdlProvider(ProviderRetryMixin, Provider):
                     return subtitles
                 raise ProviderError(error_msg)
 
-        # Merge absolute episode search results if available
-        all_items = list(result.get('subtitles', []))
+        # Merge extra search results (only populated when anime_mode enables them).
+        # Use .get('name') to skip malformed rows instead of KeyError-ing the whole query.
+        all_items = [i for i in result.get('subtitles', []) if i.get('name')]
         seen_ids = {item['name'] for item in all_items}
 
-        if res_absolute and res_absolute.status_code == 200:
-            abs_result = res_absolute.json()
-            if ('success' in abs_result and abs_result['success']) or ('status' in abs_result and abs_result['status']):
-                for item in abs_result.get('subtitles', []):
-                    if item['name'] not in seen_ids:
-                        all_items.append(item)
-                        seen_ids.add(item['name'])
-                logger.debug(f'Absolute episode search added {len(abs_result.get("subtitles", []))} more subtitles')
+        def _merge_extra(response, label):
+            if not response or response.status_code != 200:
+                return
+            data = response.json()
+            if not (('success' in data and data['success']) or ('status' in data and data['status'])):
+                return
+            added = 0
+            for item in data.get('subtitles', []):
+                name = item.get('name')
+                if not name or name in seen_ids:
+                    continue
+                all_items.append(item)
+                seen_ids.add(name)
+                added += 1
+            logger.debug(f'{label} search added {added} more subtitles')
 
-        if res_season and res_season.status_code == 200:
-            season_result = res_season.json()
-            if ('success' in season_result and season_result['success']) or ('status' in season_result and season_result['status']):
-                added = 0
-                for item in season_result.get('subtitles', []):
-                    if item['name'] not in seen_ids:
-                        all_items.append(item)
-                        seen_ids.add(item['name'])
-                        added += 1
-                logger.debug(f'Season-only search added {added} more subtitles')
+        _merge_extra(res_absolute, 'Absolute episode')
+        _merge_extra(res_season, 'Season-only')
 
-        # Last resort: if all season-filtered searches returned nothing, search by title only
-        # (no season/episode filter). This catches anime stored as season 0 on subdl (full series
-        # blocks) where season_number filtering silently excludes all results.
-        if not all_items and isinstance(self.video, Episode):
+        # Last resort (anime_mode only): if all prior searches returned nothing, search by title
+        # only. Catches anime stored as season 0 on subdl (full-series blocks) where
+        # season_number filtering silently excludes all results.
+        if self.anime_mode and not all_items and isinstance(self.video, Episode):
             logger.debug('All season-filtered searches returned 0 results, falling back to title-only search')
             res_title = self.retry(
                 lambda: self.session.get(self.server_url() + 'subtitles',
@@ -334,17 +350,7 @@ class SubdlProvider(ProviderRetryMixin, Provider):
                 amount=retry_amount,
                 retry_timeout=retry_timeout
             )
-            if res_title.status_code == 200:
-                title_result = res_title.json()
-                if ('success' in title_result and title_result['success']) or \
-                        ('status' in title_result and title_result['status']):
-                    added = 0
-                    for item in title_result.get('subtitles', []):
-                        if item['name'] not in seen_ids:
-                            all_items.append(item)
-                            seen_ids.add(item['name'])
-                            added += 1
-                    logger.debug(f'Title-only fallback search added {added} subtitles')
+            _merge_extra(res_title, 'Title-only fallback')
 
         logger.debug(f"Query returned {len(all_items)} subtitles")
 
@@ -354,32 +360,40 @@ class SubdlProvider(ProviderRetryMixin, Provider):
             for item in all_items:
                 is_pack = False
                 if isinstance(self.video, Episode):
-                    ep_from = item.get('episode_from')
-                    ep_end = item.get('episode_end')
-                    # Fallback: parse episode range from release names when the API
-                    # does not provide episode_from/episode_end fields.
-                    if not (ep_from and ep_end and ep_from != ep_end):
-                        ep_from_parsed, ep_end_parsed = self._parse_episode_range_from_releases(
-                            item.get('releases', [])
-                        )
-                        if ep_from_parsed and ep_end_parsed and ep_from_parsed != ep_end_parsed:
-                            ep_from = ep_from_parsed
-                            ep_end = ep_end_parsed
-                            logger.debug(
-                                f'Parsed episode range {ep_from}-{ep_end} from release names'
+                    ep_from = _coerce_int(item.get('episode_from'))
+                    ep_end = _coerce_int(item.get('episode_end'))
+                    # Pack branch only considered in anime_mode: legacy behavior was to
+                    # skip packs outright when ep_from != ep_end. Preserve that for
+                    # non-anime users to keep score/selection stable.
+                    if self.anime_mode:
+                        # Fallback: parse episode range from release names when the API
+                        # does not provide episode_from/episode_end fields.
+                        if not (ep_from and ep_end and ep_from != ep_end):
+                            ep_from_parsed, ep_end_parsed = self._parse_episode_range_from_releases(
+                                item.get('releases', [])
                             )
-                    if ep_from and ep_end and ep_from != ep_end:
-                        # Multi-episode pack: allow if target episode is within range
-                        target_ep = self.video.episode
-                        if absolute_episode:
-                            # Check both standard and absolute episode against the range
-                            if not ((ep_from <= target_ep <= ep_end) or
-                                    (ep_from <= absolute_episode <= ep_end)):
-                                continue
-                        else:
-                            if not (ep_from <= target_ep <= ep_end):
-                                continue
-                        is_pack = True
+                            if ep_from_parsed and ep_end_parsed and ep_from_parsed != ep_end_parsed:
+                                ep_from = ep_from_parsed
+                                ep_end = ep_end_parsed
+                                logger.debug(
+                                    f'Parsed episode range {ep_from}-{ep_end} from release names'
+                                )
+                        if ep_from and ep_end and ep_from != ep_end:
+                            # Multi-episode pack: allow if target episode is within range
+                            target_ep = self.video.episode
+                            if absolute_episode:
+                                # Check both standard and absolute episode against the range
+                                if not ((ep_from <= target_ep <= ep_end) or
+                                        (ep_from <= absolute_episode <= ep_end)):
+                                    continue
+                            else:
+                                if not (ep_from <= target_ep <= ep_end):
+                                    continue
+                            is_pack = True
+                    else:
+                        # Non-anime mode: preserve upstream's pre-patch behavior — skip packs.
+                        if ep_from is not None and ep_end is not None and ep_from != ep_end:
+                            continue
 
                 subtitle = SubdlSubtitle(
                     language=Language.fromsubdl(item['language']),

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -453,6 +453,11 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
         type: "text",
         key: "api_key",
       },
+      {
+        type: "switch",
+        key: "anime_mode",
+        name: "Anime mode (extra searches for absolute episode numbers and subtitle packs, uses more API calls)",
+      },
     ],
   },
   {

--- a/tests/subliminal_patch/test_subdl_anime_mode.py
+++ b/tests/subliminal_patch/test_subdl_anime_mode.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from subliminal_patch.core import Episode
+from subliminal_patch.exceptions import APIThrottled
 from subzero.language import Language
 
 from subliminal_patch.providers.subdl import (
@@ -241,3 +242,79 @@ def test_query_anime_mode_skips_pack_not_covering_target():
         subs = provider.query({Language("eng")}, video)
 
     assert subs == []
+
+
+def test_query_anime_mode_merges_fallbacks_when_primary_reports_cant_find():
+    """Primary 'cant find' must not short-circuit: anime_mode fallbacks must still run
+    and their results must flow through (covers Codex review P1)."""
+    provider = SubdlProvider(api_key="fake", anime_mode=True)
+    video = _episode(season=1, episode=3)
+
+    primary = _mock_response({
+        "status": False,
+        "error": "Sorry, we can't find any subtitles.",
+    })
+    # Season-only fallback returns the real match
+    season_fallback = _mock_response({
+        "success": True,
+        "subtitles": [
+            {
+                "name": "found_in_fallback.srt", "url": "/u/99", "language": "EN",
+                "subtitlePage": "/s/99", "releases": ["Dummy.Show.S01E03"],
+                "season": 1, "episode": 3,
+            },
+        ],
+    })
+    empty = _mock_response({"success": True, "subtitles": []})
+
+    # Sequence: [primary, season_fallback, title_fallback_empty]
+    # (no absolute_episode on this video, so res_absolute is skipped.)
+    with patch.object(provider, "retry", side_effect=[primary, season_fallback, empty]):
+        subs = provider.query({Language("eng")}, video)
+
+    assert len(subs) == 1
+    assert subs[0].page_link.endswith("/s/99")
+
+
+def test_query_non_anime_mode_short_circuits_on_cant_find():
+    """Non-anime mode preserves original early-return on 'cant find' error."""
+    provider = SubdlProvider(api_key="fake", anime_mode=False)
+    video = _episode()
+
+    primary = _mock_response({
+        "status": False,
+        "error": "Sorry, we can't find any subtitles.",
+    })
+    with patch.object(provider, "retry", return_value=primary) as retry_mock:
+        subs = provider.query({Language("eng")}, video)
+
+    assert subs == []
+    # Exactly 1 call: no fallbacks fired.
+    assert retry_mock.call_count == 1
+
+
+def test_query_raises_on_fallback_throttle():
+    """Extra anime-mode searches hitting 429 must raise APIThrottled instead of
+    silently dropping the response (covers Codex review P2)."""
+    provider = SubdlProvider(api_key="fake", anime_mode=True)
+    video = _episode()
+
+    primary = _mock_response({"success": True, "subtitles": []})
+    throttled = MagicMock()
+    throttled.status_code = 429
+
+    with patch.object(provider, "retry", side_effect=[primary, throttled]):
+        with pytest.raises(APIThrottled):
+            provider.query({Language("eng")}, video)
+
+
+def test_query_still_raises_non_can_find_primary_error():
+    """A non-'cant find' primary error must still raise ProviderError even in anime_mode."""
+    from subliminal.exceptions import ProviderError
+    provider = SubdlProvider(api_key="fake", anime_mode=True)
+    video = _episode()
+
+    bad = _mock_response({"status": False, "error": "Something broke internally"})
+    with patch.object(provider, "retry", return_value=bad):
+        with pytest.raises(ProviderError):
+            provider.query({Language("eng")}, video)

--- a/tests/subliminal_patch/test_subdl_anime_mode.py
+++ b/tests/subliminal_patch/test_subdl_anime_mode.py
@@ -1,0 +1,243 @@
+# -*- coding: utf-8 -*-
+"""Offline unit tests for subdl anime_mode gating and correctness hardening.
+
+These tests never hit the subdl API. They cover:
+- `_coerce_int` helper (episode_from / episode_end int coercion).
+- `_parse_episode_range_from_releases` release-name range parsing.
+- `SubdlProvider.__init__` anime_mode plumbing.
+- `SubdlSubtitle.get_matches` absolute-episode / pack branches.
+- Merge-path KeyError safety for malformed subdl rows missing 'name'.
+- Gating: non-anime_mode uses the original single-call path.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from subliminal_patch.core import Episode
+from subzero.language import Language
+
+from subliminal_patch.providers.subdl import (
+    SubdlProvider,
+    SubdlSubtitle,
+    _coerce_int,
+)
+
+
+def _episode(**overrides):
+    defaults = dict(
+        name="Dummy.Show.S01E03.mkv",
+        series="Dummy Show",
+        season=1,
+        episode=3,
+        year=2024,
+        series_imdb_id="tt0000001",
+    )
+    defaults.update(overrides)
+    return Episode(**defaults)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, None),
+        (7, 7),
+        ("7", 7),
+        (" 12 ", 12),
+        ("not-a-number", None),
+        ("", None),
+        ({}, None),
+    ],
+)
+def test_coerce_int_variants(raw, expected):
+    assert _coerce_int(raw) == expected
+
+
+def test_provider_stores_anime_mode_flag():
+    default_provider = SubdlProvider(api_key="fake")
+    anime_provider = SubdlProvider(api_key="fake", anime_mode=True)
+
+    assert default_provider.anime_mode is False
+    assert anime_provider.anime_mode is True
+
+
+def test_provider_requires_api_key():
+    with pytest.raises(Exception):
+        SubdlProvider(api_key=None)
+
+
+def test_parse_episode_range_from_releases_detects_pack():
+    releases = ["Some.Anime.EP0264-0336.1080p"]
+    ep_from, ep_end = SubdlProvider._parse_episode_range_from_releases(releases)
+    assert ep_from == 264
+    assert ep_end == 336
+
+
+def test_parse_episode_range_returns_none_for_single_episode():
+    releases = ["Some.Show.S01E05.1080p.WEB-DL"]
+    ep_from, ep_end = SubdlProvider._parse_episode_range_from_releases(releases)
+    assert ep_from is None
+    assert ep_end is None
+
+
+def test_subtitle_get_matches_pack_with_absolute_episode():
+    video = _episode(season=11, episode=5)
+    # Patch video to carry absolute_episode (guessit-populated at runtime)
+    video.absolute_episode = 310
+
+    sub = SubdlSubtitle(
+        language=Language("eng"),
+        forced=False,
+        hearing_impaired=False,
+        page_link="https://subdl.com/dummy",
+        download_link="https://subdl.com/download/dummy.zip",
+        file_id="dummy",
+        release_names=["Anime.Pack.EP0264-0336"],
+        uploader="tester",
+        season=9,  # arc-numbered season, differs from Sonarr's S11
+        episode=None,
+        absolute_episode=310,
+        is_pack=True,
+    )
+    matches = sub.get_matches(video)
+    # Pack branch should yield season+episode matches despite season mismatch
+    assert "season" in matches
+    assert "episode" in matches
+
+
+def test_subtitle_get_matches_non_pack_exact():
+    video = _episode(season=1, episode=3)
+    sub = SubdlSubtitle(
+        language=Language("eng"),
+        forced=False,
+        hearing_impaired=False,
+        page_link="https://subdl.com/dummy",
+        download_link="https://subdl.com/download/dummy.zip",
+        file_id="dummy",
+        release_names=["Dummy.Show.S01E03"],
+        uploader="tester",
+        season=1,
+        episode=3,
+    )
+    matches = sub.get_matches(video)
+    assert "season" in matches
+    assert "episode" in matches
+
+
+def _mock_response(payload, status_code=200):
+    r = MagicMock()
+    r.status_code = status_code
+    r.json.return_value = payload
+    return r
+
+
+def test_query_does_not_keyerror_on_malformed_rows():
+    """Malformed subdl rows missing 'name' must be filtered, not crash the query."""
+    provider = SubdlProvider(api_key="fake", anime_mode=False)
+    video = _episode()
+
+    payload = {
+        "success": True,
+        "subtitles": [
+            {"name": "valid.srt", "url": "/u/1", "language": "EN",
+             "subtitlePage": "/s/1", "releases": ["Dummy.Show.S01E03"]},
+            # Malformed row: no 'name'
+            {"url": "/u/2", "language": "EN"},  # noqa: missing 'name'
+        ],
+    }
+
+    with patch.object(provider, "retry", return_value=_mock_response(payload)):
+        subs = provider.query({Language("eng")}, video)
+
+    # At minimum should not raise; valid row filtered by language converter may or may not
+    # survive, but no KeyError must leak.
+    assert isinstance(subs, list)
+
+
+def test_query_non_anime_mode_makes_single_call():
+    """Non-anime-mode must not fan out extra episode/season/title searches."""
+    provider = SubdlProvider(api_key="fake", anime_mode=False)
+    video = _episode()
+
+    payload = {"success": True, "subtitles": []}
+    with patch.object(provider, "retry", return_value=_mock_response(payload)) as retry_mock:
+        provider.query({Language("eng")}, video)
+
+    # Exactly one upstream call in non-anime mode.
+    assert retry_mock.call_count == 1
+
+
+def test_query_anime_mode_fires_extra_season_call():
+    """Anime-mode enables the season-only search to find cour-split subtitles."""
+    provider = SubdlProvider(api_key="fake", anime_mode=True)
+    video = _episode()
+
+    payload = {"success": True, "subtitles": []}
+    with patch.object(provider, "retry", return_value=_mock_response(payload)) as retry_mock:
+        provider.query({Language("eng")}, video)
+
+    # Without absolute_episode, anime_mode adds: primary + season-only + title-fallback = 3
+    assert retry_mock.call_count == 3
+
+
+def test_query_non_anime_mode_skips_packs():
+    """Non-anime users must still see packs filtered out as before."""
+    provider = SubdlProvider(api_key="fake", anime_mode=False)
+    video = _episode(season=1, episode=3)
+
+    payload = {
+        "success": True,
+        "subtitles": [
+            {
+                "name": "pack.srt", "url": "/u/1", "language": "EN",
+                "subtitlePage": "/s/1", "releases": ["Dummy.Show.S01E01-E10"],
+                "episode_from": 1, "episode_end": 10,
+            },
+        ],
+    }
+    with patch.object(provider, "retry", return_value=_mock_response(payload)):
+        subs = provider.query({Language("eng")}, video)
+
+    # Non-anime mode skips packs entirely (preserves pre-patch behavior).
+    assert subs == []
+
+
+def test_query_anime_mode_accepts_pack_covering_target():
+    """Anime mode accepts a pack subtitle whose range covers the target episode."""
+    provider = SubdlProvider(api_key="fake", anime_mode=True)
+    video = _episode(season=1, episode=3)
+
+    payload = {
+        "success": True,
+        "subtitles": [
+            {
+                "name": "pack.srt", "url": "/u/1", "language": "EN",
+                "subtitlePage": "/s/1", "releases": ["Dummy.Show.S01E01-E10"],
+                "episode_from": 1, "episode_end": 10,
+            },
+        ],
+    }
+    with patch.object(provider, "retry", return_value=_mock_response(payload)):
+        subs = provider.query({Language("eng")}, video)
+
+    assert len(subs) == 1
+    assert subs[0].is_pack is True
+
+
+def test_query_anime_mode_skips_pack_not_covering_target():
+    provider = SubdlProvider(api_key="fake", anime_mode=True)
+    video = _episode(season=1, episode=3)
+
+    payload = {
+        "success": True,
+        "subtitles": [
+            {
+                "name": "pack.srt", "url": "/u/1", "language": "EN",
+                "subtitlePage": "/s/1", "releases": ["Dummy.Show.S01E05-E10"],
+                "episode_from": 5, "episode_end": 10,
+            },
+        ],
+    }
+    with patch.object(provider, "retry", return_value=_mock_response(payload)):
+        subs = provider.query({Language("eng")}, video)
+
+    assert subs == []


### PR DESCRIPTION
## Summary
Picks upstream commit `71fc948ea` (subdl anime/pack improvements) but gates its expensive behavior behind a new `settings.subdl.anime_mode` flag (default `False`) so non-anime users do not pay the cost. Also hardens two correctness issues the jury flagged.

## Why gated
Upstream adds up to 3 extra HTTP calls per episode search plus guessit-driven release-name parsing. On a 10k-episode library scan that is estimated at 2 to 6 hours extra wall clock and 3x the subdl rate-limit pressure. Anime users benefit (issues `#2625`, `#2725`); everyone else regresses.

## Gated behind `anime_mode=True`
- Absolute-episode search (for anime with absolute numbering).
- Season-only fallback search (for cour-split internal numbering).
- Title-only last-resort search when all prior searches returned empty.
- Pack range parsing via `guessit`.
- Pack acceptance in `query()` when `ep_from <= target <= ep_end`. In non-anime mode, packs are skipped as before.

## Always applied (correctness)
- Merge helper filters rows missing `'name'` instead of `KeyError`-ing the whole query on malformed subdl responses.
- `_coerce_int` coerces `episode_from` / `episode_end` to `int` so string payloads do not raise `TypeError` in the range comparison.
- Refactor of the three merge blocks into a shared `_merge_extra` helper.

## Frontend
Adds an `anime_mode` switch under the subdl provider form with label "Anime mode (extra searches for absolute episode numbers and subtitle packs, uses more API calls)".

## Test plan
- [x] New offline suite `tests/subliminal_patch/test_subdl_anime_mode.py` — 19 passing:
  - `_coerce_int` variants (None, int, string, whitespace, garbage)
  - `_parse_episode_range_from_releases` pack vs single episode
  - `SubdlProvider.__init__` flag plumbing (default False)
  - `SubdlSubtitle.get_matches` pack + absolute-episode branches
  - Malformed-row KeyError safety
  - **Gating contract**: `anime_mode=False` makes exactly 1 upstream call; `anime_mode=True` makes 3 (primary + season-only + title fallback)
  - Non-anime mode still skips packs
  - Anime mode accepts packs covering the target episode, rejects those that do not
- [x] `npm run check:ts` clean
- [x] `npm run check` (0 errors, existing warnings unchanged)
- [x] `npm run check:fmt` clean
- [x] `npm test -- --run` (424 passed / 3 skipped)
- [x] `npm run build` successful

## Base
`development` (never `master`)

## Follow-ups (not blocking)
- Benchmark real subdl API call volume on the test server with `anime_mode=True` vs off over a 500-episode mixed-content library.
- Gate the `guessit` release-name parse with `functools.lru_cache` if benchmarks show it dominating CPU.