### PR TITLE
fix(security): address CodeQL v2.1.0 findings

### DIFF
--- a/bazarr/api/editor/editor.py
+++ b/bazarr/api/editor/editor.py
@@ -746,6 +746,11 @@ class EditorSync(Resource):
         if not content:
             return 'content is required', 400
 
+        # Whitelist the format so we never feed attacker-controlled characters
+        # (e.g. path-traversal, shell metachars) into the tempfile suffix.
+        if fmt not in ('srt', 'vtt', 'ass', 'ssa', 'sub', 'smi', 'mpl', 'txt'):
+            return 'Invalid format; must be one of srt, vtt, ass, ssa, sub, smi, mpl, txt', 400
+
         try:
             media_id = int(media_id)
         except (ValueError, TypeError):
@@ -758,7 +763,7 @@ class EditorSync(Resource):
         if not os.path.isfile(video_path):
             return 'Video file not found', 404
 
-        ext = f'.{fmt}' if fmt else '.srt'
+        ext = f'.{fmt}'
         fd, tmp_in = tempfile.mkstemp(suffix=ext, prefix='bazarr_sync_')
         os.write(fd, content.encode(encoding))
         os.close(fd)

--- a/bazarr/api/subtitles/content.py
+++ b/bazarr/api/subtitles/content.py
@@ -3,6 +3,7 @@
 import ast
 import hashlib
 import os
+import re
 import sys
 import tempfile
 
@@ -30,6 +31,16 @@ def _is_safe_path(path):
     if '..' in path.split(os.sep) or '..' in path.split('/'):
         return False
     return True
+
+
+# ISO-ish language tags used by Bazarr. e.g. "en", "pt-BR", "en:hi", "en:forced".
+# Anchored + char-class prevents `..`, slashes, or shell metachars from reaching
+# the file-system probe paths downstream.
+_LANGUAGE_CODE_RE = re.compile(r'^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,4})?(:[a-z]+)?$')
+
+
+def _is_valid_language_code(code):
+    return isinstance(code, str) and bool(_LANGUAGE_CODE_RE.match(code))
 
 SUBTITLE_EXTENSIONS = {
     '.srt', '.ass', '.ssa', '.sub', '.idx', '.sup',
@@ -60,6 +71,9 @@ def resolve_subtitle_path(media_type, media_id, language_code):
 
     Returns (path, language, metadata) on success, or (message, status_code) on failure.
     """
+    if not _is_valid_language_code(language_code):
+        return 'Invalid language code', 400
+
     metadata = {}
     if media_type == 'episode':
         row = database.execute(

--- a/docker/supervisor.py
+++ b/docker/supervisor.py
@@ -308,10 +308,19 @@ STATIC_FILE_EXTENSIONS = {
 
 
 def create_static_handler(config_dir: str):
+    static_root = STATIC_DIR.resolve()
+
     async def static_handler(request: web.Request) -> web.StreamResponse:
         """Serve static frontend files, fallback to index.html for SPA routing."""
         path = request.path.lstrip("/")
-        file_path = STATIC_DIR / path
+        # Resolve against the static root, then confirm the resolved target
+        # is still inside it. Prevents path traversal via '..' segments,
+        # encoded separators, or absolute paths in the request URL.
+        try:
+            file_path = (static_root / path).resolve()
+            file_path.relative_to(static_root)
+        except (ValueError, OSError):
+            return web.Response(status=404, text="Not found")
 
         if file_path.is_file() and path != "index.html":
             content_type = mimetypes.guess_type(str(file_path))[0] or "application/octet-stream"

--- a/frontend/src/pages/SubtitleEditor/DetailPane.tsx
+++ b/frontend/src/pages/SubtitleEditor/DetailPane.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { stripTags } from "./stripTags";
 import type { Cue } from "./types";
 
 export interface DetailPaneHandle {
@@ -475,7 +476,6 @@ const DetailPane = forwardRef<DetailPaneHandle, DetailPaneProps>(
 
     const durationMs = cue.endMs - cue.startMs;
     const durationSec = (durationMs / 1000).toFixed(3);
-    const stripTags = (s: string) => s.replace(/<[^>]+>/g, "");
     const lines = textDraft.split("\n");
 
     const cpsValue =

--- a/frontend/src/pages/SubtitleEditor/QCPanel.tsx
+++ b/frontend/src/pages/SubtitleEditor/QCPanel.tsx
@@ -9,6 +9,7 @@ import {
   QC_PRESETS,
   type QCPreset,
 } from "./document";
+import { stripTags } from "./stripTags";
 import type { Cue } from "./types";
 
 interface QCPanelProps {
@@ -53,9 +54,7 @@ function normalizeEllipsis(text: string): string {
 
 function rebreakLines(text: string, maxChars: number): string {
   const rawLines = text.split("\n");
-  const needsRebreak = rawLines.some(
-    (l) => l.replace(/<[^>]*>|\{\\[^}]*\}/g, "").length > maxChars,
-  );
+  const needsRebreak = rawLines.some((l) => stripTags(l).length > maxChars);
   if (!needsRebreak) return text;
 
   const words = text.replace(/\n/g, " ").split(/\s+/).filter(Boolean);
@@ -64,7 +63,7 @@ function rebreakLines(text: string, maxChars: number): string {
 
   for (const word of words) {
     const test = current ? current + " " + word : word;
-    if (test.replace(/<[^>]*>|\{\\[^}]*\}/g, "").length <= maxChars) {
+    if (stripTags(test).length <= maxChars) {
       current = test;
     } else {
       if (current) lines.push(current);
@@ -118,9 +117,7 @@ function countEllipsis(cues: Cue[]): number {
 
 function countLongLines(cues: Cue[], maxChars: number): number {
   return cues.filter((c) =>
-    c.text
-      .split("\n")
-      .some((l) => l.replace(/<[^>]*>|\{\\[^}]*\}/g, "").length > maxChars),
+    c.text.split("\n").some((l) => stripTags(l).length > maxChars),
   ).length;
 }
 

--- a/frontend/src/pages/SubtitleEditor/StatusBar.tsx
+++ b/frontend/src/pages/SubtitleEditor/StatusBar.tsx
@@ -1,3 +1,4 @@
+import { stripTags } from "./stripTags";
 import type { Cue } from "./types";
 
 interface StatusBarProps {
@@ -38,7 +39,7 @@ const dotStyle: React.CSSProperties = {
 function computeCps(cue: Cue): { value: number | null; color: string } {
   const durationMs = cue.endMs - cue.startMs;
   if (durationMs <= 0) return { value: null, color: "var(--bz-text-tertiary)" };
-  const chars = cue.text.replace(/<[^>]+>/g, "").replace(/\n/g, "").length;
+  const chars = stripTags(cue.text).replace(/\n/g, "").length;
   const cps = chars / (durationMs / 1000);
   const color = cps > 25 ? "#EF4444" : cps > 18 ? "#fbbf24" : "#22c55e";
   return { value: cps, color };

--- a/frontend/src/pages/SubtitleEditor/stripTags.ts
+++ b/frontend/src/pages/SubtitleEditor/stripTags.ts
@@ -1,0 +1,15 @@
+// Strip HTML-like tags and ASS override blocks from subtitle text.
+// Loops until no more matches so nested or malformed tags like "<<script>"
+// cannot survive a single pass. The result is only used for length counts
+// and display, never written back into the DOM.
+const TAG_RE = /<[^>]*>|\{\\[^}]*\}/g;
+
+export function stripTags(text: string): string {
+  let prev = "";
+  let current = text;
+  while (prev !== current) {
+    prev = current;
+    current = current.replace(TAG_RE, "");
+  }
+  return current;
+}


### PR DESCRIPTION
Addresses the 19 CodeQL findings surfaced on PR #65.

## Real issues fixed (8)

### Path-traversal hardening
- **\`bazarr/api/editor/editor.py:762\`** — \`tempfile.mkstemp(suffix=ext)\` where \`ext\` was \`.{fmt}\` with \`fmt\` user-controlled. Now whitelist \`format\` against the eight known subtitle extensions (\`srt/vtt/ass/ssa/sub/smi/mpl/txt\`) before it ever reaches the suffix.
- **\`docker/supervisor.py:316-318\`** — static handler did \`STATIC_DIR / path\` with no containment check. Resolves against the static root and verifies \`relative_to(static_root)\` before serving; returns 404 on traversal attempt.
- **\`bazarr/api/subtitles/content.py\`** — \`language_code\` flowed from HTTP request into \`os.path.isfile\` probes and filename construction before any validation. Added \`_is_valid_language_code\` regex at the top of \`resolve_subtitle_path\` (anchored ISO-639 whitelist with optional region and \`:hi\`/\`:forced\` suffix). This transitively covers the alerts on lines 150/161/167/362/368/381/493/509/523.

### Incomplete multi-character sanitisation (frontend)
- **5 sites** in \`DetailPane.tsx\`, \`QCPanel.tsx\`, \`StatusBar.tsx\` replaced their one-pass \`str.replace(/<[^>]+>/g, \"\")\` with a shared fixed-point loop in \`frontend/src/pages/SubtitleEditor/stripTags.ts\`. Nested or malformed tags like \`<<script>foo\` no longer survive. The output is only used for character-count / CPS display, never injected to DOM, so risk is defence-in-depth rather than live XSS.

## Left as-is (11, known defended)
- **\`bazarr/app/ui.py:85\`** — already whitelisted via \`path in pwa_assets\` plus explicit containment check on the resolved path.
- The 10 content.py paths are now transitively covered by the new \`_is_valid_language_code\` guard that runs before any file-system probe.

## Verification
- [x] Typecheck clean
- [x] ESLint (0 errors, 19 pre-existing warnings)
- [x] Prettier clean
- [x] 424 frontend tests pass
- [x] 96 new backend tests pass (63 editor_api + 23 subdl + 10 signalrcore)
- [x] Production build succeeds

## Context
Release-blocker for v2.1.0. Once merged to \`development\`, PR #65 (release-promotion to \`master\`) picks these up automatically.