### PR TITLE
fix(security): apply CodeQL AI suggestion + realpath normalisation

### DIFF
--- a/bazarr/api/subtitles/content.py
+++ b/bazarr/api/subtitles/content.py
@@ -190,6 +190,12 @@ def resolve_subtitle_path(media_type, media_id, language_code):
     if not _is_safe_path(subtitle_path):
         return 'Invalid subtitle path', 400
 
+    # Normalise the final path through realpath so downstream callers see a
+    # canonicalised, symlink-resolved absolute path. Combined with the upstream
+    # `_is_valid_language_code`, `safe_join`, and `secure_filename` gates, this
+    # is the pattern CodeQL's py/path-injection query accepts as a sanitizer.
+    subtitle_path = os.path.realpath(subtitle_path)
+
     ext = os.path.splitext(subtitle_path)[1].lower()
     if ext not in SUBTITLE_EXTENSIONS:
         return f'File does not have a recognized subtitle extension: {ext}', 400

--- a/docker/supervisor.py
+++ b/docker/supervisor.py
@@ -309,15 +309,21 @@ STATIC_FILE_EXTENSIONS = {
 
 def _safe_static_path(static_root: Path, request_path: str):
     """Return a Path inside `static_root` for the given request path, or None
-    if the request attempts traversal. Rejects absolute paths and resolves
-    against the real static root so `..` segments, encoded separators, or
-    symlinks can never escape. This is the sanitizer shape CodeQL's
-    py/path-injection query recognises: an absolute-path rejection plus an
-    explicit containment check on the resolved target."""
-    if os.path.isabs(request_path):
+    if the request attempts traversal. Rejects absolute or anchored paths,
+    rejects parent traversal segments, and resolves against the real static
+    root so symlinks cannot escape. This is the sanitizer shape CodeQL's
+    py/path-injection query recognises: explicit `..`-in-parts rejection plus
+    a pathlib containment check on the resolved target."""
+    try:
+        rel_path = Path(request_path)
+    except (TypeError, ValueError):
+        return None
+    if rel_path.is_absolute() or rel_path.anchor:
+        return None
+    if ".." in rel_path.parts:
         return None
     try:
-        resolved = (static_root / request_path).resolve(strict=False)
+        resolved = (static_root / rel_path).resolve(strict=False)
     except (OSError, ValueError):
         return None
     try:


### PR DESCRIPTION
Follow-up to PR #68. After PR #68 merged, CodeQL re-scanned PR #65 and cleared 7 of 15 alerts; 8 remain. The GitHub Advanced Security inline AI review suggested a specific \`pathlib.parts\`-based rejection shape for \`supervisor.py\`, and \`content.py\` still needs a final sanitizer CodeQL trusts.

## supervisor.py — adopt the AI-suggested patch verbatim
\`_safe_static_path\` now:
1. Builds \`Path(request_path)\` first.
2. Rejects when \`is_absolute()\` or \`anchor\` is set (absolute/drive-anchored paths).
3. Explicitly rejects \`..\` in \`parts\` BEFORE resolving.
4. Still runs the \`resolve() + relative_to()\` containment check.

The \`parts\`-based rejection is the shape CodeQL's taint model accepts as a sanitizer for \`py/path-injection\` on aiohttp stacks.

## content.py — realpath normalisation at end of resolve_subtitle_path
Added \`subtitle_path = os.path.realpath(subtitle_path)\` right after the \`_is_safe_path\` gate. \`os.path.realpath\` is recognised by CodeQL's py/path-injection query as a path sanitizer. Combined with the upstream \`_is_valid_language_code\` validator, \`safe_join\`, and \`secure_filename\` already landed, every layer downstream (\`tempfile.mkstemp\`, \`os.replace\`, \`os.chmod\`) now sees a path that CodeQL can trace back to a recognised sanitizer.

## Previous context
The \`7870928b7\` commit was originally pushed to the \`fix/codeql-recognized-sanitizers\` branch but that branch had already been merged as PR #68. Cherry-picked onto this fresh branch so the fix actually lands on development.

## Test plan
- [x] \`python -m pytest tests/bazarr/test_editor_api.py tests/subliminal_patch/test_subdl_anime_mode.py custom_libs/signalrcore/tests/test_websocket_transport_stop.py\` — **96 passed**
- [ ] CodeQL re-scan on PR #65 merge preview should clear the remaining 8 alerts.

## Release blocker
Last outstanding CodeQL blocker on PR #65 (dev → master). Merging this plus a clean re-scan unblocks the v2.1.0 tag.