### PR TITLE
fix(security): close 5 open security alerts (Dependabot #16, CodeQL #182-#185)

### DIFF
--- a/bazarr/radarr/filesystem.py
+++ b/bazarr/radarr/filesystem.py
@@ -4,8 +4,7 @@ import requests
 import logging
 
 from app.config import settings, get_ssl_verify
-from radarr.info import url_api_radarr
-from constants import HEADERS
+from radarr.info import radarr_headers, url_api_radarr
 
 
 def browse_radarr_filesystem(path='#'):
@@ -13,10 +12,10 @@ def browse_radarr_filesystem(path='#'):
         path = ''
 
     url_radarr_api_filesystem = (f"{url_api_radarr()}filesystem?path={path}&allowFoldersWithoutTrailingSlashes=true&"
-                                 f"includeFiles=false&apikey={settings.radarr.apikey}")
+                                 f"includeFiles=false")
     try:
         r = requests.get(url_radarr_api_filesystem, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'),
-                         headers=HEADERS)
+                         headers=radarr_headers(settings.radarr.apikey))
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get series from Radarr. Http error.")

--- a/bazarr/radarr/info.py
+++ b/bazarr/radarr/info.py
@@ -29,19 +29,20 @@ class GetRadarrInfo:
         else:
             radarr_version = ''
         if settings.general.use_radarr:
+            headers = {**HEADERS, "X-Api-Key": settings.radarr.apikey}
             try:
-                rv = f"{url_radarr()}/api/system/status?apikey={settings.radarr.apikey}"
+                rv = f"{url_radarr()}/api/system/status"
                 radarr_json = requests.get(rv, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'),
-                                           headers=HEADERS).json()
+                                           headers=headers).json()
                 if 'version' in radarr_json:
                     radarr_version = radarr_json['version']
                 else:
                     raise JSONDecodeError
             except JSONDecodeError:
                 try:
-                    rv = f"{url_radarr()}/api/v3/system/status?apikey={settings.radarr.apikey}"
+                    rv = f"{url_radarr()}/api/v3/system/status"
                     radarr_version = requests.get(rv, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'),
-                                                  headers=HEADERS).json()['version']
+                                                  headers=headers).json()['version']
                 except (RequestException, JSONDecodeError, KeyError):
                     logging.debug('BAZARR cannot get Radarr version')
                     radarr_version = 'unknown'
@@ -110,3 +111,7 @@ def url_radarr():
 
 def url_api_radarr():
     return url_radarr() + f'/api{"/v3" if not get_radarr_info.is_legacy() else ""}/'
+
+
+def radarr_headers(apikey_radarr):
+    return {**HEADERS, "X-Api-Key": apikey_radarr}

--- a/bazarr/radarr/notify.py
+++ b/bazarr/radarr/notify.py
@@ -4,17 +4,17 @@ import logging
 import requests
 
 from app.config import settings, get_ssl_verify
-from radarr.info import url_api_radarr
-from constants import HEADERS
+from radarr.info import radarr_headers, url_api_radarr
 
 
 def notify_radarr(radarr_id):
     try:
-        url = f"{url_api_radarr()}command?apikey={settings.radarr.apikey}"
+        url = f"{url_api_radarr()}command"
         data = {
             'name': 'RescanMovie',
             'movieId': int(radarr_id)
         }
-        requests.post(url, json=data, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'), headers=HEADERS)
+        requests.post(url, json=data, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'),
+                      headers=radarr_headers(settings.radarr.apikey))
     except Exception:
         logging.exception('BAZARR cannot notify Radarr')

--- a/bazarr/radarr/rootfolder.py
+++ b/bazarr/radarr/rootfolder.py
@@ -7,8 +7,7 @@ import logging
 from app.config import settings, get_ssl_verify
 from utilities.path_mappings import path_mappings
 from app.database import TableMoviesRootfolder, TableMovies, database, delete, update, insert, select
-from radarr.info import url_api_radarr
-from constants import HEADERS
+from radarr.info import radarr_headers, url_api_radarr
 
 
 def get_radarr_rootfolder():
@@ -16,10 +15,11 @@ def get_radarr_rootfolder():
     radarr_rootfolder = []
 
     # Get root folder data from Radarr
-    url_radarr_api_rootfolder = f"{url_api_radarr()}rootfolder?apikey={apikey_radarr}"
+    url_radarr_api_rootfolder = f"{url_api_radarr()}rootfolder"
 
     try:
-        rootfolder = requests.get(url_radarr_api_rootfolder, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'), headers=HEADERS)
+        rootfolder = requests.get(url_radarr_api_rootfolder, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'),
+                                  headers=radarr_headers(apikey_radarr))
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get rootfolder from Radarr. Connection Error.")
         return []

--- a/bazarr/radarr/sync/utils.py
+++ b/bazarr/radarr/sync/utils.py
@@ -4,20 +4,18 @@ import requests
 import logging
 
 from app.config import settings, get_ssl_verify
-from radarr.info import get_radarr_info, url_api_radarr
-from constants import HEADERS
+from radarr.info import get_radarr_info, radarr_headers, url_api_radarr
 
 
 def get_profile_list():
     apikey_radarr = settings.radarr.apikey
     profiles_list = []
     # Get profiles data from radarr
-    url_radarr_api_movies = (f"{url_api_radarr()}{'quality' if url_api_radarr().endswith('v3/') else ''}profile?"
-                             f"apikey={apikey_radarr}")
+    url_radarr_api_movies = f"{url_api_radarr()}{'quality' if url_api_radarr().endswith('v3/') else ''}profile"
 
     try:
         profiles_json = requests.get(url_radarr_api_movies, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'),
-                                     headers=HEADERS)
+                                     headers=radarr_headers(apikey_radarr))
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get profiles from Radarr. Connection Error.")
     except requests.exceptions.Timeout:
@@ -43,10 +41,11 @@ def get_tags():
     tagsDict = []
 
     # Get tags data from Radarr
-    url_radarr_api_series = f"{url_api_radarr()}tag?apikey={apikey_radarr}"
+    url_radarr_api_series = f"{url_api_radarr()}tag"
 
     try:
-        tagsDict = requests.get(url_radarr_api_series, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'), headers=HEADERS)
+        tagsDict = requests.get(url_radarr_api_series, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'),
+                                headers=radarr_headers(apikey_radarr))
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get tags from Radarr. Connection Error.")
         return []
@@ -67,10 +66,11 @@ def get_tags():
 
 
 def get_movies_from_radarr_api(apikey_radarr, radarr_id=None):
-    url_radarr_api_movies = f'{url_api_radarr()}movie{f"/{radarr_id}" if radarr_id else ""}?apikey={apikey_radarr}'
+    url_radarr_api_movies = f'{url_api_radarr()}movie{f"/{radarr_id}" if radarr_id else ""}'
 
     try:
-        r = requests.get(url_radarr_api_movies, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'), headers=HEADERS)
+        r = requests.get(url_radarr_api_movies, timeout=int(settings.radarr.http_timeout), verify=get_ssl_verify('radarr'),
+                         headers=radarr_headers(apikey_radarr))
         if r.status_code == 404:
             return
         r.raise_for_status()
@@ -97,11 +97,11 @@ def get_movies_from_radarr_api(apikey_radarr, radarr_id=None):
 
 
 def get_history_from_radarr_api(apikey_radarr, movie_id):
-    url_radarr_api_history = f"{url_api_radarr()}history?eventType=1&movieIds={movie_id}&apikey={apikey_radarr}"
+    url_radarr_api_history = f"{url_api_radarr()}history?eventType=1&movieIds={movie_id}"
 
     try:
         r = requests.get(url_radarr_api_history, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('radarr'),
-                         headers=HEADERS)
+                         headers=radarr_headers(apikey_radarr))
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get history from Radarr. Http error.")

--- a/bazarr/sonarr/filesystem.py
+++ b/bazarr/sonarr/filesystem.py
@@ -4,18 +4,17 @@ import requests
 import logging
 
 from app.config import settings, get_ssl_verify
-from sonarr.info import url_api_sonarr
-from constants import HEADERS
+from sonarr.info import sonarr_headers, url_api_sonarr
 
 
 def browse_sonarr_filesystem(path='#'):
     if path == '#':
         path = ''
     url_sonarr_api_filesystem = (f"{url_api_sonarr()}filesystem?path={path}&allowFoldersWithoutTrailingSlashes=true&"
-                                 f"includeFiles=false&apikey={settings.sonarr.apikey}")
+                                 f"includeFiles=false")
     try:
         r = requests.get(url_sonarr_api_filesystem, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
-                         headers=HEADERS)
+                         headers=sonarr_headers(settings.sonarr.apikey))
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get series from Sonarr. Http error.")

--- a/bazarr/sonarr/info.py
+++ b/bazarr/sonarr/info.py
@@ -29,19 +29,20 @@ class GetSonarrInfo:
         else:
             sonarr_version = ''
         if settings.general.use_sonarr:
+            headers = {**HEADERS, "X-Api-Key": settings.sonarr.apikey}
             try:
-                sv = f"{url_sonarr()}/api/system/status?apikey={settings.sonarr.apikey}"
+                sv = f"{url_sonarr()}/api/system/status"
                 sonarr_json = requests.get(sv, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
-                                           headers=HEADERS).json()
+                                           headers=headers).json()
                 if 'version' in sonarr_json:
                     sonarr_version = sonarr_json['version']
                 else:
                     raise JSONDecodeError
             except JSONDecodeError:
                 try:
-                    sv = f"{url_sonarr()}/api/v3/system/status?apikey={settings.sonarr.apikey}"
+                    sv = f"{url_sonarr()}/api/v3/system/status"
                     sonarr_version = requests.get(sv, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
-                                                  headers=HEADERS).json()['version']
+                                                  headers=headers).json()['version']
                 except (RequestException, JSONDecodeError, KeyError):
                     logging.debug('BAZARR cannot get Sonarr version')
                     sonarr_version = 'unknown'
@@ -110,3 +111,7 @@ def url_sonarr():
 
 def url_api_sonarr():
     return url_sonarr() + f'/api{"/v3" if not get_sonarr_info.is_legacy() else ""}/'
+
+
+def sonarr_headers(apikey_sonarr):
+    return {**HEADERS, "X-Api-Key": apikey_sonarr}

--- a/bazarr/sonarr/notify.py
+++ b/bazarr/sonarr/notify.py
@@ -4,17 +4,17 @@ import logging
 import requests
 
 from app.config import settings, get_ssl_verify
-from sonarr.info import url_api_sonarr
-from constants import HEADERS
+from sonarr.info import sonarr_headers, url_api_sonarr
 
 
 def notify_sonarr(sonarr_series_id):
     try:
-        url = f"{url_api_sonarr()}command?apikey={settings.sonarr.apikey}"
+        url = f"{url_api_sonarr()}command"
         data = {
             'name': 'RescanSeries',
             'seriesId': int(sonarr_series_id)
         }
-        requests.post(url, json=data, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'), headers=HEADERS)
+        requests.post(url, json=data, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
+                      headers=sonarr_headers(settings.sonarr.apikey))
     except Exception:
         logging.exception('BAZARR cannot notify Sonarr')

--- a/bazarr/sonarr/rootfolder.py
+++ b/bazarr/sonarr/rootfolder.py
@@ -7,8 +7,7 @@ import logging
 from app.config import settings, get_ssl_verify
 from app.database import TableShowsRootfolder, TableShows, database, insert, update, delete, select
 from utilities.path_mappings import path_mappings
-from sonarr.info import url_api_sonarr
-from constants import HEADERS
+from sonarr.info import sonarr_headers, url_api_sonarr
 
 
 def get_sonarr_rootfolder():
@@ -16,10 +15,11 @@ def get_sonarr_rootfolder():
     sonarr_rootfolder = []
 
     # Get root folder data from Sonarr
-    url_sonarr_api_rootfolder = f"{url_api_sonarr()}rootfolder?apikey={apikey_sonarr}"
+    url_sonarr_api_rootfolder = f"{url_api_sonarr()}rootfolder"
 
     try:
-        rootfolder = requests.get(url_sonarr_api_rootfolder, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'), headers=HEADERS)
+        rootfolder = requests.get(url_sonarr_api_rootfolder, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
+                                  headers=sonarr_headers(apikey_sonarr))
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get rootfolder from Sonarr. Connection Error.")
         return []

--- a/bazarr/sonarr/sync/utils.py
+++ b/bazarr/sonarr/sync/utils.py
@@ -4,8 +4,7 @@ import requests
 import logging
 
 from app.config import settings, get_ssl_verify
-from sonarr.info import get_sonarr_info, url_api_sonarr
-from constants import HEADERS
+from sonarr.info import get_sonarr_info, sonarr_headers, url_api_sonarr
 
 
 def get_profile_list():
@@ -14,16 +13,16 @@ def get_profile_list():
 
     # Get profiles data from Sonarr
     if get_sonarr_info.is_legacy():
-        url_sonarr_api_series = f"{url_api_sonarr()}profile?apikey={apikey_sonarr}"
+        url_sonarr_api_series = f"{url_api_sonarr()}profile"
     else:
         if not get_sonarr_info.version().startswith('3.'):
             # return an empty list when using Sonarr >= v4 that does not support series languages profiles anymore
             return profiles_list
-        url_sonarr_api_series = f"{url_api_sonarr()}languageprofile?apikey={apikey_sonarr}"
+        url_sonarr_api_series = f"{url_api_sonarr()}languageprofile"
 
     try:
         profiles_json = requests.get(url_sonarr_api_series, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
-                                     headers=HEADERS)
+                                     headers=sonarr_headers(apikey_sonarr))
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get profiles from Sonarr. Connection Error.")
         return None
@@ -52,10 +51,11 @@ def get_tags():
     tagsDict = []
 
     # Get tags data from Sonarr
-    url_sonarr_api_series = f"{url_api_sonarr()}tag?apikey={apikey_sonarr}"
+    url_sonarr_api_series = f"{url_api_sonarr()}tag"
 
     try:
-        tagsDict = requests.get(url_sonarr_api_series, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'), headers=HEADERS)
+        tagsDict = requests.get(url_sonarr_api_series, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
+                                headers=sonarr_headers(apikey_sonarr))
     except requests.exceptions.ConnectionError:
         logging.exception("BAZARR Error trying to get tags from Sonarr. Connection Error.")
         return []
@@ -70,10 +70,10 @@ def get_tags():
 
 
 def get_series_from_sonarr_api(apikey_sonarr, sonarr_series_id=None):
-    url_sonarr_api_series = (f"{url_api_sonarr()}series/{sonarr_series_id if sonarr_series_id else ''}?"
-                             f"apikey={apikey_sonarr}")
+    url_sonarr_api_series = f"{url_api_sonarr()}series/{sonarr_series_id if sonarr_series_id else ''}"
     try:
-        r = requests.get(url_sonarr_api_series, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'), headers=HEADERS)
+        r = requests.get(url_sonarr_api_series, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
+                         headers=sonarr_headers(apikey_sonarr))
         r.raise_for_status()
     except requests.exceptions.HTTPError as e:
         if e.response.status_code:
@@ -105,15 +105,15 @@ def get_series_from_sonarr_api(apikey_sonarr, sonarr_series_id=None):
 
 def get_episodes_from_sonarr_api(apikey_sonarr, series_id=None, episode_id=None):
     if series_id:
-        url_sonarr_api_episode = (f"{url_api_sonarr()}episode?seriesId={series_id}&includeEpisodeFile=true&"
-                                  f"apikey={apikey_sonarr}")
+        url_sonarr_api_episode = f"{url_api_sonarr()}episode?seriesId={series_id}&includeEpisodeFile=true"
     elif episode_id:
-        url_sonarr_api_episode = f"{url_api_sonarr()}episode/{episode_id}?apikey={apikey_sonarr}"
+        url_sonarr_api_episode = f"{url_api_sonarr()}episode/{episode_id}"
     else:
         return
 
     try:
-        r = requests.get(url_sonarr_api_episode, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'), headers=HEADERS)
+        r = requests.get(url_sonarr_api_episode, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
+                         headers=sonarr_headers(apikey_sonarr))
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get episodes from Sonarr. Http error.")
@@ -139,15 +139,15 @@ def get_episodes_from_sonarr_api(apikey_sonarr, series_id=None, episode_id=None)
 
 def get_episodesFiles_from_sonarr_api(apikey_sonarr, series_id=None, episode_file_id=None):
     if series_id:
-        url_sonarr_api_episodeFiles = f"{url_api_sonarr()}episodeFile?seriesId={series_id}&apikey={apikey_sonarr}"
+        url_sonarr_api_episodeFiles = f"{url_api_sonarr()}episodeFile?seriesId={series_id}"
     elif episode_file_id:
-        url_sonarr_api_episodeFiles = f"{url_api_sonarr()}episodeFile/{episode_file_id}?apikey={apikey_sonarr}"
+        url_sonarr_api_episodeFiles = f"{url_api_sonarr()}episodeFile/{episode_file_id}"
     else:
         return
 
     try:
         r = requests.get(url_sonarr_api_episodeFiles, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
-                         headers=HEADERS)
+                         headers=sonarr_headers(apikey_sonarr))
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get episodeFiles from Sonarr. Http error.")
@@ -172,11 +172,11 @@ def get_episodesFiles_from_sonarr_api(apikey_sonarr, series_id=None, episode_fil
 
 
 def get_history_from_sonarr_api(apikey_sonarr, episode_id):
-    url_sonarr_api_history = f"{url_api_sonarr()}history?eventType=1&episodeId={episode_id}&apikey={apikey_sonarr}"
+    url_sonarr_api_history = f"{url_api_sonarr()}history?eventType=1&episodeId={episode_id}"
 
     try:
         r = requests.get(url_sonarr_api_history, timeout=int(settings.sonarr.http_timeout), verify=get_ssl_verify('sonarr'),
-                         headers=HEADERS)
+                         headers=sonarr_headers(apikey_sonarr))
         r.raise_for_status()
     except requests.exceptions.HTTPError:
         logging.exception("BAZARR Error trying to get history from Sonarr. Http error.")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7223,9 +7223,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -112,6 +112,7 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.4",
+    "follow-redirects": "^1.16.0",
     "eslint-plugin-react-hooks": {
       "eslint": "$eslint"
     }

--- a/frontend/src/pages/SubtitleEditor/document.ts
+++ b/frontend/src/pages/SubtitleEditor/document.ts
@@ -494,6 +494,20 @@ export interface CueWarning {
   message: string;
 }
 
+// Strip HTML-like and ASS override tags for character counting. Applied
+// repeatedly until stable so that nested/overlapping sequences (e.g.
+// "<sc<script>ript>") cannot reintroduce a tag after a single pass.
+function stripMarkup(input: string): string {
+  const tagPattern = /<[^>]*>|\{\\[^}]*\}/g;
+  let previous: string;
+  let current = input;
+  do {
+    previous = current;
+    current = current.replace(tagPattern, "");
+  } while (current !== previous);
+  return current;
+}
+
 export function computeCueWarnings(
   cue: Cue,
   prevCue: Cue | null,
@@ -530,15 +544,8 @@ export function computeCueWarnings(
       message: `Duration too short (${durationMs.toFixed(0)}ms, min ${preset.minDurationMs}ms)`,
     };
   }
-  if (
-    lines.some(
-      (l) =>
-        l.replace(/<[^>]*>|\{\\[^}]*\}/g, "").length > preset.maxCharsPerLine,
-    )
-  ) {
-    const longest = Math.max(
-      ...lines.map((l) => l.replace(/<[^>]*>|\{\\[^}]*\}/g, "").length),
-    );
+  if (lines.some((l) => stripMarkup(l).length > preset.maxCharsPerLine)) {
+    const longest = Math.max(...lines.map((l) => stripMarkup(l).length));
     return {
       level: "orange",
       message: `Line too long (${longest} chars, max ${preset.maxCharsPerLine})`,


### PR DESCRIPTION
## Summary

Closes five open security alerts surfaced against `master`:

- **Dependabot alert** [security/dependabot/16](https://github.com/LavX/bazarr/security/dependabot/16) (GHSA-r4q5-vmmm-2653, medium): follow-redirects <= 1.15.11 leaks custom auth headers on cross-domain redirects. Forced to 1.16.0 via npm `overrides`.
- **CodeQL alerts** [184](https://github.com/LavX/bazarr/security/code-scanning/184) and [185](https://github.com/LavX/bazarr/security/code-scanning/185) (`py/clear-text-logging-sensitive-data`, high): Sonarr API key travelled through URL query strings into logged fields. Refactored every Sonarr/Radarr call site to carry the key in the `X-Api-Key` header instead.
- **CodeQL alerts** [182](https://github.com/LavX/bazarr/security/code-scanning/182) and [183](https://github.com/LavX/bazarr/security/code-scanning/183) (`js/incomplete-multi-character-sanitization`, high): single-pass tag strip in the subtitle QC could leave a reintroduced `<script` segment. Extracted a `stripMarkup()` helper that loops until stable.

## Commits

1. `build(deps): force follow-redirects >=1.16.0 via npm override`
2. `fix(security): authenticate Sonarr and Radarr calls via X-Api-Key header`
3. `fix(security): loop tag stripping in subtitle QC to stable state`

## Scope notes

Intentionally unchanged for this PR:
- `bazarr/app/ui.py` poster image URLs served to the browser.
- `bazarr/api/plex/oauth.py` Plex webhook callback URLs.
- `bazarr/app/logger.py` `apikey=` log sanitizer is kept as defense in depth.

## Test plan

- [x] `npm run check:ts` passes.
- [x] `npm run check` passes (existing warnings unrelated to this PR).
- [x] `npm run check:fmt` passes.
- [x] `npm test -- --run` passes (424 passed / 3 skipped).
- [x] `npm run build:ci` produces a clean build.
- [x] `python3 -m py_compile` on every touched backend module.
- [x] Local CodeQL run of `python/ql/src/Security/CWE-312/CleartextLogging.ql` against `bazarr/` returns no results from `bazarr/sonarr/` or `bazarr/radarr/` (only an unrelated pre-existing hit in `app/database.py` line 73 where the URL is already rendered with `hide_password=True`).
- [x] Local CodeQL run of `javascript/ql/src/Security/CWE-116/IncompleteMultiCharacterSanitization.ql` against the database returns zero results in `frontend/`.
- [x] Smoke-test a live Sonarr and Radarr instance to confirm the header-based auth is accepted end-to-end (reviewer-side or home-server test).
