### PR TITLE
ci(docker): pin :latest to versioned releases, ignore site/ and other doc paths

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -4,10 +4,18 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
     paths-ignore:
       - '*.md'
       - 'docs/**'
+      - 'site/**'
       - '.github/ISSUE_TEMPLATE/**'
+      - 'CHANGELOG.md'
+      - 'LICENSE*'
+      - '.editorconfig'
+      - '.gitattributes'
+      - '.gitignore'
   workflow_dispatch:
     inputs:
       version_tag:
@@ -131,14 +139,20 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # `latest` only ever points at a versioned release, never a
+          # bare master commit. A docs-only push to master used to
+          # quietly overwrite `latest` with whatever was on HEAD; we
+          # require a real `v*` tag (or a manual workflow_dispatch with
+          # version_tag) for the moving pointer to advance.
           tags: |
-            # Latest tag on main/master branch
-            type=raw,value=latest,enable={{is_default_branch}}
-            # Version tag (e.g., v2.0.0)
+            # Latest only on tag push or workflow_dispatch
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.version_tag != '') }}
+            # Version tag (e.g., v2.0.0) - emitted always so master
+            # pushes still get the computed semver from git describe.
             type=raw,value=${{ steps.version.outputs.fork_version }}
-            # Short SHA tag
+            # Short SHA tag - stable pointer for any commit.
             type=raw,value=sha-${{ steps.version.outputs.short_sha }}
-            # Branch name
+            # Branch name (e.g. `master`) - only on branch pushes.
             type=ref,event=branch
           labels: |
             org.opencontainers.image.title=Bazarr+


### PR DESCRIPTION
## Summary

Two fixes to [build-docker.yml](.github/workflows/build-docker.yml) so that publishing `latest` is intentional:

### 1. \`:latest\` no longer follows master

Before: every master push tagged the resulting image as \`:latest\` via \`enable={{is_default_branch}}\`. A docs-only commit (\`docs: add Discord server link to README and site\`, [26527bc](https://github.com/LavX/bazarr/commit/26527bc94)) silently moved \`:latest\` off the v2.1.0 image and onto an unreleased master HEAD. 146 users then pulled it.

After: \`:latest\` is only published when:
- the workflow runs from a \`v*\` tag, **or**
- \`workflow_dispatch\` is invoked with a non-empty \`version_tag\` input.

Plain master pushes still publish \`master\`, \`sha-<short>\`, and the computed semver tags. Users pinning to those continue to receive updates; only the moving \`:latest\` pointer is gated.

### 2. Docs-only pushes don't trigger a Docker build

\`site/**\` was missing from \`paths-ignore\`, so editing the marketing site triggered a full multiarch build. Added these to the ignore list:
- \`site/**\`
- \`CHANGELOG.md\`
- \`LICENSE*\`
- \`.editorconfig\`, \`.gitattributes\`, \`.gitignore\`

### 3. Workflow now subscribes to tag pushes

Added \`tags: ['v*']\` to the push trigger. The existing \`create-release\` job at the bottom of the workflow gates on \`refs/tags/v\` but had no way to fire because the workflow wasn't listening for tag events.

## Test plan

- [x] YAML validates (\`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build-docker.yml'))"\` returns OK)
- [x] Logic traced through GitHub's metadata-action [enable expression docs](https://github.com/docker/metadata-action#enable):
  - tag push \`v2.2.0\` → \`startsWith(github.ref, 'refs/tags/v')\` true → \`:latest\` published
  - master push → both clauses false → \`:latest\` skipped, \`master\` + \`sha-X\` + semver still published
  - \`workflow_dispatch\` with \`version_tag=v2.2.0\` → second clause true → \`:latest\` published
  - \`workflow_dispatch\` with no input → both false → \`:latest\` skipped