### PR TITLE
feat(secret_store): encrypt API keys / passwords / tokens at rest with auto-migration

### DIFF
--- a/bazarr/api/plex/oauth.py
+++ b/bazarr/api/plex/oauth.py
@@ -15,8 +15,7 @@ from plexapi.exceptions import BadRequest
 
 from . import api_ns_plex
 from .exceptions import *
-from .security import (TokenManager, sanitize_log_data, pin_cache, get_or_create_encryption_key, sanitize_server_url,
-                       encrypt_api_key)
+from .security import sanitize_log_data, pin_cache, sanitize_server_url
 from app.config import get_ssl_verify
 from app.config import settings, write_config
 from app.logger import logger
@@ -39,30 +38,21 @@ def _update_plexapi_headers():
     plexapi.BASE_HEADERS['X-Plex-Client-Identifier'] = client_id
 
 
-def get_token_manager():
-    # Check if encryption key exists before attempting to create one
-    key_existed = bool(getattr(settings.plex, 'encryption_key', None))
-    key = get_or_create_encryption_key(settings.plex, 'encryption_key')
-    # Save config if a new key was generated
-    if not key_existed:
-        write_config()
-    return TokenManager(key)
-
-
+# Pre-secret_store, Plex used a per-namespace TokenManager backed by
+# plex.encryption_key. encrypt_token / decrypt_token are kept as
+# compatibility shims that pass the credential through unchanged - the
+# secret_store at-rest pipeline owns encryption now, and the in-memory
+# values are already plaintext by the time these helpers see them.
 def encrypt_token(token):
-    if not token:
-        return None
-    return get_token_manager().encrypt(token)
+    return token if token else None
 
 
 def decrypt_token(encrypted_token):
     if not encrypted_token:
         return None
-    try:
-        return get_token_manager().decrypt(encrypted_token)
-    except Exception as e:
-        logger.error(f"Token decryption failed: {type(e).__name__}: {str(e)}")
-        raise InvalidTokenError("Failed to decrypt stored authentication token. The token may be corrupted or the encryption key may have changed. Please re-authenticate with Plex.")
+    # The unified pipeline decrypts on boot; what we have here IS the
+    # plaintext. Returning it unchanged is correct.
+    return encrypted_token
 
 
 def generate_client_id():
@@ -89,21 +79,9 @@ def get_decrypted_token():
 
     if auth_method == 'oauth':
         token = settings.plex.get('token')
-        if not token:
-            return None
-        return decrypt_token(token)
-    else:
-        apikey = settings.plex.get('apikey')
-        if not apikey:
-            return None
-
-        if not settings.plex.get('apikey_encrypted', False):
-            if encrypt_api_key():
-                apikey = settings.plex.get('apikey')
-            else:
-                return None
-
-        return decrypt_token(apikey)
+        return token if token else None
+    apikey = settings.plex.get('apikey')
+    return apikey if apikey else None
 
 
 def check_plex_pass_feature(account, feature_name):
@@ -781,15 +759,11 @@ class PlexEncryptApiKey(Resource):
     @authenticate
     @api_ns_plex.doc(parser=post_request_parser)
     def post(self):
-        try:
-            if encrypt_api_key():
-                return {'success': True, 'message': 'API key encrypted successfully'}
-            else:
-                return {'success': False, 'message': 'No plain text API key found or already encrypted'}
-
-        except Exception as e:
-            logger.error(f"API key encryption failed: {e}")
-            return {'error': 'Failed to encrypt API key'}, 500
+        # Encryption is now automatic at write time via secret_store, so
+        # this endpoint is a no-op. Kept for any frontend code that still
+        # POSTs here on save - returning success preserves the old
+        # protocol without touching the credential.
+        return {'success': True, 'message': 'API key encryption is automatic now'}
 
 
 @api_ns_plex.route('plex/apikey')
@@ -807,15 +781,17 @@ class PlexApiKey(Resource):
             if not apikey:
                 return {'error': 'API key is required'}, 400
 
-            encrypted_apikey = encrypt_token(apikey)
-
-            settings.plex.apikey = encrypted_apikey
-            settings.plex.apikey_encrypted = True
+            # Plaintext into in-memory settings; secret_store encrypts on
+            # write_config(). The legacy apikey_encrypted=True flag is no
+            # longer needed - leave it cleared so the legacy migration
+            # path doesn't get re-triggered on reboot.
+            settings.plex.apikey = apikey
+            settings.plex.apikey_encrypted = False
             settings.plex.auth_method = 'apikey'
 
             write_config()
 
-            logger.debug("API key saved and encrypted")
+            logger.debug("API key saved")
             return {'success': True, 'message': 'API key saved securely'}
 
         except Exception as e:

--- a/bazarr/api/plex/oauth.py
+++ b/bazarr/api/plex/oauth.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import os
+import secrets as _secrets
 import time
 import uuid
 import requests
@@ -16,6 +17,20 @@ from plexapi.exceptions import BadRequest
 from . import api_ns_plex
 from .exceptions import *
 from .security import sanitize_log_data, pin_cache, sanitize_server_url
+
+
+def _generate_state_token() -> str:
+    """OAuth CSRF state token. Just a high-entropy random string - the
+    encryption-at-rest pipeline owns the apikey/token persistence, but
+    the per-PIN state token is purely for protecting the redirect from
+    forged requests. Lives in pin_cache only, never on disk."""
+    return _secrets.token_urlsafe(32)
+
+
+def _validate_state_token(state: str, stored_state: str) -> bool:
+    if not state or not stored_state:
+        return False
+    return _secrets.compare_digest(state, stored_state)
 from app.config import get_ssl_verify
 from app.config import settings, write_config
 from app.logger import logger
@@ -233,7 +248,7 @@ class PlexPin(Resource):
             instance_name = settings.general.get('instance_name', 'Bazarr')
             bazarr_version = os.environ.get('BAZARR_VERSION', 'unknown')
 
-            state_token = get_token_manager().generate_state_token()
+            state_token = _generate_state_token()
 
             headers = {
                 'Accept': 'application/json',
@@ -302,7 +317,7 @@ class PlexPinCheck(Resource):
 
             stored_state = cached_pin.get('state_token')
             if stored_state:
-                if not state_param or not get_token_manager().validate_state_token(state_param, stored_state):
+                if not state_param or not _validate_state_token(state_param, stored_state):
                     logger.warning(f"CSRF state validation failed for PIN {pin_id}")
                     abort(403, "Request validation failed")
 

--- a/bazarr/api/system/compat_admin.py
+++ b/bazarr/api/system/compat_admin.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 import secrets
 from flask_restx import Namespace, Resource
 from ..utils import authenticate
-from bazarr.app.config import settings, write_config
-from bazarr.compat.cache import compat_region
-from bazarr.compat import service as compat_service
+from app.config import settings, write_config
+from compat.cache import compat_region
+from compat import service as compat_service
 
 api_ns_compat_admin = Namespace("compat_admin", description="Compat endpoint admin")
 
@@ -42,7 +42,7 @@ def regenerate_all_secrets(write_fn=None) -> str:
         write_config()
     compat_region.invalidate(hard=True)
     compat_service.reset_compat_pool()
-    from bazarr.compat.file_id_store import reset_store
+    from compat.file_id_store import reset_store
     reset_store()
     return new_token
 

--- a/bazarr/api/system/status.py
+++ b/bazarr/api/system/status.py
@@ -84,7 +84,7 @@ class SystemStatus(Resource):
         system_status.update({'cpu_cores': os.cpu_count()})
 
         try:
-            from bazarr.compat import compat_active
+            from compat import compat_active
             system_status.update({'compat_active': compat_active})
         except Exception:
             system_status.update({'compat_active': False})

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -618,6 +618,7 @@ from secret_store import (  # noqa: E402
     decrypt_settings_dict,
     decrypt_settings_in_place,
     encrypt_settings_dict,
+    has_plaintext_secrets_on_disk,
     migrate_legacy_plex_encryption,
 )
 
@@ -628,6 +629,14 @@ from secret_store import (  # noqa: E402
 # under the unified key and the user's Plex creds would be unrecoverable.
 # Migrate FIRST so the rest of the pipeline only sees plaintext.
 migrate_legacy_plex_encryption(settings)
+
+# Detect plaintext credentials BEFORE decrypt_settings_in_place runs - it
+# is a passthrough on plaintext, so afterwards the in-memory state and
+# the on-disk state match for plaintext fields and write_config's
+# comparison would skip the rewrite. Capture the "needs migration" bit
+# now and force a write below.
+_force_first_save_migration = has_plaintext_secrets_on_disk(settings)
+
 decrypt_settings_in_place(settings)
 
 
@@ -635,6 +644,7 @@ def write_config():
     # On-disk shape compared in plaintext form: encrypt_secret is non-
     # deterministic (per-payload salt + timestamp), so naive ciphertext
     # comparison would always diff and rewrite config.yaml on every save.
+    global _force_first_save_migration
     in_memory_plaintext = {k.lower(): v for k, v in settings.as_dict().items()}
     on_disk_dict = {
         k.lower(): v for k, v in Dynaconf(
@@ -644,9 +654,13 @@ def write_config():
     }
     on_disk_plaintext = decrypt_settings_dict(on_disk_dict)
 
-    if in_memory_plaintext == on_disk_plaintext:
+    if in_memory_plaintext == on_disk_plaintext and not _force_first_save_migration:
         logging.debug("Nothing changed when comparing to config file. Skipping write to file.")
         return
+
+    if _force_first_save_migration:
+        logging.info("secret_store: forcing config rewrite to encrypt plaintext credentials on disk")
+        _force_first_save_migration = False
 
     try:
         write(settings_path=config_yaml_file + '.tmp',

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -618,8 +618,16 @@ from secret_store import (  # noqa: E402
     decrypt_settings_dict,
     decrypt_settings_in_place,
     encrypt_settings_dict,
+    migrate_legacy_plex_encryption,
 )
 
+# Legacy Plex encryption (URLSafeSerializer + plex.encryption_key) used a
+# different at-rest format with no marker prefix. If we hand its
+# ciphertext to decrypt_settings_in_place, the marker check fails and the
+# bytes get treated as plaintext - the next save would re-encrypt them
+# under the unified key and the user's Plex creds would be unrecoverable.
+# Migrate FIRST so the rest of the pipeline only sees plaintext.
+migrate_legacy_plex_encryption(settings)
 decrypt_settings_in_place(settings)
 
 

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -656,8 +656,6 @@ def write_config():
 
 base_url = settings.general.base_url.rstrip('/')
 
-ignore_keys = ['flask_secret_key']
-
 array_keys = ['excluded_tags',
               'exclude',
               'included_codecs',
@@ -723,14 +721,23 @@ write_config()
 
 
 def get_settings():
-    # return {k.lower(): v for k, v in settings.as_dict().items()}
+    # API serializer for /api/system/settings. SYSTEM_SECRETS are masked
+    # with '***' (key still present so the wire shape is stable, value
+    # hidden); USER_VISIBLE_SECRETS pass through unchanged because the
+    # in-memory settings already hold their decrypted plaintext.
+    from secret_store import is_system_secret  # noqa: PLC0415
     settings_to_return = {}
     for k, v in settings.as_dict().items():
         if isinstance(v, dict):
             k = k.lower()
             settings_to_return[k] = dict()
             for subk, subv in v.items():
-                if subk.lower() in ignore_keys:
+                full_path = f"{k}.{subk.lower()}"
+                if is_system_secret(full_path):
+                    # Keep empty values literally empty so the UI can
+                    # distinguish "not configured" from "configured but
+                    # hidden". Non-empty system secrets get the mask.
+                    settings_to_return[k][subk] = '***' if subv else subv
                     continue
                 if subv in empty_values and subk.lower() in array_keys:
                     settings_to_return[k].update({subk: []})

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -608,26 +608,50 @@ while failed_validator:
                              f"Bazarr won't work until it's been fixed.")
             stop_bazarr(EXIT_VALIDATION_ERROR)
 
+# Decrypt every USER_VISIBLE_SECRET in the live settings object so the
+# rest of bazarr reads plaintext credentials. On a freshly-upgraded
+# instance the values are still plaintext (no marker prefix) and this
+# call is a no-op; on subsequent boots the values come from disk as
+# ciphertext and get decrypted in place. The complementary encryption
+# happens inside write_config() before the dict hits config.yaml.
+from secret_store import (  # noqa: E402
+    decrypt_settings_dict,
+    decrypt_settings_in_place,
+    encrypt_settings_dict,
+)
+
+decrypt_settings_in_place(settings)
+
 
 def write_config():
-    if settings.as_dict() == Dynaconf(
-        settings_file=config_yaml_file,
-        core_loaders=['YAML']
-    ).as_dict():
+    # On-disk shape compared in plaintext form: encrypt_secret is non-
+    # deterministic (per-payload salt + timestamp), so naive ciphertext
+    # comparison would always diff and rewrite config.yaml on every save.
+    in_memory_plaintext = {k.lower(): v for k, v in settings.as_dict().items()}
+    on_disk_dict = {
+        k.lower(): v for k, v in Dynaconf(
+            settings_file=config_yaml_file,
+            core_loaders=['YAML'],
+        ).as_dict().items()
+    }
+    on_disk_plaintext = decrypt_settings_dict(on_disk_dict)
+
+    if in_memory_plaintext == on_disk_plaintext:
         logging.debug("Nothing changed when comparing to config file. Skipping write to file.")
+        return
+
+    try:
+        write(settings_path=config_yaml_file + '.tmp',
+              settings_data=encrypt_settings_dict(in_memory_plaintext),
+              merge=False)
+    except Exception as error:
+        logging.exception(f"Exception raised while trying to save temporary settings file: {error}")
     else:
         try:
-            write(settings_path=config_yaml_file + '.tmp',
-                  settings_data={k.lower(): v for k, v in settings.as_dict().items()},
-                  merge=False)
+            move(config_yaml_file + '.tmp', config_yaml_file)
         except Exception as error:
-            logging.exception(f"Exception raised while trying to save temporary settings file: {error}")
-        else:
-            try:
-                move(config_yaml_file + '.tmp', config_yaml_file)
-            except Exception as error:
-                logging.exception(f"Exception raised while trying to overwrite settings file with temporary settings "
-                                  f"file: {error}")
+            logging.exception(f"Exception raised while trying to overwrite settings file with temporary settings "
+                              f"file: {error}")
 
 
 base_url = settings.general.base_url.rstrip('/')

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -971,7 +971,7 @@ def save_settings(settings_items):
 
         if key == 'settings-general-enabled_providers':
             try:
-                from bazarr.compat.service import reset_compat_pool
+                from compat.service import reset_compat_pool
                 reset_compat_pool()
             except Exception:
                 pass
@@ -989,7 +989,7 @@ def save_settings(settings_items):
             from .get_providers import reset_throttled_providers
             reset_throttled_providers(only_auth_or_conf_error=True)
             try:
-                from bazarr.compat.service import reset_compat_pool
+                from compat.service import reset_compat_pool
                 reset_compat_pool()
             except Exception:
                 pass

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -85,6 +85,11 @@ validators = [
     # general section
     Validator('general.flask_secret_key', must_exist=True, default=hexlify(os.urandom(16)).decode(),
               is_type_of=str),
+    # Master key for the bazarr.secrets crypto module (encrypts every
+    # user-visible credential at rest). Default empty so the key is
+    # generated lazily on first read - matches the pattern of the legacy
+    # plex.encryption_key. Never round-trips through the API.
+    Validator('general.secrets_encryption_key', must_exist=True, default='', is_type_of=str),
     Validator('general.ip', must_exist=True, default='*', is_type_of=str, condition=validate_ip_address),
     Validator('general.port', must_exist=True, default=6767, is_type_of=int, gte=1, lte=65535),
     Validator('general.hostname', must_exist=True, default=platform.node(), is_type_of=str),

--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -339,7 +339,23 @@ class TableShowsRootfolder(Base):
 
 
 def init_db():
-    database.begin()
+    # Idempotent: bazarr can end up importing `init` under both `bazarr.init`
+    # and `init` aliases when tests cross module-namespace boundaries
+    # (compat tests sometimes load via the parent-package path; everything
+    # else uses the canonical sys.path-rooted path post-encryption-pass).
+    # Each fresh import re-runs init.py which calls init_db, but the
+    # underlying `database` is a scoped_session shared across instances,
+    # so the second begin() raises "A transaction is already begun on
+    # this Session". scoped_session proxies don't expose in_transaction
+    # so we catch sqlalchemy's own signal directly.
+    from sqlalchemy.exc import InvalidRequestError
+    try:
+        database.begin()
+    except InvalidRequestError:
+        # Already in a transaction from a previous init_db (likely
+        # via a duplicate module import path). Safe to skip; the
+        # metadata create_all below is itself idempotent.
+        pass
 
     # Create tables if they don't exist.
     metadata.create_all(engine)

--- a/bazarr/app/server.py
+++ b/bazarr/app/server.py
@@ -18,7 +18,7 @@ from .database import close_database
 from .app import create_app
 
 app = create_app()
-from bazarr.compat import register as register_compat
+from compat import register as register_compat
 register_compat(app, base_url=base_url)
 app.register_blueprint(api_bp, url_prefix=base_url.rstrip('/') + '/api')
 app.register_blueprint(ui_bp, url_prefix=base_url.rstrip('/'))

--- a/bazarr/compat/__init__.py
+++ b/bazarr/compat/__init__.py
@@ -17,12 +17,17 @@ def register(app, base_url: str) -> None:
     boot HMAC self-test. Then the self-test FAILS CLOSED if anything is still
     wrong (B6).
     """
-    from bazarr.app.config import settings
+    # Use the same `app.config` import path as the rest of bazarr. Importing
+    # via `bazarr.app.config` would resolve to a SECOND module instance with
+    # its own Dynaconf state, so settings written by /api/system/settings
+    # would not be visible here and vice versa. Codex flagged this as
+    # producing UI/runtime divergence on /system/compat/regenerate writes.
+    from app.config import settings
     enabled = bool(settings.compat_endpoint.enabled)
     prefix = base_url.rstrip("/") + "/api/v1"
     global compat_active
     if enabled:
-        from bazarr.api.system.compat_admin import ensure_secrets
+        from api.system.compat_admin import ensure_secrets
         ensure_secrets()  # idempotent; auto-generates token/jwt_secret/file_id_secret if missing
         from .auth import boot_hmac_selftest
         boot_hmac_selftest()  # fail-closed if any secret is still invalid

--- a/bazarr/compat/auth.py
+++ b/bazarr/compat/auth.py
@@ -11,7 +11,7 @@ from typing import Tuple
 import jwt as pyjwt
 from flask import jsonify, make_response, request
 
-from bazarr.app.config import settings
+from app.config import settings
 
 
 _XREASON_ALLOWED = frozenset({
@@ -63,7 +63,7 @@ def validate_jwt(token: str | None) -> Tuple[bool, dict]:
         claims = pyjwt.decode(token, secret, algorithms=["HS256"])
     except pyjwt.PyJWTError:
         return False, {}
-    from bazarr.compat import jwt_denylist
+    from . import jwt_denylist
     jti = claims.get("jti")
     if jti and jwt_denylist.is_revoked(jti):
         return False, {}
@@ -72,7 +72,7 @@ def validate_jwt(token: str | None) -> Tuple[bool, dict]:
 
 def revoke_jwt(jti: str, exp: int) -> None:
     """Add a jti to the server-side revocation denylist. Called by /logout."""
-    from bazarr.compat import jwt_denylist
+    from . import jwt_denylist
     jwt_denylist.revoke(jti, exp)
 
 
@@ -112,7 +112,7 @@ def mint_file_id(provider: str, native_id: str, language: str, release_info: str
     it straight to the pool's `download_subtitle(sub)`, which is the only
     reliable way to fetch content across providers.
     """
-    from bazarr.compat.file_id_store import get_store
+    from .file_id_store import get_store
     ttl = int(settings.compat_endpoint.file_id_ttl_seconds)
     release_hash = hashlib.sha1((release_info or "").encode()).hexdigest()[:10]
     payload = {"p": provider, "i": str(native_id), "l": str(language),
@@ -122,7 +122,7 @@ def mint_file_id(provider: str, native_id: str, language: str, release_info: str
 
 def parse_file_id(fid) -> Tuple[bool, dict]:
     """Resolve an int (or digit string) file_id to its stored payload."""
-    from bazarr.compat.file_id_store import get_store
+    from .file_id_store import get_store
     return get_store().get(fid)
 
 

--- a/bazarr/compat/routes.py
+++ b/bazarr/compat/routes.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 from flask import Blueprint, request, jsonify, Response
-from bazarr.compat.auth import compat_error
-from bazarr.utilities.url_guard import UnsafeURLError
+# Intra-package and intra-app imports MUST drop the `bazarr.` prefix - the
+# rest of bazarr resolves modules from `bazarr/` as sys.path root, and a
+# `bazarr.foo` import resolves to a SECOND module instance with its own
+# state. Codex flagged duplicate settings/database instances on writes
+# from /system/compat/regenerate.
+from .auth import compat_error
+from utilities.url_guard import UnsafeURLError
 
 compat_stub_bp = Blueprint("compat_stub", __name__)
 
@@ -13,8 +18,8 @@ def _all_disabled(path):
 
 
 import datetime as _dt
-from bazarr.compat import auth, service, response_mapper as M, rate_limiter
-from bazarr.compat.auth import compat_auth
+from . import auth, service, response_mapper as M, rate_limiter
+from .auth import compat_auth
 
 
 _SUPPORTED_SUB_FORMATS = frozenset({"srt"})
@@ -41,7 +46,7 @@ def _resolve_tmdb_to_imdb(tmdb_id: str) -> str:
     resolution fails or the movie is not in the library.
     """
     try:
-        from bazarr.app.database import database, select, TableMovies
+        from app.database import database, select, TableMovies
         row = database.execute(
             select(TableMovies.imdbId)
             .where(TableMovies.tmdbId == str(tmdb_id))
@@ -54,7 +59,7 @@ def _resolve_tmdb_to_imdb(tmdb_id: str) -> str:
 
 
 def _quota_config() -> tuple[int, int]:
-    from bazarr.app.config import settings
+    from app.config import settings
     return (int(settings.compat_endpoint.downloads_per_window),
             int(settings.compat_endpoint.downloads_window_seconds))
 

--- a/bazarr/compat/service.py
+++ b/bazarr/compat/service.py
@@ -8,10 +8,10 @@ from babelfish import Language
 from subliminal.video import Episode, Movie, Video
 from subliminal_patch.core_persistent import list_all_subtitles_parallel
 
-from bazarr.app.config import settings
-from bazarr.app.get_providers import get_providers_sorted, get_providers_auth
-from bazarr.compat import auth, cache as C, response_mapper as M
-from bazarr.utilities.url_guard import assert_safe_outbound, UnsafeURLError
+from app.config import settings
+from app.get_providers import get_providers_sorted, get_providers_auth
+from . import auth, cache as C, response_mapper as M
+from utilities.url_guard import assert_safe_outbound, UnsafeURLError
 
 logger = logging.getLogger("bazarr.compat.service")
 
@@ -77,8 +77,8 @@ def _lookup_library_metadata(imdb_id: str, media_type: str,
     native manual search). Returns {} if the imdb_id is not in the library.
     """
     try:
-        from bazarr.app.database import (database, select, TableMovies,
-                                         TableShows, TableEpisodes)
+        from app.database import (database, select, TableMovies,
+                                  TableShows, TableEpisodes)
     except Exception:
         return {}
     imdb = imdb_id if str(imdb_id).startswith("tt") else f"tt{imdb_id}"
@@ -150,7 +150,7 @@ def _parse_video_from_library(path: str, meta: dict, media_type: str,
     if not os.path.exists(path):
         return None
     try:
-        from bazarr.subtitles.utils import get_video
+        from subtitles.utils import get_video
     except Exception as e:
         logger.debug("compat: get_video import failed: %s", e)
         return None

--- a/bazarr/compat/service.py
+++ b/bazarr/compat/service.py
@@ -788,8 +788,15 @@ def _fetch_subtitle_bytes(sub) -> bytes:
     # in these fields and construct the actual fetch URL inside their own
     # download_subtitle(). Running the guard on a non-URL string would reject
     # perfectly legitimate providers for the wrong reason.
+    #
+    # Scheme detection is case-insensitive: HTTP clients treat schemes as
+    # case-insensitive per RFC 3986, so a hostile provider returning
+    # `HTTP://169.254.169.254/...` (uppercase) must NOT slip past the
+    # guard just because `startswith` is byte-exact. Codex flagged this
+    # as a bypass: the request would still hit the cloud-metadata
+    # endpoint via pool.download_subtitle() with no SSRF check applied.
     url = getattr(sub, "download_link", None) or getattr(sub, "url", None)
-    if isinstance(url, str) and url.startswith(("http://", "https://")):
+    if isinstance(url, str) and url[:8].lower().startswith(("http://", "https://")):
         assert_safe_outbound(url)  # raises UnsafeURLError on private/loopback/etc.
 
     provider_name = getattr(sub, "provider_name", None)
@@ -809,7 +816,7 @@ def _fetch_subtitle_bytes(sub) -> bytes:
     # SSRF guard. Check the post-download URL if the provider updated it.
     post_url = getattr(sub, "download_link", None) or getattr(sub, "url", None)
     if (isinstance(post_url, str)
-            and post_url.startswith(("http://", "https://"))
+            and post_url[:8].lower().startswith(("http://", "https://"))
             and post_url != url):
         assert_safe_outbound(post_url)
     content = getattr(sub, "content", None)

--- a/bazarr/plex/operations.py
+++ b/bazarr/plex/operations.py
@@ -9,68 +9,43 @@ logger = logging.getLogger(__name__)
 DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 
 def get_plex_server() -> PlexServer:
-    """Connect to the Plex server and return the server instance."""
-    from api.plex.security import TokenManager, get_or_create_encryption_key, encrypt_api_key
-    
+    """Connect to the Plex server and return the server instance.
+
+    Credentials live encrypted at rest via secret_store and are decrypted
+    into the live settings object at boot, so this function reads
+    plain-text apikey / token directly from settings - no per-call
+    decryption ceremony, no auto-encrypt branch, no encryption_key /
+    apikey_encrypted bookkeeping.
+    """
     session = requests.Session()
     session.verify = False
 
     try:
         auth_method = settings.plex.get('auth_method', 'apikey')
-        
+
         if auth_method == 'oauth':
-            # OAuth authentication - use encrypted token and configured server URL
-            
-            encrypted_token = settings.plex.get('token')
-            if not encrypted_token:
+            token = settings.plex.get('token')
+            if not token:
                 raise ValueError("OAuth token not found. Please re-authenticate with Plex.")
-            
-            # Get or create encryption key
-            encryption_key = get_or_create_encryption_key(settings.plex, 'encryption_key')
-            token_manager = TokenManager(encryption_key)
-            
-            try:
-                decrypted_token = token_manager.decrypt(encrypted_token)
-            except Exception as e:
-                logger.error(f"Failed to decrypt OAuth token: {type(e).__name__}")
-                raise ValueError("Invalid OAuth token. Please re-authenticate with Plex.")
-            
-            # Use configured OAuth server URL
+
             server_url = settings.plex.get('server_url')
             if not server_url:
                 raise ValueError("Server URL not configured. Please select a Plex server.")
-            
-            plex_server = PlexServer(server_url, decrypted_token, session=session)
-            
+
+            plex_server = PlexServer(server_url, token, session=session)
+
         else:
-            # Manual/API key authentication - always use encryption now
             protocol = "https://" if settings.plex.ssl else "http://"
             baseurl = f"{protocol}{settings.plex.ip}:{settings.plex.port}"
-            
+
             apikey = settings.plex.get('apikey')
             if not apikey:
                 raise ValueError("API key not configured. Please configure Plex authentication.")
-            
-            # Auto-encrypt plain text API keys
-            if not settings.plex.get('apikey_encrypted', False):
-                logger.info("Auto-encrypting plain text API key")
-                encrypt_api_key()
-                apikey = settings.plex.get('apikey')  # Get the encrypted version
-            
-            # Decrypt the API key
-            encryption_key = get_or_create_encryption_key(settings.plex, 'encryption_key')
-            token_manager = TokenManager(encryption_key)
-            
-            try:
-                decrypted_apikey = token_manager.decrypt(apikey)
-            except Exception as e:
-                logger.error(f"Failed to decrypt API key: {type(e).__name__}")
-                raise ValueError("Invalid encrypted API key. Please reconfigure Plex authentication.")
-            
-            plex_server = PlexServer(baseurl, decrypted_apikey, session=session)
-        
+
+            plex_server = PlexServer(baseurl, apikey, session=session)
+
         return plex_server
-            
+
     except Exception as e:
         logger.error(f"Failed to connect to Plex server: {e}")
         raise

--- a/bazarr/secret_store/__init__.py
+++ b/bazarr/secret_store/__init__.py
@@ -32,6 +32,7 @@ from .migration import (
     decrypt_settings_dict,
     decrypt_settings_in_place,
     encrypt_settings_dict,
+    has_plaintext_secrets_on_disk,
     migrate_legacy_plex_encryption,
 )
 from .registry import (
@@ -54,6 +55,7 @@ __all__ = [
     "encrypt_secret",
     "encrypt_settings_dict",
     "get_master_key",
+    "has_plaintext_secrets_on_disk",
     "is_encrypted",
     "is_system_secret",
     "is_user_visible_secret",

--- a/bazarr/secret_store/__init__.py
+++ b/bazarr/secret_store/__init__.py
@@ -32,6 +32,7 @@ from .migration import (
     decrypt_settings_dict,
     decrypt_settings_in_place,
     encrypt_settings_dict,
+    migrate_legacy_plex_encryption,
 )
 from .registry import (
     SYSTEM_SECRETS,
@@ -57,4 +58,5 @@ __all__ = [
     "is_system_secret",
     "is_user_visible_secret",
     "is_user_visible_secret_list",
+    "migrate_legacy_plex_encryption",
 ]

--- a/bazarr/secret_store/__init__.py
+++ b/bazarr/secret_store/__init__.py
@@ -1,0 +1,52 @@
+# coding=utf-8
+"""Central secret-storage module.
+
+Named `secret_store` (not `secrets`) because the stdlib module `secrets`
+already owns that name - shadowing it would break `import secrets` in
+this package's own modules.
+
+Owns:
+- The master encryption key (`general.secrets_encryption_key`), generated
+  on first boot and stored alongside `flask_secret_key`.
+- A self-describing ciphertext format with a versioned marker prefix
+  (`enc:v1:`) so the same field at rest can be plaintext during the
+  migration window OR ciphertext post-migration without ambiguity.
+- A registry that classifies every sensitive setting as either a
+  user-visible credential (encrypted at rest, decrypted before the API
+  serializes the settings tree) or a system secret (never leaves the
+  backend regardless of encryption state).
+
+Commits 2-4 wire this into the config read/write paths and the
+`/api/system/settings` serializer. This commit is just the building
+blocks plus their tests.
+"""
+
+from .crypto import (
+    SECRET_MARKER_PREFIX,
+    decrypt_secret,
+    encrypt_secret,
+    get_master_key,
+    is_encrypted,
+)
+from .registry import (
+    SYSTEM_SECRETS,
+    USER_VISIBLE_SECRET_LISTS,
+    USER_VISIBLE_SECRETS,
+    is_system_secret,
+    is_user_visible_secret,
+    is_user_visible_secret_list,
+)
+
+__all__ = [
+    "SECRET_MARKER_PREFIX",
+    "SYSTEM_SECRETS",
+    "USER_VISIBLE_SECRET_LISTS",
+    "USER_VISIBLE_SECRETS",
+    "decrypt_secret",
+    "encrypt_secret",
+    "get_master_key",
+    "is_encrypted",
+    "is_system_secret",
+    "is_user_visible_secret",
+    "is_user_visible_secret_list",
+]

--- a/bazarr/secret_store/__init__.py
+++ b/bazarr/secret_store/__init__.py
@@ -28,6 +28,11 @@ from .crypto import (
     get_master_key,
     is_encrypted,
 )
+from .migration import (
+    decrypt_settings_dict,
+    decrypt_settings_in_place,
+    encrypt_settings_dict,
+)
 from .registry import (
     SYSTEM_SECRETS,
     USER_VISIBLE_SECRET_LISTS,
@@ -43,7 +48,10 @@ __all__ = [
     "USER_VISIBLE_SECRET_LISTS",
     "USER_VISIBLE_SECRETS",
     "decrypt_secret",
+    "decrypt_settings_dict",
+    "decrypt_settings_in_place",
     "encrypt_secret",
+    "encrypt_settings_dict",
     "get_master_key",
     "is_encrypted",
     "is_system_secret",

--- a/bazarr/secret_store/crypto.py
+++ b/bazarr/secret_store/crypto.py
@@ -1,40 +1,55 @@
 # coding=utf-8
-"""Symmetric crypto primitives for secrets at rest.
+"""Symmetric AEAD crypto for secrets at rest.
 
-Wraps `itsdangerous.URLSafeSerializer` (the same primitive `plex/security.py`
-uses) but adds:
+Uses `cryptography.fernet.Fernet` - AES-128-CBC + HMAC-SHA256 in a single
+authenticated primitive. Replaces an earlier signed-only design (Codex
+flagged URLSafeSerializer.dumps as encoding-not-encryption: anyone with
+config.yaml could base64-decode the JSON payload and recover the secret
+without the master key).
 
-1. A versioned marker prefix (`enc:v1:`) on the stored ciphertext. The
-   prefix lets the read path tell "this value is already encrypted, decrypt
-   it" apart from "this value is still plaintext, the auto-migrator hasn't
-   touched it yet" without a separate boolean flag per field.
+Format:
+- Stored value: `enc:v1:<urlsafe-base64 Fernet token>`
+- Marker prefix is intentionally NOT cryptographic. An attacker with
+  write access to config.yaml can drop a value without the marker; the
+  read path treats anything without `enc:v1:` as plaintext (passthrough).
+  We are protecting against accidental disclosure (logs, screenshots,
+  support bundles), not a local attacker who already owns the host.
+- Each encrypt produces a fresh ciphertext (Fernet bakes in a random IV
+  + timestamp), so two encryptions of the same plaintext will not equal
+  byte-for-byte. Defends against equality inference if config.yaml leaks.
 
-2. A salt + timestamp inside the signed payload so two encryptions of the
-   same plaintext produce different ciphertext (defends against equality
-   inference if config.yaml leaks).
+Master key derivation:
+- The master key on disk (`general.secrets_encryption_key`) can be any
+  string - we generate it as `secrets.token_urlsafe(32)` (a base64-ish
+  string), but a hand-edited master can be any length.
+- Fernet itself requires a 32-byte key, urlsafe-b64-encoded. We derive
+  it deterministically with SHA-256: `b64(sha256(master_key.utf8))`. This
+  KDF is intentionally simple - the master IS already high-entropy
+  random; we are not stretching a low-entropy passphrase.
 
-3. A single master key (`general.secrets_encryption_key`) instead of a
-   per-namespace key like `plex.encryption_key`. One key to rotate, one
-   key to redact.
-
-The marker is intentionally NOT cryptographic. An attacker who can write
-config.yaml can drop a value in plaintext without the marker; the read
-path will treat it as plaintext and either decrypt-fail (signed payload
-loaded as raw text) or hand it back as-is. We are protecting against
-accidental disclosure (logs, screenshots, support bundles), not a local
-attacker who already owns the host.
+Migration window:
+- Predecessor format (also marker-prefixed `enc:v1:`) used
+  URLSafeSerializer with a JSON payload (`{"secret": "...", "salt": ...,
+  "ts": ...}`). Anything written before this commit reads as that shape.
+- decrypt_secret first attempts Fernet decryption; on InvalidToken it
+  falls back to the legacy URLSafeSerializer reader. Either way the
+  caller gets plaintext. The next write_config rewrites all secrets in
+  the new Fernet format.
 """
 
+import base64
+import hashlib
 import logging
 import secrets as _secrets
-import time
 
+from cryptography.fernet import Fernet, InvalidToken
 from itsdangerous import BadPayload, BadSignature, URLSafeSerializer
 
 logger = logging.getLogger(__name__)
 
 # Versioned marker. Bumping the suffix lets a future change rotate the
-# format (e.g. AEAD-based payload) and still detect legacy ciphertext.
+# format and still detect legacy ciphertext via the byte shape after the
+# prefix (Fernet tokens vs URLSafeSerializer dumps look different).
 SECRET_MARKER_PREFIX = "enc:v1:"
 
 # Generated key length in bytes (token_urlsafe doubles to ~43 chars).
@@ -43,6 +58,22 @@ _MASTER_KEY_BYTES = 32
 
 def _generate_master_key() -> str:
     return _secrets.token_urlsafe(_MASTER_KEY_BYTES)
+
+
+def _fernet_key_from_master(master_key: str) -> bytes:
+    """Derive a Fernet-shaped 32-byte key (urlsafe-b64 encoded) from a
+    free-form master key. Deterministic; same master always maps to the
+    same Fernet key, so encrypt/decrypt agree across boots.
+
+    The master is already high-entropy random (`token_urlsafe(32)`), so
+    SHA-256 is sufficient as a KDF here - we are NOT stretching a
+    low-entropy passphrase. If a future version migrates to user-typed
+    passphrases, swap this for HKDF / Argon2.
+    """
+    if not isinstance(master_key, str):
+        raise TypeError("master_key must be a string")
+    digest = hashlib.sha256(master_key.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest)
 
 
 def get_master_key(settings_obj=None) -> str:
@@ -78,8 +109,8 @@ def is_encrypted(value) -> bool:
     return isinstance(value, str) and value.startswith(SECRET_MARKER_PREFIX)
 
 
-def encrypt_secret(plaintext: str, master_key: str = None) -> str:
-    """Encrypt `plaintext` and return a marker-prefixed ciphertext.
+def encrypt_secret(plaintext, master_key: str = None) -> str:
+    """Encrypt `plaintext` and return a marker-prefixed Fernet token.
 
     Empty / falsy plaintext is returned unchanged - we don't waste bytes
     encrypting an empty string, and the read path treats empty as
@@ -98,14 +129,9 @@ def encrypt_secret(plaintext: str, master_key: str = None) -> str:
     if master_key is None:
         master_key = get_master_key()
 
-    serializer = URLSafeSerializer(master_key)
-    payload = {
-        "v": 1,
-        "secret": plaintext,
-        "salt": _secrets.token_hex(16),
-        "ts": int(time.time()),
-    }
-    return SECRET_MARKER_PREFIX + serializer.dumps(payload)
+    fernet = Fernet(_fernet_key_from_master(master_key))
+    token = fernet.encrypt(plaintext.encode("utf-8"))
+    return SECRET_MARKER_PREFIX + token.decode("ascii")
 
 
 def decrypt_secret(value, master_key: str = None) -> str:
@@ -114,12 +140,17 @@ def decrypt_secret(value, master_key: str = None) -> str:
     Tolerant by design: the read path may encounter a freshly-installed
     value (plaintext, no marker) or an encrypted one. Both must work, so
     a value without the marker is returned unchanged. The auto-migrator
-    in commit 2 is responsible for rewriting plaintext to ciphertext.
+    is responsible for rewriting plaintext to ciphertext.
+
+    Tries the current Fernet format first, then falls back to the legacy
+    URLSafeSerializer payload shape (pre-AEAD migration) so installs
+    written before this change keep working until the next write_config
+    rewrites the file.
 
     Raises `ValueError` only on tampered / mis-keyed ciphertext (marker
-    present, but URLSafeSerializer rejects the payload). Callers that
-    boot with the wrong master key will see this and can surface a clear
-    error instead of silently serving garbage.
+    present, but neither Fernet nor the legacy reader accepts the
+    payload). Callers that boot with the wrong master key see this and
+    can surface a clear error instead of silently serving garbage.
     """
     if not isinstance(value, str) or not value:
         return value
@@ -130,9 +161,20 @@ def decrypt_secret(value, master_key: str = None) -> str:
         master_key = get_master_key()
 
     payload_text = value[len(SECRET_MARKER_PREFIX):]
-    serializer = URLSafeSerializer(master_key)
+
+    # Current format: Fernet (AES-128-CBC + HMAC-SHA256, authenticated).
     try:
-        payload = serializer.loads(payload_text)
+        fernet = Fernet(_fernet_key_from_master(master_key))
+        return fernet.decrypt(payload_text.encode("ascii")).decode("utf-8")
+    except (InvalidToken, ValueError):
+        # ValueError catches malformed base64; fall through to legacy.
+        pass
+
+    # Legacy format: URLSafeSerializer.dumps({"secret": ..., "salt": ..., "ts": ...})
+    # Pre-AEAD shipped ciphertext under the same marker prefix; decoding
+    # both lets a writer-then-reader cycle migrate without manual steps.
+    try:
+        payload = URLSafeSerializer(master_key).loads(payload_text)
     except (BadSignature, BadPayload, ValueError) as e:
         raise ValueError(
             "Failed to decrypt secret: ciphertext was tampered with or the "

--- a/bazarr/secret_store/crypto.py
+++ b/bazarr/secret_store/crypto.py
@@ -1,0 +1,145 @@
+# coding=utf-8
+"""Symmetric crypto primitives for secrets at rest.
+
+Wraps `itsdangerous.URLSafeSerializer` (the same primitive `plex/security.py`
+uses) but adds:
+
+1. A versioned marker prefix (`enc:v1:`) on the stored ciphertext. The
+   prefix lets the read path tell "this value is already encrypted, decrypt
+   it" apart from "this value is still plaintext, the auto-migrator hasn't
+   touched it yet" without a separate boolean flag per field.
+
+2. A salt + timestamp inside the signed payload so two encryptions of the
+   same plaintext produce different ciphertext (defends against equality
+   inference if config.yaml leaks).
+
+3. A single master key (`general.secrets_encryption_key`) instead of a
+   per-namespace key like `plex.encryption_key`. One key to rotate, one
+   key to redact.
+
+The marker is intentionally NOT cryptographic. An attacker who can write
+config.yaml can drop a value in plaintext without the marker; the read
+path will treat it as plaintext and either decrypt-fail (signed payload
+loaded as raw text) or hand it back as-is. We are protecting against
+accidental disclosure (logs, screenshots, support bundles), not a local
+attacker who already owns the host.
+"""
+
+import logging
+import secrets as _secrets
+import time
+
+from itsdangerous import BadPayload, BadSignature, URLSafeSerializer
+
+logger = logging.getLogger(__name__)
+
+# Versioned marker. Bumping the suffix lets a future change rotate the
+# format (e.g. AEAD-based payload) and still detect legacy ciphertext.
+SECRET_MARKER_PREFIX = "enc:v1:"
+
+# Generated key length in bytes (token_urlsafe doubles to ~43 chars).
+_MASTER_KEY_BYTES = 32
+
+
+def _generate_master_key() -> str:
+    return _secrets.token_urlsafe(_MASTER_KEY_BYTES)
+
+
+def get_master_key(settings_obj=None) -> str:
+    """Return the master encryption key, creating one if missing.
+
+    Reads/writes `settings.general.secrets_encryption_key`. The key is
+    generated on first call when the value is absent or empty - mirrors
+    the `flask_secret_key` lifecycle, no extra config step for the user.
+
+    `settings_obj` is the dynaconf settings root; defaults to
+    `app.config.settings`. Injectable for tests so we don't need a real
+    bazarr config to be loaded.
+    """
+    if settings_obj is None:
+        from app.config import settings as settings_obj  # noqa: PLC0415
+
+    general = settings_obj.general
+    key = getattr(general, "secrets_encryption_key", None)
+    if not key or (isinstance(key, str) and not key.strip()):
+        key = _generate_master_key()
+        general.secrets_encryption_key = key
+        logger.info("Generated new master secrets_encryption_key on first boot")
+    return key
+
+
+def is_encrypted(value) -> bool:
+    """True iff `value` is a string carrying the SECRET_MARKER_PREFIX.
+
+    Used by the read path to decide "decrypt this" vs "leave alone /
+    auto-migrate". Non-string and empty values are NOT encrypted (an
+    empty credential is just an empty credential, no migration needed).
+    """
+    return isinstance(value, str) and value.startswith(SECRET_MARKER_PREFIX)
+
+
+def encrypt_secret(plaintext: str, master_key: str = None) -> str:
+    """Encrypt `plaintext` and return a marker-prefixed ciphertext.
+
+    Empty / falsy plaintext is returned unchanged - we don't waste bytes
+    encrypting an empty string, and the read path treats empty as
+    "credential not configured" anyway.
+    """
+    if not plaintext:
+        return plaintext
+    if not isinstance(plaintext, str):
+        raise TypeError(f"encrypt_secret expects str, got {type(plaintext).__name__}")
+    if is_encrypted(plaintext):
+        # Caller passed an already-encrypted value through. Return as-is
+        # so callers can be idempotent (re-encrypting on every save would
+        # rotate ciphertext on every write for no reason).
+        return plaintext
+
+    if master_key is None:
+        master_key = get_master_key()
+
+    serializer = URLSafeSerializer(master_key)
+    payload = {
+        "v": 1,
+        "secret": plaintext,
+        "salt": _secrets.token_hex(16),
+        "ts": int(time.time()),
+    }
+    return SECRET_MARKER_PREFIX + serializer.dumps(payload)
+
+
+def decrypt_secret(value, master_key: str = None) -> str:
+    """Decrypt `value` if it carries the marker, else return it as-is.
+
+    Tolerant by design: the read path may encounter a freshly-installed
+    value (plaintext, no marker) or an encrypted one. Both must work, so
+    a value without the marker is returned unchanged. The auto-migrator
+    in commit 2 is responsible for rewriting plaintext to ciphertext.
+
+    Raises `ValueError` only on tampered / mis-keyed ciphertext (marker
+    present, but URLSafeSerializer rejects the payload). Callers that
+    boot with the wrong master key will see this and can surface a clear
+    error instead of silently serving garbage.
+    """
+    if not isinstance(value, str) or not value:
+        return value
+    if not is_encrypted(value):
+        return value
+
+    if master_key is None:
+        master_key = get_master_key()
+
+    payload_text = value[len(SECRET_MARKER_PREFIX):]
+    serializer = URLSafeSerializer(master_key)
+    try:
+        payload = serializer.loads(payload_text)
+    except (BadSignature, BadPayload, ValueError) as e:
+        raise ValueError(
+            "Failed to decrypt secret: ciphertext was tampered with or the "
+            "master key has changed. Inspect general.secrets_encryption_key "
+            "in config.yaml."
+        ) from e
+
+    if not isinstance(payload, dict) or "secret" not in payload:
+        raise ValueError("Decrypted payload has unexpected shape")
+    return payload["secret"]

--- a/bazarr/secret_store/migration.py
+++ b/bazarr/secret_store/migration.py
@@ -156,6 +156,51 @@ def migrate_legacy_plex_encryption(settings_obj) -> None:
         )
 
 
+def has_plaintext_secrets_on_disk(settings_obj) -> bool:
+    """Return True iff at least one USER_VISIBLE_SECRETS path holds a
+    non-empty string without the enc:v1: marker - i.e. somebody (manual
+    edit, fresh upgrade, registry-expansion deploy) wrote a credential
+    in clear text and write_config has not yet rewritten the file.
+
+    Lets the bootstrap force a one-time write_config call so the
+    encryption guarantee is deterministic - the operator does not have
+    to remember to touch a Settings field to trigger migration.
+
+    Reads from the LIVE settings object (which after dynaconf load
+    matches what's on disk for fields with no marker), so this is the
+    same source of truth that decrypt_settings_in_place / write_config
+    operate on.
+    """
+    for path in USER_VISIBLE_SECRETS:
+        try:
+            section, key = _split_path(path)
+            section_obj = getattr(settings_obj, section, None)
+            if section_obj is None:
+                continue
+            current = section_obj.get(key) if hasattr(section_obj, "get") \
+                else getattr(section_obj, key, None)
+            if isinstance(current, str) and current and not is_encrypted(current):
+                return True
+        except Exception:
+            continue
+
+    for path in USER_VISIBLE_SECRET_LISTS:
+        try:
+            section, key = _split_path(path)
+            section_obj = getattr(settings_obj, section, None)
+            if section_obj is None:
+                continue
+            current = section_obj.get(key) if hasattr(section_obj, "get") \
+                else getattr(section_obj, key, None)
+            if isinstance(current, list):
+                for item in current:
+                    if isinstance(item, str) and item and not is_encrypted(item):
+                        return True
+        except Exception:
+            continue
+    return False
+
+
 def decrypt_settings_in_place(settings_obj) -> None:
     """Walk every USER_VISIBLE_SECRETS / USER_VISIBLE_SECRET_LISTS path in
     the live settings object and decrypt any value carrying the marker

--- a/bazarr/secret_store/migration.py
+++ b/bazarr/secret_store/migration.py
@@ -30,6 +30,16 @@ from typing import Any, Dict
 from .crypto import decrypt_secret, encrypt_secret, is_encrypted
 from .registry import USER_VISIBLE_SECRET_LISTS, USER_VISIBLE_SECRETS
 
+
+# Plex legacy encryption fields. Pre-this-package, plex.apikey / plex.token
+# were stored encrypted under plex.encryption_key (URLSafeSerializer with
+# no marker prefix), and a sibling boolean plex.apikey_encrypted flagged
+# the apikey as encrypted. The unified pipeline doesn't need any of that
+# - encryption metadata is self-describing via the marker prefix - so on
+# first boot we decrypt them with the legacy key and let write_config
+# re-encrypt under the unified master key.
+_PLEX_LEGACY_FIELDS = ("apikey", "token")
+
 logger = logging.getLogger(__name__)
 
 
@@ -53,6 +63,94 @@ def _read_section_key(d: Dict[str, Any], path: str) -> tuple[str, str, Any]:
         if candidate in d and isinstance(d[candidate], dict) and key in d[candidate]:
             return candidate, key, d[candidate][key]
     raise KeyError(path)
+
+
+def migrate_legacy_plex_encryption(settings_obj) -> None:
+    """Decrypt any plex.apikey / plex.token still stored under the legacy
+    URLSafeSerializer + plex.encryption_key scheme, and clear the
+    accompanying apikey_encrypted boolean. Runs ONCE at boot, BEFORE
+    decrypt_settings_in_place - the legacy ciphertext does NOT carry the
+    enc:v1: marker, so without this conversion the unified pipeline
+    would treat the legacy bytes as plaintext, the next write would
+    re-encrypt them as if they were a credential, and the user's plex
+    creds would be unrecoverable.
+
+    The legacy plex.encryption_key stays in config.yaml (it's still a
+    SYSTEM_SECRET masked by the API serializer) so the migration is
+    one-way safe: a downgrade post-this-version can't read enc:v1:
+    ciphertext anyway, so leaving the legacy key around is harmless and
+    avoids a destructive deletion in the migration path.
+
+    No-op on installs that never used the legacy scheme (apikey_encrypted
+    absent or False).
+    """
+    plex = getattr(settings_obj, "plex", None)
+    if plex is None:
+        return
+
+    apikey_encrypted = bool(plex.get("apikey_encrypted", False)) \
+        if hasattr(plex, "get") else bool(getattr(plex, "apikey_encrypted", False))
+    if not apikey_encrypted:
+        return
+
+    legacy_key = plex.get("encryption_key", "") if hasattr(plex, "get") \
+        else getattr(plex, "encryption_key", "")
+    if not legacy_key:
+        # The flag is set but the key is missing - the install is in an
+        # inconsistent state. Clear the flag so the unified pipeline
+        # doesn't re-trigger this branch on every boot, and leave the
+        # values in place for the user to recover from the Settings page.
+        plex.apikey_encrypted = False
+        logger.warning(
+            "plex.apikey_encrypted=True but plex.encryption_key is empty; "
+            "skipping legacy decryption. Reconfigure Plex from Settings."
+        )
+        return
+
+    # Lazy import - keeps the secret_store package usable without a full
+    # bazarr environment for the simpler tests.
+    try:
+        from api.plex.security import TokenManager  # noqa: PLC0415
+    except Exception as e:  # pragma: no cover
+        logger.error(
+            f"Cannot load legacy Plex TokenManager for migration: "
+            f"{type(e).__name__}; leaving legacy values in place."
+        )
+        return
+
+    token_manager = TokenManager(legacy_key)
+    migrated_any = False
+    for field in _PLEX_LEGACY_FIELDS:
+        ciphertext = plex.get(field, "") if hasattr(plex, "get") \
+            else getattr(plex, field, "")
+        if not ciphertext:
+            continue
+        if is_encrypted(ciphertext):
+            # Already on the unified format (someone re-saved between
+            # commit 2 deploy and this migration running). Nothing to do.
+            continue
+        try:
+            plaintext = token_manager.decrypt(ciphertext)
+        except Exception as e:
+            # A genuine corruption / wrong-key situation. Don't crash
+            # the boot; the user can re-paste the credential.
+            logger.error(
+                f"Legacy Plex decryption failed for plex.{field}: "
+                f"{type(e).__name__}. Reconfigure Plex from Settings."
+            )
+            continue
+        plex[field] = plaintext
+        migrated_any = True
+
+    # Always clear the legacy flag once we've handled the fields - leaving
+    # it True would mean the next boot tries to legacy-decrypt plaintext.
+    plex.apikey_encrypted = False
+    if migrated_any:
+        logger.info(
+            "Migrated legacy-encrypted Plex credentials to the unified "
+            "secret_store format. They will be re-persisted under "
+            "general.secrets_encryption_key on next config save."
+        )
 
 
 def decrypt_settings_in_place(settings_obj) -> None:

--- a/bazarr/secret_store/migration.py
+++ b/bazarr/secret_store/migration.py
@@ -1,0 +1,194 @@
+# coding=utf-8
+"""Bidirectional secret crossing between in-memory plaintext and on-disk
+ciphertext.
+
+The model:
+- In memory (`settings.sonarr.apikey`, etc.): always plaintext. Application
+  code reads creds the same way it always has.
+- On disk (`config.yaml`): always ciphertext, post-migration. The first-
+  boot-after-upgrade path is plaintext; the bootstrap decrypter is a
+  passthrough on plaintext (`decrypt_secret` returns plaintext unchanged
+  when the marker prefix is missing) and the next `write_config()`
+  rewrites the file in encrypted form. Auto-migration is implicit -
+  there is no separate one-shot script.
+
+Two boundaries:
+1. After dynaconf finishes loading config.yaml: walk USER_VISIBLE_SECRETS
+   and decrypt anything carrying the marker prefix. After this runs, the
+   live settings object holds plaintext for every credential.
+2. Inside `write_config()`: snapshot settings as a dict, encrypt every
+   USER_VISIBLE_SECRETS in the snapshot, persist that. Only the
+   snapshot is encrypted; the live settings object stays plaintext.
+"""
+
+from __future__ import annotations
+
+import logging
+from copy import deepcopy
+from typing import Any, Dict
+
+from .crypto import decrypt_secret, encrypt_secret, is_encrypted
+from .registry import USER_VISIBLE_SECRET_LISTS, USER_VISIBLE_SECRETS
+
+logger = logging.getLogger(__name__)
+
+
+def _split_path(path: str) -> tuple[str, str]:
+    """Split 'section.key' into ('section', 'key'). Always yields exactly
+    two parts because the registry keys are flat dotted paths by contract."""
+    section, _, key = path.partition(".")
+    if not key:
+        raise ValueError(f"Registry path {path!r} must be 'section.key'")
+    return section, key
+
+
+def _read_section_key(d: Dict[str, Any], path: str) -> tuple[str, str, Any]:
+    """Look up `section.key` in a dict whose top-level keys may be either
+    case. Returns (section_lookup_key, attr_key, value) or raises KeyError.
+    """
+    section, key = _split_path(path)
+    # Settings dicts have section keys in mixed case depending on origin;
+    # match either casing without rewriting the dict.
+    for candidate in (section, section.lower(), section.upper()):
+        if candidate in d and isinstance(d[candidate], dict) and key in d[candidate]:
+            return candidate, key, d[candidate][key]
+    raise KeyError(path)
+
+
+def decrypt_settings_in_place(settings_obj) -> None:
+    """Walk every USER_VISIBLE_SECRETS / USER_VISIBLE_SECRET_LISTS path in
+    the live settings object and decrypt any value carrying the marker
+    prefix. Plaintext values are left untouched (decrypt_secret is a
+    passthrough on plaintext - that's the auto-migration story).
+
+    Failures are logged but non-fatal: a corrupt single ciphertext should
+    not stop bazarr from starting. The operator can rotate that credential
+    via the Settings page; everything else continues to work.
+
+    Runs exactly once at bootstrap, after settings.validators.validate_all
+    finishes. Re-running is harmless (decrypt_secret is idempotent on
+    already-plaintext values).
+    """
+    for path in USER_VISIBLE_SECRETS:
+        try:
+            section, key = _split_path(path)
+            section_obj = getattr(settings_obj, section, None)
+            if section_obj is None:
+                continue
+            current = section_obj.get(key) if hasattr(section_obj, "get") \
+                else getattr(section_obj, key, None)
+            if isinstance(current, str) and is_encrypted(current):
+                decrypted = decrypt_secret(current)
+                section_obj[key] = decrypted
+        except Exception as e:
+            # Don't print the credential value or section/key hint that could
+            # be inferred to a specific provider in a public bug report.
+            logger.error(
+                f"Failed to decrypt secret at rest: {type(e).__name__}; "
+                f"continuing with the value unchanged so the rest of bazarr "
+                f"can boot. Rotate the credential to recover."
+            )
+
+    for path in USER_VISIBLE_SECRET_LISTS:
+        try:
+            section, key = _split_path(path)
+            section_obj = getattr(settings_obj, section, None)
+            if section_obj is None:
+                continue
+            current = section_obj.get(key) if hasattr(section_obj, "get") \
+                else getattr(section_obj, key, None)
+            if not isinstance(current, list):
+                continue
+            new_items = []
+            for item in current:
+                if isinstance(item, str) and is_encrypted(item):
+                    new_items.append(decrypt_secret(item))
+                else:
+                    new_items.append(item)
+            section_obj[key] = new_items
+        except Exception as e:
+            logger.error(
+                f"Failed to decrypt list-shaped secret at rest: "
+                f"{type(e).__name__}; continuing unchanged."
+            )
+
+
+def encrypt_settings_dict(plaintext_dict: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a new dict identical to `plaintext_dict` except that every
+    USER_VISIBLE_SECRETS / USER_VISIBLE_SECRET_LISTS path is encrypted.
+
+    Used by `write_config()` to produce the on-disk form. The dict is
+    deep-copied so the in-memory settings (which is what the caller
+    snapshots) is never mutated to ciphertext.
+
+    Already-encrypted values are returned unchanged (encrypt_secret is
+    idempotent on its own ciphertext) - that handles the case where a
+    config save races with a fresh load and the live settings already
+    carry marker prefixes.
+    """
+    out = deepcopy(plaintext_dict)
+    for path in USER_VISIBLE_SECRETS:
+        try:
+            section_key, attr, value = _read_section_key(out, path)
+            if isinstance(value, str) and value:
+                out[section_key][attr] = encrypt_secret(value)
+        except KeyError:
+            continue
+
+    for path in USER_VISIBLE_SECRET_LISTS:
+        try:
+            section_key, attr, value = _read_section_key(out, path)
+            if isinstance(value, list):
+                out[section_key][attr] = [
+                    encrypt_secret(v) if isinstance(v, str) and v else v
+                    for v in value
+                ]
+        except KeyError:
+            continue
+    return out
+
+
+def decrypt_settings_dict(encrypted_dict: Dict[str, Any]) -> Dict[str, Any]:
+    """Symmetric counterpart of encrypt_settings_dict. Returns a new dict
+    where every USER_VISIBLE_SECRETS / USER_VISIBLE_SECRET_LISTS path is
+    decrypted to plaintext.
+
+    Used by `write_config()` to compare the in-memory plaintext settings
+    against the on-disk dict in plaintext form. Without this normalization
+    the comparison would always differ (encrypt_secret is non-deterministic
+    by design), and write_config would rewrite the file on every save
+    even when nothing changed.
+
+    Decrypt failures (corrupt cipher, wrong master key) leave the value
+    untouched so the comparison fails safely - the rewrite proceeds and
+    overwrites the bad cipher with a fresh one.
+    """
+    out = deepcopy(encrypted_dict)
+    for path in USER_VISIBLE_SECRETS:
+        try:
+            section_key, attr, value = _read_section_key(out, path)
+            if isinstance(value, str) and is_encrypted(value):
+                try:
+                    out[section_key][attr] = decrypt_secret(value)
+                except ValueError:
+                    pass  # leave the bad cipher in place; compare will diff
+        except KeyError:
+            continue
+
+    for path in USER_VISIBLE_SECRET_LISTS:
+        try:
+            section_key, attr, value = _read_section_key(out, path)
+            if isinstance(value, list):
+                new_items = []
+                for v in value:
+                    if isinstance(v, str) and is_encrypted(v):
+                        try:
+                            new_items.append(decrypt_secret(v))
+                        except ValueError:
+                            new_items.append(v)
+                    else:
+                        new_items.append(v)
+                out[section_key][attr] = new_items
+        except KeyError:
+            continue
+    return out

--- a/bazarr/secret_store/migration.py
+++ b/bazarr/secret_store/migration.py
@@ -27,6 +27,9 @@ import logging
 from copy import deepcopy
 from typing import Any, Dict
 
+from . import crypto as _crypto  # module reference so test patches on
+                                  # _crypto.get_master_key apply uniformly
+                                  # across this module's call sites
 from .crypto import decrypt_secret, encrypt_secret, is_encrypted
 from .registry import USER_VISIBLE_SECRET_LISTS, USER_VISIBLE_SECRETS
 
@@ -223,13 +226,32 @@ def encrypt_settings_dict(plaintext_dict: Dict[str, Any]) -> Dict[str, Any]:
     idempotent on its own ciphertext) - that handles the case where a
     config save races with a fresh load and the live settings already
     carry marker prefixes.
+
+    First-boot ordering: get_master_key() lazily generates the master key
+    when general.secrets_encryption_key is empty. We must call it ONCE up
+    front and write the result into the snapshot we're about to persist;
+    otherwise the lazy generator only mutates the live settings object,
+    while the disk file gets `enc:v1:` ciphertext alongside an empty
+    secrets_encryption_key - on next boot, decrypt_settings_in_place
+    would generate a DIFFERENT master key, decryption would silently
+    fail, and the application would start using the bad ciphertext as
+    the credential. (Codex P1 finding.)
     """
     out = deepcopy(plaintext_dict)
+
+    # Resolve the master key once and pass it explicitly to every
+    # encrypt_secret call so the snapshot's general.secrets_encryption_key
+    # ends up consistent with the ciphertext we generate from it.
+    master_key = _crypto.get_master_key()
+    out.setdefault("general", {})
+    if not out["general"].get("secrets_encryption_key"):
+        out["general"]["secrets_encryption_key"] = master_key
+
     for path in USER_VISIBLE_SECRETS:
         try:
             section_key, attr, value = _read_section_key(out, path)
             if isinstance(value, str) and value:
-                out[section_key][attr] = encrypt_secret(value)
+                out[section_key][attr] = encrypt_secret(value, master_key=master_key)
         except KeyError:
             continue
 
@@ -238,7 +260,7 @@ def encrypt_settings_dict(plaintext_dict: Dict[str, Any]) -> Dict[str, Any]:
             section_key, attr, value = _read_section_key(out, path)
             if isinstance(value, list):
                 out[section_key][attr] = [
-                    encrypt_secret(v) if isinstance(v, str) and v else v
+                    encrypt_secret(v, master_key=master_key) if isinstance(v, str) and v else v
                     for v in value
                 ]
         except KeyError:

--- a/bazarr/secret_store/migration.py
+++ b/bazarr/secret_store/migration.py
@@ -70,13 +70,12 @@ def _read_section_key(d: Dict[str, Any], path: str) -> tuple[str, str, Any]:
 
 def migrate_legacy_plex_encryption(settings_obj) -> None:
     """Decrypt any plex.apikey / plex.token still stored under the legacy
-    URLSafeSerializer + plex.encryption_key scheme, and clear the
-    accompanying apikey_encrypted boolean. Runs ONCE at boot, BEFORE
-    decrypt_settings_in_place - the legacy ciphertext does NOT carry the
-    enc:v1: marker, so without this conversion the unified pipeline
-    would treat the legacy bytes as plaintext, the next write would
-    re-encrypt them as if they were a credential, and the user's plex
-    creds would be unrecoverable.
+    URLSafeSerializer + plex.encryption_key scheme. Runs ONCE at boot,
+    BEFORE decrypt_settings_in_place - the legacy ciphertext does NOT
+    carry the enc:v1: marker, so without this conversion the unified
+    pipeline would treat the legacy bytes as plaintext, the next write
+    would re-encrypt them as if they were a credential, and the user's
+    plex creds would be unrecoverable.
 
     The legacy plex.encryption_key stays in config.yaml (it's still a
     SYSTEM_SECRET masked by the API serializer) so the migration is
@@ -84,30 +83,41 @@ def migrate_legacy_plex_encryption(settings_obj) -> None:
     ciphertext anyway, so leaving the legacy key around is harmless and
     avoids a destructive deletion in the migration path.
 
-    No-op on installs that never used the legacy scheme (apikey_encrypted
-    absent or False).
+    Trigger semantics: detection is value-shaped, NOT flag-shaped. The
+    legacy apikey path set `plex.apikey_encrypted = True`, but the OAuth
+    flow stored `settings.plex.token = encrypt_token(...)` and never
+    touched that flag. Gating on `apikey_encrypted` left OAuth tokens
+    untouched, the unified pipeline then encrypted the legacy URLSafe
+    payload as if it were plaintext, and Plex got the unwrapped JSON
+    blob as the auth token after decrypt - breaking OAuth users on
+    upgrade.
+
+    Approach: when plex.encryption_key is non-empty, attempt
+    `TokenManager.decrypt` on every legacy field. URLSafeSerializer
+    raises on plaintext / empty / already-unified-marker values, so
+    the same code path covers both the apikey-encrypted flag case AND
+    the OAuth-no-flag case without false positives.
     """
     plex = getattr(settings_obj, "plex", None)
     if plex is None:
         return
 
-    apikey_encrypted = bool(plex.get("apikey_encrypted", False)) \
-        if hasattr(plex, "get") else bool(getattr(plex, "apikey_encrypted", False))
-    if not apikey_encrypted:
-        return
-
     legacy_key = plex.get("encryption_key", "") if hasattr(plex, "get") \
         else getattr(plex, "encryption_key", "")
+
+    apikey_encrypted = bool(plex.get("apikey_encrypted", False)) \
+        if hasattr(plex, "get") else bool(getattr(plex, "apikey_encrypted", False))
+
     if not legacy_key:
-        # The flag is set but the key is missing - the install is in an
-        # inconsistent state. Clear the flag so the unified pipeline
-        # doesn't re-trigger this branch on every boot, and leave the
-        # values in place for the user to recover from the Settings page.
-        plex.apikey_encrypted = False
-        logger.warning(
-            "plex.apikey_encrypted=True but plex.encryption_key is empty; "
-            "skipping legacy decryption. Reconfigure Plex from Settings."
-        )
+        # Without the key we can't decrypt anything. Clear the flag if it
+        # was set so the migration check doesn't trip on every boot, and
+        # leave the values for the operator to fix from Settings.
+        if apikey_encrypted:
+            plex.apikey_encrypted = False
+            logger.warning(
+                "plex.apikey_encrypted=True but plex.encryption_key is empty; "
+                "skipping legacy decryption. Reconfigure Plex from Settings."
+            )
         return
 
     # Lazy import - keeps the secret_store package usable without a full
@@ -134,20 +144,24 @@ def migrate_legacy_plex_encryption(settings_obj) -> None:
             continue
         try:
             plaintext = token_manager.decrypt(ciphertext)
-        except Exception as e:
-            # A genuine corruption / wrong-key situation. Don't crash
-            # the boot; the user can re-paste the credential.
-            logger.error(
-                f"Legacy Plex decryption failed for plex.{field}: "
-                f"{type(e).__name__}. Reconfigure Plex from Settings."
-            )
+        except Exception:
+            # URLSafeSerializer rejects this payload. Two legitimate
+            # causes: the value was already plaintext (fresh manual
+            # edit, never went through encrypt_token), OR the legacy key
+            # was rotated. Either way the unified pipeline downstream
+            # treats no-marker non-empty strings as plaintext and
+            # re-encrypts them on next save. Silent passthrough is the
+            # right choice; an error log here would fire on every fresh
+            # install with a non-empty plex.encryption_key, which is
+            # noisy and misleading.
             continue
         plex[field] = plaintext
         migrated_any = True
 
-    # Always clear the legacy flag once we've handled the fields - leaving
-    # it True would mean the next boot tries to legacy-decrypt plaintext.
-    plex.apikey_encrypted = False
+    # Clear the legacy flag if it was set; on plaintext-only installs we
+    # leave it absent (don't materialize a False where there was nothing).
+    if apikey_encrypted:
+        plex.apikey_encrypted = False
     if migrated_any:
         logger.info(
             "Migrated legacy-encrypted Plex credentials to the unified "

--- a/bazarr/secret_store/registry.py
+++ b/bazarr/secret_store/registry.py
@@ -32,8 +32,13 @@ before checking, so this stays simple.
 """
 
 USER_VISIBLE_SECRETS = frozenset({
-    # Bazarr's own API key + admin password
+    # Bazarr's own admin login (username + password) and the API key that
+    # the SPA uses on every authenticated request. Username is NOT
+    # universally treated as secret, but encrypting it alongside the
+    # password preserves account privacy in support bundles / leaked
+    # config.yaml uploads.
     "auth.apikey",
+    "auth.username",
     "auth.password",
     # Compat endpoint token (user copies this into VLSub / Jellyfin plugin)
     "compat_endpoint.token",
@@ -42,13 +47,20 @@ USER_VISIBLE_SECRETS = frozenset({
     # *arr API keys
     "sonarr.apikey",
     "radarr.apikey",
-    # Plex (apikey + token; encryption_key stays in SYSTEM_SECRETS)
+    # Plex (apikey + token; encryption_key stays in SYSTEM_SECRETS).
+    # plex.username / plex.email come from the OAuth flow and are user
+    # PII, encrypted at rest alongside the token.
     "plex.apikey",
     "plex.token",
+    "plex.username",
+    "plex.email",
     # Jellyfin
     "jellyfin.apikey",
-    # Network proxy + database
+    # Network proxy (full login pair).
+    "proxy.username",
     "proxy.password",
+    # External Postgres (full login pair).
+    "postgresql.username",
     "postgresql.password",
     # AI Subtitle Translator. The "encryption_key" here is a USER-managed
     # secret - the Translator settings page exposes it as a Password field
@@ -58,18 +70,46 @@ USER_VISIBLE_SECRETS = frozenset({
     "translator.openrouter_api_key",
     "translator.openrouter_encryption_key",
     "translator.lingarr_token",
-    # Subtitle providers - passwords
+    # Subtitle providers - full login pairs (username + password) so a
+    # leaked config.yaml doesn't expose which provider accounts the
+    # operator owns even when the password is the only crackable bit.
+    "opensubtitles.username",
     "opensubtitles.password",
+    "opensubtitlescom.username",
     "opensubtitlescom.password",
+    "addic7ed.username",
     "addic7ed.password",
+    "legendasdivx.username",
     "legendasdivx.password",
+    "legendasnet.username",
     "legendasnet.password",
+    "xsubs.username",
     "xsubs.password",
+    "deathbycaptcha.username",
     "deathbycaptcha.password",
+    "napisy24.username",
     "napisy24.password",
+    "titlovi.username",
     "titlovi.password",
+    "titulky.username",
     "titulky.password",
+    "karagarga.username",
     "karagarga.password",
+    # karagarga forum login is a separate credential pair (no f_username
+    # validator exists - the same `username` is reused).
+    "karagarga.f_password",
+    # ktuvit: separate field names but same pattern (login pair).
+    "ktuvit.email",
+    "ktuvit.hashed_password",
+    # Private-tracker passkey (single credential, no separate password).
+    "hdbits.username",
+    "hdbits.passkey",
+    # Session cookies - functionally equivalent to a long-lived auth
+    # token once the provider login has happened.
+    "addic7ed.cookies",
+    "avistaz.cookies",
+    "cinemaz.cookies",
+    "turkcealtyaziorg.cookies",
     # Subtitle providers - tokens / keys
     "assrt.token",
     "betaseries.token",

--- a/bazarr/secret_store/registry.py
+++ b/bazarr/secret_store/registry.py
@@ -1,0 +1,119 @@
+# coding=utf-8
+"""Registry of every sensitive setting in config.yaml.
+
+Two tiers:
+
+USER_VISIBLE_SECRETS - credentials the user types in, copies, or rotates
+    via the Settings page. They are encrypted at rest, but the
+    `/api/system/settings` serializer decrypts before returning so the
+    UI can show / let the user copy them. Examples: provider API keys,
+    auth.apikey, compat_endpoint.token (which the user copies into
+    Jellyfin OS plugin / VLSub).
+
+USER_VISIBLE_SECRET_LISTS - same tier as above, but the value is a list
+    of strings (e.g. translator.gemini_keys), each item handled
+    individually.
+
+SYSTEM_SECRETS - cryptographic primitives the user MUST NOT see and the
+    backend MUST NOT leak. These are scoped to backend-internal use:
+    flask_secret_key for session signing, jwt_secret / file_id_secret
+    for compat token signing, the encryption keys themselves. The API
+    serializer masks these with `***`.
+
+The boundary matters because the user clarification was explicit:
+"we should able to see the compat on the frontend" applies to
+compat_endpoint.token (the API token they copy). The compat_endpoint's
+internal jwt_secret / file_id_secret are NOT visible - they're signing
+keys, never shown to the user.
+
+Membership tests use exact-match dotted paths (e.g. "sonarr.apikey").
+The dynaconf API serializer flattens nested settings to that form
+before checking, so this stays simple.
+"""
+
+USER_VISIBLE_SECRETS = frozenset({
+    # Bazarr's own API key + admin password
+    "auth.apikey",
+    "auth.password",
+    # Compat endpoint token (user copies this into VLSub / Jellyfin plugin)
+    "compat_endpoint.token",
+    # External webhook
+    "general.external_webhook_password",
+    # *arr API keys
+    "sonarr.apikey",
+    "radarr.apikey",
+    # Plex (apikey + token; encryption_key stays in SYSTEM_SECRETS)
+    "plex.apikey",
+    "plex.token",
+    # Jellyfin
+    "jellyfin.apikey",
+    # Network proxy + database
+    "proxy.password",
+    "postgresql.password",
+    # AI Subtitle Translator
+    "translator.openrouter_api_key",
+    "translator.lingarr_token",
+    # Subtitle providers - passwords
+    "opensubtitles.password",
+    "opensubtitlescom.password",
+    "addic7ed.password",
+    "legendasdivx.password",
+    "legendasnet.password",
+    "xsubs.password",
+    "deathbycaptcha.password",
+    "napisy24.password",
+    "titlovi.password",
+    "titulky.password",
+    "karagarga.password",
+    # Subtitle providers - tokens / keys
+    "assrt.token",
+    "betaseries.token",
+    "jimaku.api_key",
+    "subdl.api_key",
+    "subsource.apikey",
+    "subx.api_key",
+    "subsro.api_key",
+    "omdb.apikey",
+})
+
+
+USER_VISIBLE_SECRET_LISTS = frozenset({
+    # AI Subtitle Translator's pool of Gemini API keys
+    "translator.gemini_keys",
+})
+
+
+SYSTEM_SECRETS = frozenset({
+    # Flask session signing
+    "general.flask_secret_key",
+    # Master encryption key - never round-trips through the API
+    "general.secrets_encryption_key",
+    # Compat endpoint signing keys (NOT the user-facing token)
+    "compat_endpoint.jwt_secret",
+    "compat_endpoint.file_id_secret",
+    # Plex legacy per-namespace key (commit 4 unifies under
+    # general.secrets_encryption_key; left here so the legacy read
+    # path still has it masked in API responses during the migration
+    # window)
+    "plex.encryption_key",
+    # AI Subtitle Translator's local OpenRouter encryption key
+    "translator.openrouter_encryption_key",
+})
+
+
+def is_user_visible_secret(key: str) -> bool:
+    """True iff `key` is a scalar credential that should be encrypted at
+    rest and decrypted before the API returns it."""
+    return key in USER_VISIBLE_SECRETS
+
+
+def is_user_visible_secret_list(key: str) -> bool:
+    """True iff `key` is a list of credentials, each item handled like a
+    USER_VISIBLE_SECRET (encrypt at rest per-element, decrypt for API)."""
+    return key in USER_VISIBLE_SECRET_LISTS
+
+
+def is_system_secret(key: str) -> bool:
+    """True iff `key` is a backend-only cryptographic primitive that
+    must be masked by the API serializer."""
+    return key in SYSTEM_SECRETS

--- a/bazarr/secret_store/registry.py
+++ b/bazarr/secret_store/registry.py
@@ -50,8 +50,13 @@ USER_VISIBLE_SECRETS = frozenset({
     # Network proxy + database
     "proxy.password",
     "postgresql.password",
-    # AI Subtitle Translator
+    # AI Subtitle Translator. The "encryption_key" here is a USER-managed
+    # secret - the Translator settings page exposes it as a Password field
+    # ("Encryption Key (optional)") that the user enters and rotates. It
+    # is NOT a master key that signs other secrets, so it's user-visible
+    # at rest and decrypted before the API returns it.
     "translator.openrouter_api_key",
+    "translator.openrouter_encryption_key",
     "translator.lingarr_token",
     # Subtitle providers - passwords
     "opensubtitles.password",
@@ -96,8 +101,6 @@ SYSTEM_SECRETS = frozenset({
     # path still has it masked in API responses during the migration
     # window)
     "plex.encryption_key",
-    # AI Subtitle Translator's local OpenRouter encryption key
-    "translator.openrouter_encryption_key",
 })
 
 

--- a/bazarr/subtitles/manual.py
+++ b/bazarr/subtitles/manual.py
@@ -25,7 +25,7 @@ from subtitles.indexer.series import store_subtitles
 from subtitles.indexer.movies import store_subtitles_movie
 from subtitles.processing import ProcessSubtitlesResult
 
-from bazarr.subtitles.cache import subtitle_cache
+from .cache import subtitle_cache
 from .pool import update_pools, _get_pool
 from .utils import get_video, _get_lang_obj, _get_scores, _set_forced_providers
 from .processing import process_subtitle

--- a/custom_libs/subliminal_patch/core_persistent.py
+++ b/custom_libs/subliminal_patch/core_persistent.py
@@ -129,7 +129,7 @@ _abandoned_total = 0  # all-time counter, for diagnostics
 def _read_settings() -> Tuple[int, int]:
     """Pool-sizing knobs from settings, with defensive fallbacks."""
     try:
-        from bazarr.app.config import settings
+        from app.config import settings
         max_workers = max(4, int(getattr(
             settings.compat_endpoint, "fanout_max_workers",
             _DEFAULT_MAX_WORKERS,

--- a/custom_libs/subliminal_patch/refiners/omdb.py
+++ b/custom_libs/subliminal_patch/refiners/omdb.py
@@ -28,7 +28,7 @@ def _resolve_omdb_apikey():
     the envelope is malformed.
     """
     try:
-        from bazarr.app.config import settings
+        from app.config import settings
         apikey = (settings.omdb.apikey or "").strip()
         if apikey:
             return apikey

--- a/docker/supervisor.py
+++ b/docker/supervisor.py
@@ -25,10 +25,43 @@ from pathlib import Path
 
 from aiohttp import ClientSession, ClientTimeout, WSMsgType, web
 
-# Add bundled libs to path so we can import yaml (PyYAML)
+# Add bundled libs to path so we can import yaml (PyYAML) + itsdangerous
+# (used to decrypt the at-rest apikey before injecting into index.html;
+# the supervisor reads config.yaml directly without going through the
+# bazarr settings pipeline, so it has to do the decrypt itself).
 APP_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(APP_DIR / "libs"))
 import yaml  # noqa: E402
+from itsdangerous import BadPayload, BadSignature, URLSafeSerializer  # noqa: E402
+
+# Same marker as bazarr.secret_store.crypto.SECRET_MARKER_PREFIX. Kept as
+# a literal here (instead of importing from bazarr/) so the supervisor
+# doesn't pull in the full bazarr bootstrap (Dynaconf, validators, etc.)
+# just to decrypt one value.
+_SECRET_MARKER_PREFIX = "enc:v1:"
+
+
+def _decrypt_apikey_if_encrypted(apikey: str, master_key: str) -> str:
+    """If the apikey carries the secret_store marker prefix, decrypt it
+    with URLSafeSerializer + master_key. Mirrors the read half of
+    bazarr.secret_store.crypto.decrypt_secret without importing it.
+
+    Tolerant: a missing master_key, a corrupt payload, or a value with no
+    marker is returned unchanged. The supervisor MUST keep starting even
+    when the credential is unreadable - the user can still fix things
+    once the backend boots and the Settings page renders.
+    """
+    if not isinstance(apikey, str) or not apikey.startswith(_SECRET_MARKER_PREFIX):
+        return apikey
+    if not master_key:
+        return apikey
+    try:
+        payload = URLSafeSerializer(master_key).loads(apikey[len(_SECRET_MARKER_PREFIX):])
+    except (BadSignature, BadPayload, ValueError):
+        return apikey
+    if isinstance(payload, dict) and "secret" in payload:
+        return payload["secret"]
+    return apikey
 
 # Unbuffered print so logs appear immediately when redirected to a file
 _print = print
@@ -291,7 +324,14 @@ async def _proxy_websocket(request: web.Request, target_url: str) -> web.WebSock
 
 
 def _read_bazarr_config(config_dir: str) -> dict:
-    """Read the bazarr config.yaml to extract apiKey and baseUrl."""
+    """Read the bazarr config.yaml to extract apiKey and baseUrl.
+
+    The apikey on disk is encrypted under general.secrets_encryption_key
+    via bazarr.secret_store. Decrypt it before injecting into index.html
+    so the SPA receives the same plaintext value the backend serves over
+    /api/system/settings. Without this, the bundle gets the ciphertext as
+    its X-API-KEY and every authenticated API call returns 401.
+    """
     config_path = Path(config_dir) / "config" / "config.yaml"
     defaults = {"baseUrl": "/", "apiKey": "", "canUpdate": False, "hasUpdate": False}
     try:
@@ -300,8 +340,10 @@ def _read_bazarr_config(config_dir: str) -> dict:
                 cfg = yaml.safe_load(f) or {}
             auth = cfg.get("auth", {})
             general = cfg.get("general", {})
-            if auth.get("apikey"):
-                defaults["apiKey"] = auth["apikey"]
+            apikey = auth.get("apikey") or ""
+            if apikey:
+                master_key = general.get("secrets_encryption_key") or ""
+                defaults["apiKey"] = _decrypt_apikey_if_encrypted(apikey, master_key)
             if general.get("base_url"):
                 defaults["baseUrl"] = general["base_url"]
     except Exception as e:

--- a/docker/supervisor.py
+++ b/docker/supervisor.py
@@ -25,13 +25,16 @@ from pathlib import Path
 
 from aiohttp import ClientSession, ClientTimeout, WSMsgType, web
 
-# Add bundled libs to path so we can import yaml (PyYAML) + itsdangerous
-# (used to decrypt the at-rest apikey before injecting into index.html;
-# the supervisor reads config.yaml directly without going through the
-# bazarr settings pipeline, so it has to do the decrypt itself).
+# Add bundled libs to path so we can import yaml (PyYAML), cryptography
+# (Fernet), and itsdangerous (legacy URLSafeSerializer fallback). The
+# supervisor reads config.yaml directly without going through the bazarr
+# settings pipeline, so it has to do the decrypt itself.
 APP_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(APP_DIR / "libs"))
+import base64  # noqa: E402
+import hashlib  # noqa: E402
 import yaml  # noqa: E402
+from cryptography.fernet import Fernet, InvalidToken  # noqa: E402
 from itsdangerous import BadPayload, BadSignature, URLSafeSerializer  # noqa: E402
 
 # Same marker as bazarr.secret_store.crypto.SECRET_MARKER_PREFIX. Kept as
@@ -41,10 +44,20 @@ from itsdangerous import BadPayload, BadSignature, URLSafeSerializer  # noqa: E4
 _SECRET_MARKER_PREFIX = "enc:v1:"
 
 
+def _fernet_key_from_master(master_key: str) -> bytes:
+    """Mirrors bazarr.secret_store.crypto._fernet_key_from_master. Same KDF
+    so encrypt-via-bazarr and decrypt-via-supervisor agree on the key."""
+    digest = hashlib.sha256(master_key.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest)
+
+
 def _decrypt_apikey_if_encrypted(apikey: str, master_key: str) -> str:
-    """If the apikey carries the secret_store marker prefix, decrypt it
-    with URLSafeSerializer + master_key. Mirrors the read half of
-    bazarr.secret_store.crypto.decrypt_secret without importing it.
+    """If the apikey carries the secret_store marker prefix, decrypt it.
+
+    Tries Fernet (current AEAD format) first, then falls back to the
+    legacy URLSafeSerializer payload shape so a config written before
+    the AEAD migration still serves login bytes correctly until the
+    backend re-saves under Fernet.
 
     Tolerant: a missing master_key, a corrupt payload, or a value with no
     marker is returned unchanged. The supervisor MUST keep starting even
@@ -55,8 +68,19 @@ def _decrypt_apikey_if_encrypted(apikey: str, master_key: str) -> str:
         return apikey
     if not master_key:
         return apikey
+    payload_text = apikey[len(_SECRET_MARKER_PREFIX):]
+
+    # Current format: Fernet (AES-128-CBC + HMAC-SHA256)
     try:
-        payload = URLSafeSerializer(master_key).loads(apikey[len(_SECRET_MARKER_PREFIX):])
+        return Fernet(_fernet_key_from_master(master_key)).decrypt(
+            payload_text.encode("ascii")
+        ).decode("utf-8")
+    except (InvalidToken, ValueError):
+        pass
+
+    # Legacy URLSafeSerializer payload (pre-AEAD)
+    try:
+        payload = URLSafeSerializer(master_key).loads(payload_text)
     except (BadSignature, BadPayload, ValueError):
         return apikey
     if isinstance(payload, dict) and "secret" in payload:

--- a/frontend/src/pages/Settings/General/index.tsx
+++ b/frontend/src/pages/Settings/General/index.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useState } from "react";
+import { FunctionComponent, useRef, useState } from "react";
 import {
   Box,
   Group as MantineGroup,
@@ -41,9 +41,8 @@ import { branchOptions, proxyOptions, securityOptions } from "./options";
 // back to the backend. save_settings's `value != settings.auth.password`
 // check would catch that exact case - but ONLY when the value sent in
 // matches the stored hash byte-for-byte, which fails the moment a hash
-// is encrypted-then-decrypted across a single character (the
-// equality compare is strict). So we never read the stored value into
-// the input at all.
+// is encrypted-then-decrypted across a single character. So we never
+// read the stored value into the input at all.
 //
 // State machine:
 // - User loads page: input empty, draft="", touched=false. No setValue
@@ -52,11 +51,19 @@ import { branchOptions, proxyOptions, securityOptions } from "./options";
 // - User types "newpw": draft="newpw", touched=true, update("newpw")
 //   stages the new password. save_settings hashes it via hash_password.
 // - User clears the field after typing: draft="", touched=true. We push
-//   the existing stored hash back in via update(stored) so the
-//   save_settings comparison `value == settings.auth.password` is true
-//   and no re-hash happens. Without this, a stray clear would submit
-//   None (or "") and either null out the password or hash an empty
-//   string.
+//   the ORIGINAL hash (snapshotted on first render via originalRef)
+//   back in via update(...) so save_settings's
+//   `value == settings.auth.password` matches and no re-hash happens.
+//
+// originalRef vs reading `stored` directly: useBaseInput returns the
+// staged form value, which becomes whatever update() last set it to.
+// After typing "newpw", a fresh `stored` read returns "newpw", so a
+// fall-back to `stored` on clear would re-stage the new password
+// instead of the original hash - silently saving the typed-then-
+// cancelled password. Codex flagged this. The ref captures the value
+// once on first render (before any user interaction can stage anything)
+// and stays pinned to the loaded hash for the lifetime of the
+// component.
 const AuthPasswordInput: FunctionComponent = () => {
   const { value: stored, update } = useBaseInput<
     { settingKey: string },
@@ -64,6 +71,14 @@ const AuthPasswordInput: FunctionComponent = () => {
   >({
     settingKey: "settings-auth-password",
   });
+  const originalRef = useRef<string | null>(null);
+  if (
+    originalRef.current === null &&
+    typeof stored === "string" &&
+    stored.length > 0
+  ) {
+    originalRef.current = stored;
+  }
   const [draft, setDraft] = useState("");
   const [touched, setTouched] = useState(false);
   return (
@@ -78,7 +93,7 @@ const AuthPasswordInput: FunctionComponent = () => {
           if (!touched) setTouched(true);
           update(next);
         } else if (touched) {
-          update(stored ?? null);
+          update(originalRef.current);
         }
       }}
     />

--- a/frontend/src/pages/Settings/General/index.tsx
+++ b/frontend/src/pages/Settings/General/index.tsx
@@ -1,5 +1,10 @@
 import { FunctionComponent, useState } from "react";
-import { Box, Group as MantineGroup, Text as MantineText } from "@mantine/core";
+import {
+  Box,
+  Group as MantineGroup,
+  PasswordInput,
+  Text as MantineText,
+} from "@mantine/core";
 import { useClipboard } from "@mantine/hooks";
 import {
   faCheck,
@@ -22,9 +27,63 @@ import {
   Selector,
   Text,
 } from "@/pages/Settings/components";
+import { useBaseInput } from "@/pages/Settings/utilities/hooks";
 import { Environment, toggleState } from "@/utilities";
 import ExternalWebhookSelector from "./ExternalWebhookSelector";
 import { branchOptions, proxyOptions, securityOptions } from "./options";
+
+// Auth password input that NEVER displays the stored value.
+//
+// At rest, settings.auth.password holds a one-way hash (PBKDF2 since the
+// post-md5 migration). Pre-populating the input with that hash would
+// either reveal it via the eye toggle (useless to the user, but harmful
+// in screen-shares / support bundles) or, on submit, round-trip the hash
+// back to the backend. save_settings's `value != settings.auth.password`
+// check would catch that exact case - but ONLY when the value sent in
+// matches the stored hash byte-for-byte, which fails the moment a hash
+// is encrypted-then-decrypted across a single character (the
+// equality compare is strict). So we never read the stored value into
+// the input at all.
+//
+// State machine:
+// - User loads page: input empty, draft="", touched=false. No setValue
+//   call -> form has no pending change for this key -> save preserves
+//   the existing hash.
+// - User types "newpw": draft="newpw", touched=true, update("newpw")
+//   stages the new password. save_settings hashes it via hash_password.
+// - User clears the field after typing: draft="", touched=true. We push
+//   the existing stored hash back in via update(stored) so the
+//   save_settings comparison `value == settings.auth.password` is true
+//   and no re-hash happens. Without this, a stray clear would submit
+//   None (or "") and either null out the password or hash an empty
+//   string.
+const AuthPasswordInput: FunctionComponent = () => {
+  const { value: stored, update } = useBaseInput<
+    { settingKey: string },
+    string
+  >({
+    settingKey: "settings-auth-password",
+  });
+  const [draft, setDraft] = useState("");
+  const [touched, setTouched] = useState(false);
+  return (
+    <PasswordInput
+      label="Password"
+      placeholder="Leave empty to keep current password"
+      value={draft}
+      onChange={(e) => {
+        const next = e.currentTarget.value;
+        setDraft(next);
+        if (next.length > 0) {
+          if (!touched) setTouched(true);
+          update(next);
+        } else if (touched) {
+          update(stored ?? null);
+        }
+      }}
+    />
+  );
+};
 
 const characters = "abcdef0123456789";
 const settingApiKey = "settings-auth-apikey";
@@ -97,10 +156,7 @@ const SettingsGeneralView: FunctionComponent = () => {
         ></Selector>
         <CollapseBox settingKey="settings-auth-type">
           <Text label="Username" settingKey="settings-auth-username"></Text>
-          <Password
-            label="Password"
-            settingKey="settings-auth-password"
-          ></Password>
+          <AuthPasswordInput />
         </CollapseBox>
         <Text
           label="API Key"

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -57,7 +57,7 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
         key: "password",
       },
       {
-        type: "text",
+        type: "password",
         key: "cookies",
         name: "Cookies, e.g., PHPSESSID=abc; wikisubtitlesuser=xyz; wikisubtitlespass=efg",
       },
@@ -105,7 +105,7 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
       "avistaz.to - AvistaZ is an Asian torrent tracker for HD movies, TV shows and music",
     inputs: [
       {
-        type: "text",
+        type: "password",
         key: "cookies",
         name: "Cookies, e.g., PHPSESSID=abc; wikisubtitlesuser=xyz; wikisubtitlespass=efg",
       },
@@ -121,7 +121,7 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
     description: "Chinese Subtitles Provider",
     inputs: [
       {
-        type: "text",
+        type: "password",
         key: "token",
       },
     ],
@@ -132,7 +132,7 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
     description: "French / English Provider for TV Shows Only",
     inputs: [
       {
-        type: "text",
+        type: "password",
         key: "token",
         name: "API KEY",
       },
@@ -151,7 +151,7 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
       "cinemaz.to - CinemaZ is a private torrent tracker which is dedicated to little-known\nand cult films that you will not find on other popular torrent resources.",
     inputs: [
       {
-        type: "text",
+        type: "password",
         key: "cookies",
         name: "Cookies, e.g., PHPSESSID=abc; wikisubtitlesuser=xyz; wikisubtitlespass=efg",
       },
@@ -298,7 +298,7 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
         key: "email",
       },
       {
-        type: "text",
+        type: "password",
         key: "hashed_password",
         name: "Hashed Password",
       },
@@ -450,7 +450,7 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
     key: "subdl",
     inputs: [
       {
-        type: "text",
+        type: "password",
         key: "api_key",
       },
       {
@@ -529,7 +529,7 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
       "API key required. Get your key from Subs.ro website: https://subs.ro/api",
     inputs: [
       {
-        type: "text",
+        type: "password",
         key: "api_key",
         name: "API Key",
       },
@@ -571,7 +571,7 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
       "API key required. Get your key from SubX website: https://subx-api.duckdns.org/",
     inputs: [
       {
-        type: "text",
+        type: "password",
         key: "api_key",
         name: "API Key",
       },
@@ -629,7 +629,7 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
       "For requests coming from outside of Turkey, cookies and user agent are required. Especially cf_clearance cookie.",
     inputs: [
       {
-        type: "text",
+        type: "password",
         key: "cookies",
         name: "Cookies, e.g., PHPSESSID=abc; wikisubtitlesuser=xyz; wikisubtitlespass=efg",
       },

--- a/frontend/src/pages/Settings/Radarr/index.tsx
+++ b/frontend/src/pages/Settings/Radarr/index.tsx
@@ -7,6 +7,7 @@ import {
   Layout,
   Message,
   Number,
+  Password,
   PathMappingTable,
   Section,
   Selector,
@@ -42,7 +43,10 @@ const SettingsRadarrView: FunctionComponent = () => {
             options={timeoutOptions}
             settingKey="settings-radarr-http_timeout"
           ></Selector>
-          <Text label="API Key" settingKey="settings-radarr-apikey"></Text>
+          <Password
+            label="API Key"
+            settingKey="settings-radarr-apikey"
+          ></Password>
           <Check label="SSL" settingKey="settings-radarr-ssl"></Check>
           <URLTestButton category="radarr"></URLTestButton>
         </Section>

--- a/frontend/src/pages/Settings/Sonarr/index.tsx
+++ b/frontend/src/pages/Settings/Sonarr/index.tsx
@@ -8,6 +8,7 @@ import {
   Message,
   MultiSelector,
   Number,
+  Password,
   PathMappingTable,
   Section,
   Selector,
@@ -44,7 +45,10 @@ const SettingsSonarrView: FunctionComponent = () => {
             options={timeoutOptions}
             settingKey="settings-sonarr-http_timeout"
           ></Selector>
-          <Text label="API Key" settingKey="settings-sonarr-apikey"></Text>
+          <Password
+            label="API Key"
+            settingKey="settings-sonarr-apikey"
+          ></Password>
           <Check label="SSL" settingKey="settings-sonarr-ssl"></Check>
           <URLTestButton category="sonarr"></URLTestButton>
         </Section>

--- a/tests/bazarr/test_app_get_providers.py
+++ b/tests/bazarr/test_app_get_providers.py
@@ -3,7 +3,7 @@ import inspect
 import pytest
 from subliminal_patch.core import Language
 
-from bazarr.app import get_providers
+from app import get_providers
 
 
 def test_get_providers_auth():

--- a/tests/bazarr/test_app_notifier.py
+++ b/tests/bazarr/test_app_notifier.py
@@ -1,4 +1,4 @@
-from bazarr.app import notifier
+from app import notifier
 
 
 class DummyRecord:

--- a/tests/bazarr/test_config.py
+++ b/tests/bazarr/test_config.py
@@ -1,4 +1,4 @@
-from bazarr.app import config
+from app import config
 
 
 def test_get_settings():

--- a/tests/bazarr/test_editor_api.py
+++ b/tests/bazarr/test_editor_api.py
@@ -82,7 +82,7 @@ _patches = {
     'utilities.path_mappings': MagicMock(),
     'utilities.binaries': MagicMock(),
     'api.utils': _api_utils_mock,
-    'bazarr.api.utils': _api_utils_mock,
+    'api.utils': _api_utils_mock,
     'api.subtitles.content': MagicMock(),
     'flask_restx': _fake_flask_restx,
     'init': MagicMock(startTime=0),
@@ -93,7 +93,7 @@ for mod_name, mock_obj in _patches.items():
     sys.modules.setdefault(mod_name, mock_obj)
 
 # Now safe to import
-from bazarr.api.editor.editor import (
+from api.editor.editor import (
     _resolve_video_path,
     _probe_video,
     _validate_params,
@@ -105,7 +105,7 @@ from bazarr.api.editor.editor import (
 )
 
 # Re-import database and path_mappings as the module sees them
-from bazarr.api.editor import editor as editor_module
+from api.editor import editor as editor_module
 
 
 # ---------------------------------------------------------------------------
@@ -470,9 +470,9 @@ class TestRunEditorSync:
         mock_subsync_cls = MagicMock(return_value=mock_subsync)
         mock_jobs_queue = MagicMock()
 
-        with patch('bazarr.api.editor.editor.SubSyncer', mock_subsync_cls, create=True), \
+        with patch('api.editor.editor.SubSyncer', mock_subsync_cls, create=True), \
              patch.dict('sys.modules', {'subtitles.tools.subsyncer': MagicMock(SubSyncer=mock_subsync_cls)}), \
-             patch('bazarr.api.editor.editor.jobs_queue', mock_jobs_queue, create=True), \
+             patch('api.editor.editor.jobs_queue', mock_jobs_queue, create=True), \
              patch.dict('sys.modules', {'app.jobs_queue': MagicMock(jobs_queue=mock_jobs_queue)}), \
              patch('threading.Timer'):  # prevent cleanup timer
 
@@ -506,9 +506,9 @@ class TestRunEditorSync:
         mock_subsync_cls = MagicMock(return_value=mock_subsync)
         mock_jobs_queue = MagicMock()
 
-        with patch('bazarr.api.editor.editor.SubSyncer', mock_subsync_cls, create=True), \
+        with patch('api.editor.editor.SubSyncer', mock_subsync_cls, create=True), \
              patch.dict('sys.modules', {'subtitles.tools.subsyncer': MagicMock(SubSyncer=mock_subsync_cls)}), \
-             patch('bazarr.api.editor.editor.jobs_queue', mock_jobs_queue, create=True), \
+             patch('api.editor.editor.jobs_queue', mock_jobs_queue, create=True), \
              patch.dict('sys.modules', {'app.jobs_queue': MagicMock(jobs_queue=mock_jobs_queue)}), \
              patch('threading.Timer'):
             run_editor_sync(
@@ -542,9 +542,9 @@ class TestRunEditorSync:
         mock_subsync_cls = MagicMock(return_value=mock_subsync)
         mock_jobs_queue = MagicMock()
 
-        with patch('bazarr.api.editor.editor.SubSyncer', mock_subsync_cls, create=True), \
+        with patch('api.editor.editor.SubSyncer', mock_subsync_cls, create=True), \
              patch.dict('sys.modules', {'subtitles.tools.subsyncer': MagicMock(SubSyncer=mock_subsync_cls)}), \
-             patch('bazarr.api.editor.editor.jobs_queue', mock_jobs_queue, create=True), \
+             patch('api.editor.editor.jobs_queue', mock_jobs_queue, create=True), \
              patch.dict('sys.modules', {'app.jobs_queue': MagicMock(jobs_queue=mock_jobs_queue)}), \
              patch('threading.Timer'):
             run_editor_sync(
@@ -580,9 +580,9 @@ class TestRunEditorSync:
         mock_subsync_cls = MagicMock(return_value=mock_subsync)
         mock_jobs_queue = MagicMock()
 
-        with patch('bazarr.api.editor.editor.SubSyncer', mock_subsync_cls, create=True), \
+        with patch('api.editor.editor.SubSyncer', mock_subsync_cls, create=True), \
              patch.dict('sys.modules', {'subtitles.tools.subsyncer': MagicMock(SubSyncer=mock_subsync_cls)}), \
-             patch('bazarr.api.editor.editor.jobs_queue', mock_jobs_queue, create=True), \
+             patch('api.editor.editor.jobs_queue', mock_jobs_queue, create=True), \
              patch.dict('sys.modules', {'app.jobs_queue': MagicMock(jobs_queue=mock_jobs_queue)}), \
              patch('threading.Timer'):
             run_editor_sync(
@@ -777,7 +777,7 @@ class TestEditorSyncPost:
              patch('os.write'), \
              patch('os.close'), \
              patch.dict('sys.modules', {'app.jobs_queue': MagicMock(jobs_queue=mock_jobs_queue)}), \
-             patch('bazarr.api.editor.editor.jobs_queue', mock_jobs_queue, create=True), \
+             patch('api.editor.editor.jobs_queue', mock_jobs_queue, create=True), \
              patch('threading.Thread') as mock_thread:
 
             # Need to also patch the import inside the method

--- a/tests/bazarr/test_gemini_translator.py
+++ b/tests/bazarr/test_gemini_translator.py
@@ -2,7 +2,7 @@ import time
 
 import pytest
 
-from bazarr.subtitles.tools.translate.services import gemini_translator
+from subtitles.tools.translate.services import gemini_translator
 
 
 def _build_service():

--- a/tests/bazarr/test_jellyfin_client.py
+++ b/tests/bazarr/test_jellyfin_client.py
@@ -7,7 +7,7 @@ import os
 from unittest.mock import patch, MagicMock
 
 import pytest
-from bazarr.jellyfin.client import JellyfinClient
+from jellyfin.client import JellyfinClient
 from fake_jellyfin import (
     FakeJellyfinClient,
     OPENAPI_PATH,
@@ -103,7 +103,7 @@ def test_session_can_opt_out_of_tls_verification():
 def test_redact_secret_strips_token_and_key():
     """Helper underpinning operations._redact: api_key never appears in
     redacted output; the Authorization Token form is also masked."""
-    from bazarr.jellyfin.client import _redact_secret
+    from jellyfin.client import _redact_secret
     raw = 'GET https://x/y Token="SECRET-LEAK" failed: bad SECRET-LEAK'
     assert "SECRET-LEAK" not in _redact_secret(raw, "SECRET-LEAK")
     # Token="..." form is masked even when the literal secret is unknown

--- a/tests/bazarr/test_jellyfin_operations.py
+++ b/tests/bazarr/test_jellyfin_operations.py
@@ -16,9 +16,9 @@ import pytest
 # upstream design used `sys.modules.setdefault("app.config", ...)` which
 # becomes a no-op once any other test imports app.config and so the mock
 # never won when run with the broader suite).
-import bazarr.jellyfin.operations as _ops_module  # noqa: E402
+import jellyfin.operations as _ops_module  # noqa: E402
 
-from bazarr.jellyfin.operations import (  # noqa: E402
+from jellyfin.operations import (  # noqa: E402
     jellyfin_test_connection,
     jellyfin_get_libraries,
     jellyfin_refresh_item,
@@ -46,7 +46,7 @@ def _isolated_settings():
 def fake():
     """Provide a FakeJellyfinClient and patch get_jellyfin_client to return it."""
     client = FakeJellyfinClient()
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client", return_value=client):
+    with patch("jellyfin.operations.get_jellyfin_client", return_value=client):
         yield client
 
 
@@ -57,7 +57,7 @@ def settings(_isolated_settings):
 
 
 def test_test_connection_success():
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client") as mock_get:
+    with patch("jellyfin.operations.get_jellyfin_client") as mock_get:
         client = FakeJellyfinClient()
         mock_get.return_value = client
         result = jellyfin_test_connection()
@@ -71,7 +71,7 @@ def test_test_connection_failure():
     text. Server banners, URLs, and any echoed Authorization data must stay
     server-side (logged after redaction). The api_key in particular must NEVER
     appear in the response payload."""
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client",
+    with patch("jellyfin.operations.get_jellyfin_client",
                side_effect=Exception("refused at https://jf:8096 SECRET")):
         result = jellyfin_test_connection()
     assert result["success"] is False
@@ -87,7 +87,7 @@ def test_test_connection_configuration_error():
     """Missing url / apikey are configuration errors (raised by our own
     get_jellyfin_client). Surface a distinct error_code so the UI can prompt
     correctly."""
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client",
+    with patch("jellyfin.operations.get_jellyfin_client",
                side_effect=ValueError("Jellyfin URL not configured.")):
         result = jellyfin_test_connection()
     assert result["success"] is False
@@ -95,7 +95,7 @@ def test_test_connection_configuration_error():
 
 
 def test_test_connection_with_explicit_params():
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client") as mock_get:
+    with patch("jellyfin.operations.get_jellyfin_client") as mock_get:
         mock_get.return_value = FakeJellyfinClient()
         jellyfin_test_connection(url="http://custom:8096", apikey="key")
         mock_get.assert_called_once_with("http://custom:8096", "key",
@@ -105,14 +105,14 @@ def test_test_connection_with_explicit_params():
 def test_test_connection_passes_verify_ssl_override():
     """When the UI toggle is honored without saving first, the override must
     flow all the way to JellyfinClient via get_jellyfin_client."""
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client") as mock_get:
+    with patch("jellyfin.operations.get_jellyfin_client") as mock_get:
         mock_get.return_value = FakeJellyfinClient()
         jellyfin_test_connection(url="https://j", apikey="k", verify_ssl=False)
         mock_get.assert_called_once_with("https://j", "k", verify_ssl=False)
 
 
 def test_get_libraries_passes_verify_ssl_override():
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client") as mock_get:
+    with patch("jellyfin.operations.get_jellyfin_client") as mock_get:
         mock_get.return_value = FakeJellyfinClient()
         jellyfin_get_libraries(url="https://j", apikey="k", verify_ssl=False)
         mock_get.assert_called_once_with("https://j", "k", verify_ssl=False)
@@ -120,7 +120,7 @@ def test_get_libraries_passes_verify_ssl_override():
 
 
 def test_get_libraries_filters_by_collection_type():
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client") as mock_get:
+    with patch("jellyfin.operations.get_jellyfin_client") as mock_get:
         client = FakeJellyfinClient()
         client.libraries.append({
             "Name": "Music", "Locations": [], "CollectionType": "music", "ItemId": "lib-music",
@@ -140,7 +140,7 @@ def test_get_libraries_handles_null_collection_type():
     content libraries before classification). The filter must drop them, not
     crash. Note: bypasses the fake's OpenAPI validator (jsonschema rejects
     null where OpenAPI 3.0 marks `nullable: true`)."""
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client") as mock_get:
+    with patch("jellyfin.operations.get_jellyfin_client") as mock_get:
         client = FakeJellyfinClient()
         client.get_libraries = lambda: [
             {"Name": "Misc", "Locations": [], "CollectionType": None, "ItemId": "x"},
@@ -155,7 +155,7 @@ def test_get_libraries_returns_connection_failed_on_error():
     """Connection/auth/TLS failures must surface as `connection_failed`, NOT
     silently as an empty list. Otherwise the UI cannot distinguish 'server
     unreachable' from 'no libraries exist' and renders the wrong guidance."""
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client", side_effect=Exception("fail")):
+    with patch("jellyfin.operations.get_jellyfin_client", side_effect=Exception("fail")):
         result = jellyfin_get_libraries()
     assert result == {"libraries": [], "error_code": "connection_failed"}
 
@@ -189,7 +189,7 @@ def test_test_connection_falls_back_when_overrides_are_None(settings):
     callers like jellyfin_refresh_item()."""
     settings.jellyfin.url = "https://saved.example"
     settings.jellyfin.apikey = "saved-key"
-    with patch("bazarr.jellyfin.operations.JellyfinClient") as mock_client:
+    with patch("jellyfin.operations.JellyfinClient") as mock_client:
         mock_client.return_value.get_system_info.return_value = {
             "ServerName": "S", "Version": "1.0",
         }
@@ -202,7 +202,7 @@ def test_get_libraries_returns_configuration_when_url_or_key_missing():
     """ValueErrors from get_jellyfin_client (missing URL/apikey) get a
     distinct error_code so the UI guides 'configure URL/key first'
     instead of conflating with connectivity failures."""
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client",
+    with patch("jellyfin.operations.get_jellyfin_client",
                side_effect=ValueError("Jellyfin URL not configured.")):
         result = jellyfin_get_libraries()
     assert result == {"libraries": [], "error_code": "configuration"}
@@ -381,7 +381,7 @@ def test_refresh_all_success_counts(fake, settings):
 def test_refresh_all_no_libraries_configured(settings):
     settings.jellyfin.movie_library_ids = []
     settings.jellyfin.series_library_ids = []
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client",
+    with patch("jellyfin.operations.get_jellyfin_client",
                return_value=FakeJellyfinClient()):
         result = jellyfin_refresh_all_libraries()
     assert result["success"] is False
@@ -389,7 +389,7 @@ def test_refresh_all_no_libraries_configured(settings):
 
 
 def test_refresh_all_configuration_error():
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client",
+    with patch("jellyfin.operations.get_jellyfin_client",
                side_effect=ValueError("Jellyfin URL not configured.")):
         result = jellyfin_refresh_all_libraries()
     assert result["success"] is False
@@ -397,7 +397,7 @@ def test_refresh_all_configuration_error():
 
 
 def test_refresh_all_connection_failure():
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client",
+    with patch("jellyfin.operations.get_jellyfin_client",
                side_effect=Exception("connection refused at https://x SECRET")):
         result = jellyfin_refresh_all_libraries()
     assert result["success"] is False
@@ -461,7 +461,7 @@ def test_redact_strips_override_apikey_when_test_connection_fails(settings):
     override = "override-key-LEAK-CANDIDATE"
     err = f"401 Unauthorized for /System/Info?api_key={override}"
 
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client",
+    with patch("jellyfin.operations.get_jellyfin_client",
                side_effect=Exception(err)):
         with patch.object(_ops_module.logger, "error") as mock_error:
             result = jellyfin_test_connection(url="https://j", apikey=override,
@@ -508,7 +508,7 @@ def test_redact_strips_override_apikey_when_get_libraries_fails(settings):
     override = "override-libs-LEAK-CANDIDATE"
     err = f"timeout fetching /Library/VirtualFolders for token {override}"
 
-    with patch("bazarr.jellyfin.operations.get_jellyfin_client",
+    with patch("jellyfin.operations.get_jellyfin_client",
                side_effect=Exception(err)):
         with patch.object(_ops_module.logger, "error") as mock_error:
             result = jellyfin_get_libraries(url="https://j", apikey=override,

--- a/tests/bazarr/test_logging_filters.py
+++ b/tests/bazarr/test_logging_filters.py
@@ -1,6 +1,6 @@
 import logging
 
-from bazarr.app.logger import UnwantedWaitressMessageFilter
+from app.logger import UnwantedWaitressMessageFilter
 
 def test_true_for_bazarr():
   record = logging.LogRecord("", logging.INFO, "", 0, "a message from BAZARR for logging", (), None)

--- a/tests/bazarr/test_mass_operations.py
+++ b/tests/bazarr/test_mass_operations.py
@@ -7,15 +7,15 @@ class TestParseSubtitlesColumn:
     """Test _parse_subtitles_column helper."""
 
     def test_empty_input_none(self):
-        from bazarr.subtitles.mass_operations import _parse_subtitles_column
+        from subtitles.mass_operations import _parse_subtitles_column
         assert _parse_subtitles_column(None) == []
 
     def test_empty_input_string(self):
-        from bazarr.subtitles.mass_operations import _parse_subtitles_column
+        from subtitles.mass_operations import _parse_subtitles_column
         assert _parse_subtitles_column('') == []
 
     def test_valid_subtitles(self):
-        from bazarr.subtitles.mass_operations import _parse_subtitles_column
+        from subtitles.mass_operations import _parse_subtitles_column
         raw = "[['en', '/path/to/sub.srt'], ['fr:forced', '/path/to/sub.fr.srt']]"
         result = _parse_subtitles_column(raw)
         assert len(result) == 2
@@ -23,18 +23,18 @@ class TestParseSubtitlesColumn:
         assert result[1] == ('fr:forced', '/path/to/sub.fr.srt')
 
     def test_invalid_syntax(self):
-        from bazarr.subtitles.mass_operations import _parse_subtitles_column
+        from subtitles.mass_operations import _parse_subtitles_column
         assert _parse_subtitles_column('not valid python') == []
 
     def test_skips_entries_without_path(self):
-        from bazarr.subtitles.mass_operations import _parse_subtitles_column
+        from subtitles.mass_operations import _parse_subtitles_column
         raw = "[['en', '/path/to/sub.srt'], ['fr', '']]"
         result = _parse_subtitles_column(raw)
         assert len(result) == 1
         assert result[0] == ('en', '/path/to/sub.srt')
 
     def test_short_entries(self):
-        from bazarr.subtitles.mass_operations import _parse_subtitles_column
+        from subtitles.mass_operations import _parse_subtitles_column
         raw = "[['en']]"
         assert _parse_subtitles_column(raw) == []
 
@@ -57,9 +57,9 @@ class TestProcessSubtitleItem:
             'gss': True,
         }
 
-    @patch('bazarr.subtitles.mass_operations.sync_subtitles', return_value=True)
+    @patch('subtitles.mass_operations.sync_subtitles', return_value=True)
     def test_sync_action(self, mock_sync):
-        from bazarr.subtitles.mass_operations import _process_subtitle_item
+        from subtitles.mass_operations import _process_subtitle_item
         item = self._make_item()
         result = _process_subtitle_item(item, 'sync', {}, 'test_job')
         assert result is True
@@ -80,17 +80,17 @@ class TestProcessSubtitleItem:
             job_id='test_job',
         )
 
-    @patch('bazarr.subtitles.mass_operations.subtitles_apply_mods')
+    @patch('subtitles.mass_operations.subtitles_apply_mods')
     def test_mod_action_remove_hi(self, mock_mods):
-        from bazarr.subtitles.mass_operations import _process_subtitle_item
+        from subtitles.mass_operations import _process_subtitle_item
         item = self._make_item()
         result = _process_subtitle_item(item, 'remove_HI', {}, 'test_job')
         assert result is True
         mock_mods.assert_called_once_with('en', '/subs/test.en.srt', ['remove_HI'], '/video/test.mkv')
 
-    @patch('bazarr.subtitles.mass_operations.subtitles_apply_mods')
+    @patch('subtitles.mass_operations.subtitles_apply_mods')
     def test_mod_action_ocr_fixes(self, mock_mods):
-        from bazarr.subtitles.mass_operations import _process_subtitle_item
+        from subtitles.mass_operations import _process_subtitle_item
         item = self._make_item()
         result = _process_subtitle_item(item, 'OCR_fixes', {}, 'test_job')
         assert result is True
@@ -98,7 +98,7 @@ class TestProcessSubtitleItem:
 
     @patch('subtitles.tools.translate.main.translate_subtitles_file', return_value=True)
     def test_translate_action(self, mock_translate):
-        from bazarr.subtitles.mass_operations import _process_subtitle_item
+        from subtitles.mass_operations import _process_subtitle_item
         item = self._make_item()
         result = _process_subtitle_item(item, 'translate', {'from_lang': 'en', 'to_lang': 'hu'}, 'test_job')
         assert result is True
@@ -118,7 +118,7 @@ class TestProcessSubtitleItem:
 
     @patch('subtitles.tools.translate.main.translate_subtitles_file', return_value=True)
     def test_translate_action_movie(self, mock_translate):
-        from bazarr.subtitles.mass_operations import _process_subtitle_item
+        from subtitles.mass_operations import _process_subtitle_item
         item = self._make_item(sonarr_series_id=None, sonarr_episode_id=None, radarr_id=5)
         result = _process_subtitle_item(item, 'translate', {'from_lang': 'en', 'to_lang': 'fr'}, 'test_job')
         assert result is True
@@ -129,7 +129,7 @@ class TestProcessSubtitleItem:
         assert 'job_id' not in call_kwargs
 
     def test_unknown_action_returns_false(self):
-        from bazarr.subtitles.mass_operations import _process_subtitle_item
+        from subtitles.mass_operations import _process_subtitle_item
         item = self._make_item()
         result = _process_subtitle_item(item, 'nonexistent', {}, 'test_job')
         assert result is False
@@ -138,61 +138,61 @@ class TestProcessSubtitleItem:
 class TestMassBatchOperationValidation:
     """Test mass_batch_operation input validation and routing."""
 
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_invalid_action_returns_error(self, mock_jobs_queue):
-        from bazarr.subtitles.mass_operations import mass_batch_operation
+        from subtitles.mass_operations import mass_batch_operation
         result = mass_batch_operation(items=[], action='invalid_action', job_id='test')
         assert result['queued'] == 0
         assert result['skipped'] == 0
         assert len(result['errors']) == 1
         assert 'invalid' in result['errors'][0].lower()
 
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_empty_items_returns_zeros(self, mock_jobs_queue):
-        from bazarr.subtitles.mass_operations import mass_batch_operation
+        from subtitles.mass_operations import mass_batch_operation
         result = mass_batch_operation(items=[], action='sync', job_id='test')
         assert result['queued'] == 0
         assert result['skipped'] == 0
 
-    @patch('bazarr.subtitles.mass_operations._collect_subtitle_items')
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations._collect_subtitle_items')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_sync_action_calls_collect_subtitle_items(self, mock_jobs_queue, mock_collect):
-        from bazarr.subtitles.mass_operations import mass_batch_operation
+        from subtitles.mass_operations import mass_batch_operation
         mock_collect.return_value = ([], 0)
         items = [{'type': 'series', 'sonarrSeriesId': 1}]
         mass_batch_operation(items=items, action='sync', job_id='test')
         mock_collect.assert_called_once()
 
-    @patch('bazarr.subtitles.mass_operations._collect_subtitle_items')
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations._collect_subtitle_items')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_mod_action_calls_collect_subtitle_items(self, mock_jobs_queue, mock_collect):
-        from bazarr.subtitles.mass_operations import mass_batch_operation
+        from subtitles.mass_operations import mass_batch_operation
         mock_collect.return_value = ([], 0)
         items = [{'type': 'movie', 'radarrId': 10}]
         mass_batch_operation(items=items, action='remove_HI', job_id='test')
         mock_collect.assert_called_once()
 
-    @patch('bazarr.subtitles.mass_operations._process_media_action')
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations._process_media_action')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_scan_disk_calls_process_media_action(self, mock_jobs_queue, mock_process):
-        from bazarr.subtitles.mass_operations import mass_batch_operation
+        from subtitles.mass_operations import mass_batch_operation
         mock_process.return_value = {'queued': 0, 'skipped': 0, 'errors': []}
         items = [{'type': 'series', 'sonarrSeriesId': 1}]
         mass_batch_operation(items=items, action='scan-disk', job_id='test')
         mock_process.assert_called_once()
 
-    @patch('bazarr.subtitles.mass_operations._process_media_action')
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations._process_media_action')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_search_missing_calls_process_media_action(self, mock_jobs_queue, mock_process):
-        from bazarr.subtitles.mass_operations import mass_batch_operation
+        from subtitles.mass_operations import mass_batch_operation
         mock_process.return_value = {'queued': 0, 'skipped': 0, 'errors': []}
         items = [{'type': 'movie', 'radarrId': 10}]
         mass_batch_operation(items=items, action='search-missing', job_id='test')
         mock_process.assert_called_once()
 
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_media_action_with_empty_items(self, mock_jobs_queue):
-        from bazarr.subtitles.mass_operations import mass_batch_operation
+        from subtitles.mass_operations import mass_batch_operation
         result = mass_batch_operation(items=[], action='scan-disk', job_id='test')
         assert result['queued'] == 0
         assert result['skipped'] == 0
@@ -219,16 +219,16 @@ class TestCollectSubtitleItems:
         movie.subtitles = subtitles
         return movie
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations._get_synced_episode_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations._get_synced_movie_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_collects_episode_subtitles(self, mock_settings, mock_db, mock_synced_mov,
                                          mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -248,16 +248,16 @@ class TestCollectSubtitleItems:
         assert items[0]['sonarr_series_id'] == 10
         assert items[0]['srt_path'] == '/subs/ep1.en.srt'
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations._get_synced_episode_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations._get_synced_movie_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_collects_movie_subtitles(self, mock_settings, mock_db, mock_synced_mov,
                                        mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -276,16 +276,16 @@ class TestCollectSubtitleItems:
         assert items[0]['radarr_id'] == 10
         assert items[0]['srt_path'] == '/subs/movie.en.srt'
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations._get_synced_episode_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations._get_synced_movie_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_skips_forced_subtitles(self, mock_settings, mock_db, mock_synced_mov,
                                      mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -302,16 +302,16 @@ class TestCollectSubtitleItems:
         assert len(items) == 0
         assert skipped == 1
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=False)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations._get_synced_episode_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations._get_synced_movie_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=False)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_skips_missing_files(self, mock_settings, mock_db, mock_synced_mov,
                                   mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -328,16 +328,16 @@ class TestCollectSubtitleItems:
         assert len(items) == 0
         assert skipped == 1
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations._get_synced_episode_paths')
-    @patch('bazarr.subtitles.mass_operations._get_synced_movie_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths')
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_skips_already_synced_episodes(self, mock_settings, mock_db, mock_synced_mov,
                                             mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -356,16 +356,16 @@ class TestCollectSubtitleItems:
         assert len(items) == 0
         assert skipped == 1
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations._get_synced_episode_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations._get_synced_movie_paths')
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths')
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_skips_already_synced_movies(self, mock_settings, mock_db, mock_synced_mov,
                                           mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -384,16 +384,16 @@ class TestCollectSubtitleItems:
         assert len(items) == 0
         assert skipped == 1
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations._get_synced_episode_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations._get_synced_movie_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_skips_forced_movie_subtitles(self, mock_settings, mock_db, mock_synced_mov,
                                            mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -410,17 +410,17 @@ class TestCollectSubtitleItems:
         assert len(items) == 0
         assert skipped == 1
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations._get_synced_episode_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations._get_synced_movie_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_forced_subs_allowed_for_mod_actions(self, mock_settings, mock_db, mock_synced_mov,
                                                   mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
         """Forced subtitles should be processed by mod actions like OCR_fixes, not skipped."""
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -438,16 +438,16 @@ class TestCollectSubtitleItems:
         assert skipped == 0
         assert items[0]['forced'] is True
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=False)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations._get_synced_episode_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations._get_synced_movie_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=False)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_skips_missing_movie_files(self, mock_settings, mock_db, mock_synced_mov,
                                         mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -464,17 +464,17 @@ class TestCollectSubtitleItems:
         assert len(items) == 0
         assert skipped == 1
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations._get_synced_episode_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations._get_synced_movie_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_series_type_collects_episodes(self, mock_settings, mock_db, mock_synced_mov,
                                             mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
         """Passing type='series' with sonarrSeriesId collects all episodes for that series."""
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -497,10 +497,10 @@ class TestCollectSubtitleItems:
 class TestGetSyncedPaths:
     """Test _get_synced_episode_paths and _get_synced_movie_paths."""
 
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.select')
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.select')
     def test_get_synced_episode_paths(self, mock_select, mock_db):
-        from bazarr.subtitles.mass_operations import _get_synced_episode_paths
+        from subtitles.mass_operations import _get_synced_episode_paths
 
         row1 = MagicMock()
         row1.subtitles_path = '/subs/ep1.srt'
@@ -513,10 +513,10 @@ class TestGetSyncedPaths:
         result = _get_synced_episode_paths()
         assert result == {'/subs/ep1.srt', '/subs/ep2.srt'}
 
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.select')
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.select')
     def test_get_synced_movie_paths(self, mock_select, mock_db):
-        from bazarr.subtitles.mass_operations import _get_synced_movie_paths
+        from subtitles.mass_operations import _get_synced_movie_paths
 
         row1 = MagicMock()
         row1.subtitles_path = '/subs/movie1.srt'
@@ -532,10 +532,10 @@ class TestGetSyncedPaths:
 class TestProcessMediaActions:
     """Test _process_media_action for scan-disk and search-missing."""
 
-    @patch('bazarr.subtitles.mass_operations.series_scan_subtitles')
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations.series_scan_subtitles')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_scan_disk_series(self, mock_jobs_queue, mock_scan):
-        from bazarr.subtitles.mass_operations import _process_media_action
+        from subtitles.mass_operations import _process_media_action
 
         items = [{'type': 'series', 'sonarrSeriesId': 1}]
         result = _process_media_action(items, action='scan-disk', job_id='test')
@@ -543,10 +543,10 @@ class TestProcessMediaActions:
         mock_scan.assert_called_once_with(1)
         assert result['queued'] == 1
 
-    @patch('bazarr.subtitles.mass_operations.movies_scan_subtitles')
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations.movies_scan_subtitles')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_scan_disk_movies(self, mock_jobs_queue, mock_scan):
-        from bazarr.subtitles.mass_operations import _process_media_action
+        from subtitles.mass_operations import _process_media_action
 
         items = [{'type': 'movie', 'radarrId': 10}]
         result = _process_media_action(items, action='scan-disk', job_id='test')
@@ -554,10 +554,10 @@ class TestProcessMediaActions:
         mock_scan.assert_called_once_with(10)
         assert result['queued'] == 1
 
-    @patch('bazarr.subtitles.mass_operations.series_download_subtitles')
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations.series_download_subtitles')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_search_missing_series(self, mock_jobs_queue, mock_download):
-        from bazarr.subtitles.mass_operations import _process_media_action
+        from subtitles.mass_operations import _process_media_action
 
         items = [{'type': 'series', 'sonarrSeriesId': 1}]
         result = _process_media_action(items, action='search-missing', job_id='test')
@@ -565,10 +565,10 @@ class TestProcessMediaActions:
         mock_download.assert_called_once_with(1)
         assert result['queued'] == 1
 
-    @patch('bazarr.subtitles.mass_operations.movies_download_subtitles')
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations.movies_download_subtitles')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_search_missing_movies(self, mock_jobs_queue, mock_download):
-        from bazarr.subtitles.mass_operations import _process_media_action
+        from subtitles.mass_operations import _process_media_action
 
         items = [{'type': 'movie', 'radarrId': 10}]
         result = _process_media_action(items, action='search-missing', job_id='test')
@@ -576,10 +576,10 @@ class TestProcessMediaActions:
         mock_download.assert_called_once_with(10)
         assert result['queued'] == 1
 
-    @patch('bazarr.subtitles.mass_operations.series_scan_subtitles')
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations.series_scan_subtitles')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_error_handling(self, mock_jobs_queue, mock_scan):
-        from bazarr.subtitles.mass_operations import _process_media_action
+        from subtitles.mass_operations import _process_media_action
 
         mock_scan.side_effect = RuntimeError("scan failed")
         items = [{'type': 'series', 'sonarrSeriesId': 1}]
@@ -588,9 +588,9 @@ class TestProcessMediaActions:
         assert len(result['errors']) == 1
         assert 'scan failed' in result['errors'][0]
 
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_unknown_type_skipped_scan_disk(self, mock_jobs_queue):
-        from bazarr.subtitles.mass_operations import _process_media_action
+        from subtitles.mass_operations import _process_media_action
 
         items = [{'type': 'unknown', 'id': 1}]
         result = _process_media_action(items, action='scan-disk', job_id='test')
@@ -598,9 +598,9 @@ class TestProcessMediaActions:
         assert result['skipped'] == 1
         assert result['queued'] == 0
 
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_unknown_type_skipped_search_missing(self, mock_jobs_queue):
-        from bazarr.subtitles.mass_operations import _process_media_action
+        from subtitles.mass_operations import _process_media_action
 
         items = [{'type': 'unknown', 'id': 1}]
         result = _process_media_action(items, action='search-missing', job_id='test')
@@ -621,16 +621,16 @@ class TestForceResync:
         ep.subtitles = subtitles
         return ep
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations._get_synced_episode_paths')
-    @patch('bazarr.subtitles.mass_operations._get_synced_movie_paths', return_value=set())
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths')
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_force_resync_collects_already_synced(self, mock_settings, mock_db, mock_synced_mov,
                                                    mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -671,14 +671,14 @@ class TestTranslateSkipsExistingLang:
         movie.subtitles = subtitles
         return movie
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_skips_episode_when_target_lang_exists(self, mock_settings, mock_db,
                                                     mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -699,14 +699,14 @@ class TestTranslateSkipsExistingLang:
         assert len(collected) == 0
         assert skipped == 1
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_collects_episode_when_target_lang_missing(self, mock_settings, mock_db,
                                                         mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -726,14 +726,14 @@ class TestTranslateSkipsExistingLang:
         assert len(collected) == 1
         assert skipped == 0
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_skips_movie_when_target_lang_exists(self, mock_settings, mock_db,
                                                   mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -773,14 +773,14 @@ class TestTranslateSourceLanguageFilter:
         movie.subtitles = subtitles
         return movie
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_translate_only_queues_source_language_episodes(self, mock_settings, mock_db,
                                                             mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -802,14 +802,14 @@ class TestTranslateSourceLanguageFilter:
         assert collected[0]['srt_lang'] == 'en'
         assert skipped == 1  # FR subtitle skipped
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_translate_only_queues_source_language_movies(self, mock_settings, mock_db,
                                                           mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -831,14 +831,14 @@ class TestTranslateSourceLanguageFilter:
         assert collected[0]['srt_lang'] == 'en'
         assert skipped == 1  # FR skipped
 
-    @patch('bazarr.subtitles.mass_operations.languages_from_colon_seperated_string')
-    @patch('bazarr.subtitles.mass_operations.os.path.isfile', return_value=True)
-    @patch('bazarr.subtitles.mass_operations.path_mappings')
-    @patch('bazarr.subtitles.mass_operations.database')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
     def test_translate_without_source_lang_queues_all(self, mock_settings, mock_db,
                                                        mock_path_map, mock_isfile, mock_lang):
-        from bazarr.subtitles.mass_operations import _collect_subtitle_items
+        from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
@@ -864,7 +864,7 @@ class TestTranslateDefaultOptions:
 
     @patch('subtitles.tools.translate.main.translate_subtitles_file', return_value=True)
     def test_translate_default_options(self, mock_translate):
-        from bazarr.subtitles.mass_operations import _process_subtitle_item
+        from subtitles.mass_operations import _process_subtitle_item
         item = {
             'video_path': '/video/test.mkv',
             'srt_path': '/subs/test.en.srt',
@@ -890,10 +890,10 @@ class TestTranslateDefaultOptions:
 class TestMediaActionEpisodeType:
     """Test scan-disk with type='episode'."""
 
-    @patch('bazarr.subtitles.mass_operations.series_scan_subtitles')
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations.series_scan_subtitles')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_scan_disk_episode_type(self, mock_jobs_queue, mock_scan):
-        from bazarr.subtitles.mass_operations import _process_media_action
+        from subtitles.mass_operations import _process_media_action
 
         items = [{'type': 'episode', 'sonarrSeriesId': 5}]
         result = _process_media_action(items, action='scan-disk', job_id='test')
@@ -906,12 +906,12 @@ class TestMediaActionEpisodeType:
 class TestSchedulerIntegration:
     """Test scheduler integration when items=None."""
 
-    @patch('bazarr.subtitles.mass_operations._collect_subtitle_items')
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
-    @patch('bazarr.subtitles.mass_operations.settings')
+    @patch('subtitles.mass_operations._collect_subtitle_items')
+    @patch('subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations.settings')
     def test_items_none_with_job_id_syncs_entire_library(self, mock_settings, mock_jobs_queue,
                                                           mock_collect):
-        from bazarr.subtitles.mass_operations import mass_batch_operation
+        from subtitles.mass_operations import mass_batch_operation
 
         mock_settings.general.use_sonarr = True
         mock_settings.general.use_radarr = True
@@ -924,11 +924,11 @@ class TestSchedulerIntegration:
         args = mock_collect.call_args
         assert args[0][0] is None  # items arg should be None
 
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations.jobs_queue')
     def test_no_job_id_requeues_via_jobs_queue(self, mock_jobs_queue):
         """When called without job_id (e.g. from scheduler), should re-queue itself
         via add_job_from_function instead of processing inline."""
-        from bazarr.subtitles.mass_operations import mass_batch_operation
+        from subtitles.mass_operations import mass_batch_operation
 
         result = mass_batch_operation(items=None, action='sync', job_id=None)
 
@@ -944,11 +944,11 @@ class TestSchedulerIntegration:
 class TestMassBatchOperationProcessing:
     """Test mass_batch_operation end-to-end processing loop."""
 
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
-    @patch('bazarr.subtitles.mass_operations._process_subtitle_item', return_value=True)
-    @patch('bazarr.subtitles.mass_operations._collect_subtitle_items')
+    @patch('subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations._process_subtitle_item', return_value=True)
+    @patch('subtitles.mass_operations._collect_subtitle_items')
     def test_processes_collected_items(self, mock_collect, mock_process, mock_jq):
-        from bazarr.subtitles.mass_operations import mass_batch_operation
+        from subtitles.mass_operations import mass_batch_operation
         mock_collect.return_value = ([
             {'srt_path': '/subs/test.srt', 'video_path': '/video/test.mkv'},
         ], 0)
@@ -961,11 +961,11 @@ class TestMassBatchOperationProcessing:
         assert result['skipped'] == 0
         mock_process.assert_called_once()
 
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
-    @patch('bazarr.subtitles.mass_operations._process_subtitle_item', side_effect=Exception("failed"))
-    @patch('bazarr.subtitles.mass_operations._collect_subtitle_items')
+    @patch('subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations._process_subtitle_item', side_effect=Exception("failed"))
+    @patch('subtitles.mass_operations._collect_subtitle_items')
     def test_handles_processing_errors(self, mock_collect, mock_process, mock_jq):
-        from bazarr.subtitles.mass_operations import mass_batch_operation
+        from subtitles.mass_operations import mass_batch_operation
         mock_collect.return_value = ([
             {'srt_path': '/subs/test.srt', 'video_path': '/video/test.mkv'},
         ], 0)
@@ -978,11 +978,11 @@ class TestMassBatchOperationProcessing:
         assert len(result['errors']) == 1
         assert 'failed' in result['errors'][0]
 
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
-    @patch('bazarr.subtitles.mass_operations._process_subtitle_item', return_value=False)
-    @patch('bazarr.subtitles.mass_operations._collect_subtitle_items')
+    @patch('subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations._process_subtitle_item', return_value=False)
+    @patch('subtitles.mass_operations._collect_subtitle_items')
     def test_counts_failed_processing(self, mock_collect, mock_process, mock_jq):
-        from bazarr.subtitles.mass_operations import mass_batch_operation
+        from subtitles.mass_operations import mass_batch_operation
         mock_collect.return_value = ([
             {'srt_path': '/subs/test.srt', 'video_path': '/video/test.mkv'},
         ], 0)
@@ -995,11 +995,11 @@ class TestMassBatchOperationProcessing:
         assert result['queued'] == 0
         assert result['skipped'] == 1
 
-    @patch('bazarr.subtitles.mass_operations.jobs_queue')
-    @patch('bazarr.subtitles.mass_operations._process_subtitle_item', return_value=True)
-    @patch('bazarr.subtitles.mass_operations._collect_subtitle_items')
+    @patch('subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations._process_subtitle_item', return_value=True)
+    @patch('subtitles.mass_operations._collect_subtitle_items')
     def test_processes_multiple_items(self, mock_collect, mock_process, mock_jq):
-        from bazarr.subtitles.mass_operations import mass_batch_operation
+        from subtitles.mass_operations import mass_batch_operation
         mock_collect.return_value = ([
             {'srt_path': '/subs/test1.srt', 'video_path': '/video/test1.mkv'},
             {'srt_path': '/subs/test2.srt', 'video_path': '/video/test2.mkv'},

--- a/tests/bazarr/test_secret_store_crypto.py
+++ b/tests/bazarr/test_secret_store_crypto.py
@@ -1,0 +1,136 @@
+# coding=utf-8
+"""Unit tests for bazarr.secrets.crypto.
+
+Comprehensive end-to-end coverage (migration paths, masking, key rotation,
+bad-cipher diagnostics) lives in commit 5's test_secrets_e2e.py. This file
+covers just the crypto primitives.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from bazarr.secret_store.crypto import (
+    SECRET_MARKER_PREFIX,
+    decrypt_secret,
+    encrypt_secret,
+    get_master_key,
+    is_encrypted,
+)
+
+
+@pytest.fixture
+def settings_obj():
+    """Minimal stand-in for the dynaconf settings root with a writable
+    `general.secrets_encryption_key` slot."""
+    s = MagicMock()
+    # MagicMock auto-creates attributes, so `s.general.secrets_encryption_key`
+    # returns another MagicMock unless we set it. Force it to a real string
+    # to mirror dynaconf's typed Validator behavior.
+    s.general.secrets_encryption_key = ""
+    return s
+
+
+@pytest.fixture
+def master_key(settings_obj):
+    return get_master_key(settings_obj)
+
+
+def test_get_master_key_generates_when_missing(settings_obj):
+    settings_obj.general.secrets_encryption_key = ""
+    key = get_master_key(settings_obj)
+    assert isinstance(key, str)
+    assert len(key) >= 32  # token_urlsafe(32) base64 is ~43 chars
+    # It was persisted back into settings so subsequent boots see the same key.
+    assert settings_obj.general.secrets_encryption_key == key
+
+
+def test_get_master_key_reuses_existing(settings_obj):
+    settings_obj.general.secrets_encryption_key = "preexisting-key-must-not-change"
+    key = get_master_key(settings_obj)
+    assert key == "preexisting-key-must-not-change"
+
+
+def test_get_master_key_regenerates_when_whitespace_only(settings_obj):
+    """An accidentally-blanked key (user edited config.yaml) gets a fresh
+    one rather than failing the boot. Same lifecycle as flask_secret_key."""
+    settings_obj.general.secrets_encryption_key = "   "
+    key = get_master_key(settings_obj)
+    assert key.strip() != ""
+    assert key != "   "
+
+
+def test_encrypt_decrypt_roundtrip(master_key):
+    plaintext = "sonarr-api-key-1234567890abcdef"
+    ciphertext = encrypt_secret(plaintext, master_key=master_key)
+    assert ciphertext != plaintext
+    assert ciphertext.startswith(SECRET_MARKER_PREFIX)
+    assert decrypt_secret(ciphertext, master_key=master_key) == plaintext
+
+
+def test_encrypt_same_plaintext_yields_different_ciphertext(master_key):
+    """Salt + timestamp inside the payload means equal plaintexts MUST
+    NOT produce equal ciphertext - defends against equality inference if
+    config.yaml leaks."""
+    a = encrypt_secret("repeated", master_key=master_key)
+    b = encrypt_secret("repeated", master_key=master_key)
+    assert a != b
+    assert decrypt_secret(a, master_key=master_key) == "repeated"
+    assert decrypt_secret(b, master_key=master_key) == "repeated"
+
+
+def test_encrypt_empty_returns_empty(master_key):
+    """Empty / falsy plaintext skips encryption - empty credentials are
+    just empty, no migration to do."""
+    assert encrypt_secret("", master_key=master_key) == ""
+    assert encrypt_secret(None, master_key=master_key) is None
+
+
+def test_encrypt_idempotent_on_already_encrypted(master_key):
+    """A re-encrypt pass on an already-encrypted value returns it
+    unchanged. Otherwise every config write would rotate ciphertext."""
+    once = encrypt_secret("token", master_key=master_key)
+    twice = encrypt_secret(once, master_key=master_key)
+    assert once == twice
+
+
+def test_encrypt_rejects_non_string(master_key):
+    with pytest.raises(TypeError, match="expects str"):
+        encrypt_secret(42, master_key=master_key)
+
+
+def test_decrypt_passes_plaintext_through(master_key):
+    """A plaintext value (no marker) is returned as-is. The migrator
+    rewrites it; the read path must not raise on first boot."""
+    assert decrypt_secret("plaintext-not-yet-migrated", master_key=master_key) \
+        == "plaintext-not-yet-migrated"
+
+
+def test_decrypt_passes_empty_through(master_key):
+    assert decrypt_secret("", master_key=master_key) == ""
+    assert decrypt_secret(None, master_key=master_key) is None
+
+
+def test_decrypt_raises_on_tampered_ciphertext(master_key):
+    valid = encrypt_secret("authentic", master_key=master_key)
+    tampered = valid[:-2] + "AA"  # corrupt the signature suffix
+    with pytest.raises(ValueError, match="tampered|master key"):
+        decrypt_secret(tampered, master_key=master_key)
+
+
+def test_decrypt_raises_on_wrong_master_key(master_key):
+    """Bootstrapping with a different key (e.g. user copied config.yaml
+    from another instance without the matching general.secrets_encryption_key)
+    must fail loudly so the operator can diagnose, not silently serve
+    garbage."""
+    encrypted = encrypt_secret("authentic", master_key=master_key)
+    wrong_key = "completely-different-master-key-aaa"
+    with pytest.raises(ValueError, match="tampered|master key"):
+        decrypt_secret(encrypted, master_key=wrong_key)
+
+
+def test_is_encrypted_recognizes_marker():
+    assert is_encrypted(SECRET_MARKER_PREFIX + "anything")
+    assert not is_encrypted("plaintext")
+    assert not is_encrypted("")
+    assert not is_encrypted(None)
+    assert not is_encrypted(42)

--- a/tests/bazarr/test_secret_store_crypto.py
+++ b/tests/bazarr/test_secret_store_crypto.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from bazarr.secret_store.crypto import (
+from secret_store.crypto import (
     SECRET_MARKER_PREFIX,
     decrypt_secret,
     encrypt_secret,

--- a/tests/bazarr/test_secret_store_e2e.py
+++ b/tests/bazarr/test_secret_store_e2e.py
@@ -157,6 +157,43 @@ def test_e2e_first_save_persists_master_key_alongside_ciphertext():
     assert decrypted == "real-sonarr-key"
 
 
+def test_has_plaintext_secrets_on_disk_detects_clear_text_credential():
+    """Force-migration trigger: if any USER_VISIBLE_SECRETS path is
+    non-empty plaintext (no marker), bootstrap must KNOW so it can call
+    write_config unconditionally. Otherwise the lazy migration story
+    leaves clear-text credentials sitting on disk indefinitely until
+    the operator happens to touch a Settings field."""
+    from secret_store.migration import has_plaintext_secrets_on_disk
+
+    # Mixed shape: one clear-text password, one already-encrypted token.
+    settings = _FakeSettings({
+        "sonarr": {"apikey": "still-clear-text-from-an-edit"},
+        "compat_endpoint": {"token": SECRET_MARKER_PREFIX + "ignored"},
+    })
+    assert has_plaintext_secrets_on_disk(settings) is True
+
+    # All ciphertext / empty -> nothing to migrate.
+    fully_encrypted = _FakeSettings({
+        "sonarr": {"apikey": encrypt_secret("real-apikey")},
+        "compat_endpoint": {"token": encrypt_secret("real-token")},
+    })
+    assert has_plaintext_secrets_on_disk(fully_encrypted) is False
+
+    # Empty values are not flagged - empty stays empty, no migration.
+    empty = _FakeSettings({"sonarr": {"apikey": ""}})
+    assert has_plaintext_secrets_on_disk(empty) is False
+
+
+def test_has_plaintext_secrets_on_disk_detects_clear_text_in_list():
+    """Same trigger for USER_VISIBLE_SECRET_LISTS - a single plaintext
+    list element flips the bit."""
+    from secret_store.migration import has_plaintext_secrets_on_disk
+    settings = _FakeSettings({
+        "translator": {"gemini_keys": [encrypt_secret("g1"), "still-plain"]},
+    })
+    assert has_plaintext_secrets_on_disk(settings) is True
+
+
 def test_e2e_save_after_first_boot_does_not_double_encrypt():
     """Once a credential is on disk in ciphertext form, a normal save
     cycle (no user edit) must not produce a fresh ciphertext - encrypt

--- a/tests/bazarr/test_secret_store_e2e.py
+++ b/tests/bazarr/test_secret_store_e2e.py
@@ -372,6 +372,40 @@ def test_legacy_plex_migration_skips_when_flag_unset():
     assert settings.plex.apikey == "fresh-install-plaintext"
 
 
+def test_legacy_plex_migration_recovers_oauth_token_without_apikey_flag():
+    """The Plex OAuth flow stored `settings.plex.token = encrypt_token(...)`
+    but never set `apikey_encrypted` - that flag was scoped to the
+    apikey path only. Codex flagged that gating migration on the flag
+    leaves OAuth users with a legacy ciphertext that the unified
+    pipeline then re-encrypts as if it were plaintext, breaking login
+    after upgrade.
+
+    Detection has to be value-shaped (try legacy decrypt; succeed -> use
+    plaintext) so the OAuth-no-flag case is covered alongside the
+    apikey-with-flag case."""
+    legacy_key = "legacy-plex-encryption-key-pre-unification"
+    plaintext_token = "real-plex-oauth-token-from-myplex-account"
+    legacy_token = _legacy_plex_encrypt(plaintext_token, legacy_key)
+
+    settings = _FakeSettings({
+        "plex": {
+            # apikey path NOT used by this OAuth install
+            "apikey": "",
+            # OAuth token IS encrypted under the legacy scheme
+            "token": legacy_token,
+            "encryption_key": legacy_key,
+            # Critically: NO apikey_encrypted=True flag, because OAuth
+            # never wrote it.
+            "apikey_encrypted": False,
+        },
+    })
+
+    migrate_legacy_plex_encryption(settings)
+
+    assert settings.plex.token == plaintext_token
+    assert settings.plex.encryption_key == legacy_key
+
+
 def test_legacy_plex_migration_handles_missing_encryption_key():
     """An install with apikey_encrypted=True but no encryption_key is in
     an inconsistent state. The migration must clear the flag (so it

--- a/tests/bazarr/test_secret_store_e2e.py
+++ b/tests/bazarr/test_secret_store_e2e.py
@@ -24,12 +24,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from itsdangerous import URLSafeSerializer
 
-from bazarr.secret_store.crypto import (
+from secret_store.crypto import (
     SECRET_MARKER_PREFIX,
     encrypt_secret,
     is_encrypted,
 )
-from bazarr.secret_store.migration import (
+from secret_store.migration import (
     decrypt_settings_dict,
     decrypt_settings_in_place,
     encrypt_settings_dict,
@@ -41,7 +41,7 @@ from bazarr.secret_store.migration import (
 def stable_master_key(monkeypatch):
     key = "deterministic-test-master-key-do-not-rotate-during-test"
     monkeypatch.setattr(
-        "bazarr.secret_store.crypto.get_master_key",
+        "secret_store.crypto.get_master_key",
         lambda settings_obj=None: key,
     )
     yield key
@@ -126,6 +126,37 @@ def test_e2e_plaintext_first_boot_persists_ciphertext_then_decrypts_on_reboot():
     assert rebooted.translator.gemini_keys == ["g1", "g2"]
 
 
+def test_e2e_first_save_persists_master_key_alongside_ciphertext():
+    """Codex P1 regression: the master key MUST land in the snapshot
+    that gets written to disk. Bug pre-fix: encrypt_settings_dict
+    deep-copies the input, then encrypt_secret lazy-generates the
+    master key on the LIVE settings object - the snapshot still has
+    empty general.secrets_encryption_key, so disk gets enc:v1: values
+    paired with no key, and next reboot can't decrypt anything (and
+    silently uses ciphertext as the credential)."""
+    # Input shape: post-validate, pre-first-save. master key is empty;
+    # user-visible secrets are non-empty plaintext.
+    initial = {
+        "general": {"secrets_encryption_key": "", "flask_secret_key": "f"},
+        "sonarr": {"apikey": "real-sonarr-key"},
+    }
+    encrypted = encrypt_settings_dict(initial)
+
+    # The snapshot we'd persist must have the master key set.
+    persisted_master = encrypted["general"]["secrets_encryption_key"]
+    assert persisted_master  # non-empty
+    assert persisted_master != ""
+
+    # That same master must successfully decrypt the ciphertext we
+    # produced (otherwise the disk file is unrecoverable).
+    from secret_store.crypto import decrypt_secret
+    decrypted = decrypt_secret(
+        encrypted["sonarr"]["apikey"],
+        master_key=persisted_master,
+    )
+    assert decrypted == "real-sonarr-key"
+
+
 def test_e2e_save_after_first_boot_does_not_double_encrypt():
     """Once a credential is on disk in ciphertext form, a normal save
     cycle (no user edit) must not produce a fresh ciphertext - encrypt
@@ -169,7 +200,7 @@ def test_e2e_master_key_change_is_detected_and_isolates_failure():
     # Simulate boot under a different master key by patching get_master_key
     # to return something else.
     with patch(
-        "bazarr.secret_store.crypto.get_master_key",
+        "secret_store.crypto.get_master_key",
         lambda settings_obj=None: "completely-different-master-key-aaa",
     ):
         decrypt_settings_in_place(settings)
@@ -202,7 +233,7 @@ def test_e2e_api_serializer_masks_only_system_secrets():
     """Reproduces the get_settings() behavior: USER_VISIBLE pass plaintext,
     SYSTEM are masked with ***, empty system stays empty (so UI can tell
     'configured-but-hidden' from 'not configured')."""
-    from bazarr.secret_store import is_system_secret
+    from secret_store import is_system_secret
 
     settings_dict = {
         "auth": {"apikey": "user-can-see-this"},

--- a/tests/bazarr/test_secret_store_e2e.py
+++ b/tests/bazarr/test_secret_store_e2e.py
@@ -1,0 +1,340 @@
+# coding=utf-8
+"""End-to-end tests for the at-rest encryption pipeline.
+
+Builds on the unit tests in:
+- test_secret_store_crypto.py (encrypt / decrypt primitives)
+- test_secret_store_registry.py (USER_VISIBLE vs SYSTEM tier)
+- test_secret_store_migration.py (per-field decrypt / encrypt helpers)
+
+Covers the integration paths that the per-module tests can't:
+- Full bootstrap simulation (plaintext config -> migrate -> persist
+  ciphertext -> reboot -> decrypt -> plaintext in memory)
+- Key-rotation failure mode (master key changes between reboots)
+- Legacy Plex compatibility (apikey_encrypted=True under the old
+  per-namespace key; new pipeline must rescue them)
+- Bad-cipher tolerance (corrupt one credential, others keep working,
+  bad one stays so the user can rotate it via Settings)
+
+These are higher-cost tests that exercise crypto + registry + migration
+together; the simpler unit suites already prove each piece in
+isolation.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from itsdangerous import URLSafeSerializer
+
+from bazarr.secret_store.crypto import (
+    SECRET_MARKER_PREFIX,
+    encrypt_secret,
+    is_encrypted,
+)
+from bazarr.secret_store.migration import (
+    decrypt_settings_dict,
+    decrypt_settings_in_place,
+    encrypt_settings_dict,
+    migrate_legacy_plex_encryption,
+)
+
+
+@pytest.fixture(autouse=True)
+def stable_master_key(monkeypatch):
+    key = "deterministic-test-master-key-do-not-rotate-during-test"
+    monkeypatch.setattr(
+        "bazarr.secret_store.crypto.get_master_key",
+        lambda settings_obj=None: key,
+    )
+    yield key
+
+
+class _FakeSection(dict):
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as e:
+            raise AttributeError(name) from e
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+
+class _FakeSettings:
+    """Stand-in for the dynaconf settings root: attribute-and-dict access
+    on each section, with a `get` that returns the section if present."""
+
+    _sections = (
+        "general", "auth", "compat_endpoint", "sonarr", "radarr", "plex",
+        "jellyfin", "translator", "proxy", "postgresql", "opensubtitles",
+        "opensubtitlescom", "addic7ed", "legendasdivx", "legendasnet",
+        "xsubs", "deathbycaptcha", "napisy24", "titlovi", "titulky",
+        "karagarga", "assrt", "betaseries", "jimaku", "subdl", "subsource",
+        "subx", "subsro", "omdb",
+    )
+
+    def __init__(self, data):
+        for section in self._sections:
+            setattr(self, section, _FakeSection(data.get(section, {})))
+
+
+# --- E2E: full plaintext-to-ciphertext-and-back -----------------------------
+
+
+def test_e2e_plaintext_first_boot_persists_ciphertext_then_decrypts_on_reboot():
+    """Simulate the auto-migration story end to end:
+    1. config.yaml on disk is plaintext (post-upgrade, pre-migration).
+    2. decrypt_settings_in_place is a passthrough (no marker).
+    3. encrypt_settings_dict produces ciphertext for write_config.
+    4. Reboot: ciphertext on disk -> decrypt_settings_in_place restores
+       plaintext in memory.
+    """
+    initial_disk = {
+        "sonarr": {"apikey": "tt-sonarr"},
+        "radarr": {"apikey": "tt-radarr"},
+        "compat_endpoint": {"token": "tt-compat", "jwt_secret": "system"},
+        "translator": {"gemini_keys": ["g1", "g2"]},
+    }
+
+    # Step 1: load disk (plaintext) into live settings.
+    settings = _FakeSettings(initial_disk)
+
+    # Step 2: passthrough decrypter (no markers present).
+    decrypt_settings_in_place(settings)
+    assert settings.sonarr.apikey == "tt-sonarr"
+    assert settings.radarr.apikey == "tt-radarr"
+    assert settings.compat_endpoint.token == "tt-compat"
+    assert settings.translator.gemini_keys == ["g1", "g2"]
+
+    # Step 3: write_config snapshots in-memory and encrypts before persist.
+    snapshot = {s: dict(getattr(settings, s)) for s in _FakeSettings._sections}
+    encrypted_disk = encrypt_settings_dict(snapshot)
+
+    assert is_encrypted(encrypted_disk["sonarr"]["apikey"])
+    assert is_encrypted(encrypted_disk["radarr"]["apikey"])
+    assert is_encrypted(encrypted_disk["compat_endpoint"]["token"])
+    assert all(is_encrypted(k) for k in encrypted_disk["translator"]["gemini_keys"])
+    # System secret stays plaintext at the migration layer (the API
+    # serializer is what masks it; the on-disk file keeps the raw value).
+    assert encrypted_disk["compat_endpoint"]["jwt_secret"] == "system"
+
+    # Step 4: reboot. Build a fresh live settings from the encrypted disk
+    # form, decrypt in place, confirm plaintext restored.
+    rebooted = _FakeSettings(encrypted_disk)
+    decrypt_settings_in_place(rebooted)
+    assert rebooted.sonarr.apikey == "tt-sonarr"
+    assert rebooted.radarr.apikey == "tt-radarr"
+    assert rebooted.compat_endpoint.token == "tt-compat"
+    assert rebooted.translator.gemini_keys == ["g1", "g2"]
+
+
+def test_e2e_save_after_first_boot_does_not_double_encrypt():
+    """Once a credential is on disk in ciphertext form, a normal save
+    cycle (no user edit) must not produce a fresh ciphertext - encrypt
+    on top of the in-memory plaintext, get bytes that decrypt back to
+    the same value. The non-determinism of encrypt_secret would otherwise
+    make every save churn config.yaml even when nothing changed."""
+    initial_disk = {"sonarr": {"apikey": "tt-sonarr"}}
+    settings = _FakeSettings(initial_disk)
+    decrypt_settings_in_place(settings)
+
+    snap1 = {s: dict(getattr(settings, s)) for s in _FakeSettings._sections}
+    encrypted1 = encrypt_settings_dict(snap1)
+
+    # Pretend write_config ran. Reload, decrypt in place, encrypt again.
+    settings2 = _FakeSettings(encrypted1)
+    decrypt_settings_in_place(settings2)
+    snap2 = {s: dict(getattr(settings2, s)) for s in _FakeSettings._sections}
+    encrypted2 = encrypt_settings_dict(snap2)
+
+    # Bytes differ (salt + timestamp), but plaintext compare is identity.
+    assert encrypted1 != encrypted2
+    assert decrypt_settings_dict(encrypted1) == decrypt_settings_dict(encrypted2)
+
+
+# --- Key rotation -----------------------------------------------------------
+
+
+def test_e2e_master_key_change_is_detected_and_isolates_failure():
+    """If config.yaml is restored from another instance (different master
+    key) the bad cipher must NOT crash bazarr - it leaves the bad value
+    in place, the rest of the tier decrypts normally, and the user can
+    re-paste the affected credential."""
+    encrypted_apikey = encrypt_secret("real-sonarr-key")
+    encrypted_radarr = encrypt_secret("real-radarr-key")
+
+    settings = _FakeSettings({
+        "sonarr": {"apikey": encrypted_apikey},
+        "radarr": {"apikey": encrypted_radarr},
+    })
+
+    # Simulate boot under a different master key by patching get_master_key
+    # to return something else.
+    with patch(
+        "bazarr.secret_store.crypto.get_master_key",
+        lambda settings_obj=None: "completely-different-master-key-aaa",
+    ):
+        decrypt_settings_in_place(settings)
+
+    # Both fail to decrypt; both stay as the original (encrypted) bytes
+    # so the operator can see "something's wrong" and rotate.
+    assert settings.sonarr.apikey == encrypted_apikey
+    assert settings.radarr.apikey == encrypted_radarr
+
+
+def test_e2e_partial_corruption_isolated_to_one_field():
+    """Corrupting one ciphertext must not block the others from decrypting."""
+    good = encrypt_secret("good-sonarr")
+    bad = SECRET_MARKER_PREFIX + "tampered-payload-here"
+
+    settings = _FakeSettings({
+        "sonarr": {"apikey": bad},
+        "radarr": {"apikey": good},
+    })
+    decrypt_settings_in_place(settings)
+
+    assert settings.sonarr.apikey == bad  # left alone, operator can rotate
+    assert settings.radarr.apikey == "good-sonarr"  # neighbor still works
+
+
+# --- API-serializer masking integrated with at-rest plaintext memory --------
+
+
+def test_e2e_api_serializer_masks_only_system_secrets():
+    """Reproduces the get_settings() behavior: USER_VISIBLE pass plaintext,
+    SYSTEM are masked with ***, empty system stays empty (so UI can tell
+    'configured-but-hidden' from 'not configured')."""
+    from bazarr.secret_store import is_system_secret
+
+    settings_dict = {
+        "auth": {"apikey": "user-can-see-this"},
+        "sonarr": {"apikey": "user-can-see-this-too"},
+        "compat_endpoint": {
+            "token": "user-pastes-this-into-vlsub",  # USER_VISIBLE
+            "jwt_secret": "internal-signing-key",     # SYSTEM
+            "file_id_secret": "",                      # SYSTEM, empty
+        },
+        "general": {
+            "flask_secret_key": "session-signing",
+            "secrets_encryption_key": "master-encryption",
+        },
+        "plex": {"encryption_key": "legacy-plex-key"},
+    }
+
+    # Mimic get_settings() masking behaviour.
+    serialized = {}
+    for section, fields in settings_dict.items():
+        serialized[section] = {}
+        for k, v in fields.items():
+            full = f"{section}.{k.lower()}"
+            if is_system_secret(full):
+                serialized[section][k] = "***" if v else v
+            else:
+                serialized[section][k] = v
+
+    # USER_VISIBLE: plaintext flows through.
+    assert serialized["auth"]["apikey"] == "user-can-see-this"
+    assert serialized["sonarr"]["apikey"] == "user-can-see-this-too"
+    assert serialized["compat_endpoint"]["token"] == "user-pastes-this-into-vlsub"
+
+    # SYSTEM: masked when set.
+    assert serialized["compat_endpoint"]["jwt_secret"] == "***"
+    assert serialized["general"]["flask_secret_key"] == "***"
+    assert serialized["general"]["secrets_encryption_key"] == "***"
+    assert serialized["plex"]["encryption_key"] == "***"
+
+    # SYSTEM empty stays empty (no false positive of "configured").
+    assert serialized["compat_endpoint"]["file_id_secret"] == ""
+
+
+# --- Legacy Plex compatibility ---------------------------------------------
+
+
+def _legacy_plex_encrypt(plaintext: str, legacy_key: str) -> str:
+    """Reproduces the legacy api/plex/security.py:TokenManager.encrypt
+    output shape: URLSafeSerializer.dumps of a dict, NO marker prefix."""
+    return URLSafeSerializer(legacy_key).dumps({
+        "token": plaintext,
+        "salt": "deterministic-salt-for-tests",
+        "timestamp": 1700000000,
+    })
+
+
+def test_legacy_plex_migration_recovers_plaintext():
+    """Pre-secret_store, plex.apikey was stored as URLSafeSerializer dump
+    under plex.encryption_key, with apikey_encrypted=True. The unified
+    pipeline can't recognise this format (no enc:v1: marker), so the
+    legacy migration runs first to convert the values to plaintext in
+    memory and clear the flag. After that the standard pipeline takes
+    over and write_config re-encrypts under the master key."""
+    legacy_key = "legacy-plex-encryption-key-pre-unification"
+    plaintext_apikey = "real-plex-apikey-12345"
+    plaintext_token = "real-plex-oauth-token-67890"
+    legacy_apikey = _legacy_plex_encrypt(plaintext_apikey, legacy_key)
+    legacy_token = _legacy_plex_encrypt(plaintext_token, legacy_key)
+
+    settings = _FakeSettings({
+        "plex": {
+            "apikey": legacy_apikey,
+            "token": legacy_token,
+            "encryption_key": legacy_key,
+            "apikey_encrypted": True,
+        },
+    })
+
+    migrate_legacy_plex_encryption(settings)
+
+    # Plaintext recovered into in-memory settings.
+    assert settings.plex.apikey == plaintext_apikey
+    assert settings.plex.token == plaintext_token
+    # Flag cleared so the migration doesn't re-trigger on next boot.
+    assert settings.plex.apikey_encrypted is False
+    # Legacy encryption_key intentionally left in place (still SYSTEM,
+    # masked by the API serializer) for downgrade safety.
+    assert settings.plex.encryption_key == legacy_key
+
+
+def test_legacy_plex_migration_skips_when_flag_unset():
+    """Fresh installs have apikey_encrypted=False (or absent). The
+    migration must not try to legacy-decrypt plaintext - that would
+    URLSafeSerializer.loads() a non-payload and raise, replacing real
+    creds with garbage."""
+    settings = _FakeSettings({
+        "plex": {"apikey": "fresh-install-plaintext", "apikey_encrypted": False},
+    })
+    migrate_legacy_plex_encryption(settings)
+    assert settings.plex.apikey == "fresh-install-plaintext"
+
+
+def test_legacy_plex_migration_handles_missing_encryption_key():
+    """An install with apikey_encrypted=True but no encryption_key is in
+    an inconsistent state. The migration must clear the flag (so it
+    doesn't retry forever) and surface a warning, leaving the bytes
+    alone so the operator can fix from Settings."""
+    settings = _FakeSettings({
+        "plex": {
+            "apikey": "<unreadable-without-key>",
+            "apikey_encrypted": True,
+            "encryption_key": "",
+        },
+    })
+    migrate_legacy_plex_encryption(settings)
+    # Flag cleared, value left for operator to manually rotate.
+    assert settings.plex.apikey_encrypted is False
+    assert settings.plex.apikey == "<unreadable-without-key>"
+
+
+def test_legacy_plex_migration_already_unified_is_passthrough():
+    """If a value already carries the enc:v1: marker (e.g. a previous
+    migration ran and apikey_encrypted got reset to True somehow), the
+    legacy migration must NOT try to legacy-decrypt unified ciphertext
+    - that would corrupt it."""
+    unified_cipher = encrypt_secret("real-plex-key")
+    settings = _FakeSettings({
+        "plex": {
+            "apikey": unified_cipher,
+            "apikey_encrypted": True,  # somehow stuck
+            "encryption_key": "irrelevant",
+        },
+    })
+    migrate_legacy_plex_encryption(settings)
+    assert settings.plex.apikey == unified_cipher  # left unchanged
+    assert settings.plex.apikey_encrypted is False  # flag cleared

--- a/tests/bazarr/test_secret_store_migration.py
+++ b/tests/bazarr/test_secret_store_migration.py
@@ -1,0 +1,208 @@
+# coding=utf-8
+"""Tests for bazarr.secret_store.migration.
+
+Sanity coverage for the encrypt/decrypt-dict helpers and the in-place
+decrypter. Auto-migration end-to-end (load plaintext config -> live
+plaintext memory -> persist as ciphertext -> reload -> decrypt back) is
+covered in commit 5's test_secret_store_e2e.py.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from bazarr.secret_store.crypto import (
+    SECRET_MARKER_PREFIX,
+    encrypt_secret,
+    get_master_key,
+    is_encrypted,
+)
+from bazarr.secret_store.migration import (
+    decrypt_settings_dict,
+    decrypt_settings_in_place,
+    encrypt_settings_dict,
+)
+
+
+@pytest.fixture(autouse=True)
+def fixed_master_key(monkeypatch):
+    """Patch get_master_key so tests don't reach for app.config.settings."""
+    key = "test-master-key-not-secret-but-stable-for-tests"
+    monkeypatch.setattr(
+        "bazarr.secret_store.crypto.get_master_key",
+        lambda settings_obj=None: key,
+    )
+    yield key
+
+
+@pytest.fixture
+def plaintext_dict():
+    return {
+        "general": {"flask_secret_key": "system", "instance_name": "Bazarr+"},
+        "sonarr": {"apikey": "sonarr-plain-key", "url": "http://sonarr"},
+        "radarr": {"apikey": "radarr-plain-key"},
+        "translator": {
+            "gemini_keys": ["gemini-1", "gemini-2", ""],
+            "openrouter_api_key": "openrouter-key",
+        },
+        "compat_endpoint": {
+            "token": "compat-user-token",
+            "jwt_secret": "system-jwt",
+        },
+    }
+
+
+def test_encrypt_settings_dict_encrypts_user_visible(plaintext_dict):
+    out = encrypt_settings_dict(plaintext_dict)
+    # User-visible scalars get the marker
+    assert out["sonarr"]["apikey"].startswith(SECRET_MARKER_PREFIX)
+    assert out["radarr"]["apikey"].startswith(SECRET_MARKER_PREFIX)
+    assert out["compat_endpoint"]["token"].startswith(SECRET_MARKER_PREFIX)
+    assert out["translator"]["openrouter_api_key"].startswith(SECRET_MARKER_PREFIX)
+
+
+def test_encrypt_settings_dict_leaves_system_secrets_alone(plaintext_dict):
+    """SYSTEM_SECRETS are NOT encrypted by this helper - they're masked
+    by the API serializer (commit 3) and otherwise stay plaintext on disk.
+    encrypt_settings_dict's job is the user-visible tier only."""
+    out = encrypt_settings_dict(plaintext_dict)
+    assert out["general"]["flask_secret_key"] == "system"
+    assert out["compat_endpoint"]["jwt_secret"] == "system-jwt"
+
+
+def test_encrypt_settings_dict_handles_lists(plaintext_dict):
+    out = encrypt_settings_dict(plaintext_dict)
+    keys = out["translator"]["gemini_keys"]
+    assert keys[0].startswith(SECRET_MARKER_PREFIX)
+    assert keys[1].startswith(SECRET_MARKER_PREFIX)
+    assert keys[2] == ""  # empty stays empty - no point encrypting nothing
+
+
+def test_encrypt_settings_dict_does_not_mutate_input(plaintext_dict):
+    """Caller hands in the live snapshot; we must not mutate it to
+    ciphertext or in-memory reads break."""
+    out = encrypt_settings_dict(plaintext_dict)
+    assert plaintext_dict["sonarr"]["apikey"] == "sonarr-plain-key"
+    assert out is not plaintext_dict
+
+
+def test_encrypt_dict_idempotent_on_already_encrypted(plaintext_dict):
+    """Re-encrypting an already-encrypted dict is a no-op (encrypt_secret
+    short-circuits on its own marker)."""
+    once = encrypt_settings_dict(plaintext_dict)
+    twice = encrypt_settings_dict(once)
+    assert twice == once
+
+
+def test_decrypt_dict_inverts_encrypt(plaintext_dict):
+    encrypted = encrypt_settings_dict(plaintext_dict)
+    decrypted = decrypt_settings_dict(encrypted)
+    assert decrypted == plaintext_dict
+
+
+def test_decrypt_dict_passes_plaintext_through(plaintext_dict):
+    """Pre-migration shape: disk has plaintext. The decrypt helper must
+    not corrupt it - that's how auto-migration works."""
+    out = decrypt_settings_dict(plaintext_dict)
+    assert out == plaintext_dict
+
+
+def test_decrypt_dict_tolerates_corrupt_cipher(plaintext_dict):
+    """A bad ciphertext should not raise from decrypt_settings_dict;
+    write_config uses this for comparison and a single bad cipher would
+    otherwise crash every save. The bad value stays in the comparison
+    form, which forces the diff-and-rewrite path."""
+    encrypted = encrypt_settings_dict(plaintext_dict)
+    # corrupt one cipher
+    encrypted["sonarr"]["apikey"] = SECRET_MARKER_PREFIX + "garbage"
+    out = decrypt_settings_dict(encrypted)
+    assert out["sonarr"]["apikey"] == SECRET_MARKER_PREFIX + "garbage"
+
+
+class _FakeSection(dict):
+    """Stand-in for a dynaconf section: behaves like a dict and supports
+    attribute access too (settings.sonarr.apikey)."""
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as e:
+            raise AttributeError(name) from e
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+
+class _FakeSettings:
+    """Stand-in for the live dynaconf settings root."""
+
+    def __init__(self, data):
+        for section, values in data.items():
+            setattr(self, section, _FakeSection(values))
+
+
+def test_decrypt_settings_in_place_decrypts_encrypted_values():
+    encrypted_apikey = encrypt_secret("real-sonarr-key")
+    settings = _FakeSettings({
+        "sonarr": {"apikey": encrypted_apikey, "url": "http://x"},
+        "radarr": {"apikey": "radarr-plain-already"},
+        "translator": {"gemini_keys": [encrypt_secret("g1"), "g2-plain"]},
+        "general": {},
+        "auth": {},
+        "compat_endpoint": {},
+        "plex": {},
+        "jellyfin": {},
+        "proxy": {},
+        "postgresql": {},
+        "opensubtitles": {},
+        "opensubtitlescom": {},
+        "addic7ed": {},
+        "legendasdivx": {},
+        "legendasnet": {},
+        "xsubs": {},
+        "deathbycaptcha": {},
+        "napisy24": {},
+        "titlovi": {},
+        "titulky": {},
+        "karagarga": {},
+        "assrt": {},
+        "betaseries": {},
+        "jimaku": {},
+        "subdl": {},
+        "subsource": {},
+        "subx": {},
+        "subsro": {},
+        "omdb": {},
+    })
+    decrypt_settings_in_place(settings)
+    assert settings.sonarr.apikey == "real-sonarr-key"
+    assert settings.radarr.apikey == "radarr-plain-already"
+    assert settings.translator.gemini_keys == ["g1", "g2-plain"]
+
+
+def test_decrypt_settings_in_place_tolerates_bad_cipher_per_field(caplog):
+    """A single corrupt cipher must not stop bazarr from booting. The
+    bad value stays in place; the operator can rotate that one credential
+    via the Settings page."""
+    bad = SECRET_MARKER_PREFIX + "tampered-payload"
+    good = encrypt_secret("good-key")
+    settings = _FakeSettings({
+        "sonarr": {"apikey": bad},
+        "radarr": {"apikey": good},
+        "general": {}, "auth": {}, "compat_endpoint": {}, "plex": {},
+        "jellyfin": {}, "translator": {}, "proxy": {}, "postgresql": {},
+        "opensubtitles": {}, "opensubtitlescom": {}, "addic7ed": {},
+        "legendasdivx": {}, "legendasnet": {}, "xsubs": {},
+        "deathbycaptcha": {}, "napisy24": {}, "titlovi": {}, "titulky": {},
+        "karagarga": {}, "assrt": {}, "betaseries": {}, "jimaku": {},
+        "subdl": {}, "subsource": {}, "subx": {}, "subsro": {}, "omdb": {},
+    })
+    with caplog.at_level("ERROR"):
+        decrypt_settings_in_place(settings)
+    assert settings.radarr.apikey == "good-key"
+    # bad value untouched, error logged without leaking the value
+    assert settings.sonarr.apikey == bad
+    assert any("Failed to decrypt secret" in r.message for r in caplog.records)
+    # The error message must NOT include the section/key name (which is
+    # narrow enough that "sonarr.apikey corrupt" leaks deployment shape).
+    for r in caplog.records:
+        assert "sonarr" not in r.message.lower()

--- a/tests/bazarr/test_secret_store_migration.py
+++ b/tests/bazarr/test_secret_store_migration.py
@@ -10,13 +10,13 @@ from unittest.mock import patch
 
 import pytest
 
-from bazarr.secret_store.crypto import (
+from secret_store.crypto import (
     SECRET_MARKER_PREFIX,
     encrypt_secret,
     get_master_key,
     is_encrypted,
 )
-from bazarr.secret_store.migration import (
+from secret_store.migration import (
     decrypt_settings_dict,
     decrypt_settings_in_place,
     encrypt_settings_dict,
@@ -28,7 +28,7 @@ def fixed_master_key(monkeypatch):
     """Patch get_master_key so tests don't reach for app.config.settings."""
     key = "test-master-key-not-secret-but-stable-for-tests"
     monkeypatch.setattr(
-        "bazarr.secret_store.crypto.get_master_key",
+        "secret_store.crypto.get_master_key",
         lambda settings_obj=None: key,
     )
     yield key
@@ -37,7 +37,16 @@ def fixed_master_key(monkeypatch):
 @pytest.fixture
 def plaintext_dict():
     return {
-        "general": {"flask_secret_key": "system", "instance_name": "Bazarr+"},
+        # Mirrors the post-bootstrap shape: get_master_key has already
+        # generated and persisted general.secrets_encryption_key. The
+        # encrypt-settings-dict path expects the master key to be in
+        # the snapshot so on-disk ciphertext stays paired with the key
+        # that decrypts it (Codex P1 fix on a first-write race).
+        "general": {
+            "flask_secret_key": "system",
+            "instance_name": "Bazarr+",
+            "secrets_encryption_key": "test-master-key-not-secret-but-stable-for-tests",
+        },
         "sonarr": {"apikey": "sonarr-plain-key", "url": "http://sonarr"},
         "radarr": {"apikey": "radarr-plain-key"},
         "translator": {

--- a/tests/bazarr/test_secret_store_registry.py
+++ b/tests/bazarr/test_secret_store_registry.py
@@ -71,6 +71,57 @@ def test_translator_gemini_keys_classified_as_list():
     assert not is_user_visible_secret("translator.gemini_keys")
 
 
+def test_provider_login_pairs_are_both_classified():
+    """Every provider with a password / passkey / cookies field also has
+    its username / email companion in the registry, so a leaked
+    config.yaml does not expose which accounts the operator owns even
+    when the password is the harder bit."""
+    pairs = [
+        ("opensubtitles.username", "opensubtitles.password"),
+        ("opensubtitlescom.username", "opensubtitlescom.password"),
+        ("addic7ed.username", "addic7ed.password"),
+        ("legendasdivx.username", "legendasdivx.password"),
+        ("legendasnet.username", "legendasnet.password"),
+        ("xsubs.username", "xsubs.password"),
+        ("deathbycaptcha.username", "deathbycaptcha.password"),
+        ("napisy24.username", "napisy24.password"),
+        ("titlovi.username", "titlovi.password"),
+        ("titulky.username", "titulky.password"),
+        ("karagarga.username", "karagarga.password"),
+        ("ktuvit.email", "ktuvit.hashed_password"),
+        ("hdbits.username", "hdbits.passkey"),
+        ("proxy.username", "proxy.password"),
+        ("postgresql.username", "postgresql.password"),
+        ("auth.username", "auth.password"),
+    ]
+    for username_key, password_key in pairs:
+        assert is_user_visible_secret(username_key), \
+            f"{username_key} missing from USER_VISIBLE_SECRETS"
+        assert is_user_visible_secret(password_key), \
+            f"{password_key} missing from USER_VISIBLE_SECRETS"
+
+
+def test_session_cookies_are_classified():
+    """Session cookies are functionally long-lived auth tokens after the
+    initial login - encrypt them at rest like passwords."""
+    for key in ("addic7ed.cookies", "avistaz.cookies", "cinemaz.cookies",
+                "turkcealtyaziorg.cookies"):
+        assert is_user_visible_secret(key), f"{key} missing"
+
+
+def test_karagarga_forum_password_is_classified():
+    """karagarga has TWO passwords (main + forum). Both must be encrypted."""
+    assert is_user_visible_secret("karagarga.password")
+    assert is_user_visible_secret("karagarga.f_password")
+
+
+def test_plex_oauth_pii_is_classified():
+    """Plex OAuth populates plex.username + plex.email from the linked
+    Plex account. Treat as PII and encrypt at rest."""
+    assert is_user_visible_secret("plex.username")
+    assert is_user_visible_secret("plex.email")
+
+
 def test_unknown_keys_not_classified():
     """Defaults are 'no, this isn't a secret' - a brand-new setting must
     explicitly opt in or it stays plaintext (and the unit test for the

--- a/tests/bazarr/test_secret_store_registry.py
+++ b/tests/bazarr/test_secret_store_registry.py
@@ -51,9 +51,17 @@ def test_system_includes_master_and_signing_keys():
                 "general.secrets_encryption_key",
                 "compat_endpoint.jwt_secret",
                 "compat_endpoint.file_id_secret",
-                "plex.encryption_key",
-                "translator.openrouter_encryption_key"):
+                "plex.encryption_key"):
         assert is_system_secret(key), f"{key} should be system-only"
+
+
+def test_translator_openrouter_encryption_key_is_user_visible():
+    """The Translator settings page exposes a 'Encryption Key (optional)'
+    Password field for translator.openrouter_encryption_key. It's a
+    user-managed credential, NOT a master key - so it's user-visible at
+    rest and decrypted before the API returns it."""
+    assert is_user_visible_secret("translator.openrouter_encryption_key")
+    assert not is_system_secret("translator.openrouter_encryption_key")
 
 
 def test_translator_gemini_keys_classified_as_list():

--- a/tests/bazarr/test_secret_store_registry.py
+++ b/tests/bazarr/test_secret_store_registry.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 """Tests for bazarr.secrets.registry classification."""
 
-from bazarr.secret_store.registry import (
+from secret_store.registry import (
     SYSTEM_SECRETS,
     USER_VISIBLE_SECRET_LISTS,
     USER_VISIBLE_SECRETS,

--- a/tests/bazarr/test_secret_store_registry.py
+++ b/tests/bazarr/test_secret_store_registry.py
@@ -1,0 +1,73 @@
+# coding=utf-8
+"""Tests for bazarr.secrets.registry classification."""
+
+from bazarr.secret_store.registry import (
+    SYSTEM_SECRETS,
+    USER_VISIBLE_SECRET_LISTS,
+    USER_VISIBLE_SECRETS,
+    is_system_secret,
+    is_user_visible_secret,
+    is_user_visible_secret_list,
+)
+
+
+def test_user_visible_includes_compat_token():
+    """Per the user clarification - the compat endpoint TOKEN (the API
+    token that gets pasted into VLSub / Jellyfin OS plugin) is visible
+    on the frontend; only the compat endpoint's signing keys
+    (jwt_secret, file_id_secret) stay backend-only."""
+    assert is_user_visible_secret("compat_endpoint.token")
+    assert is_system_secret("compat_endpoint.jwt_secret")
+    assert is_system_secret("compat_endpoint.file_id_secret")
+
+
+def test_user_visible_includes_arr_apikeys():
+    for key in ("sonarr.apikey", "radarr.apikey", "jellyfin.apikey",
+                "plex.apikey", "plex.token"):
+        assert is_user_visible_secret(key), f"{key} should be user-visible"
+
+
+def test_user_visible_includes_provider_passwords_and_keys():
+    """Spot-check the provider list - if validators get added without
+    updating the registry, those credentials would ship plaintext."""
+    for key in ("opensubtitles.password", "addic7ed.password",
+                "subdl.api_key", "subsource.apikey",
+                "translator.openrouter_api_key", "translator.lingarr_token"):
+        assert is_user_visible_secret(key), f"{key} should be user-visible"
+
+
+def test_system_secrets_never_user_visible():
+    """Disjoint sets - a secret cannot be both backend-only and visible."""
+    overlap = USER_VISIBLE_SECRETS & SYSTEM_SECRETS
+    assert not overlap, f"keys must not be in both tiers: {overlap}"
+    overlap_lists = USER_VISIBLE_SECRET_LISTS & SYSTEM_SECRETS
+    assert not overlap_lists, f"list keys must not be in SYSTEM: {overlap_lists}"
+
+
+def test_system_includes_master_and_signing_keys():
+    """Every cryptographic primitive (anything used to sign / encrypt
+    OTHER secrets) must be SYSTEM, never visible to the frontend."""
+    for key in ("general.flask_secret_key",
+                "general.secrets_encryption_key",
+                "compat_endpoint.jwt_secret",
+                "compat_endpoint.file_id_secret",
+                "plex.encryption_key",
+                "translator.openrouter_encryption_key"):
+        assert is_system_secret(key), f"{key} should be system-only"
+
+
+def test_translator_gemini_keys_classified_as_list():
+    """List-shaped credentials need a different code path (encrypt each
+    element). Confirm they live in their own tier."""
+    assert is_user_visible_secret_list("translator.gemini_keys")
+    assert not is_user_visible_secret("translator.gemini_keys")
+
+
+def test_unknown_keys_not_classified():
+    """Defaults are 'no, this isn't a secret' - a brand-new setting must
+    explicitly opt in or it stays plaintext (and the unit test for the
+    next migration commit will catch that)."""
+    assert not is_user_visible_secret("general.debug")
+    assert not is_user_visible_secret("sonarr.url")
+    assert not is_system_secret("general.port")
+    assert not is_user_visible_secret_list("general.path_mappings")

--- a/tests/bazarr/test_subtitles_pool.py
+++ b/tests/bazarr/test_subtitles_pool.py
@@ -1,16 +1,16 @@
 from unittest.mock import patch, MagicMock
 
-from bazarr.subtitles import pool
+from subtitles import pool
 
 
 def test_init_pool():
-    with patch("bazarr.subtitles.pool.provider_pool") as mock_pool:
+    with patch("subtitles.pool.provider_pool") as mock_pool:
         mock_pool.return_value = MagicMock()
         assert pool._init_pool("movie")
 
 
 def test_pool_update():
-    with patch("bazarr.subtitles.pool.provider_pool") as mock_pool:
+    with patch("subtitles.pool.provider_pool") as mock_pool:
         mock_pool.return_value = MagicMock()
         pool_ = pool._init_pool("movie")
         assert pool._pool_update(pool_, "movie")

--- a/tests/bazarr/test_ui.py
+++ b/tests/bazarr/test_ui.py
@@ -5,7 +5,7 @@ import pytest
 from unittest.mock import Mock, patch
 from flask import Flask
 
-from bazarr.app.ui import check_login
+from app.ui import check_login
 
 
 def test_check_login_decorator_preserves_function_signature():
@@ -58,7 +58,7 @@ def test_check_login_no_authentication():
         return "success_response"
 
     # Mock settings for no authentication
-    with patch('bazarr.app.ui.settings') as mock_settings:
+    with patch('app.ui.settings') as mock_settings:
         mock_settings.auth.type = None
 
         decorated_function = check_login(test_function)
@@ -77,8 +77,8 @@ def test_check_login_basic_auth_success():
     # Mock Flask request context with basic auth
     app = Flask(__name__)
     with app.test_request_context(headers={'Authorization': 'Basic dGVzdDp0ZXN0'}):
-        with patch('bazarr.app.ui.settings') as mock_settings, \
-             patch('bazarr.app.ui.check_credentials', return_value=True):
+        with patch('app.ui.settings') as mock_settings, \
+             patch('app.ui.check_credentials', return_value=True):
 
             mock_settings.auth.type = 'basic'
 
@@ -98,8 +98,8 @@ def test_check_login_basic_auth_failure():
     # Mock Flask request context with invalid basic auth
     app = Flask(__name__)
     with app.test_request_context(headers={'Authorization': 'Basic aW52YWxpZA=='}):
-        with patch('bazarr.app.ui.settings') as mock_settings, \
-             patch('bazarr.app.ui.check_credentials', return_value=False):
+        with patch('app.ui.settings') as mock_settings, \
+             patch('app.ui.check_credentials', return_value=False):
 
             mock_settings.auth.type = 'basic'
 
@@ -122,7 +122,7 @@ def test_check_login_basic_auth_missing():
     # Mock Flask request context without authorization header
     app = Flask(__name__)
     with app.test_request_context():
-        with patch('bazarr.app.ui.settings') as mock_settings:
+        with patch('app.ui.settings') as mock_settings:
             mock_settings.auth.type = 'basic'
 
             decorated_function = check_login(test_function)
@@ -146,8 +146,8 @@ def test_check_login_form_auth_success():
     app.secret_key = 'test_secret'
 
     with app.test_request_context():
-        with patch('bazarr.app.ui.settings') as mock_settings, \
-             patch('bazarr.app.ui.session', {'logged_in': True}):
+        with patch('app.ui.settings') as mock_settings, \
+             patch('app.ui.session', {'logged_in': True}):
 
             mock_settings.auth.type = 'form'
 
@@ -166,9 +166,9 @@ def test_check_login_form_auth_failure():
 
     app = Flask(__name__)
     with app.test_request_context():
-        with patch('bazarr.app.ui.settings') as mock_settings, \
-             patch('bazarr.app.ui.session', {}) as mock_session, \
-             patch('bazarr.app.ui.abort') as mock_abort:
+        with patch('app.ui.settings') as mock_settings, \
+             patch('app.ui.session', {}) as mock_session, \
+             patch('app.ui.abort') as mock_abort:
 
             mock_settings.auth.type = 'form'
             mock_abort.return_value = ('Unauthorized', 401)
@@ -187,7 +187,7 @@ def test_check_login_preserves_function_arguments():
     def test_function(arg1, arg2, kwarg1=None):
         return f"args:{arg1},{arg2} kwargs:{kwarg1}"
 
-    with patch('bazarr.app.ui.settings') as mock_settings:
+    with patch('app.ui.settings') as mock_settings:
         mock_settings.auth.type = None
 
         decorated_function = check_login(test_function)
@@ -203,7 +203,7 @@ def test_check_login_preserves_function_exceptions():
     def test_function():
         raise ValueError("Test exception")
 
-    with patch('bazarr.app.ui.settings') as mock_settings:
+    with patch('app.ui.settings') as mock_settings:
         mock_settings.auth.type = None
 
         decorated_function = check_login(test_function)
@@ -224,7 +224,7 @@ def test_check_login_with_different_return_types():
         (None, type(None)),
     ]
 
-    with patch('bazarr.app.ui.settings') as mock_settings:
+    with patch('app.ui.settings') as mock_settings:
         mock_settings.auth.type = None
 
         for expected_value, expected_type in test_cases:

--- a/tests/bazarr/test_utilities_video_analyzer.py
+++ b/tests/bazarr/test_utilities_video_analyzer.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from bazarr.utilities import video_analyzer
+from utilities import video_analyzer
 
 logging.getLogger("knowit").setLevel(logging.WARNING)
 
@@ -237,10 +237,10 @@ def mediainfo_data():
 def test_embedded_subs_reader(mediainfo_data, video_file):
     from unittest.mock import patch
     with patch(
-        "bazarr.utilities.video_analyzer.parse_video_metadata",
+        "utilities.video_analyzer.parse_video_metadata",
         return_value={"mediainfo": mediainfo_data},
     ), patch(
-        "bazarr.utilities.video_analyzer.alpha3_from_alpha2", return_value=None
+        "utilities.video_analyzer.alpha3_from_alpha2", return_value=None
     ):
         result = video_analyzer.embedded_subs_reader(video_file, 1e6)
         assert ["spl", False, False, "SubRip"] in result
@@ -251,10 +251,10 @@ def test_embedded_subs_reader(mediainfo_data, video_file):
 def test_embedded_audio_reader(mediainfo_data, video_file):
     from unittest.mock import patch
     with patch(
-        "bazarr.utilities.video_analyzer.parse_video_metadata",
+        "utilities.video_analyzer.parse_video_metadata",
         return_value={"mediainfo": mediainfo_data},
     ), patch(
-        "bazarr.utilities.video_analyzer.language_from_alpha3", side_effect=lambda alpha3: alpha3
+        "utilities.video_analyzer.language_from_alpha3", side_effect=lambda alpha3: alpha3
     ):
         result = video_analyzer.embedded_audio_reader(video_file, 1e6)
         assert {"pob", "por"} == set(result)

--- a/tests/compat/conftest.py
+++ b/tests/compat/conftest.py
@@ -7,7 +7,7 @@ os.environ["NO_CLI"] = "true"
 os.environ.setdefault("SZ_USER_AGENT", "test")
 os.environ.setdefault("BAZARR_VERSION", "test")
 
-# Add bazarr source trees to sys.path so that `from bazarr.app.config import ...`
+# Add bazarr source trees to sys.path so that `from app.config import ...`
 # resolves correctly, matching what tests/bazarr/conftest.py does.
 _repo = os.path.join(os.path.dirname(__file__), "../..")
 sys.path.insert(0, os.path.join(_repo, "libs"))
@@ -35,7 +35,7 @@ def _guarantee_compat_secrets():
     monkeypatches touch. Hitting both guarantees the values are in
     sync regardless of which layer any individual caller reads.
     """
-    from bazarr.app.config import settings
+    from app.config import settings
     _defaults = {
         "token": "t" * 32,
         "jwt_secret": "j" * 32,

--- a/tests/compat/contract/test_plugin_contract.py
+++ b/tests/compat/contract/test_plugin_contract.py
@@ -21,8 +21,8 @@ FID_SECRET = "f" * 32
 
 @pytest.fixture(autouse=True)
 def _compat_secrets():
-    from bazarr.app.config import settings
-    from bazarr.compat.file_id_store import reset_store
+    from app.config import settings
+    from compat.file_id_store import reset_store
     originals = {
         n: getattr(settings.compat_endpoint, n, "")
         for n in ("token", "jwt_secret", "file_id_secret",
@@ -43,7 +43,7 @@ def _compat_secrets():
 
 
 def _app():
-    from bazarr.compat.routes import compat_bp
+    from compat.routes import compat_bp
     app = Flask(__name__)
     app.register_blueprint(compat_bp, url_prefix="/api/v1")
     return app
@@ -112,7 +112,7 @@ def test_logout_requires_bearer_to_revoke():
 
 
 def test_logout_with_bearer_returns_2xx_and_revokes():
-    from bazarr.compat import auth, jwt_denylist
+    from compat import auth, jwt_denylist
     jwt_denylist.reset()
     tok = auth.mint_jwt()
     r = _app().test_client().delete(
@@ -201,7 +201,7 @@ def _fake_search_result(attrs_override=None):
 
 def test_subtitles_envelope_has_all_strict_fields():
     """total_pages, total_count, per_page, page are all strict."""
-    with patch("bazarr.compat.service.search",
+    with patch("compat.service.search",
                 return_value=_fake_search_result()):
         r = _app().test_client().get(
             "/api/v1/subtitles?imdb_id=111161&languages=en&type=movie",
@@ -221,7 +221,7 @@ def test_subtitles_upload_date_is_never_empty_string():
     System.Text.Json.JsonException in the plugin. Must be a valid ISO
     datetime, with 1970 epoch as the fallback."""
     # Mock the response_mapper directly so we test the mapper path.
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(upload_date=None, id="1", language=MagicMock(alpha2="en"),
                     download_count=0, ratings=0.0, release_info="",
                     uploader=None, provider_name="os")
@@ -240,7 +240,7 @@ def test_subtitles_upload_date_from_provider_is_preserved():
     """When a provider DOES expose upload_date, we must pass it through,
     not replace it with the epoch fallback."""
     from datetime import datetime
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     provider_date = datetime(2023, 1, 15, 12, 34, 56)
     sub = MagicMock(upload_date=provider_date, id="1",
                     language=MagicMock(alpha2="en"),
@@ -253,7 +253,7 @@ def test_subtitles_upload_date_from_provider_is_preserved():
 
 def test_subtitles_feature_details_imdb_id_is_int_not_string():
     """Filter-inducing: plugin drops results where imdb_id is a string."""
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(upload_date=None, id="1", language=MagicMock(alpha2="en"),
                     download_count=0, ratings=0.0, release_info="",
                     uploader=None, provider_name="os")
@@ -265,7 +265,7 @@ def test_subtitles_feature_details_imdb_id_is_int_not_string():
 
 def test_subtitles_feature_details_feature_type_case_exact():
     """'Movie' vs 'movie' matters - plugin does case-SENSITIVE compare."""
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(upload_date=None, id="1", language=MagicMock(alpha2="en"),
                     download_count=0, ratings=0.0, release_info="",
                     uploader=None, provider_name="os")
@@ -280,7 +280,7 @@ def test_subtitles_feature_details_feature_type_case_exact():
 
 def test_subtitles_files_has_positive_int_file_id():
     """String or null file_id → result silently dropped by plugin."""
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(upload_date=None, id="1", language=MagicMock(alpha2="en"),
                     download_count=0, ratings=0.0, release_info="",
                     uploader=None, provider_name="os")
@@ -294,7 +294,7 @@ def test_subtitles_files_has_positive_int_file_id():
 
 def test_subtitles_episode_season_episode_numbers_are_ints():
     """Filter-inducing: wrong type or 0/0 on an episode search gets dropped."""
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(upload_date=None, id="1", language=MagicMock(alpha2="en"),
                     download_count=0, ratings=0.0, release_info="",
                     uploader=None, provider_name="os")
@@ -309,7 +309,7 @@ def test_subtitles_route_accepts_query_only_search():
     """Plugin sends either imdb_id OR query+season+episode. Query-only
     must not 400, and must not smuggle the filename into imdb_id."""
     result = _fake_search_result()
-    with patch("bazarr.compat.service.search", return_value=result) as s:
+    with patch("compat.service.search", return_value=result) as s:
         r = _app().test_client().get(
             "/api/v1/subtitles?query=For.All.Mankind.S01E01.mkv"
             "&languages=en&type=episode&season_number=1&episode_number=1",
@@ -332,7 +332,7 @@ def test_subtitles_route_accepts_query_only_search():
 def test_download_link_is_absolute_url():
     """Plugin runs HttpClient.GetAsync(link) - relative URL throws when no
     BaseAddress. Must be scheme://host/path."""
-    from bazarr.compat import auth
+    from compat import auth
     fake_sub = MagicMock(provider_name="os", id="1")
     fid = auth.mint_file_id("os", "1", "eng", "", subtitle=fake_sub)
     jwt_tok = auth.mint_jwt()
@@ -349,7 +349,7 @@ def test_download_link_is_absolute_url():
 
 
 def test_download_link_honors_forwarded_headers():
-    from bazarr.compat import auth
+    from compat import auth
     fake_sub = MagicMock(provider_name="os", id="1")
     fid = auth.mint_file_id("os", "1", "eng", "", subtitle=fake_sub)
     jwt_tok = auth.mint_jwt()
@@ -375,9 +375,9 @@ def test_download_stream_url_accepts_no_auth_headers():
     The HMAC-signed stream token IS the auth - the route MUST NOT gate on
     Api-Key or Bearer. If it did, the plugin's follow-up GET of the link
     would 403 immediately after every successful download-link mint."""
-    from bazarr.compat import auth
+    from compat import auth
     # Patch serve_subtitle_content so we don't need a real provider backend.
-    with patch("bazarr.compat.service.serve_subtitle_content",
+    with patch("compat.service.serve_subtitle_content",
                 return_value=(b"1\n00:00:01,000 --> 00:00:02,000\nhi\n",
                               "application/x-subrip")):
         token = auth.mint_file_stream_token(1)
@@ -417,7 +417,7 @@ def test_missing_jwt_on_download_returns_401():
 
 
 def test_contract_attributes_include_comments():
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(
         upload_date=None, id="1", language=MagicMock(alpha2="en"),
         download_count=0, ratings=0.0, release_info="Rel.info",
@@ -428,7 +428,7 @@ def test_contract_attributes_include_comments():
 
 
 def test_contract_moviehash_match_is_hash_aware():
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub_with = MagicMock(
         upload_date=None, id="1", language=MagicMock(alpha2="en"),
         download_count=0, ratings=0.0, release_info="",
@@ -446,7 +446,7 @@ def test_contract_moviehash_match_is_hash_aware():
 
 
 def test_contract_ratings_is_in_0_to_10_range():
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(
         upload_date=None, id="1", language=MagicMock(alpha2="en"),
         download_count=0, ratings=0.0, release_info="",
@@ -459,7 +459,7 @@ def test_contract_ratings_is_in_0_to_10_range():
 
 
 def test_contract_file_name_never_leading_dot():
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(
         upload_date=None, id="1", language=MagicMock(alpha2="en"),
         download_count=0, ratings=0.0, release_info="",
@@ -472,8 +472,8 @@ def test_contract_file_name_never_leading_dot():
 def test_contract_stream_accepts_api_key_header_too():
     """Plugin actually sends Api-Key on the follow-up even though HMAC
     is the auth. Route must still 200."""
-    from bazarr.compat import auth
-    with patch("bazarr.compat.service.serve_subtitle_content",
+    from compat import auth
+    with patch("compat.service.serve_subtitle_content",
                 return_value=(b"hi", "application/x-subrip")):
         token = auth.mint_file_stream_token(1)
         r = _app().test_client().get(

--- a/tests/compat/contract/test_vlsub_contract.py
+++ b/tests/compat/contract/test_vlsub_contract.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from babelfish import Language
-from bazarr.compat import service, cache as C
+from compat import service, cache as C
 
 
 def _resolve(obj, path):
@@ -33,7 +33,7 @@ def _check_type(value, type_name: str) -> bool:
 def test_vlsub_contract(monkeypatch):
     """Every JSON path VLSub reads from a subtitle search response must resolve
     with the correct primitive type. Extracted from the VLSub audit report."""
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.file_id_secret", "f" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.file_id_secret", "f" * 32)
     contract_file = Path(__file__).parent.parent / "fixtures" / "client_contracts" / "vlsub_required.json"
     contract = json.loads(contract_file.read_text())
     C.invalidate_all()
@@ -46,9 +46,9 @@ def test_vlsub_contract(monkeypatch):
         ratings=0, uploader="Anon", upload_date=None,
     )
 
-    with patch("bazarr.compat.service._get_compat_pool") as gp, \
-         patch("bazarr.compat.service.list_all_subtitles_parallel") as lf, \
-         patch("bazarr.compat.service.auth.mint_file_id", return_value=42):
+    with patch("compat.service._get_compat_pool") as gp, \
+         patch("compat.service.list_all_subtitles_parallel") as lf, \
+         patch("compat.service.auth.mint_file_id", return_value=42):
         lf.return_value = {MagicMock(): [fake_sub]}
         gp.return_value.providers = ["opensubtitlescom"]
         gp.return_value.discarded_providers = set()

--- a/tests/compat/integration/test_all_fail.py
+++ b/tests/compat/integration/test_all_fail.py
@@ -1,16 +1,16 @@
 from unittest.mock import patch
 from babelfish import Language
-from bazarr.compat import service, cache as C
+from compat import service, cache as C
 
 
 def test_all_providers_return_empty_returns_empty_data(monkeypatch):
     """When every provider errors/returns empty, search still succeeds with empty data.
     The HTTP layer (routes.py) is responsible for translating empty providers to 503
     when needed; service.search itself returns the empty-data shape."""
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.file_id_secret", "f" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.file_id_secret", "f" * 32)
     C.invalidate_all()
-    with patch("bazarr.compat.service._get_compat_pool") as gp, \
-         patch("bazarr.compat.service.list_all_subtitles_parallel") as lf:
+    with patch("compat.service._get_compat_pool") as gp, \
+         patch("compat.service.list_all_subtitles_parallel") as lf:
         lf.return_value = {}  # no results at all
         gp.return_value.providers = ["p1", "p2"]
         gp.return_value.discarded_providers = set()

--- a/tests/compat/integration/test_bootstrap.py
+++ b/tests/compat/integration/test_bootstrap.py
@@ -1,11 +1,11 @@
 def test_first_enable_autogenerates_secrets(monkeypatch):
     """When compat_endpoint.enabled flips True and secrets are missing/short,
     ensure_secrets() auto-generates them via secrets.token_urlsafe(32)."""
-    from bazarr.api.system.compat_admin import ensure_secrets
-    monkeypatch.setattr("bazarr.app.config.settings.compat_endpoint.enabled", True)
-    monkeypatch.setattr("bazarr.app.config.settings.compat_endpoint.token", "")
-    monkeypatch.setattr("bazarr.app.config.settings.compat_endpoint.jwt_secret", "")
-    monkeypatch.setattr("bazarr.app.config.settings.compat_endpoint.file_id_secret", "")
+    from api.system.compat_admin import ensure_secrets
+    monkeypatch.setattr("app.config.settings.compat_endpoint.enabled", True)
+    monkeypatch.setattr("app.config.settings.compat_endpoint.token", "")
+    monkeypatch.setattr("app.config.settings.compat_endpoint.jwt_secret", "")
+    monkeypatch.setattr("app.config.settings.compat_endpoint.file_id_secret", "")
     writes = {}
     ensure_secrets(write_fn=lambda k, v: writes.__setitem__(k, v))
     assert len(writes["compat_endpoint.token"]) >= 32
@@ -15,12 +15,12 @@ def test_first_enable_autogenerates_secrets(monkeypatch):
 
 def test_ensure_secrets_idempotent_when_secrets_present(monkeypatch):
     """If all 3 secrets already >=32 chars, ensure_secrets is a no-op."""
-    from bazarr.api.system.compat_admin import ensure_secrets
-    from bazarr.app.config import settings
-    monkeypatch.setattr("bazarr.app.config.settings.compat_endpoint.enabled", True)
-    monkeypatch.setattr("bazarr.app.config.settings.compat_endpoint.token", "a" * 32)
-    monkeypatch.setattr("bazarr.app.config.settings.compat_endpoint.jwt_secret", "b" * 32)
-    monkeypatch.setattr("bazarr.app.config.settings.compat_endpoint.file_id_secret", "c" * 32)
+    from api.system.compat_admin import ensure_secrets
+    from app.config import settings
+    monkeypatch.setattr("app.config.settings.compat_endpoint.enabled", True)
+    monkeypatch.setattr("app.config.settings.compat_endpoint.token", "a" * 32)
+    monkeypatch.setattr("app.config.settings.compat_endpoint.jwt_secret", "b" * 32)
+    monkeypatch.setattr("app.config.settings.compat_endpoint.file_id_secret", "c" * 32)
     writes = {}
     ensure_secrets(write_fn=lambda k, v: writes.__setitem__(k, v))
     assert writes == {}, "no regeneration when secrets already valid"

--- a/tests/compat/integration/test_coalescing.py
+++ b/tests/compat/integration/test_coalescing.py
@@ -2,12 +2,12 @@ import threading
 import time
 from unittest.mock import MagicMock, patch
 from babelfish import Language
-from bazarr.compat import service, cache as C
+from compat import service, cache as C
 
 
 def test_concurrent_identical_queries_coalesce(monkeypatch):
     """Two concurrent identical search queries must share ONE fanout via dogpile."""
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.file_id_secret", "f" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.file_id_secret", "f" * 32)
     C.invalidate_all()
     call_count = {"n": 0}
     lock = threading.Lock()
@@ -18,8 +18,8 @@ def test_concurrent_identical_queries_coalesce(monkeypatch):
         time.sleep(0.3)
         return {MagicMock(): []}
 
-    with patch("bazarr.compat.service._get_compat_pool") as gp, \
-         patch("bazarr.compat.service.list_all_subtitles_parallel", side_effect=slow_fanout):
+    with patch("compat.service._get_compat_pool") as gp, \
+         patch("compat.service.list_all_subtitles_parallel", side_effect=slow_fanout):
         gp.return_value.providers = ["p"]
         gp.return_value.discarded_providers = set()
         results = []

--- a/tests/compat/integration/test_download_flow.py
+++ b/tests/compat/integration/test_download_flow.py
@@ -8,7 +8,7 @@ def _set_secrets():
     doesn't reliably restore on teardown (monkeypatch's revert mutates
     the wrapper in a way Dynaconf's layered storage doesn't always see),
     causing flakes when tests run in different orders across the suite."""
-    from bazarr.app.config import settings
+    from app.config import settings
     settings["compat_endpoint"]["file_id_secret"] = "f" * 32
     settings["compat_endpoint"]["file_id_ttl_seconds"] = 3600
     settings["compat_endpoint"]["stream_token_ttl_seconds"] = 300
@@ -18,8 +18,8 @@ def _set_secrets():
 def test_download_returns_relative_link_by_default():
     """Relative link is the default: Bazarr+ can't know its public URL behind
     the supervisor proxy, so the client prepends the host it connected to."""
-    from bazarr.compat import service, auth
-    from bazarr.compat.file_id_store import reset_store
+    from compat import service, auth
+    from compat.file_id_store import reset_store
     reset_store()
 
     fid = auth.mint_file_id("opensubtitlescom", "123", "eng", "")
@@ -33,8 +33,8 @@ def test_download_returns_relative_link_by_default():
 def test_download_honors_base_host_when_provided():
     """Backwards-compat: callers that pass an explicit base_host get an
     absolute URL."""
-    from bazarr.compat import service, auth
-    from bazarr.compat.file_id_store import reset_store
+    from compat import service, auth
+    from compat.file_id_store import reset_store
     reset_store()
     fid = auth.mint_file_id("opensubtitlescom", "123", "eng", "")
     resp = service.download(fid, base_host="http://bazarr.local",
@@ -43,7 +43,7 @@ def test_download_honors_base_host_when_provided():
 
 
 def test_download_rejects_invalid_file_id():
-    from bazarr.compat import service
+    from compat import service
     with pytest.raises(FileNotFoundError):
         service.download(999999999)
     with pytest.raises(FileNotFoundError):
@@ -54,9 +54,9 @@ def test_serve_subtitle_content_runs_ssrf_guard():
     """serve_subtitle_content resolves file_id -> subtitle -> _fetch_subtitle_bytes,
     which runs the SSRF guard against the subtitle's download URL before the
     provider dereferences it."""
-    from bazarr.compat import service, auth
-    from bazarr.compat.file_id_store import reset_store
-    from bazarr.utilities.url_guard import UnsafeURLError
+    from compat import service, auth
+    from compat.file_id_store import reset_store
+    from utilities.url_guard import UnsafeURLError
     reset_store()
     fake_sub = MagicMock()
     fake_sub.download_link = "http://127.0.0.1/sub.srt"
@@ -64,14 +64,14 @@ def test_serve_subtitle_content_runs_ssrf_guard():
     fake_sub.provider_name = "opensubtitlescom"
     fid = auth.mint_file_id("opensubtitlescom", "123", "eng", "", subtitle=fake_sub)
     tok = auth.mint_file_stream_token(fid)
-    with patch("bazarr.compat.service.assert_safe_outbound") as guard:
+    with patch("compat.service.assert_safe_outbound") as guard:
         guard.side_effect = UnsafeURLError("loopback")
         with pytest.raises(UnsafeURLError):
             service.serve_subtitle_content(tok)
 
 
 def test_serve_subtitle_content_rejects_invalid_token():
-    from bazarr.compat import service
+    from compat import service
     with pytest.raises(ValueError):
         service.serve_subtitle_content("not-a-valid-token")
 
@@ -79,15 +79,15 @@ def test_serve_subtitle_content_rejects_invalid_token():
 def test_fetch_subtitle_bytes_invokes_guard_before_download():
     """_fetch_subtitle_bytes runs the SSRF guard, calls pool.download_subtitle(sub),
     then returns sub.content bytes."""
-    from bazarr.compat import service
+    from compat import service
     fake_sub = MagicMock()
     fake_sub.download_link = "https://safe.example.com/sub.srt"
     fake_sub.url = None
     fake_sub.provider_name = "opensubtitlescom"
     fake_sub.content = b"1\n00:00:00,000 --> 00:00:01,000\nhi"
 
-    with patch("bazarr.compat.service.assert_safe_outbound") as guard, \
-         patch("bazarr.compat.service._get_compat_pool") as pool:
+    with patch("compat.service.assert_safe_outbound") as guard, \
+         patch("compat.service._get_compat_pool") as pool:
         pool.return_value.download_subtitle = MagicMock(return_value=None)
         out = service._fetch_subtitle_bytes(fake_sub)
         assert guard.called, "assert_safe_outbound MUST be called before fetch"

--- a/tests/compat/integration/test_empty_content.py
+++ b/tests/compat/integration/test_empty_content.py
@@ -4,7 +4,7 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _secrets():
-    from bazarr.app.config import settings
+    from app.config import settings
     settings["compat_endpoint"]["file_id_secret"] = "f" * 32
     settings["compat_endpoint"]["file_id_ttl_seconds"] = 3600
     settings["compat_endpoint"]["stream_token_ttl_seconds"] = 300
@@ -15,14 +15,14 @@ def test_fetch_subtitle_bytes_returns_empty_on_missing_content():
     """P0: plugin's blocklist signal is 200 + empty body. Previous
     behavior raised FileNotFoundError -> route returned 404 -> plugin
     treated as transient and retried forever."""
-    from bazarr.compat import service
+    from compat import service
     sub = MagicMock()
     sub.download_link = "https://safe.example.com/sub.srt"
     sub.url = None
     sub.provider_name = "os"
     sub.content = None  # provider returned nothing
-    with patch("bazarr.compat.service.assert_safe_outbound"), \
-         patch("bazarr.compat.service._get_compat_pool") as pool:
+    with patch("compat.service.assert_safe_outbound"), \
+         patch("compat.service._get_compat_pool") as pool:
         pool.return_value.download_subtitle = MagicMock(return_value=None)
         out = service._fetch_subtitle_bytes(sub)
     assert out == b""
@@ -30,6 +30,6 @@ def test_fetch_subtitle_bytes_returns_empty_on_missing_content():
 
 def test_fetch_subtitle_bytes_still_raises_for_none_sub():
     """sub=None is a genuine 404 (file_id unknown). Keep that path."""
-    from bazarr.compat import service
+    from compat import service
     with pytest.raises(FileNotFoundError):
         service._fetch_subtitle_bytes(None)

--- a/tests/compat/integration/test_fanout_timeout.py
+++ b/tests/compat/integration/test_fanout_timeout.py
@@ -1,11 +1,11 @@
 import time
 from unittest.mock import MagicMock
-from bazarr.compat import cache as C
+from compat import cache as C
 
 
 def test_fanout_respects_wall_timeout(monkeypatch):
     """A slow provider dropped at wall_timeout; fast provider results included."""
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.file_id_secret", "f" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.file_id_secret", "f" * 32)
     C.invalidate_all()
     from subliminal_patch.core_persistent import list_all_subtitles_parallel
 

--- a/tests/compat/integration/test_feature_gate_at_boot.py
+++ b/tests/compat/integration/test_feature_gate_at_boot.py
@@ -4,8 +4,8 @@ import pytest
 
 def test_disabled_state_404s_json(monkeypatch):
     """enabled=False: all /api/v1/* return stub JSON 404."""
-    from bazarr.compat import register
-    monkeypatch.setattr("bazarr.app.config.settings.compat_endpoint.enabled", False)
+    from compat import register
+    monkeypatch.setattr("app.config.settings.compat_endpoint.enabled", False)
     app = Flask(__name__)
     register(app, base_url="")
     r = app.test_client().get("/api/v1/subtitles")
@@ -23,9 +23,9 @@ def test_enabled_state_auto_generates_missing_secrets(monkeypatch):
     would crash the Flask app on next boot. Auto-generation is the recovery
     path.
     """
-    import bazarr.api.system.compat_admin as admin
-    from bazarr.app.config import settings
-    from bazarr.compat import register
+    import api.system.compat_admin as admin
+    from app.config import settings
+    from compat import register
 
     monkeypatch.setattr(settings.compat_endpoint, "enabled", True)
     monkeypatch.setattr(settings.compat_endpoint, "token", "")

--- a/tests/compat/integration/test_kill_switch.py
+++ b/tests/compat/integration/test_kill_switch.py
@@ -1,5 +1,5 @@
 from flask import Flask
-from bazarr.compat.routes import compat_stub_bp
+from compat.routes import compat_stub_bp
 
 
 def test_stub_returns_json_404_with_x_reason():

--- a/tests/compat/integration/test_login_and_user.py
+++ b/tests/compat/integration/test_login_and_user.py
@@ -4,7 +4,7 @@ from flask import Flask
 
 @pytest.fixture(autouse=True)
 def _reset_compat_secrets():
-    from bazarr.app.config import settings
+    from app.config import settings
     original = {
         name: getattr(settings.compat_endpoint, name, "")
         for name in ("token", "jwt_secret", "file_id_secret",
@@ -23,7 +23,7 @@ def _reset_compat_secrets():
 
 
 def _make_app():
-    from bazarr.compat.routes import compat_bp
+    from compat.routes import compat_bp
     app = Flask(__name__)
     app.register_blueprint(compat_bp, url_prefix="/api/v1")
     return app
@@ -62,8 +62,8 @@ def test_login_base_url_honors_x_forwarded_host():
 def test_download_link_uses_forwarded_host_for_fqdn():
     """When X-Forwarded-Host/Proto are set, the download link is absolute so
     OS-compat clients can hand it to an HTTP client without computing a base."""
-    from bazarr.compat import auth
-    from bazarr.compat.file_id_store import reset_store
+    from compat import auth
+    from compat.file_id_store import reset_store
     from unittest.mock import MagicMock
     reset_store()
     fake_sub = MagicMock(provider_name="os", id="1", language=MagicMock(),
@@ -91,8 +91,8 @@ def test_download_link_is_always_absolute():
     crash HttpClient.GetAsync when the plugin has no BaseAddress set.
     With only loopback visible we fall back to request.host_url, which
     is at least a valid absolute URL the client actually hit."""
-    from bazarr.compat import auth
-    from bazarr.compat.file_id_store import reset_store
+    from compat import auth
+    from compat.file_id_store import reset_store
     from unittest.mock import MagicMock
     reset_store()
     fake_sub = MagicMock(provider_name="os", id="1")

--- a/tests/compat/integration/test_logout_revocation.py
+++ b/tests/compat/integration/test_logout_revocation.py
@@ -9,8 +9,8 @@ FID_SECRET = "f" * 32
 
 @pytest.fixture(autouse=True)
 def _secrets():
-    from bazarr.app.config import settings
-    from bazarr.compat import jwt_denylist
+    from app.config import settings
+    from compat import jwt_denylist
     settings["compat_endpoint"]["token"] = API_KEY
     settings["compat_endpoint"]["jwt_secret"] = JWT_SECRET
     settings["compat_endpoint"]["file_id_secret"] = FID_SECRET
@@ -21,14 +21,14 @@ def _secrets():
 
 
 def _app():
-    from bazarr.compat.routes import compat_bp
+    from compat.routes import compat_bp
     app = Flask(__name__)
     app.register_blueprint(compat_bp, url_prefix="/api/v1")
     return app
 
 
 def test_logout_revokes_jwt():
-    from bazarr.compat import auth
+    from compat import auth
     c = _app().test_client()
     tok = auth.mint_jwt()
 

--- a/tests/compat/integration/test_moviehash_only.py
+++ b/tests/compat/integration/test_moviehash_only.py
@@ -5,8 +5,8 @@ from babelfish import Language
 
 @pytest.fixture(autouse=True)
 def _secrets_and_cache():
-    from bazarr.app.config import settings
-    from bazarr.compat import cache as C
+    from app.config import settings
+    from compat import cache as C
     settings["compat_endpoint"]["file_id_secret"] = "f" * 32
     C.invalidate_all()
     yield
@@ -26,11 +26,11 @@ def _mk(provider_name, sub_id, matches):
 
 
 def test_moviehash_only_drops_non_hash_rows():
-    from bazarr.compat import service
+    from compat import service
     hash_sub = _mk("os", "1", {"hash", "series"})
     plain_sub = _mk("os", "2", {"series"})
-    with patch("bazarr.compat.service._get_compat_pool") as gp, \
-         patch("bazarr.compat.service.list_all_subtitles_parallel") as lf:
+    with patch("compat.service._get_compat_pool") as gp, \
+         patch("compat.service.list_all_subtitles_parallel") as lf:
         gp.return_value.providers = ["os"]
         lf.return_value = {MagicMock(): [hash_sub, plain_sub]}
         res = service.search("tt1", None, None, [Language("eng")],
@@ -41,11 +41,11 @@ def test_moviehash_only_drops_non_hash_rows():
 
 
 def test_moviehash_include_keeps_all_rows():
-    from bazarr.compat import service
+    from compat import service
     hash_sub = _mk("os", "1", {"hash"})
     plain_sub = _mk("os", "2", {"series"})
-    with patch("bazarr.compat.service._get_compat_pool") as gp, \
-         patch("bazarr.compat.service.list_all_subtitles_parallel") as lf:
+    with patch("compat.service._get_compat_pool") as gp, \
+         patch("compat.service.list_all_subtitles_parallel") as lf:
         gp.return_value.providers = ["os"]
         lf.return_value = {MagicMock(): [hash_sub, plain_sub]}
         res = service.search("tt1", None, None, [Language("eng")],
@@ -54,10 +54,10 @@ def test_moviehash_include_keeps_all_rows():
 
 
 def test_moviehash_match_only_marks_matched_rows_true():
-    from bazarr.compat import service
+    from compat import service
     hash_sub = _mk("os", "1", {"hash"})
-    with patch("bazarr.compat.service._get_compat_pool") as gp, \
-         patch("bazarr.compat.service.list_all_subtitles_parallel") as lf:
+    with patch("compat.service._get_compat_pool") as gp, \
+         patch("compat.service.list_all_subtitles_parallel") as lf:
         gp.return_value.providers = ["os"]
         lf.return_value = {MagicMock(): [hash_sub]}
         res = service.search("tt1", None, None, [Language("eng")],

--- a/tests/compat/integration/test_partial_success.py
+++ b/tests/compat/integration/test_partial_success.py
@@ -1,19 +1,19 @@
 from unittest.mock import MagicMock, patch
 from babelfish import Language
-from bazarr.compat import service, cache as C
+from compat import service, cache as C
 
 
 def test_partial_success_returns_available_results(monkeypatch):
     """When some providers return subs and others fail, return the successful ones."""
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.file_id_secret", "f" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.file_id_secret", "f" * 32)
     C.invalidate_all()
     good_sub = MagicMock(
         provider_name="good", id="99",
         language=Language("eng"), release_info="x",
         download_count=100, hearing_impaired=False, matches=set(),
     )
-    with patch("bazarr.compat.service._get_compat_pool") as gp, \
-         patch("bazarr.compat.service.list_all_subtitles_parallel") as lf:
+    with patch("compat.service._get_compat_pool") as gp, \
+         patch("compat.service.list_all_subtitles_parallel") as lf:
         # Simulate 3 providers succeeded (good_sub * 3 flattened), 2 errored silently (dropped)
         lf.return_value = {MagicMock(): [good_sub, good_sub, good_sub]}
         gp.return_value.providers = ["good", "good2", "good3", "bad1", "bad2"]

--- a/tests/compat/integration/test_rate_limit.py
+++ b/tests/compat/integration/test_rate_limit.py
@@ -7,8 +7,8 @@ API_KEY = "t" * 32
 
 @pytest.fixture(autouse=True)
 def _secrets():
-    from bazarr.app.config import settings
-    from bazarr.compat import rate_limiter, jwt_denylist
+    from app.config import settings
+    from compat import rate_limiter, jwt_denylist
     settings["compat_endpoint"]["token"] = API_KEY
     settings["compat_endpoint"]["jwt_secret"] = "j" * 32
     settings["compat_endpoint"]["file_id_secret"] = "f" * 32
@@ -22,14 +22,14 @@ def _secrets():
 
 
 def _app():
-    from bazarr.compat.routes import compat_bp
+    from compat.routes import compat_bp
     app = Flask(__name__)
     app.register_blueprint(compat_bp, url_prefix="/api/v1")
     return app
 
 
 def test_download_emits_406_after_quota_exhausted():
-    from bazarr.compat import auth
+    from compat import auth
     fake_sub = MagicMock(provider_name="os", id="1")
     fid = auth.mint_file_id("os", "1", "eng", "", subtitle=fake_sub)
     jwt_tok = auth.mint_jwt()
@@ -54,7 +54,7 @@ def test_download_emits_406_after_quota_exhausted():
 
 
 def test_download_remaining_decrements():
-    from bazarr.compat import auth
+    from compat import auth
     fake_sub = MagicMock(provider_name="os", id="1")
     fid = auth.mint_file_id("os", "1", "eng", "", subtitle=fake_sub)
     jwt_tok = auth.mint_jwt()
@@ -73,7 +73,7 @@ def test_download_remaining_decrements():
 
 
 def test_infos_user_reports_real_remaining():
-    from bazarr.compat import auth
+    from compat import auth
     fake_sub = MagicMock(provider_name="os", id="1")
     fid = auth.mint_file_id("os", "1", "eng", "", subtitle=fake_sub)
     jwt_tok = auth.mint_jwt()

--- a/tests/compat/integration/test_search_flow.py
+++ b/tests/compat/integration/test_search_flow.py
@@ -5,20 +5,20 @@ from babelfish import Language
 
 @pytest.fixture(autouse=True)
 def _set_file_id_secret(monkeypatch):
-    from bazarr.app.config import settings
+    from app.config import settings
     monkeypatch.setattr(settings.compat_endpoint, "file_id_secret", "f" * 32)
 
 
 def test_search_calls_parallel_fanout_and_caches():
-    from bazarr.compat import service, cache as C
+    from compat import service, cache as C
     C.invalidate_all()
     fake_sub = MagicMock(
         provider_name="opensubtitlescom", id="123",
         language=Language("eng"), release_info="Movie.2020.1080p",
         download_count=500, hearing_impaired=False, matches={"hash"},
     )
-    with patch("bazarr.compat.service._get_compat_pool") as gp, \
-         patch("bazarr.compat.service.list_all_subtitles_parallel") as lf:
+    with patch("compat.service._get_compat_pool") as gp, \
+         patch("compat.service.list_all_subtitles_parallel") as lf:
         lf.return_value = {MagicMock(): [fake_sub]}
         gp.return_value.providers = ["opensubtitlescom"]
         gp.return_value.discarded_providers = set()
@@ -38,8 +38,8 @@ def test_search_calls_parallel_fanout_and_caches():
 
 def test_subtitles_endpoint_requires_api_key(monkeypatch):
     from flask import Flask
-    from bazarr.compat.routes import compat_bp
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.token", "a" * 32)
+    from compat.routes import compat_bp
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.token", "a" * 32)
     app = Flask(__name__)
     app.register_blueprint(compat_bp, url_prefix="/api/v1")
     r = app.test_client().get("/api/v1/subtitles?imdb_id=tt1&languages=en")
@@ -49,8 +49,8 @@ def test_subtitles_endpoint_requires_api_key(monkeypatch):
 
 def test_subtitles_requires_languages(monkeypatch):
     from flask import Flask
-    from bazarr.compat.routes import compat_bp
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.token", "a" * 32)
+    from compat.routes import compat_bp
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.token", "a" * 32)
     app = Flask(__name__)
     app.register_blueprint(compat_bp, url_prefix="/api/v1")
     r = app.test_client().get("/api/v1/subtitles", headers={"Api-Key": "a" * 32})

--- a/tests/compat/integration/test_secret_rotation.py
+++ b/tests/compat/integration/test_secret_rotation.py
@@ -1,9 +1,9 @@
 def test_regenerate_rotates_all_three_and_invalidates_cache(monkeypatch):
-    from bazarr.api.system.compat_admin import regenerate_all_secrets
-    from bazarr.compat.cache import compat_region
-    monkeypatch.setattr("bazarr.app.config.settings.compat_endpoint.token", "o" * 32)
-    monkeypatch.setattr("bazarr.app.config.settings.compat_endpoint.jwt_secret", "o" * 32)
-    monkeypatch.setattr("bazarr.app.config.settings.compat_endpoint.file_id_secret", "o" * 32)
+    from api.system.compat_admin import regenerate_all_secrets
+    from compat.cache import compat_region
+    monkeypatch.setattr("app.config.settings.compat_endpoint.token", "o" * 32)
+    monkeypatch.setattr("app.config.settings.compat_endpoint.jwt_secret", "o" * 32)
+    monkeypatch.setattr("app.config.settings.compat_endpoint.file_id_secret", "o" * 32)
     compat_region.set("somekey", {"cached": True})
     assert compat_region.get("somekey") == {"cached": True}
     new_token = regenerate_all_secrets(write_fn=lambda k, v: None)

--- a/tests/compat/integration/test_sub_format.py
+++ b/tests/compat/integration/test_sub_format.py
@@ -7,8 +7,8 @@ API_KEY = "t" * 32
 
 @pytest.fixture(autouse=True)
 def _secrets():
-    from bazarr.app.config import settings
-    from bazarr.compat import rate_limiter
+    from app.config import settings
+    from compat import rate_limiter
     settings["compat_endpoint"]["token"] = API_KEY
     settings["compat_endpoint"]["jwt_secret"] = "j" * 32
     settings["compat_endpoint"]["file_id_secret"] = "f" * 32
@@ -20,14 +20,14 @@ def _secrets():
 
 
 def _app():
-    from bazarr.compat.routes import compat_bp
+    from compat.routes import compat_bp
     app = Flask(__name__)
     app.register_blueprint(compat_bp, url_prefix="/api/v1")
     return app
 
 
 def test_download_accepts_srt():
-    from bazarr.compat import auth
+    from compat import auth
     fake_sub = MagicMock(provider_name="os", id="1")
     fid = auth.mint_file_id("os", "1", "eng", "", subtitle=fake_sub)
     jwt_tok = auth.mint_jwt()
@@ -41,7 +41,7 @@ def test_download_accepts_srt():
 
 
 def test_download_rejects_non_srt_sub_format():
-    from bazarr.compat import auth
+    from compat import auth
     fake_sub = MagicMock(provider_name="os", id="1")
     fid = auth.mint_file_id("os", "1", "eng", "", subtitle=fake_sub)
     jwt_tok = auth.mint_jwt()
@@ -57,7 +57,7 @@ def test_download_rejects_non_srt_sub_format():
 
 def test_download_defaults_sub_format_to_srt():
     """sub_format missing entirely is fine (plugin may omit)."""
-    from bazarr.compat import auth
+    from compat import auth
     fake_sub = MagicMock(provider_name="os", id="1")
     fid = auth.mint_file_id("os", "1", "eng", "", subtitle=fake_sub)
     jwt_tok = auth.mint_jwt()

--- a/tests/compat/unit/test_auth.py
+++ b/tests/compat/unit/test_auth.py
@@ -1,5 +1,5 @@
 import pytest
-from bazarr.compat import auth as A
+from compat import auth as A
 
 
 @pytest.fixture(autouse=True)
@@ -10,7 +10,7 @@ def _reset_compat_secrets():
     Dynaconf attributes between tests, causing full-suite ordering flakes.
     Setting and restoring directly on the live DynaBox is deterministic.
     """
-    from bazarr.app.config import settings
+    from app.config import settings
     original = {
         name: getattr(settings.compat_endpoint, name, "")
         for name in ("token", "jwt_secret", "file_id_secret",
@@ -31,17 +31,17 @@ def _reset_compat_secrets():
 
 
 def test_validate_compat_token_accepts_exact_match(monkeypatch):
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.token", "a" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.token", "a" * 32)
     assert A.validate_compat_token("a" * 32) is True
 
 
 def test_validate_compat_token_rejects_wrong(monkeypatch):
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.token", "a" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.token", "a" * 32)
     assert A.validate_compat_token("b" * 32) is False
 
 
 def test_validate_compat_token_empty_returns_false(monkeypatch):
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.token", "a" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.token", "a" * 32)
     assert A.validate_compat_token("") is False
     assert A.validate_compat_token(None) is False
 
@@ -57,16 +57,16 @@ import time
 
 
 def test_mint_and_validate_jwt_roundtrip(monkeypatch):
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.jwt_secret", "j" * 32)
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.jwt_ttl_seconds", 60)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.jwt_secret", "j" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.jwt_ttl_seconds", 60)
     tok = A.mint_jwt()
     ok, claims = A.validate_jwt(tok)
     assert ok is True and "exp" in claims
 
 
 def test_validate_jwt_rejects_expired(monkeypatch):
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.jwt_secret", "j" * 32)
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.jwt_ttl_seconds", 1)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.jwt_secret", "j" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.jwt_ttl_seconds", 1)
     tok = A.mint_jwt()
     time.sleep(2)
     ok, _ = A.validate_jwt(tok)
@@ -74,7 +74,7 @@ def test_validate_jwt_rejects_expired(monkeypatch):
 
 
 def test_validate_jwt_rejects_bad_signature(monkeypatch):
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.jwt_secret", "j" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.jwt_secret", "j" * 32)
     tok = A.mint_jwt()
     # Replace the signature segment entirely with a clearly invalid payload.
     header_payload, _ = tok.rsplit(".", 1)
@@ -84,14 +84,14 @@ def test_validate_jwt_rejects_bad_signature(monkeypatch):
 
 
 def test_boot_hmac_selftest_passes_with_valid_secrets(monkeypatch):
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.token", "t" * 32)
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.jwt_secret", "j" * 32)
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.file_id_secret", "f" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.token", "t" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.jwt_secret", "j" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.file_id_secret", "f" * 32)
     A.boot_hmac_selftest()  # no exception
 
 
 def test_boot_hmac_selftest_fails_closed_with_empty_secret(monkeypatch):
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.jwt_secret", "")
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.jwt_secret", "")
     with pytest.raises(A.CompatBootError):
         A.boot_hmac_selftest()
 
@@ -99,9 +99,9 @@ def test_boot_hmac_selftest_fails_closed_with_empty_secret(monkeypatch):
 def test_file_id_roundtrip(monkeypatch):
     """mint_file_id now returns an int (OS.com wire contract); parse resolves
     via the in-memory store."""
-    from bazarr.compat.file_id_store import reset_store
+    from compat.file_id_store import reset_store
     reset_store()
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.file_id_ttl_seconds", 60)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.file_id_ttl_seconds", 60)
     fid = A.mint_file_id(
         provider="opensubtitlescom",
         native_id="12345",
@@ -118,9 +118,9 @@ def test_file_id_roundtrip(monkeypatch):
 
 def test_file_id_unknown_rejected(monkeypatch):
     """An int that was never minted must return (False, {})."""
-    from bazarr.compat.file_id_store import reset_store
+    from compat.file_id_store import reset_store
     reset_store()
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.file_id_ttl_seconds", 60)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.file_id_ttl_seconds", 60)
     ok, _ = A.parse_file_id(999999999)
     assert not ok
     ok, _ = A.parse_file_id("not-a-number")
@@ -130,9 +130,9 @@ def test_file_id_unknown_rejected(monkeypatch):
 
 
 def test_file_id_expired_rejected(monkeypatch):
-    from bazarr.compat.file_id_store import reset_store
+    from compat.file_id_store import reset_store
     reset_store()
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.file_id_ttl_seconds", 1)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.file_id_ttl_seconds", 1)
     fid = A.mint_file_id("p", "i", "eng", "")
     time.sleep(2)
     ok, _ = A.parse_file_id(fid)
@@ -140,7 +140,7 @@ def test_file_id_expired_rejected(monkeypatch):
 
 
 def test_stream_token_roundtrip():
-    from bazarr.app.config import settings
+    from app.config import settings
     settings["compat_endpoint"]["file_id_secret"] = "f" * 32
     settings["compat_endpoint"]["stream_token_ttl_seconds"] = 60
     tok = A.mint_stream_token("p", "i")
@@ -154,7 +154,7 @@ def test_stream_token_roundtrip_all_byte_values_in_sig():
     makes the parser deterministic regardless of signature content.
     1000 iterations with varying payloads should exercise a signature
     whose last byte is b'.' (0x2e) many times over."""
-    from bazarr.app.config import settings
+    from app.config import settings
     settings["compat_endpoint"]["file_id_secret"] = "f" * 32
     settings["compat_endpoint"]["stream_token_ttl_seconds"] = 60
     for i in range(1000):
@@ -167,7 +167,7 @@ def test_stream_token_roundtrip_all_byte_values_in_sig():
 
 def test_stream_token_expiry():
     """Expiry path: TTL=1, sleep 2s, parse must reject."""
-    from bazarr.app.config import settings
+    from app.config import settings
     settings["compat_endpoint"]["file_id_secret"] = "f" * 32
     settings["compat_endpoint"]["stream_token_ttl_seconds"] = 1
     tok = A.mint_stream_token("p", "i")
@@ -178,8 +178,8 @@ def test_stream_token_expiry():
 
 def test_mint_jwt_includes_jti_claim():
     import jwt as pyjwt
-    from bazarr.compat import auth
-    from bazarr.app.config import settings
+    from compat import auth
+    from app.config import settings
     settings["compat_endpoint"]["jwt_secret"] = "j" * 32
     tok = auth.mint_jwt()
     claims = pyjwt.decode(tok, "j" * 32, algorithms=["HS256"])
@@ -187,8 +187,8 @@ def test_mint_jwt_includes_jti_claim():
 
 
 def test_validate_jwt_rejects_revoked_jti():
-    from bazarr.compat import auth, jwt_denylist
-    from bazarr.app.config import settings
+    from compat import auth, jwt_denylist
+    from app.config import settings
     settings["compat_endpoint"]["jwt_secret"] = "j" * 32
     jwt_denylist.reset()
     tok = auth.mint_jwt()
@@ -203,5 +203,5 @@ def test_validate_jwt_rejects_revoked_jti():
 
 
 def test_revoke_jwt_is_noop_for_empty_jti():
-    from bazarr.compat import auth
+    from compat import auth
     auth.revoke_jwt("", 9999999999)  # must not raise

--- a/tests/compat/unit/test_auth_decorator.py
+++ b/tests/compat/unit/test_auth_decorator.py
@@ -1,11 +1,11 @@
 import pytest
 from flask import Flask
-from bazarr.compat.auth import compat_auth, compat_error
+from compat.auth import compat_auth, compat_error
 
 
 @pytest.fixture
 def app(monkeypatch):
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.token", "a" * 32)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.token", "a" * 32)
     app = Flask(__name__)
 
     @app.route("/protected")
@@ -34,10 +34,10 @@ def test_jwt_failures_still_use_401(monkeypatch):
     """401 is reserved for JWT-specific failures so the plugin can
     retry with a fresh login."""
     from flask import Flask
-    from bazarr.compat.auth import compat_auth
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.token",
+    from compat.auth import compat_auth
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.token",
                         "a" * 32)
-    monkeypatch.setattr("bazarr.compat.auth.settings.compat_endpoint.jwt_secret",
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.jwt_secret",
                         "b" * 32)
     app = Flask(__name__)
 

--- a/tests/compat/unit/test_build_video.py
+++ b/tests/compat/unit/test_build_video.py
@@ -13,13 +13,13 @@ import pytest
 def _no_library(monkeypatch):
     """Force the library metadata lookup to return empty by default; tests
     that care about it patch the function explicitly."""
-    from bazarr.compat import service
+    from compat import service
     monkeypatch.setattr(service, "_lookup_library_metadata",
                         lambda imdb_id, media_type, season=None, episode=None: {})
 
 
 def test_movie_without_query_is_bare_but_has_imdb_id():
-    from bazarr.compat.service import _build_video
+    from compat.service import _build_video
     from subliminal.video import Movie
     v = _build_video("tt0111161", None, None, "movie")
     assert isinstance(v, Movie)
@@ -30,7 +30,7 @@ def test_movie_without_query_is_bare_but_has_imdb_id():
 
 def test_movie_with_filename_extracts_release_metadata():
     """guessit should populate source/release_group/resolution/codec."""
-    from bazarr.compat.service import _build_video
+    from compat.service import _build_video
     v = _build_video(
         "tt0111161", None, None, "movie",
         query="The.Shawshank.Redemption.1994.1080p.BluRay.x264-RARBG.mkv",
@@ -44,8 +44,8 @@ def test_movie_with_filename_extracts_release_metadata():
 
 
 def test_movie_uses_library_title_when_available():
-    from bazarr.compat import service
-    from bazarr.compat.service import _build_video
+    from compat import service
+    from compat.service import _build_video
     with patch.object(service, "_lookup_library_metadata",
                        return_value={"title": "The Shawshank Redemption", "year": "1994"}):
         v = _build_video("tt0111161", None, None, "movie")
@@ -54,7 +54,7 @@ def test_movie_uses_library_title_when_available():
 
 
 def test_episode_sets_series_imdb_and_season_episode():
-    from bazarr.compat.service import _build_video
+    from compat.service import _build_video
     from subliminal.video import Episode
     v = _build_video("tt0903747", 1, 2, "episode",
                      query="Breaking.Bad.S01E02.720p.HDTV.x264-GROUP.mkv")
@@ -67,7 +67,7 @@ def test_episode_sets_series_imdb_and_season_episode():
 
 def test_moviehash_is_wired_for_opensubtitles_providers():
     """OS-style moviehash enables exact-hash matching on the OS providers."""
-    from bazarr.compat.service import _build_video
+    from compat.service import _build_video
     v = _build_video("tt0111161", None, None, "movie",
                      moviehash="8e245d9679d31e12")
     assert v.hashes.get("opensubtitles") == "8e245d9679d31e12"
@@ -78,7 +78,7 @@ def test_imdb_id_normalized_to_tt_prefix():
     """OS-compat clients (Jellyfin plugin) strip 'tt' before sending.
     OMDB / TVDB v1 / v4 all reject the bare numeric form, so we normalize
     at Video construction and carry the tt-prefixed value downstream."""
-    from bazarr.compat.service import _tt, _build_video
+    from compat.service import _tt, _build_video
     assert _tt("9198004") == "tt9198004"
     assert _tt("tt9198004") == "tt9198004"
     assert _tt("TT9198004") == "tt9198004"
@@ -95,8 +95,8 @@ def test_imdb_id_normalized_to_tt_prefix():
 def test_library_title_wins_over_guessit_title_but_guessit_fills_gaps():
     """When both sources have info, library title wins (curated); guessit
     provides the release-quality fields library lookup can't supply."""
-    from bazarr.compat import service
-    from bazarr.compat.service import _build_video
+    from compat import service
+    from compat.service import _build_video
     with patch.object(service, "_lookup_library_metadata",
                        return_value={"title": "The Shawshank Redemption", "year": "1994"}):
         v = _build_video(
@@ -114,8 +114,8 @@ def test_library_path_delegates_to_parse_video():
     native manual search). Falls back to virtual Video when the file is
     missing or parse_video fails."""
     from unittest.mock import MagicMock
-    from bazarr.compat import service
-    from bazarr.compat.service import _build_video
+    from compat import service
+    from compat.service import _build_video
     from subliminal.video import Movie
 
     fake_video = Movie(name="Shawshank.2160p.BluRay.mkv",
@@ -131,7 +131,7 @@ def test_library_path_delegates_to_parse_video():
                                      "path": "/storage/shawshank.mkv",
                                      "sceneName": "shawshank.2160p.bluray"}), \
          patch("os.path.exists", return_value=True), \
-         patch("bazarr.subtitles.utils.get_video",
+         patch("subtitles.utils.get_video",
                 return_value=fake_video) as gv:
         v = _build_video("tt0111161", None, None, "movie")
 
@@ -144,8 +144,8 @@ def test_library_path_delegates_to_parse_video():
 def test_library_path_missing_file_falls_back_to_virtual():
     """If the library has a path but the file isn't accessible, build the
     virtual Video rather than erroring."""
-    from bazarr.compat import service
-    from bazarr.compat.service import _build_video
+    from compat import service
+    from compat.service import _build_video
     with patch.object(service, "_lookup_library_metadata",
                        return_value={"title": "Shawshank", "year": "1994",
                                      "path": "/nonexistent/file.mkv"}), \

--- a/tests/compat/unit/test_cache.py
+++ b/tests/compat/unit/test_cache.py
@@ -1,4 +1,4 @@
-from bazarr.compat import cache as C
+from compat import cache as C
 from subzero.language import Language
 
 

--- a/tests/compat/unit/test_config_validators.py
+++ b/tests/compat/unit/test_config_validators.py
@@ -9,7 +9,7 @@ from dynaconf.validator import ValidationError
 # Pull the real validators list from the application config module.
 # This is the source of truth: the same Validator objects registered
 # into the production `settings` singleton at startup.
-from bazarr.app.config import validators as app_validators
+from app.config import validators as app_validators
 
 
 def _compat_validators():

--- a/tests/compat/unit/test_fanout_bounded.py
+++ b/tests/compat/unit/test_fanout_bounded.py
@@ -132,7 +132,7 @@ def test_concurrent_fanout_cap_blocks_extra_callers():
     from subliminal_patch.core_persistent import (
         list_all_subtitles_parallel,
     )
-    from bazarr.app.config import settings
+    from app.config import settings
 
     cap = int(settings.compat_endpoint.max_concurrent_fanouts)
 
@@ -198,7 +198,7 @@ def test_queued_futures_cancelled_after_wall_timeout(monkeypatch):
     picked up by a worker must be cancelled, not left to run after the
     caller returned. This guards against unbounded queue growth under
     repeated timed-out searches when provider count exceeds workers."""
-    from bazarr.app.config import settings
+    from app.config import settings
     from subliminal_patch.core_persistent import (
         list_all_subtitles_parallel, reset_pool,
     )
@@ -259,7 +259,7 @@ def test_wall_timeout_includes_semaphore_wait(monkeypatch):
     """The wall timeout is a hard total budget. Time spent waiting for
     the concurrency semaphore must count toward it, so a saturated cap
     cannot cause the request to spend nearly 2 * wall_timeout."""
-    from bazarr.app.config import settings
+    from app.config import settings
     from subliminal_patch.core_persistent import (
         list_all_subtitles_parallel, reset_pool,
     )

--- a/tests/compat/unit/test_file_id_store.py
+++ b/tests/compat/unit/test_file_id_store.py
@@ -1,5 +1,5 @@
 import time
-from bazarr.compat.file_id_store import FileIdStore, get_store, reset_store
+from compat.file_id_store import FileIdStore, get_store, reset_store
 
 
 def test_put_returns_monotonic_int():

--- a/tests/compat/unit/test_jwt_denylist.py
+++ b/tests/compat/unit/test_jwt_denylist.py
@@ -1,5 +1,5 @@
 import time
-from bazarr.compat import jwt_denylist as D
+from compat import jwt_denylist as D
 
 
 def test_fresh_jti_is_not_revoked():

--- a/tests/compat/unit/test_omdb_apikey.py
+++ b/tests/compat/unit/test_omdb_apikey.py
@@ -21,14 +21,14 @@ def _isolate_env(monkeypatch):
     monkeypatch.delenv("U1pfT01EQl9LRVk", raising=False)
     # Clear Dynaconf setting so env-var tests aren't masked by a live config.
     try:
-        from bazarr.app.config import settings
+        from app.config import settings
         monkeypatch.setattr(settings.omdb, "apikey", "")
     except Exception:
         pass
 
 
 def test_settings_apikey_wins_over_env(monkeypatch):
-    from bazarr.app.config import settings
+    from app.config import settings
     settings.omdb.apikey = "fromSettings"
     monkeypatch.setenv("OMDB_API_KEY", "fromEnv")
     assert _resolve_omdb_apikey() == "fromSettings"

--- a/tests/compat/unit/test_rate_limiter.py
+++ b/tests/compat/unit/test_rate_limiter.py
@@ -1,5 +1,5 @@
 import time
-from bazarr.compat import rate_limiter as R
+from compat import rate_limiter as R
 
 
 def test_first_consume_returns_allowed():

--- a/tests/compat/unit/test_release_normalization.py
+++ b/tests/compat/unit/test_release_normalization.py
@@ -4,7 +4,7 @@ Providers pack multiple releases into one field with inconsistent separators.
 These tests pin the picking rule: prefer the part with the most release-
 quality markers (resolution/source/codec), tiebreak on length.
 """
-from bazarr.compat.response_mapper import _normalize_release
+from compat.response_mapper import _normalize_release
 
 
 def test_empty_returns_empty():
@@ -96,7 +96,7 @@ def test_comma_is_NOT_a_separator():
 def test_response_mapper_applies_normalization():
     """End-to-end: subtitle_to_os_entry uses the normalizer."""
     from unittest.mock import MagicMock
-    from bazarr.compat.response_mapper import subtitle_to_os_entry
+    from compat.response_mapper import subtitle_to_os_entry
     sub = MagicMock(
         language=MagicMock(alpha2="hu"),
         release_info="WEB-DL\nx264",

--- a/tests/compat/unit/test_response_mapper.py
+++ b/tests/compat/unit/test_response_mapper.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 from babelfish import Language
-from bazarr.compat import response_mapper as M
+from compat import response_mapper as M
 
 
 def make_sub():
@@ -58,7 +58,7 @@ def test_search_envelope_paginates_total_pages():
 
 
 def test_download_response_emits_remaining_and_reset():
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     r = M.download_response("https://example/link",
                              remaining=42,
                              reset_iso="2099-01-01T00:00:00Z")
@@ -72,7 +72,7 @@ def test_download_response_emits_remaining_and_reset():
 
 
 def test_user_info_response_takes_real_counters():
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     r = M.user_info_response(remaining=17, allowed=1000,
                               reset_iso="2099-01-01T00:00:00Z")
     d = r["data"]
@@ -133,7 +133,7 @@ def test_upload_date_tz_aware_does_not_double_suffix():
     """Regression: tz-aware isoformat() + 'Z' produced '+00:00Z'."""
     from datetime import datetime, timezone
     from unittest.mock import MagicMock
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     aware = datetime(2023, 1, 15, 12, 34, 56, tzinfo=timezone.utc)
     sub = MagicMock(upload_date=aware, id="1",
                     language=MagicMock(alpha2="en"),
@@ -148,7 +148,7 @@ def test_upload_date_tz_aware_does_not_double_suffix():
 def test_upload_date_naive_gets_z_suffix():
     from datetime import datetime
     from unittest.mock import MagicMock
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     naive = datetime(2023, 1, 15, 12, 34, 56)
     sub = MagicMock(upload_date=naive, id="1",
                     language=MagicMock(alpha2="en"),
@@ -163,7 +163,7 @@ def test_provider_attributes_pass_through():
     """ai_translated, machine_translated, foreign_parts_only, fps are no
     longer hardcoded."""
     from unittest.mock import MagicMock
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(
         upload_date=None, id="1", language=MagicMock(alpha2="en"),
         download_count=0, ratings=0.0, release_info="Movie.2020.1080p.WEB-DL",
@@ -180,7 +180,7 @@ def test_provider_attributes_pass_through():
 
 def test_hd_derived_from_release_info():
     from unittest.mock import MagicMock
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
 
     def mk(release):
         return MagicMock(
@@ -197,7 +197,7 @@ def test_hd_derived_from_release_info():
 def test_comments_field_populated_from_release_info():
     """Plugin reads attributes.comments; used to be dropped."""
     from unittest.mock import MagicMock
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(
         upload_date=None, id="1", language=MagicMock(alpha2="en"),
         download_count=0, ratings=0.0,
@@ -210,7 +210,7 @@ def test_comments_field_populated_from_release_info():
 
 def test_moviehash_match_reflects_hash_in_matches():
     from unittest.mock import MagicMock
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(
         upload_date=None, id="1", language=MagicMock(alpha2="en"),
         download_count=0, ratings=0.0, release_info="",
@@ -223,7 +223,7 @@ def test_moviehash_match_reflects_hash_in_matches():
 
 def test_moviehash_match_false_when_hash_missing():
     from unittest.mock import MagicMock
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(
         upload_date=None, id="1", language=MagicMock(alpha2="en"),
         download_count=0, ratings=0.0, release_info="",
@@ -236,7 +236,7 @@ def test_moviehash_match_false_when_hash_missing():
 
 def test_file_name_uses_provider_filename_when_available():
     from unittest.mock import MagicMock
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(
         upload_date=None, id="1", language=MagicMock(alpha2="en"),
         download_count=0, ratings=0.0, release_info="",
@@ -249,7 +249,7 @@ def test_file_name_uses_provider_filename_when_available():
 
 def test_file_name_never_starts_with_dot_when_imdb_empty():
     from unittest.mock import MagicMock
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(
         upload_date=None, id="1", language=MagicMock(alpha2="en"),
         download_count=0, ratings=0.0, release_info="",
@@ -265,7 +265,7 @@ def test_file_name_never_starts_with_dot_when_imdb_empty():
 def test_ratings_derived_from_score_tuple():
     """When caller threads (score, max_score), ratings is 0.0-10.0."""
     from unittest.mock import MagicMock
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(
         upload_date=None, id="1", language=MagicMock(alpha2="en"),
         download_count=0, ratings=0.0, release_info="",
@@ -278,7 +278,7 @@ def test_ratings_derived_from_score_tuple():
 
 def test_requested_language_is_preserved_for_region_subtag():
     from unittest.mock import MagicMock
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(
         upload_date=None, id="1",
         language=MagicMock(alpha2="zh"),
@@ -296,7 +296,7 @@ def test_provider_rating_wins_over_score_derived():
     used. Score-derived is only the fallback for providers without a
     native rating."""
     from unittest.mock import MagicMock
-    from bazarr.compat import response_mapper as M
+    from compat import response_mapper as M
     sub = MagicMock(
         upload_date=None, id="1", language=MagicMock(alpha2="en"),
         download_count=1000, ratings=8.5, release_info="",

--- a/tests/compat/unit/test_service.py
+++ b/tests/compat/unit/test_service.py
@@ -1,5 +1,5 @@
 import pytest
-from bazarr.compat import service
+from compat import service
 
 
 def test_guessit_returns_native_dict():

--- a/tests/compat/unit/test_tvdb_v4.py
+++ b/tests/compat/unit/test_tvdb_v4.py
@@ -66,7 +66,7 @@ def test_client_survives_login_failure():
 def test_v4_episode_lookup_populates_series_and_episode_fields():
     """Given a v4 match with episode+seriesId, populate tvdb_id, series name,
     year, and fall through to subliminal v1 get_series for anything missing."""
-    from bazarr.compat.service import _tvdb_v4_episode_lookup
+    from compat.service import _tvdb_v4_episode_lookup
     video = MagicMock(spec=["series_imdb_id", "tvdb_id", "title",
                             "series", "year", "series_tvdb_id"])
     video.series_imdb_id = "tt1480055"
@@ -92,7 +92,7 @@ def test_v4_episode_lookup_populates_series_and_episode_fields():
 
 
 def test_v4_episode_lookup_returns_false_on_miss():
-    from bazarr.compat.service import _tvdb_v4_episode_lookup
+    from compat.service import _tvdb_v4_episode_lookup
     video = MagicMock(spec=["series_imdb_id"])
     video.series_imdb_id = "tt0000000"
     with patch("subliminal_patch.refiners.tvdb_v4.get_client") as gc:

--- a/tests/compat/unit/test_url_guard.py
+++ b/tests/compat/unit/test_url_guard.py
@@ -1,5 +1,5 @@
 import pytest
-from bazarr.utilities.url_guard import assert_safe_outbound, UnsafeURLError
+from utilities.url_guard import assert_safe_outbound, UnsafeURLError
 
 @pytest.mark.parametrize("url", [
     "https://api.opensubtitles.com/api/v1/subtitles",


### PR DESCRIPTION
## Summary

Hardens every credential in `config.yaml` with authenticated encryption at rest, transparent auto-migration on first boot, and a registry-driven boundary between user-visible secrets (decrypted before the API serializer returns them) and system secrets (masked as `***`). Closes the request to "harden every api key storage method (with auto-migration)" plus follow-ups around UI hide-by-default and force-migration coverage.

### What encryption protects

- **Threat model**: passive disclosure of `config.yaml` (logs, screenshots, support bundles, backup tarballs uploaded to bug reports). Not a defence against an attacker who already has write access to the host.
- **Primitive**: `cryptography.fernet.Fernet` (AES-128-CBC + HMAC-SHA256, authenticated encryption). The first revision used `URLSafeSerializer.dumps` which only signs the payload, so the first Codex review correctly flagged it as encoding-not-encryption. Round 2 swapped to Fernet with a legacy URLSafeSerializer reader for the migration window.
- **Master key**: `general.secrets_encryption_key` lives next to `flask_secret_key`. Auto-generated on first read via `secrets.token_urlsafe(32)`. SHA-256 + base64 derives the 32-byte Fernet key.
- **Marker prefix**: `enc:v1:` lets the read path distinguish ciphertext from plaintext without a per-field boolean flag (the legacy `plex.apikey_encrypted` pattern). `is_encrypted(value)` checks the prefix; non-marker values pass through unchanged so freshly upgraded installs work transparently.

### Coverage

User-visible (encrypted at rest, decrypted in API responses, hidden by default in the UI with reveal toggle):

- `auth.apikey`, `auth.username`, `auth.password`
- `compat_endpoint.token`
- `general.external_webhook_password`
- `sonarr.apikey`, `radarr.apikey`, `jellyfin.apikey`
- `plex.apikey`, `plex.token`, `plex.username`, `plex.email`
- `proxy.username` + `proxy.password`, `postgresql.username` + `postgresql.password`
- `translator.openrouter_api_key`, `translator.openrouter_encryption_key`, `translator.lingarr_token`
- Every provider login pair: opensubtitles, opensubtitlescom, addic7ed, legendasdivx, legendasnet, xsubs, deathbycaptcha, napisy24, titlovi, titulky, karagarga (incl. `f_password`), ktuvit (`email` + `hashed_password`), hdbits (`username` + `passkey`)
- Session cookies: addic7ed, avistaz, cinemaz, turkcealtyaziorg
- Provider tokens: assrt, betaseries, jimaku, subdl, subsource, subx, subsro, omdb
- Translator gemini key list (per-element)

System-only (masked as `***` in the API response, never round-trips through the UI):

- `general.flask_secret_key`, `general.secrets_encryption_key`
- `compat_endpoint.jwt_secret`, `compat_endpoint.file_id_secret`
- `plex.encryption_key` (legacy, kept for downgrade safety)

### Auto-migration

- **Bootstrap read**: `migrate_legacy_plex_encryption(settings)` runs first; detection is value-shaped (try `TokenManager.decrypt` when `plex.encryption_key` exists, succeed → use plaintext). Covers BOTH the legacy apikey-with-flag case AND the OAuth-no-flag case the second-round Codex review flagged.
- `decrypt_settings_in_place(settings)` walks every USER_VISIBLE path, decrypts marker-prefixed values, leaves plaintext alone.
- **Force-migrate trigger**: `has_plaintext_secrets_on_disk(settings)` runs BEFORE the decrypter (which is a passthrough on plaintext, so afterwards in-memory and on-disk match for plaintext fields and `write_config()`'s comparison would skip the rewrite). When True, write_config bypasses the no-change short-circuit exactly once.
- **Bootstrap write**: `encrypt_settings_dict(snapshot)` produces the on-disk form. Resolves the master key once up front and writes it into the snapshot's `general.secrets_encryption_key` when missing - prevents the first-save race the first-round Codex review flagged where ciphertext could land on disk paired with an empty master key.
- **Post-migration**: any clear-text credential the operator drops into `config.yaml` (manual edit, fresh upgrade, registry expansion) is auto-encrypted on the next boot. Verified end-to-end on the test instance with both `auth.password = e10adc...` (md5 plaintext) and `opensubtitles.username = testuser` - both came back as `enc:v1:gAAAAA...` after restart, with login still working.

### Codex review feedback addressed

Two rounds of findings, all fixed:

**Round 1**

- P1: replace URLSafeSerializer (signature-only) with Fernet AEAD; legacy reader kept for migration window
- P1: persist freshly-generated master key into snapshot before encrypting fields
- P2: rewire `bazarr.compat` and related imports to canonical `app.config` / `compat` / `utilities` namespace so `/api/system/settings` writes and runtime reads share one settings instance
- P2: restore Plex OAuth state-token helper (PlexPin/PlexPinCheck NameError after the previous get_token_manager removal)

**Round 2**

- P1: migrate Plex OAuth token regardless of `apikey_encrypted` flag (OAuth never set it; gating on the flag broke OAuth login on upgrade)
- P1: case-insensitive scheme check in compat SSRF guard (`HTTP://169.254.169.254/...` slipped past `startswith(("http://", "https://"))`)
- P2: snapshot original `auth.password` hash on first render so clear-after-type restores the ORIGINAL instead of the staged value

### UI

Mantine's `PasswordInput` already has a built-in eye-icon reveal toggle. Switched all credential-shaped `<Text>` inputs to `<Password>` (Sonarr API Key, Radarr API Key, Settings/Providers/list.ts entries for cookies / tokens / api_keys / hashed_password). Username fields stay as `<Text>` since they're identifiers, not secrets - encryption-at-rest covers them on disk regardless.

The `auth.password` field gets a custom `AuthPasswordInput`: never displays the stored hash (revealing it would be useless to the user and harmful in screen-shares), placeholder reads "Leave empty to keep current password", and the form stays clean unless the user actually types a new password.

The `docker/supervisor.py` static SPA renderer also reads `config.yaml` directly to inject `window.Bazarr.apiKey`. Mirrored the Fernet+legacy decrypt logic inline so the SPA receives plaintext apikey for `X-API-KEY` instead of ciphertext (would have 401'd every API call after first boot post-deploy).

## Test plan

- [x] 47 secret_store tests cover crypto roundtrip, registry classification, migration helpers, force-migrate detection, e2e plaintext→ciphertext→plaintext roundtrip, key-rotation failure, partial corruption isolation, legacy Plex migration (apikey + OAuth + missing-key + already-unified)
- [x] 223 compat tests pass; 430 frontend tests pass
- [x] On-disk verification: every USER_VISIBLE field shows `enc:v1:gAAAAA...` after first boot
- [x] Restart cycle: ciphertext on disk → plaintext in memory → plaintext in API response → plaintext apiKey in injected SPA HTML
- [x] Force-migrate: plaintext `auth.password = <md5>` and `opensubtitles.username = testuser` confirmed both became `enc:v1:...` on next boot, login (LavX / 123456) still 204
- [x] Plex OAuth path: regression test for legacy URLSafe-encrypted token without `apikey_encrypted` flag
- [x] SSRF guard: `HTTP://...` (uppercase) now reaches `assert_safe_outbound`
- [x] Settings UI: `auth.password` field renders empty with placeholder, login still works