### PR TITLE
fix(tests): resolve test_editor_api.py pytest collection error

### DIFF
--- a/tests/bazarr/test_editor_api.py
+++ b/tests/bazarr/test_editor_api.py
@@ -24,24 +24,73 @@ import pytest
 _mock_args = MagicMock()
 _mock_args.config_dir = '/tmp/bazarr_test'
 
-# Patch modules that would otherwise require a running application
+# Pass-through flask_restx stand-ins so the class decorators
+# (@api_ns_editor.route(...), @Resource, etc.) do not replace the real
+# methods with MagicMocks at import time.
+def _passthrough_decorator(*args, **kwargs):
+    """Return a decorator that yields the target unchanged."""
+    def wrap(target):
+        return target
+    return wrap
+
+
+class _FakeNamespace:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def route(self, *args, **kwargs):
+        return _passthrough_decorator()
+
+    def doc(self, *args, **kwargs):
+        return _passthrough_decorator()
+
+    def expect(self, *args, **kwargs):
+        return _passthrough_decorator()
+
+    def marshal_with(self, *args, **kwargs):
+        return _passthrough_decorator()
+
+    def __getattr__(self, name):
+        # Any other attribute (model, parser, response, etc.) becomes
+        # a harmless MagicMock. Keeps downstream module imports happy
+        # without having to enumerate flask_restx's full surface.
+        return MagicMock()
+
+
+class _FakeResource:
+    """Minimal Resource base so classes like EditorSync subclass cleanly."""
+    pass
+
+
+_fake_flask_restx = MagicMock()
+_fake_flask_restx.Namespace = _FakeNamespace
+_fake_flask_restx.Resource = _FakeResource
+_fake_flask_restx.fields = MagicMock()
+
+# Patch modules that would otherwise require a running application.
+# `init` is patched because importing `bazarr.api.*` triggers
+# `bazarr/init.py` which runs `os.environ["SZ_HI_EXTENSION"] = settings.general.hi_extension`
+# during import. When `app.config` is mocked, that returns a MagicMock
+# and `os.environ.__setitem__` rejects anything that is not a string.
+_api_utils_mock = MagicMock()
+_api_utils_mock.authenticate = lambda fn: fn
+
 _patches = {
     'app.get_args': MagicMock(args=_mock_args),
     'app.config': MagicMock(),
     'app.database': MagicMock(),
     'utilities.path_mappings': MagicMock(),
     'utilities.binaries': MagicMock(),
-    'api.utils': MagicMock(),
+    'api.utils': _api_utils_mock,
+    'bazarr.api.utils': _api_utils_mock,
     'api.subtitles.content': MagicMock(),
-    'flask_restx': MagicMock(),
+    'flask_restx': _fake_flask_restx,
+    'init': MagicMock(startTime=0),
 }
 
 import sys
 for mod_name, mock_obj in _patches.items():
     sys.modules.setdefault(mod_name, mock_obj)
-
-# Make the authenticate decorator a no-op pass-through
-sys.modules['api.utils'].authenticate = lambda fn: fn
 
 # Now safe to import
 from bazarr.api.editor.editor import (


### PR DESCRIPTION
## Summary
The 63 new backend tests in `tests/bazarr/test_editor_api.py` (added in this release cycle) never ran: pytest collection died with \`TypeError: str expected, not MagicMock\` before any test executed.

Three root causes stacked on top of each other:

1. Importing \`bazarr.api.editor.editor\` triggered the full \`bazarr.api.*\` init chain → \`bazarr/init.py\` → \`os.environ[\"SZ_HI_EXTENSION\"] = settings.general.hi_extension\`. With \`app.config\` mocked to a bare MagicMock, the RHS was a MagicMock and \`os.environ.__setitem__\` rejected it.
2. \`flask_restx.Namespace(...)\` was a bare MagicMock, so \`@api_ns_editor.route('editor/sync')\` replaced every Resource class with a MagicMock at import time. Resource constructors returned MagicMocks, and \`.post()\` returned a MagicMock instead of the real method.
3. \`authenticate\` came from \`bazarr.api.utils\` (relative import \`from ..utils import authenticate\`), but the test patched \`sys.modules['api.utils']\` only. So the real \`authenticate\` ran, reached \`request.headers.get('X-API-KEY')\`, and died on \`RuntimeError: Working outside of request context.\`

## Fix
- Register a pass-through mock for \`init\` (with \`startTime=0\`) so \`bazarr/init.py\` is never actually imported.
- Add \`_FakeNamespace\` / \`_FakeResource\` with pass-through \`route\` / \`doc\` / \`expect\` / \`marshal_with\` decorators. \`__getattr__\` falls back to MagicMock for rarely-used methods like \`model\` or \`parser\`.
- Register the authenticate-passthrough mock under BOTH \`api.utils\` and \`bazarr.api.utils\` so relative imports pick it up.

## Test plan
- [x] \`python -m pytest tests/bazarr/test_editor_api.py\` → **63 passed**
- [x] Combined new-in-release backend suite → **96 passed** (63 editor_api + 23 subdl_anime_mode + 10 signalrcore FD-leak)
- [x] No production code touched; only the test's module-level fixtures

## Context
This is the v2.1.0 release-notes blocker flagged by cross-check agents. Once merged, the "474 tests passing" headline in the v2.1.0 release notes becomes **520 tests passing** (424 frontend + 96 new backend).