### PR TITLE
fix(notifier): skip full-row fetch + variable expansion when no custom notifier

### DIFF
--- a/bazarr/app/notifier.py
+++ b/bazarr/app/notifier.py
@@ -8,6 +8,30 @@ from urllib.parse import quote
 from .database import TableSettingsNotifier, TableEpisodes, TableShows, TableMovies, database, insert, delete, select
 
 
+# Notifier providers that accept `{bazarr_*}` placeholders in the URL and
+# need the full media record's columns to expand them. Any other provider
+# uses the URL verbatim, so the variable expansion + full-row fetch is
+# pure overhead - notably TableEpisodes carries a large ffprobe_cache
+# blob that we should not pull on every sub download for non-custom
+# notifier deployments.
+_CUSTOM_NOTIFIER_NAMES = frozenset({"Form", "XML", "JSON"})
+
+
+def _has_custom_notifier(providers):
+    """True iff any enabled provider is one of Form / XML / JSON, the
+    only notifiers whose URL accepts `{bazarr_*}` placeholders."""
+    return any(p.name in _CUSTOM_NOTIFIER_NAMES for p in providers)
+
+
+def _format_year_suffix(year):
+    """Render a `(year)` suffix only when the year is actually populated.
+    Tracks the existing notification body shape so behaviour stays
+    identical to the pre-refactor code."""
+    if year in (None, '', '0'):
+        return ''
+    return f' ({year})'
+
+
 def update_notifier():
     # define apprise object
     a = Apprise()
@@ -57,44 +81,69 @@ def send_notifications(sonarr_series_id, sonarr_episode_id, message):
     providers = get_notifier_providers()
     if not len(providers):
         return
-    series = database.execute(
-        select(TableShows)
-        .where(TableShows.sonarrSeriesId == sonarr_series_id))\
-        .scalars()\
-        .first()
-    if not series:
-        return
-    series_title = series.title
-    series_year = series.year
-    if series_year not in [None, '', '0']:
-        series_year = f' ({series_year})'
-    else:
-        series_year = ''
-    episode = database.execute(
-        select(TableEpisodes)
-        .where(TableEpisodes.sonarrEpisodeId == sonarr_episode_id))\
-        .scalars()\
-        .first()
-    if not episode:
-        return
 
-    media_variables = {}
-    media_variables.update(_build_media_variables(series, 'series'))
-    media_variables.update(_build_media_variables(episode, 'episode'))
+    # When no custom notifier is enabled, only the title/year/season/
+    # episode/title fields land in the notification body - we MUST NOT
+    # SELECT * on TableEpisodes (which includes the heavy ffprobe_cache
+    # blob) just to throw the rest away. Codex flagged this as a
+    # noticeable cost on bulk subtitle ops.
+    custom_notifier_used = _has_custom_notifier(providers)
+
+    if custom_notifier_used:
+        series = database.execute(
+            select(TableShows)
+            .where(TableShows.sonarrSeriesId == sonarr_series_id))\
+            .scalars()\
+            .first()
+        if not series:
+            return
+        series_title = series.title
+        series_year = series.year
+        episode = database.execute(
+            select(TableEpisodes)
+            .where(TableEpisodes.sonarrEpisodeId == sonarr_episode_id))\
+            .scalars()\
+            .first()
+        if not episode:
+            return
+        episode_season = episode.season
+        episode_number = episode.episode
+        episode_title = episode.title
+        media_variables = {}
+        media_variables.update(_build_media_variables(series, 'series'))
+        media_variables.update(_build_media_variables(episode, 'episode'))
+    else:
+        series_row = database.execute(
+            select(TableShows.title, TableShows.year)
+            .where(TableShows.sonarrSeriesId == sonarr_series_id))\
+            .first()
+        if not series_row:
+            return
+        series_title, series_year = series_row
+        episode_row = database.execute(
+            select(TableEpisodes.season, TableEpisodes.episode, TableEpisodes.title)
+            .where(TableEpisodes.sonarrEpisodeId == sonarr_episode_id))\
+            .first()
+        if not episode_row:
+            return
+        episode_season, episode_number, episode_title = episode_row
+        media_variables = None  # not consulted on this path
+
+    series_year_suffix = _format_year_suffix(series_year)
 
     asset = AppriseAsset(async_mode=False)
 
     apobj = Apprise(asset=asset)
 
     for provider in providers:
-        if provider.name in {"Form", "XML", "JSON"}:
+        if provider.name in _CUSTOM_NOTIFIER_NAMES:
             apobj.add(_expand_notifier_url(provider.url, media_variables))
         else:
             apobj.add(provider.url)
 
     apobj.notify(
         title='Bazarr notification',
-        body=f"{series_title}{series_year} - S{episode.season:02d}E{episode.episode:02d} - {episode.title} : {message}",
+        body=f"{series_title}{series_year_suffix} - S{episode_season:02d}E{episode_number:02d} - {episode_title} : {message}",
     )
 
 
@@ -102,35 +151,45 @@ def send_notifications_movie(radarr_id, message):
     providers = get_notifier_providers()
     if not len(providers):
         return
-    movie = database.execute(
-        select(TableMovies)
-        .where(TableMovies.radarrId == radarr_id))\
-        .scalars()\
-        .first()
-    if not movie:
-        return
-    movie_title = movie.title
-    movie_year = movie.year
-    if movie_year not in [None, '', '0']:
-        movie_year = f' ({movie_year})'
-    else:
-        movie_year = ''
 
-    media_variables = _build_media_variables(movie, 'movie')
+    custom_notifier_used = _has_custom_notifier(providers)
+
+    if custom_notifier_used:
+        movie = database.execute(
+            select(TableMovies)
+            .where(TableMovies.radarrId == radarr_id))\
+            .scalars()\
+            .first()
+        if not movie:
+            return
+        movie_title = movie.title
+        movie_year = movie.year
+        media_variables = _build_media_variables(movie, 'movie')
+    else:
+        movie_row = database.execute(
+            select(TableMovies.title, TableMovies.year)
+            .where(TableMovies.radarrId == radarr_id))\
+            .first()
+        if not movie_row:
+            return
+        movie_title, movie_year = movie_row
+        media_variables = None  # not consulted on this path
+
+    movie_year_suffix = _format_year_suffix(movie_year)
 
     asset = AppriseAsset(async_mode=False)
 
     apobj = Apprise(asset=asset)
 
     for provider in providers:
-        if provider.name in {"Form", "XML", "JSON"}:
+        if provider.name in _CUSTOM_NOTIFIER_NAMES:
             apobj.add(_expand_notifier_url(provider.url, media_variables))
         else:
             apobj.add(provider.url)
 
     apobj.notify(
         title='Bazarr notification',
-        body=f"{movie_title}{movie_year} : {message}",
+        body=f"{movie_title}{movie_year_suffix} : {message}",
     )
 
 

--- a/tests/bazarr/test_app_notifier.py
+++ b/tests/bazarr/test_app_notifier.py
@@ -75,3 +75,51 @@ def test_expand_notifier_url_concatenation_blanks_missing_bazarr_key():
 
     assert 'path=%2Fmedia%2FMovies%2FMy%20Movie%20%282024%29.mkv' in result
     assert '{bazarr_episode_path}' not in result
+
+
+# ---------------------------------------------------------------------------
+# _has_custom_notifier gates the expensive full-row + variable-expansion path
+# ---------------------------------------------------------------------------
+
+
+class _Provider:
+    """Tiny stand-in for the named-tuple-ish rows that
+    get_notifier_providers() returns."""
+
+    def __init__(self, name, url):
+        self.name = name
+        self.url = url
+
+
+def test_has_custom_notifier_true_for_form_xml_json():
+    for name in ("Form", "XML", "JSON"):
+        assert notifier._has_custom_notifier([_Provider(name, "x://y")]) is True
+
+
+def test_has_custom_notifier_false_for_regular_providers():
+    assert notifier._has_custom_notifier([
+        _Provider("Discord", "discord://w/t"),
+        _Provider("Telegram", "tgram://x"),
+    ]) is False
+
+
+def test_has_custom_notifier_true_when_any_one_is_custom():
+    """A single Form/XML/JSON entry alongside regular providers still
+    triggers the full-row fetch path; that's correct because the custom
+    one needs the variables."""
+    assert notifier._has_custom_notifier([
+        _Provider("Discord", "discord://w/t"),
+        _Provider("JSON", "json://example/"),
+    ]) is True
+
+
+def test_has_custom_notifier_false_on_empty_list():
+    assert notifier._has_custom_notifier([]) is False
+
+
+def test_format_year_suffix_renders_only_when_populated():
+    assert notifier._format_year_suffix(2024) == ' (2024)'
+    assert notifier._format_year_suffix("2024") == ' (2024)'
+    assert notifier._format_year_suffix(None) == ''
+    assert notifier._format_year_suffix("") == ''
+    assert notifier._format_year_suffix("0") == ''


### PR DESCRIPTION
## Summary

Codex flagged that `send_notifications()` and `send_notifications_movie()` always fetch the full `TableShows` / `TableEpisodes` / `TableMovies` record and build the `{bazarr_*}` variable map, even when every enabled notifier is a regular Apprise provider that uses the URL verbatim. `TableEpisodes` carries a heavy `ffprobe_cache` blob, so this is pure overhead on bulk subtitle ops in deployments with only Discord / Telegram / etc. notifiers.

- New `_has_custom_notifier(providers)` returns true iff any enabled provider is one of `Form` / `XML` / `JSON` (the notifiers that accept `{bazarr_*}` placeholders).
- When false: narrow column-list `SELECT` (only `title` / `year` + `season` / `episode` / `title` for series; `title` / `year` for movies) and `_build_media_variables` skipped entirely.
- When true: full-row path runs as before so URL expansion has the columns it needs.

Custom-notifier behaviour is byte-identical to before. Regular-notifier hot path got cheaper.

## Test plan

- [x] 11 unit tests pass (5 existing + 6 new covering the gate function and the year-suffix helper)
- [x] Custom-notifier path still exercises the full-row + `_expand_notifier_url` flow
- [x] Year suffix helper collapses the duplicated `"(year) when truthy"` logic