### PR TITLE
fix(compat): bound the fanout thread pool, cancel queued work on timeout

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -505,6 +505,15 @@ validators = [
     # per_provider_timeout is not a user-facing knob: it's derived as
     # 60% of the wall timeout inside _do_fanout. The log-label threshold
     # should scale with the wall, not be tuned independently.
+    # Compat fanout shares one process-wide bounded ThreadPoolExecutor
+    # so repeated timed-out searches cannot keep spawning provider
+    # threads. fanout_max_workers caps total background provider
+    # threads; max_concurrent_fanouts caps simultaneous fanouts so a
+    # burst of requests cannot drain the pool with abandoned work.
+    Validator('compat_endpoint.fanout_max_workers',
+              default=32, cast=int, gte=4, lte=256),
+    Validator('compat_endpoint.max_concurrent_fanouts',
+              default=4, cast=int, gte=1, lte=16),
     Validator('compat_endpoint.file_id_ttl_seconds',
               default=3600, cast=int, gte=300, lte=86400),
     Validator('compat_endpoint.stream_token_ttl_seconds',
@@ -723,6 +732,7 @@ def save_settings(settings_items):
     undefined_subtitles_track_default_changed = False
     audio_tracks_parsing_changed = False
     reset_providers = False
+    reset_fanout_pool = False
 
     # Subzero Mods
     update_subzero = False
@@ -906,6 +916,15 @@ def save_settings(settings_items):
             except Exception:
                 pass
 
+        if key in ('settings-compat_endpoint-fanout_max_workers',
+                   'settings-compat_endpoint-max_concurrent_fanouts'):
+            # Defer the reset until AFTER all values in this batch are
+            # written. Resetting in-loop opens a window where a
+            # concurrent compat request could re-init the shared
+            # executor by reading the OLD value before the assignment
+            # at the bottom of the loop body lands.
+            reset_fanout_pool = True
+
         if reset_providers:
             from .get_providers import reset_throttled_providers
             reset_throttled_providers(only_auth_or_conf_error=True)
@@ -971,6 +990,15 @@ def save_settings(settings_items):
 
     if update_subzero:
         settings.general.subzero_mods = ','.join(subzero_mods)
+
+    if reset_fanout_pool:
+        # All in-loop assignments have committed by now, so the next
+        # _get_pool() call will read the new sizing values.
+        try:
+            from subliminal_patch.core_persistent import reset_pool as _reset_fanout
+            _reset_fanout()
+        except Exception:
+            pass
 
     try:
         settings.validators.validate()

--- a/custom_libs/subliminal_patch/core_persistent.py
+++ b/custom_libs/subliminal_patch/core_persistent.py
@@ -2,9 +2,16 @@
 from __future__ import absolute_import
 
 from collections import defaultdict
-from concurrent.futures import ThreadPoolExecutor, as_completed, TimeoutError as FTimeout
+from concurrent.futures import (
+    ThreadPoolExecutor,
+    as_completed,
+    Future,
+    TimeoutError as FTimeout,
+)
 import logging
+import threading
 import time
+from typing import Dict, Optional, Tuple
 
 from subliminal.core import check_video
 
@@ -90,32 +97,163 @@ def download_best_subtitles(
     return downloaded_subtitles
 
 
+# ---- Shared bounded executor for compat fanout ----
+#
+# A single process-wide ThreadPoolExecutor is shared across every
+# compat fanout. The previous design created (and abandoned) a fresh
+# executor per request, which under repeated timed-out searches would
+# accumulate background threads without any global cap. Sharing one
+# bounded pool gives us:
+#   - hard ceiling on total live provider threads
+#   - back-pressure when many fanouts time out at once: new submissions
+#     queue inside the pool instead of spawning more OS threads
+#   - observable abandoned-future count
+# Workers whose providers blocked on network I/O still finish
+# out-of-band because Python cannot cancel a blocking requests.get().
+# What changed is that they now finish inside this bounded pool.
+
+_DEFAULT_MAX_WORKERS = 32
+_DEFAULT_MAX_CONCURRENT_FANOUTS = 4
+
+_pool_lock = threading.Lock()
+_executor: Optional[ThreadPoolExecutor] = None
+_fanout_sem: Optional[threading.Semaphore] = None
+_pool_max_workers = _DEFAULT_MAX_WORKERS
+_pool_max_fanouts = _DEFAULT_MAX_CONCURRENT_FANOUTS
+
+_abandoned_lock = threading.Lock()
+_abandoned: Dict[Future, Tuple[str, float]] = {}
+_abandoned_total = 0  # all-time counter, for diagnostics
+
+
+def _read_settings() -> Tuple[int, int]:
+    """Pool-sizing knobs from settings, with defensive fallbacks."""
+    try:
+        from bazarr.app.config import settings
+        max_workers = max(4, int(getattr(
+            settings.compat_endpoint, "fanout_max_workers",
+            _DEFAULT_MAX_WORKERS,
+        )))
+        max_fanouts = max(1, int(getattr(
+            settings.compat_endpoint, "max_concurrent_fanouts",
+            _DEFAULT_MAX_CONCURRENT_FANOUTS,
+        )))
+    except Exception:
+        return _DEFAULT_MAX_WORKERS, _DEFAULT_MAX_CONCURRENT_FANOUTS
+    return max_workers, max_fanouts
+
+
+def _get_pool() -> Tuple[ThreadPoolExecutor, threading.Semaphore]:
+    """Lazy-init the shared executor and concurrency semaphore."""
+    global _executor, _fanout_sem, _pool_max_workers, _pool_max_fanouts
+    with _pool_lock:
+        if _executor is None:
+            _pool_max_workers, _pool_max_fanouts = _read_settings()
+            _executor = ThreadPoolExecutor(
+                max_workers=_pool_max_workers,
+                thread_name_prefix="compat-fanout",
+            )
+            _fanout_sem = threading.Semaphore(_pool_max_fanouts)
+            logger.info(
+                "compat fanout pool initialised: max_workers=%d "
+                "max_concurrent_fanouts=%d",
+                _pool_max_workers, _pool_max_fanouts,
+            )
+        return _executor, _fanout_sem
+
+
+def _reap_abandoned() -> None:
+    """Drop completed abandoned futures from the registry. The pool
+    keeps internal refs to running futures; this just prevents the
+    diagnostics dict from growing unboundedly."""
+    with _abandoned_lock:
+        done = [f for f in _abandoned if f.done()]
+        for f in done:
+            _abandoned.pop(f, None)
+
+
+def fanout_stats() -> dict:
+    """Snapshot for tests and diagnostics."""
+    _reap_abandoned()
+    with _abandoned_lock:
+        pending = len(_abandoned)
+    with _pool_lock:
+        max_workers = _pool_max_workers
+        max_fanouts = _pool_max_fanouts
+        live = _executor is not None
+    return {
+        "live": live,
+        "max_workers": max_workers,
+        "max_concurrent_fanouts": max_fanouts,
+        "abandoned_pending": pending,
+        "abandoned_total": _abandoned_total,
+    }
+
+
+def reset_pool() -> None:
+    """Tear down the shared executor and clear the abandoned registry.
+    Intended for tests and for code paths that change the pool's sizing
+    knobs (config save). New fanouts after reset will lazily re-init.
+
+    A concurrent fanout that already captured a reference to the old
+    executor before reset can still submit work to it briefly; the
+    submission path uses _safe_submit() which retries against a fresh
+    pool if it hits the executor-after-shutdown RuntimeError."""
+    global _executor, _fanout_sem, _abandoned_total
+    with _pool_lock:
+        ex = _executor
+        _executor = None
+        _fanout_sem = None
+    if ex is not None:
+        ex.shutdown(wait=False, cancel_futures=True)
+    with _abandoned_lock:
+        _abandoned.clear()
+        _abandoned_total = 0
+
+
+def _safe_submit(executor: ThreadPoolExecutor, fn, *args, **kwargs):
+    """Submit fn to the captured executor; if it was shutdown by a
+    concurrent reset_pool() (config change), grab a fresh executor and
+    retry once. Returning the Future as if nothing happened keeps the
+    fanout's as_completed() loop oblivious to the swap; futures from
+    two pools mix fine since as_completed accepts an arbitrary set."""
+    try:
+        return executor.submit(fn, *args, **kwargs)
+    except RuntimeError:
+        # Most likely "cannot schedule new futures after shutdown".
+        # Reload and retry exactly once.
+        fresh, _ = _get_pool()
+        return fresh.submit(fn, *args, **kwargs)
+
+
 def list_all_subtitles_parallel(videos, languages, pool_instance,
                                  per_provider_timeout: int = 5,
                                  wall_timeout: int = 8,
                                  exclude_providers=None,
                                  on_result=None):
-    """Parallel fanout with a hard wall-clock timeout.
+    """Parallel fanout with a hard wall-clock timeout, sharing one
+    bounded executor process-wide.
 
     Used exclusively by the compat endpoint. DO NOT replace
     list_subtitles_prioritized for existing code paths.
 
     Contract:
-      - Submits every non-excluded provider to a ThreadPoolExecutor.
-      - Iterates `as_completed(futures, timeout=wall_timeout)` so the wall
-        is enforced by cpython itself, not by a per-iteration check.
+      - Submits every non-excluded provider to the shared compat-fanout
+        ThreadPoolExecutor (bounded; see module docstring).
+      - Iterates `as_completed(futures, timeout=wall_timeout)` so the
+        wall is enforced by cpython itself, not by a per-iteration check.
       - On wall expiry, any future that finished before the wall but was
         not yet yielded is harvested (no results dropped); futures still
-        running are reported as "abandoned" - the caller decides what
-        that means (see provider_health).
-      - `ex.shutdown(wait=False, cancel_futures=True)` lets this function
-        return on time even when some provider threads are still blocked
-        on network I/O. Those threads finish out-of-band because Python
-        cannot cancel a blocking `requests.get()` call.
+        running are reported as "abandoned" via on_result and registered
+        in the module-level abandoned set so they remain observable.
+      - Concurrency cap: a process-wide semaphore allows at most
+        max_concurrent_fanouts simultaneous fanouts. If the cap is hit
+        for longer than wall_timeout, the request degrades to "no
+        results" rather than spawning more background work.
 
-    Invariant (load-bearing): `out[video].extend(...)` is called ONLY from
-    the calling thread, never from a worker thread or done-callback. The
-    dogpile.cache.region write path reads `out` after this function
+    Invariant (load-bearing): `out[video].extend(...)` is called ONLY
+    from the calling thread, never from a worker thread or done-callback.
+    The dogpile.cache.region write path reads `out` after this function
     returns; if a worker mutated it concurrently, the cached dict would
     grow after the cache entry was frozen. Do not refactor to
     add_done_callback(...) writing to `out`.
@@ -133,6 +271,7 @@ def list_all_subtitles_parallel(videos, languages, pool_instance,
         ``"exception"`` (raised),
         ``"abandoned"`` (wall fired before completion).
     """
+    global _abandoned_total
     exclude = set(exclude_providers or ())
     out = defaultdict(list)
     if not videos:
@@ -140,65 +279,118 @@ def list_all_subtitles_parallel(videos, languages, pool_instance,
     providers = [p for p in pool_instance.providers
                  if p not in getattr(pool_instance, "discarded_providers", set())
                  and p not in exclude]
-    for video in videos:
-        ex = ThreadPoolExecutor(max_workers=max(1, len(providers)))
-        futures = {}
-        start_times = {}
-        for p in providers:
-            fut = ex.submit(pool_instance.list_subtitles_provider,
-                            p, video, languages)
-            futures[fut] = p
-            start_times[fut] = time.monotonic()
+    if not providers:
+        return out
 
-        slow_threshold = float(per_provider_timeout)
-        processed = set()
+    executor, sem = _get_pool()
+    _reap_abandoned()
 
-        def _emit(name, outcome, latency_s):
-            if on_result is not None:
+    # The wall_timeout is the contract caller's hard budget for the
+    # whole fanout. Track a deadline so the semaphore wait, future
+    # submission, and as_completed iteration ALL fit inside it. Without
+    # this, a saturated semaphore could double the effective wall.
+    deadline = time.monotonic() + float(wall_timeout)
+
+    if not sem.acquire(timeout=float(wall_timeout)):
+        logger.warning(
+            "compat fanout: dropped (concurrency cap reached, wall=%ds)",
+            wall_timeout,
+        )
+        return out
+
+    try:
+        for video in videos:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                # Sem wait consumed the entire budget. Skip the fanout
+                # rather than start work the caller no longer has time
+                # to wait for.
+                logger.warning(
+                    "compat fanout: dropped (no budget left after "
+                    "concurrency wait, wall=%ds)",
+                    wall_timeout,
+                )
+                return out
+
+            futures: Dict[Future, str] = {}
+            start_times: Dict[Future, float] = {}
+            for p in providers:
+                fut = _safe_submit(executor,
+                                    pool_instance.list_subtitles_provider,
+                                    p, video, languages)
+                futures[fut] = p
+                start_times[fut] = time.monotonic()
+
+            slow_threshold = float(per_provider_timeout)
+            processed = set()
+
+            def _emit(name, outcome, latency_s):
+                if on_result is not None:
+                    try:
+                        on_result(name, outcome, int(latency_s * 1000))
+                    except Exception:
+                        logger.debug("on_result callback raised", exc_info=True)
+
+            def _ingest(fut, name, latency_s):
+                # Process a done future: record outcome, extend `out` on success.
                 try:
-                    on_result(name, outcome, int(latency_s * 1000))
+                    result = fut.result(timeout=0)
                 except Exception:
-                    logger.debug("on_result callback raised", exc_info=True)
+                    _emit(name, "exception", latency_s)
+                    return
+                if isinstance(result, tuple) and len(result) == 2:
+                    _, subs = result
+                else:
+                    subs = result
+                _emit(name, "slow" if latency_s > slow_threshold else "ok", latency_s)
+                if subs:
+                    out[video].extend(subs)
 
-        def _ingest(fut, name, latency_s):
-            # Process a done future: record outcome, extend `out` on success.
             try:
-                result = fut.result(timeout=0)
-            except Exception:
-                _emit(name, "exception", latency_s)
-                return
-            if isinstance(result, tuple) and len(result) == 2:
-                _, subs = result
-            else:
-                subs = result
-            _emit(name, "slow" if latency_s > slow_threshold else "ok", latency_s)
-            if subs:
-                out[video].extend(subs)
-
-        try:
-            try:
-                for fut in as_completed(futures, timeout=wall_timeout):
+                for fut in as_completed(futures, timeout=remaining):
                     processed.add(fut)
                     _ingest(fut, futures[fut],
                              time.monotonic() - start_times[fut])
             except FTimeout:
                 pass
-        finally:
-            # Two groups left:
-            #   1. futures that finished but weren't yielded before the
-            #      wall - harvest their results.
-            #   2. futures still running - report abandoned.
-            now = time.monotonic()
-            for fut, name in futures.items():
-                if fut in processed:
-                    continue
-                latency_s = now - start_times[fut]
-                if fut.done() and not fut.cancelled():
-                    _ingest(fut, name, latency_s)
-                else:
-                    _emit(name, "abandoned", latency_s)
-            # cancel_futures=True drains queued tasks that never started.
-            # wait=False returns immediately; running workers finish in
-            # the background (see module docstring for why this is safe).
-            ex.shutdown(wait=False, cancel_futures=True)
+            finally:
+                # Three groups left:
+                #   1. futures that finished but weren't yielded before
+                #      the wall - harvest their results.
+                #   2. futures still queued (never picked up by a worker
+                #      because the shared pool was saturated) - cancel
+                #      them so no provider work runs after the caller
+                #      has returned. cancel() returns True only when the
+                #      future hadn't started yet.
+                #   3. futures already running - cannot be cancelled.
+                #      Report abandoned and register them so they're
+                #      observable. They keep running in the shared pool;
+                #      max_workers caps the total background work
+                #      regardless of how many fanouts have been
+                #      abandoned.
+                now = time.monotonic()
+                still_running = []
+                for fut, name in futures.items():
+                    if fut in processed:
+                        continue
+                    latency_s = now - start_times[fut]
+                    if fut.done() and not fut.cancelled():
+                        _ingest(fut, name, latency_s)
+                    elif fut.cancel():
+                        # Was queued, not running. No work happened, no
+                        # work will happen. Still report as abandoned
+                        # for the health tracker - a queued provider
+                        # that never got CPU time is just as useless to
+                        # the caller as one that timed out.
+                        _emit(name, "abandoned", latency_s)
+                    else:
+                        _emit(name, "abandoned", latency_s)
+                        still_running.append((fut, name))
+                if still_running:
+                    with _abandoned_lock:
+                        for fut, name in still_running:
+                            _abandoned[fut] = (name, now)
+                        _abandoned_total += len(still_running)
+    finally:
+        sem.release()
     return out

--- a/tests/compat/unit/test_fanout_bounded.py
+++ b/tests/compat/unit/test_fanout_bounded.py
@@ -1,0 +1,413 @@
+"""Regression tests for the bounded compat fanout executor.
+
+The previous implementation created a fresh ThreadPoolExecutor per
+request and on wall timeout called shutdown(wait=False, cancel_futures=
+True). cancel_futures only cancels QUEUED tasks, leaving running
+provider threads alive in an abandoned executor. Under repeated timed-
+out searches this would accumulate background threads without bound.
+
+These tests pin the new contract:
+  - one process-wide executor, sized by config (with a defensive default)
+  - a concurrency semaphore bounds simultaneous fanouts
+  - abandoned futures are observable via fanout_stats() and reaped on
+    completion
+  - thread count returns to baseline after timed-out fanouts complete
+"""
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _baseline_compat_threads() -> int:
+    """Count live threads whose name starts with the compat-fanout prefix."""
+    return sum(1 for t in threading.enumerate()
+               if t.is_alive() and t.name.startswith("compat-fanout"))
+
+
+@pytest.fixture(autouse=True)
+def _reset_fanout_pool():
+    """Each test starts and ends with a fresh pool so other tests are
+    isolated and the abandoned counter is accurate per-test."""
+    from subliminal_patch.core_persistent import reset_pool
+    reset_pool()
+    yield
+    reset_pool()
+
+
+def test_max_workers_cap_respected_under_repeated_timeouts():
+    """Even with many fanouts that all abandon their workers, the live
+    compat-fanout thread count must not exceed max_workers."""
+    from subliminal_patch.core_persistent import (
+        list_all_subtitles_parallel, fanout_stats,
+    )
+
+    pool = MagicMock()
+    pool.providers = ["p1", "p2", "p3", "p4"]
+    pool.discarded_providers = set()
+
+    def list_fn(provider, video, languages):
+        time.sleep(2.5)  # exceeds wall, will be abandoned
+        return []
+
+    pool.list_subtitles_provider.side_effect = list_fn
+
+    # Drive 10 fanouts against the same shared pool. With 4 providers
+    # each, that's 40 logical submissions. The shared pool's max_workers
+    # default is 32, but the concurrency semaphore caps simultaneous
+    # fanouts at 4 by default - so at most 4 * 4 = 16 threads alive at
+    # peak, well under the 32 cap.
+    def _drive():
+        v = MagicMock()
+        list_all_subtitles_parallel(
+            [v], set(), pool,
+            per_provider_timeout=1, wall_timeout=1,
+        )
+
+    drivers = [threading.Thread(target=_drive) for _ in range(10)]
+    for d in drivers:
+        d.start()
+    for d in drivers:
+        d.join(timeout=15)
+
+    stats = fanout_stats()
+    live = _baseline_compat_threads()
+    # Hard ceiling: never more than max_workers compat-fanout threads,
+    # regardless of how many fanouts were issued.
+    assert live <= stats["max_workers"], (
+        f"compat-fanout threads={live} exceeded max_workers="
+        f"{stats['max_workers']}"
+    )
+
+
+def test_threads_return_to_baseline_after_workers_finish():
+    """Once provider workers return, all abandoned threads should be
+    reusable / reaped, not leaking forever."""
+    from subliminal_patch.core_persistent import (
+        list_all_subtitles_parallel, fanout_stats,
+    )
+
+    pool = MagicMock()
+    pool.providers = ["a", "b", "c"]
+    pool.discarded_providers = set()
+
+    def list_fn(provider, video, languages):
+        # Long enough to be abandoned by wall=1, short enough that we
+        # can wait it out and observe completion within the test.
+        time.sleep(2.0)
+        return []
+
+    pool.list_subtitles_provider.side_effect = list_fn
+
+    v = MagicMock()
+    list_all_subtitles_parallel(
+        [v], set(), pool,
+        per_provider_timeout=1, wall_timeout=1,
+    )
+
+    # Right after the wall fires, abandoned futures should still be in
+    # the registry (workers still sleeping).
+    immediate = fanout_stats()
+    assert immediate["abandoned_pending"] >= 1, (
+        f"expected at least one abandoned future, got {immediate}"
+    )
+
+    # Wait long enough for the sleeping provider workers to return.
+    time.sleep(2.5)
+
+    # Trigger a reap by calling fanout_stats (which calls _reap_abandoned).
+    after = fanout_stats()
+    assert after["abandoned_pending"] == 0, (
+        f"abandoned futures did not drain after workers returned: {after}"
+    )
+    assert after["abandoned_total"] >= immediate["abandoned_pending"], (
+        "all-time abandoned counter must be monotonic"
+    )
+
+
+def test_concurrent_fanout_cap_blocks_extra_callers():
+    """When more fanouts arrive than max_concurrent_fanouts, extras
+    must wait or degrade rather than spawn unbounded background work."""
+    from subliminal_patch.core_persistent import (
+        list_all_subtitles_parallel,
+    )
+    from bazarr.app.config import settings
+
+    cap = int(settings.compat_endpoint.max_concurrent_fanouts)
+
+    enter = threading.Event()
+    enter_count = threading.Semaphore(0)
+    release = threading.Event()
+    in_flight = []
+    in_flight_lock = threading.Lock()
+
+    def list_fn(provider, video, languages):
+        with in_flight_lock:
+            in_flight.append(1)
+        enter_count.release()
+        # Block until the test releases us.
+        release.wait(timeout=10)
+        with in_flight_lock:
+            in_flight.pop()
+        return []
+
+    pool = MagicMock()
+    pool.providers = ["only"]
+    pool.discarded_providers = set()
+    pool.list_subtitles_provider.side_effect = list_fn
+
+    def _drive():
+        v = MagicMock()
+        list_all_subtitles_parallel(
+            [v], set(), pool,
+            per_provider_timeout=10, wall_timeout=10,
+        )
+
+    drivers = [threading.Thread(target=_drive) for _ in range(cap + 3)]
+    for d in drivers:
+        d.start()
+
+    # Wait until cap workers have entered list_fn.
+    deadline = time.monotonic() + 5.0
+    entered = 0
+    while entered < cap and time.monotonic() < deadline:
+        if enter_count.acquire(timeout=0.2):
+            entered += 1
+    assert entered == cap, (
+        f"expected {cap} concurrent workers, got {entered}"
+    )
+
+    # The remaining drivers must still be blocked on the semaphore.
+    # No more workers should have entered list_fn.
+    time.sleep(0.5)
+    with in_flight_lock:
+        live_workers = len(in_flight)
+    assert live_workers == cap, (
+        f"concurrency cap broken: in_flight={live_workers} cap={cap}"
+    )
+
+    # Release everything and let the threads drain.
+    release.set()
+    for d in drivers:
+        d.join(timeout=15)
+
+
+def test_queued_futures_cancelled_after_wall_timeout(monkeypatch):
+    """When the shared pool is saturated, providers that never got
+    picked up by a worker must be cancelled, not left to run after the
+    caller returned. This guards against unbounded queue growth under
+    repeated timed-out searches when provider count exceeds workers."""
+    from bazarr.app.config import settings
+    from subliminal_patch.core_persistent import (
+        list_all_subtitles_parallel, reset_pool,
+    )
+
+    # Force a tiny pool so queueing is guaranteed.
+    monkeypatch.setattr(
+        settings.compat_endpoint, "fanout_max_workers", 4,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        settings.compat_endpoint, "max_concurrent_fanouts", 1,
+        raising=False,
+    )
+    reset_pool()
+
+    pool = MagicMock()
+    # 8 providers but only 4 worker slots -> 4 queued.
+    pool.providers = [f"p{i}" for i in range(8)]
+    pool.discarded_providers = set()
+
+    started_count = [0]
+    started_lock = threading.Lock()
+
+    def list_fn(provider, video, languages):
+        with started_lock:
+            started_count[0] += 1
+        time.sleep(2.0)  # exceeds wall, will be abandoned
+        return []
+
+    pool.list_subtitles_provider.side_effect = list_fn
+
+    v = MagicMock()
+    list_all_subtitles_parallel(
+        [v], set(), pool,
+        per_provider_timeout=1, wall_timeout=1,
+    )
+
+    # Right after the wall fires, the 4 running providers haven't
+    # returned (they sleep 2s) but the 4 queued ones must have been
+    # cancelled and never invoked.
+    assert started_count[0] == 4, (
+        f"expected exactly 4 providers to start (max_workers cap), "
+        f"got {started_count[0]}"
+    )
+
+    # Wait for the running providers to finish.
+    time.sleep(2.5)
+
+    # Even after the running providers complete, the cancelled queued
+    # providers must NOT have run. Total invocations should still be 4.
+    assert started_count[0] == 4, (
+        f"queued providers ran after the caller returned: "
+        f"started={started_count[0]} (expected 4)"
+    )
+
+
+def test_wall_timeout_includes_semaphore_wait(monkeypatch):
+    """The wall timeout is a hard total budget. Time spent waiting for
+    the concurrency semaphore must count toward it, so a saturated cap
+    cannot cause the request to spend nearly 2 * wall_timeout."""
+    from bazarr.app.config import settings
+    from subliminal_patch.core_persistent import (
+        list_all_subtitles_parallel, reset_pool,
+    )
+
+    monkeypatch.setattr(
+        settings.compat_endpoint, "max_concurrent_fanouts", 1,
+        raising=False,
+    )
+    reset_pool()
+
+    pool = MagicMock()
+    pool.providers = ["only"]
+    pool.discarded_providers = set()
+
+    holder_release = threading.Event()
+
+    def list_fn(provider, video, languages):
+        holder_release.wait(timeout=10)
+        return []
+
+    pool.list_subtitles_provider.side_effect = list_fn
+
+    # Holder fanout: takes the only slot for the whole wall budget.
+    def _holder():
+        v = MagicMock()
+        list_all_subtitles_parallel(
+            [v], set(), pool,
+            per_provider_timeout=10, wall_timeout=2,
+        )
+
+    holder = threading.Thread(target=_holder)
+    holder.start()
+    # Give the holder time to acquire the semaphore.
+    time.sleep(0.3)
+
+    # Second caller arrives while holder owns the slot. Its wall is 2s.
+    # Total elapsed must NOT approach 4s (sem wait + new wall).
+    pool2 = MagicMock()
+    pool2.providers = ["fast"]
+    pool2.discarded_providers = set()
+    fast_sub = MagicMock(provider_name="fast", language=MagicMock())
+
+    def fast_fn(provider, video, languages):
+        return [fast_sub]
+
+    pool2.list_subtitles_provider.side_effect = fast_fn
+
+    t0 = time.monotonic()
+    v2 = MagicMock()
+    list_all_subtitles_parallel(
+        [v2], set(), pool2,
+        per_provider_timeout=1, wall_timeout=2,
+    )
+    elapsed = time.monotonic() - t0
+
+    # Cleanup: release holder.
+    holder_release.set()
+    holder.join(timeout=10)
+
+    # Must respect wall_timeout as a total budget, with a small grace
+    # for thread-pool overhead. Pre-fix this would be ~4s.
+    assert elapsed < 3.0, (
+        f"wall_timeout contract broken: elapsed={elapsed:.2f}s "
+        f"(expected < 3s for wall=2s including sem wait)"
+    )
+
+
+def test_concurrent_reset_does_not_break_in_flight_fanout(monkeypatch):
+    """A reset_pool() call (e.g. config save) racing with an in-flight
+    fanout's submit loop must not turn the search into a 500.
+    _safe_submit transparently swaps to a fresh pool on RuntimeError."""
+    from subliminal_patch.core_persistent import (
+        list_all_subtitles_parallel, reset_pool, _get_pool,
+    )
+
+    pool = MagicMock()
+    pool.providers = ["a", "b", "c", "d"]
+    pool.discarded_providers = set()
+    fast_sub = MagicMock(provider_name="ok", language=MagicMock())
+
+    submit_count = [0]
+    submit_lock = threading.Lock()
+    reset_done = threading.Event()
+
+    def list_fn(provider, video, languages):
+        with submit_lock:
+            submit_count[0] += 1
+        return [fast_sub]
+
+    pool.list_subtitles_provider.side_effect = list_fn
+
+    # Force the in-flight fanout to observe a reset midway through
+    # submitting providers by patching submit on the captured executor
+    # to call reset_pool() the first time it's invoked.
+    real_executor, _ = _get_pool()
+    original_submit = real_executor.submit
+    submit_calls = [0]
+
+    def racy_submit(*args, **kwargs):
+        submit_calls[0] += 1
+        if submit_calls[0] == 2:
+            # Second submit: simulate a config save interleaving here.
+            reset_pool()
+            reset_done.set()
+        return original_submit(*args, **kwargs)
+
+    monkeypatch.setattr(real_executor, "submit", racy_submit)
+
+    v = MagicMock()
+    # Should NOT raise. Some providers may finish on the old executor,
+    # the rest on the fresh one. Either way, the fanout must complete
+    # and return collected results, not a RuntimeError.
+    results = list_all_subtitles_parallel(
+        [v], set(), pool,
+        per_provider_timeout=2, wall_timeout=3,
+    )
+    assert reset_done.is_set(), "reset_pool was supposed to fire mid-fanout"
+    flat = [s for subs in results.values() for s in subs]
+    assert any(getattr(s, "provider_name", "") == "ok" for s in flat), (
+        "expected at least one provider's results despite mid-fanout reset"
+    )
+
+
+def test_existing_short_circuit_behavior_preserved():
+    """The original test_fanout.py's contract still holds with the
+    shared-pool implementation: a slow provider must not starve the
+    wall, and the fast provider's results come back."""
+    from subliminal_patch.core_persistent import list_all_subtitles_parallel
+
+    pool = MagicMock()
+    fast_subs = [MagicMock(provider_name="fast", language=MagicMock())]
+    slow_subs = [MagicMock(provider_name="slow", language=MagicMock())]
+
+    def list_fn(provider, video, languages):
+        if provider == "slow":
+            time.sleep(2.5)
+        return slow_subs if provider == "slow" else fast_subs
+
+    pool.providers = ["fast", "slow"]
+    pool.discarded_providers = set()
+    pool.list_subtitles_provider.side_effect = list_fn
+
+    v = MagicMock()
+    t0 = time.time()
+    results = list_all_subtitles_parallel(
+        [v], set(), pool,
+        per_provider_timeout=1, wall_timeout=2,
+    )
+    elapsed = time.time() - t0
+    assert elapsed < 3
+    assert any(getattr(s, "provider_name", "") == "fast" for s in results[v])


### PR DESCRIPTION
## Summary

The compat search fanout was creating a fresh ThreadPoolExecutor per request and calling `shutdown(wait=False, cancel_futures=True)` on wall timeout. `cancel_futures` only cancels QUEUED tasks, so running provider calls leaked into the background after the caller returned. Under repeated timed-out searches this accumulated provider threads without any global cap, contributing to the long-running CPU spikes observed on shared bazarr instances.

## What changed

- **Bounded shared executor.** One process-wide ThreadPoolExecutor sized by `compat_endpoint.fanout_max_workers` (default 32, gte=4 lte=256) replaces the per-request executor. Workers stuck on blocking `requests.get()` now finish in this bounded pool instead of an abandoned one.
- **Concurrency cap.** `compat_endpoint.max_concurrent_fanouts` (default 4, gte=1 lte=16) limits simultaneous fanouts via a semaphore so a burst cannot drain the pool with abandoned work.
- **Deadline-based wall budget.** Time spent waiting on the concurrency semaphore now counts toward `search_timeout_seconds` instead of doubling it.
- **Queued futures cancelled.** On wall timeout, futures that never got picked up by a worker are cancelled (`fut.cancel()`) so they cannot run after the caller has returned. Running futures are reported abandoned and registered in a module-level dict so they remain observable via `fanout_stats()`.
- **Race-safe config reset.** `reset_pool()` is deferred until after `save_settings` commits all values, so a concurrent fanout cannot re-init the singleton with stale sizing. Submission inside the fanout uses `_safe_submit`, which transparently swaps to a fresh pool if it hits `cannot schedule new futures after shutdown` mid-batch, so a config save racing with active traffic does not turn searches into 500s.

## Test plan

- [x] 223/223 compat pytest suite passes (6 new regression tests)
  - max_workers cap respected under repeated timeouts
  - threads return to baseline after workers finish
  - concurrent fanout cap blocks extras
  - queued futures are cancelled (not run) after wall expiry
  - semaphore wait counts toward wall_timeout
  - in-flight fanout survives a concurrent reset_pool() without raising
- [x] Full frontend CI green (ts, lint, fmt, 424/424 tests, build)
- [x] Three rounds of Codex review (P1 cancel queued, P2 deadline budget, P3 config save race, P4 in-flight reset race) — all addressed and verified clean on the final iteration
- [x] Image built and deployed to test server before commit

## Notes

The two new sizing knobs are deliberately conservative: 32 max threads × 1 second per provider call ≈ enough for a Bazarr instance with 10 providers serving compat clients. Bumping them is a config edit; the executor is rebuilt automatically on save.