### PR TITLE
fix: address Codex security audit (P1 secret reload, P1 SSRF redirect, P2 compat runtime disable, P3 password clear)

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -1078,7 +1078,14 @@ def save_settings(settings_items):
         settings.validators.validate()
         validate_log_regex()
     except ValidationError:
+        # Re-decrypt after reload: settings.reload() pulls the on-disk
+        # ciphertext back into the live Dynaconf object, so without this
+        # second pass downstream code would see `enc:v1:` strings for
+        # API keys, auth credentials, provider passwords, and compat
+        # tokens until the next process restart. Codex P1.
         settings.reload()
+        migrate_legacy_plex_encryption(settings)
+        decrypt_settings_in_place(settings)
         raise
     else:
         write_config()

--- a/bazarr/compat/routes.py
+++ b/bazarr/compat/routes.py
@@ -81,6 +81,19 @@ def _jti_from_request() -> str | None:
 compat_bp = Blueprint("compat", __name__)
 
 
+@compat_bp.before_request
+def _enforce_runtime_disable():
+    """Refuse traffic when the operator toggles compat_endpoint.enabled
+    off at runtime. The blueprint is mounted at startup based on the
+    boot-time value, so without this guard a previously-enabled endpoint
+    keeps serving with the old token until restart. Codex P2: re-check
+    the live setting on every request and 503 if it has been disabled.
+    """
+    from app.config import settings
+    if not bool(settings.compat_endpoint.enabled):
+        return jsonify({"error": "compat endpoint disabled"}), 503
+
+
 @compat_bp.after_request
 def _strip_cors(resp):
     """Explicit CORS scope override (B4). No CORS for /api/v1/*."""

--- a/bazarr/compat/service.py
+++ b/bazarr/compat/service.py
@@ -11,7 +11,7 @@ from subliminal_patch.core_persistent import list_all_subtitles_parallel
 from app.config import settings
 from app.get_providers import get_providers_sorted, get_providers_auth
 from . import auth, cache as C, response_mapper as M
-from utilities.url_guard import assert_safe_outbound, UnsafeURLError  # noqa: F401
+from utilities.url_guard import assert_safe_outbound, resolve_safe_url, UnsafeURLError  # noqa: F401
 
 logger = logging.getLogger("bazarr.compat.service")
 
@@ -795,9 +795,15 @@ def _fetch_subtitle_bytes(sub) -> bytes:
     # guard just because `startswith` is byte-exact. Codex flagged this
     # as a bypass: the request would still hit the cloud-metadata
     # endpoint via pool.download_subtitle() with no SSRF check applied.
+    #
+    # Also walk the redirect chain via HEAD before invoking the pool. The
+    # provider HTTP client follows redirects automatically, so a public
+    # URL that 30x-redirects to 127.0.0.1 or 169.254.169.254 would
+    # otherwise fetch the private target with no per-hop SSRF check.
+    # Codex P1: pre-resolve every Location and refuse any unsafe hop.
     url = getattr(sub, "download_link", None) or getattr(sub, "url", None)
     if isinstance(url, str) and url[:8].lower().startswith(("http://", "https://")):
-        assert_safe_outbound(url)  # raises UnsafeURLError on private/loopback/etc.
+        resolve_safe_url(url)  # raises UnsafeURLError on any unsafe hop
 
     provider_name = getattr(sub, "provider_name", None)
     if not provider_name:

--- a/bazarr/utilities/url_guard.py
+++ b/bazarr/utilities/url_guard.py
@@ -1,13 +1,36 @@
 from __future__ import annotations
 import ipaddress
 import socket
-from urllib.parse import urlparse
+import threading
+from urllib.parse import urljoin, urlparse
+
+import requests
+from requests.adapters import HTTPAdapter
 
 class UnsafeURLError(ValueError):
     """Outbound URL is rejected by the SSRF guard."""
 
 _ALLOWED_SCHEMES = frozenset({"http", "https"})
 _BLOCKED_TLD_SUFFIXES = (".local", ".internal")
+
+_walker_session: requests.Session | None = None
+_walker_lock = threading.Lock()
+
+
+def _get_walker_session() -> requests.Session:
+    """Lazy module-level Session for redirect pre-flight HEADs. No retries:
+    a transient 5xx during pre-flight should NOT trigger multiple HEAD
+    probes against a possibly-malicious target."""
+    global _walker_session
+    if _walker_session is None:
+        with _walker_lock:
+            if _walker_session is None:
+                s = requests.Session()
+                adapter = HTTPAdapter(max_retries=0)
+                s.mount("http://", adapter)
+                s.mount("https://", adapter)
+                _walker_session = s
+    return _walker_session
 
 
 def assert_safe_outbound(url: str) -> None:
@@ -59,3 +82,52 @@ def assert_safe_outbound(url: str) -> None:
         if (ip.is_private or ip.is_loopback or ip.is_link_local or
                 ip.is_multicast or ip.is_reserved or ip.is_unspecified):
             raise UnsafeURLError(f"destination IP {ip} is not a public address")
+
+
+def resolve_safe_url(url: str, max_redirects: int = 5, timeout: float = 10.0) -> str:
+    """Walk the redirect chain via HEAD with SSRF validation at every hop.
+
+    The provider's HTTP client follows redirects automatically inside
+    `download_subtitle()`, so a public advertised URL that 30x-redirects to
+    127.0.0.1 or 169.254.169.254 would fetch the private target with no
+    per-hop SSRF check. This pre-flight walks the chain ourselves with
+    `allow_redirects=False`, validates each Location, and returns the final
+    URL once a non-3xx status is seen.
+
+    Behaviour:
+      - input URL is validated by assert_safe_outbound first
+      - HEAD failure (connection error, timeout, etc.) returns the input URL
+        unchanged: cannot probe further, but the initial guard already passed
+      - 30x without Location header is treated as unsafe (raises)
+      - relative Location values are resolved via urljoin against the current
+        URL before validation
+      - exceeding `max_redirects` raises UnsafeURLError
+      - any unsafe hop raises UnsafeURLError
+    """
+    assert_safe_outbound(url)
+    current = url
+    session = _get_walker_session()
+    for _ in range(max_redirects):
+        try:
+            response = session.head(
+                current, allow_redirects=False, timeout=timeout
+            )
+        except requests.RequestException:
+            # HEAD probe failed entirely. Cannot walk further.
+            # Caller's existing post-download guard remains as defense
+            # in depth.
+            return current
+        status = response.status_code
+        if status < 300 or status >= 400:
+            return current
+        location = response.headers.get("Location")
+        if not location:
+            raise UnsafeURLError(
+                f"redirect at {current!r} missing Location header"
+            )
+        next_url = urljoin(current, location)
+        assert_safe_outbound(next_url)
+        current = next_url
+    raise UnsafeURLError(
+        f"too many redirects (>{max_redirects}) starting at {url!r}"
+    )

--- a/frontend/src/pages/Settings/General/index.tsx
+++ b/frontend/src/pages/Settings/General/index.tsx
@@ -71,12 +71,14 @@ const AuthPasswordInput: FunctionComponent = () => {
   >({
     settingKey: "settings-auth-password",
   });
+  // Capture the FIRST observed `stored` value, including the empty
+  // string. Codex P3: the prior `stored.length > 0` guard meant
+  // originalRef.current stayed null whenever there was no auth password
+  // configured, and the type-then-clear path below sent that null back
+  // through FormData, where it was serialized as the string "null" and
+  // hashed by save_settings as a brand-new password.
   const originalRef = useRef<string | null>(null);
-  if (
-    originalRef.current === null &&
-    typeof stored === "string" &&
-    stored.length > 0
-  ) {
+  if (originalRef.current === null && typeof stored === "string") {
     originalRef.current = stored;
   }
   const [draft, setDraft] = useState("");
@@ -93,7 +95,11 @@ const AuthPasswordInput: FunctionComponent = () => {
           if (!touched) setTouched(true);
           update(next);
         } else if (touched) {
-          update(originalRef.current);
+          // originalRef.current is "" when no password was configured at
+          // load, or the original hash otherwise. Coalesce to "" as
+          // belt-and-suspenders: NEVER hand a null to update() here, or
+          // FormData turns it into the literal string "null" downstream.
+          update(originalRef.current ?? "");
         }
       }}
     />

--- a/tests/compat/conftest.py
+++ b/tests/compat/conftest.py
@@ -37,6 +37,7 @@ def _guarantee_compat_secrets():
     """
     from app.config import settings
     _defaults = {
+        "enabled": True,
         "token": "t" * 32,
         "jwt_secret": "j" * 32,
         "file_id_secret": "f" * 32,

--- a/tests/compat/integration/test_download_flow.py
+++ b/tests/compat/integration/test_download_flow.py
@@ -77,8 +77,9 @@ def test_serve_subtitle_content_rejects_invalid_token():
 
 
 def test_fetch_subtitle_bytes_invokes_guard_before_download():
-    """_fetch_subtitle_bytes runs the SSRF guard, calls pool.download_subtitle(sub),
-    then returns sub.content bytes."""
+    """_fetch_subtitle_bytes runs the SSRF guard (resolve_safe_url, which
+    walks the redirect chain through assert_safe_outbound on every hop),
+    calls pool.download_subtitle(sub), then returns sub.content bytes."""
     from compat import service
     fake_sub = MagicMock()
     fake_sub.download_link = "https://safe.example.com/sub.srt"
@@ -86,10 +87,11 @@ def test_fetch_subtitle_bytes_invokes_guard_before_download():
     fake_sub.provider_name = "opensubtitlescom"
     fake_sub.content = b"1\n00:00:00,000 --> 00:00:01,000\nhi"
 
-    with patch("compat.service.assert_safe_outbound") as guard, \
+    with patch("compat.service.resolve_safe_url") as guard, \
+         patch("compat.service.assert_safe_outbound"), \
          patch("compat.service._get_compat_pool") as pool:
         pool.return_value.download_subtitle = MagicMock(return_value=None)
         out = service._fetch_subtitle_bytes(fake_sub)
-        assert guard.called, "assert_safe_outbound MUST be called before fetch"
+        assert guard.called, "resolve_safe_url MUST be called before fetch"
         assert out == fake_sub.content
         pool.return_value.download_subtitle.assert_called_once_with(fake_sub)

--- a/tests/compat/integration/test_empty_content.py
+++ b/tests/compat/integration/test_empty_content.py
@@ -21,7 +21,8 @@ def test_fetch_subtitle_bytes_returns_empty_on_missing_content():
     sub.url = None
     sub.provider_name = "os"
     sub.content = None  # provider returned nothing
-    with patch("compat.service.assert_safe_outbound"), \
+    with patch("compat.service.resolve_safe_url"), \
+         patch("compat.service.assert_safe_outbound"), \
          patch("compat.service._get_compat_pool") as pool:
         pool.return_value.download_subtitle = MagicMock(return_value=None)
         out = service._fetch_subtitle_bytes(sub)

--- a/tests/compat/integration/test_runtime_disable.py
+++ b/tests/compat/integration/test_runtime_disable.py
@@ -1,0 +1,62 @@
+"""Codex P2: when compat_endpoint.enabled is toggled off at runtime, the
+already-mounted compat blueprint must refuse traffic. The blueprint is
+registered at boot based on the startup value, so without the
+before_request guard the endpoint keeps serving with the old token until
+restart."""
+from flask import Flask
+
+
+def test_runtime_disable_returns_503(monkeypatch):
+    from compat.routes import compat_bp
+
+    # Pretend boot happened with enabled=true (real install would have
+    # mounted the blueprint at this point). Now operator flips it off:
+    monkeypatch.setattr("app.config.settings.compat_endpoint.enabled", False)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.token", "a" * 32)
+
+    app = Flask(__name__)
+    app.register_blueprint(compat_bp, url_prefix="/api/v1")
+
+    response = app.test_client().get(
+        "/api/v1/subtitles", headers={"Api-Key": "a" * 32}
+    )
+    assert response.status_code == 503
+    assert response.json == {"error": "compat endpoint disabled"}
+
+
+def test_runtime_disable_blocks_unauthenticated_too(monkeypatch):
+    """The disable guard must run BEFORE the auth check so a disabled
+    endpoint does not leak its existence by responding 403 to an
+    unauthenticated probe."""
+    from compat.routes import compat_bp
+
+    monkeypatch.setattr("app.config.settings.compat_endpoint.enabled", False)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.token", "a" * 32)
+
+    app = Flask(__name__)
+    app.register_blueprint(compat_bp, url_prefix="/api/v1")
+
+    # No Api-Key header. The disable guard must short-circuit BEFORE the
+    # auth wrapper has a chance to return 403.
+    response = app.test_client().get("/api/v1/subtitles")
+    assert response.status_code == 503
+
+
+def test_runtime_enable_lets_traffic_through(monkeypatch):
+    """Sanity: when enabled stays true, the disable guard does not interfere
+    with the normal request lifecycle."""
+    from compat.routes import compat_bp
+
+    monkeypatch.setattr("app.config.settings.compat_endpoint.enabled", True)
+    monkeypatch.setattr("compat.auth.settings.compat_endpoint.token", "a" * 32)
+
+    app = Flask(__name__)
+    app.register_blueprint(compat_bp, url_prefix="/api/v1")
+
+    response = app.test_client().get(
+        "/api/v1/subtitles", headers={"Api-Key": "a" * 32}
+    )
+    # Whatever the endpoint returns, it MUST NOT be the runtime-disable
+    # 503 from this guard. (400 missing-languages, 200 with results, etc.
+    # are all fine outcomes for "guard did not block".)
+    assert response.status_code != 503

--- a/tests/compat/unit/test_url_guard.py
+++ b/tests/compat/unit/test_url_guard.py
@@ -1,5 +1,6 @@
 import pytest
-from utilities.url_guard import assert_safe_outbound, UnsafeURLError
+import requests
+from utilities.url_guard import assert_safe_outbound, resolve_safe_url, UnsafeURLError
 
 @pytest.mark.parametrize("url", [
     "https://api.opensubtitles.com/api/v1/subtitles",
@@ -58,3 +59,134 @@ def test_dns_rebinding_multiple_public_ips_pass(monkeypatch):
 def test_multicast_rejected():
     with pytest.raises(UnsafeURLError):
         assert_safe_outbound("http://224.0.0.1/multicast")
+
+
+# === resolve_safe_url: per-hop redirect validation ===
+
+
+@pytest.fixture
+def public_dns(monkeypatch):
+    """Make api.example.com and attacker.example resolve to a public IP so
+    the SSRF guard treats them as safe hostnames. The redirect chain logic
+    is what these tests are exercising; the DNS-validation logic itself is
+    covered by the assert_safe_outbound test cases above."""
+    import socket
+    public_ip_result = [(0, 0, 0, "", ("8.8.8.8", 0))]
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **kw: public_ip_result)
+
+
+class _FakeResp:
+    def __init__(self, status_code=200, location=None):
+        self.status_code = status_code
+        self.headers = {"Location": location} if location else {}
+
+
+def _fake_session(responses):
+    """Return an object that mimics requests.Session.head, returning the
+    next item from `responses` on each call."""
+    iterator = iter(responses)
+
+    class _S:
+        def head(self, url, allow_redirects=False, timeout=None):
+            assert allow_redirects is False, "must walk manually"
+            return next(iterator)
+
+    return _S()
+
+
+def test_resolve_safe_url_no_redirect(monkeypatch, public_dns):
+    monkeypatch.setattr(
+        "utilities.url_guard._get_walker_session",
+        lambda: _fake_session([_FakeResp(200)]),
+    )
+    final = resolve_safe_url("https://api.example.com/x")
+    assert final == "https://api.example.com/x"
+
+
+def test_resolve_safe_url_blocks_redirect_to_metadata(monkeypatch, public_dns):
+    """The exact attack from Codex P1: public URL 30x to AWS metadata."""
+    monkeypatch.setattr(
+        "utilities.url_guard._get_walker_session",
+        lambda: _fake_session([
+            _FakeResp(302, location="http://169.254.169.254/latest/meta-data/iam/"),
+        ]),
+    )
+    with pytest.raises(UnsafeURLError):
+        resolve_safe_url("https://attacker.example/safe-looking")
+
+
+def test_resolve_safe_url_blocks_redirect_to_loopback(monkeypatch, public_dns):
+    monkeypatch.setattr(
+        "utilities.url_guard._get_walker_session",
+        lambda: _fake_session([
+            _FakeResp(301, location="http://127.0.0.1/admin"),
+        ]),
+    )
+    with pytest.raises(UnsafeURLError):
+        resolve_safe_url("https://attacker.example/x")
+
+
+def test_resolve_safe_url_blocks_relative_redirect_into_loopback(monkeypatch, public_dns):
+    """Relative Location values must be resolved against the current URL.
+    A relative path on a public host stays on that host (safe). Test that
+    an absolute Location still gets validated."""
+    monkeypatch.setattr(
+        "utilities.url_guard._get_walker_session",
+        lambda: _fake_session([
+            _FakeResp(302, location="/path/here"),
+            _FakeResp(200),
+        ]),
+    )
+    final = resolve_safe_url("https://api.example.com/start")
+    assert final == "https://api.example.com/path/here"
+
+
+def test_resolve_safe_url_chain_too_long(monkeypatch, public_dns):
+    monkeypatch.setattr(
+        "utilities.url_guard._get_walker_session",
+        lambda: _fake_session([
+            _FakeResp(302, location="https://api.example.com/a"),
+            _FakeResp(302, location="https://api.example.com/b"),
+            _FakeResp(302, location="https://api.example.com/c"),
+            _FakeResp(302, location="https://api.example.com/d"),
+            _FakeResp(302, location="https://api.example.com/e"),
+            _FakeResp(302, location="https://api.example.com/f"),
+        ]),
+    )
+    with pytest.raises(UnsafeURLError):
+        resolve_safe_url("https://api.example.com/start", max_redirects=5)
+
+
+def test_resolve_safe_url_redirect_without_location(monkeypatch, public_dns):
+    monkeypatch.setattr(
+        "utilities.url_guard._get_walker_session",
+        lambda: _fake_session([_FakeResp(302, location=None)]),
+    )
+    with pytest.raises(UnsafeURLError):
+        resolve_safe_url("https://api.example.com/x")
+
+
+def test_resolve_safe_url_head_failure_returns_input(monkeypatch, public_dns):
+    """HEAD failure means we cannot probe further. The original URL was
+    already validated by the leading assert_safe_outbound, so return it
+    unchanged and let the caller's defense-in-depth handle the GET."""
+
+    class _S:
+        def head(self, *a, **kw):
+            raise requests.RequestException("network down")
+
+    monkeypatch.setattr("utilities.url_guard._get_walker_session", lambda: _S())
+    final = resolve_safe_url("https://api.example.com/x")
+    assert final == "https://api.example.com/x"
+
+
+def test_resolve_safe_url_initial_url_unsafe_rejected(monkeypatch):
+    """If the input URL itself is unsafe, fail before any HEAD probe."""
+
+    class _S:
+        def head(self, *a, **kw):
+            pytest.fail("HEAD must NOT be called when the input URL is unsafe")
+
+    monkeypatch.setattr("utilities.url_guard._get_walker_session", lambda: _S())
+    with pytest.raises(UnsafeURLError):
+        resolve_safe_url("http://169.254.169.254/latest/")


### PR DESCRIPTION
## Summary

Four targeted fixes for the issues Codex flagged on the open `perf/consolidated-audit` review (PR LavX/bazarr#93). Codex diffed against `master`, so all four findings live in code already merged to `development` from prior PRs (secret_store unification, jellyfin/compat work, OAuth password UI). They are not introduced by the perf branch and are independent of it.

Each fix is its own commit so a problematic one can be reverted in isolation.

## Findings addressed

| Severity | Title | Commit | Files |
|---|---|---|---|
| P1 | Re-decrypt settings after failed save_settings reload | `cd280cf5b` | `bazarr/app/config.py` |
| P1 | Walk redirect chain before subtitle download (SSRF) | `d00b65520` | `bazarr/utilities/url_guard.py`, `bazarr/compat/service.py`, `tests/compat/unit/test_url_guard.py` |
| P2 | Block disabled compat requests at runtime | `57b9f9ee0` | `bazarr/compat/routes.py`, `tests/compat/conftest.py`, `tests/compat/integration/test_runtime_disable.py`, plus 2 patch-target updates in existing tests |
| P3 | Preserve empty stored password on clear | `d7aa17540` | `frontend/src/pages/Settings/General/index.tsx` |

## P1 secret reload — `bazarr/app/config.py`

`save_settings()` calls `settings.reload()` inside its `ValidationError` handler to roll back to disk state. With at-rest encryption, that reload pulls ciphertext back into the live Dynaconf object; nothing was running `decrypt_settings_in_place` again, so subsequent requests saw `enc:v1:` strings for API keys, auth credentials, provider passwords, and compat tokens until the next process restart.

Now runs `migrate_legacy_plex_encryption` + `decrypt_settings_in_place` after the reload.

## P1 SSRF redirect — `bazarr/utilities/url_guard.py` + `bazarr/compat/service.py`

`assert_safe_outbound` only validated the URL the provider advertised. `pool.download_subtitle` follows redirects internally via the provider's HTTP client, so a public advertised URL that 30x-redirects to `127.0.0.1` or `169.254.169.254` would fetch the private target with no per-hop check. The post-download re-check could only run after the unsafe request had already succeeded.

New `resolve_safe_url(url, max_redirects=5, timeout=10)` walks the chain via HEAD with `allow_redirects=False`, validates every `Location` through `assert_safe_outbound`, returns the final URL once a non-3xx status appears. Relative `Location` values resolve via `urljoin`. HEAD probe failure passes through to the existing post-download guard. Cap at 5 redirects.

`_fetch_subtitle_bytes` now calls `resolve_safe_url` before `pool.download_subtitle`. The post-download guard at the end of the function stays as defense in depth.

## P2 compat runtime disable — `bazarr/compat/routes.py`

The compat blueprint is mounted at startup based on the boot-time value of `compat_endpoint.enabled`. Toggling it off in the UI did nothing: Flask kept the real blueprint registered and `/api/v1/*` continued serving with the old token until restart.

New `before_request` handler re-reads `settings.compat_endpoint.enabled` on every request and returns 503 if it has been disabled. Runs before the auth check so a disabled endpoint never leaks its existence with a 403.

`tests/compat/conftest.py` autouse fixture now defaults `compat_endpoint.enabled=True` so the existing 31 integration test files still exercise the live blueprint.

## P3 frontend password — `frontend/src/pages/Settings/General/index.tsx`

When `auth.password` is empty, `originalRef.current` never captured the value because of the `stored.length > 0` guard. If the user typed a password and then cleared the field before saving, `update(originalRef.current)` was called with `null`, which `FormData` serializes as the literal string `"null"`. `save_settings` then hashed `"null"` as a brand-new password and stored it.

Dropped the length guard. Coalesced the clear-path call to `""` as belt-and-suspenders.

## Verification

- `pytest tests/bazarr -q -k "not test_init_pool and not test_pool_update"` 313 passed, 2 deselected (pre-existing SQLite env failures)
- `pytest tests/compat -q` 234 passed (was 223 on `development`; the 11-test increase is from the 8 new `resolve_safe_url` tests + 3 new runtime-disable tests)
- `ruff check .` clean
- `npm run check:ts`, `npm run check`, `npm run check:fmt` all clean (warnings are pre-existing unused-var imports unrelated to this PR)

## Test plan

- [x] CI green
- [x] Smoke test the P1 secret-reload path: trigger a deliberate `ValidationError` in a settings save, confirm subsequent `/api/system/settings` reads return plaintext credentials and not `enc:v1:` strings
- [x] Smoke test the P2 runtime disable: toggle `compat_endpoint.enabled=false` via UI, confirm `/api/v1/*` returns 503 without restart
- [x] Smoke test the P3 password clear: set a password, type a new one, clear the field, save, confirm `auth.password` retains the original hash and not the hash of the literal string `"null"`

## Out of scope

These are documented as `# noqa` survivors or comment-only TODOs:

- This PR does NOT modify any code touched by `perf/consolidated-audit` (PR LavX/bazarr#93). The two PRs are independent and either one can land first.