### PR TITLE
fix(ui): allow localhost + link-local in Sonarr/Radarr connection test

### DIFF
--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -209,6 +209,157 @@ def _resolve_and_validate(url_str):
     return safe_ip, hostname, parsed
 
 
+def _resolve_and_validate_constrained(url_str):
+    """Relaxed twin of _resolve_and_validate for the connection-test path.
+
+    Caller hard-codes the request path to /api/system/status or
+    /api/v3/system/status, so an authenticated UI session can only probe
+    whether a Sonarr/Radarr-shaped service is listening at the user's
+    typed host:port. The bounded surface justifies allowing loopback,
+    link-local, and private targets that the strict guard rejects.
+
+    Loopback supports bare-metal installs where Bazarr+ and Sonarr both
+    bind to localhost. IPv6 link-local (fe80::/10) is the default for
+    every IPv6 NIC on a single-host install. IPv4 link-local
+    (169.254.0.0/16) is the DHCP fallback. None of these are valid
+    rejection targets once the path is locked.
+
+    The IP-class guard is reduced to a sanity filter: only multicast
+    and unspecified addresses are rejected because those cannot host a
+    TCP service. Everything else passes.
+
+    Returns (resolved_ip, hostname, parsed) or raises ValueError.
+    """
+    parsed = urlparse(url_str)
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("No hostname in URL")
+    port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+    addrs = socket.getaddrinfo(hostname, port)
+    if not addrs:
+        raise ValueError("DNS resolution returned no results")
+    safe_ip = None
+    for _, _, _, _, sockaddr in addrs:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if ip.is_multicast or ip.is_unspecified:
+            continue
+        safe_ip = sockaddr[0]
+        break
+    if safe_ip is None:
+        raise ValueError(
+            "No usable address resolved (multicast and unspecified are not valid TCP targets)"
+        )
+    return safe_ip, hostname, parsed
+
+
+_TEST_STATUS_PATHS = ('/api/system/status', '/api/v3/system/status')
+
+
+def _validate_test_base_url(base):
+    """Reject obviously hostile or nonsensical inputs. Allow reverse-proxy
+    base paths like /sonarr but refuse anything that smuggles a different
+    request via .., query string, or fragment.
+    """
+    parsed = urlparse(base)
+    if parsed.scheme not in ('http', 'https'):
+        raise ValueError('unsupported protocol')
+    if not parsed.hostname:
+        raise ValueError('missing host')
+    if parsed.query or parsed.fragment:
+        raise ValueError('query strings and fragments are not allowed in url')
+    if '..' in (parsed.path or ''):
+        raise ValueError('relative path segments are not allowed in url')
+    return parsed
+
+
+def _build_pinned_request(base_parsed, status_path, service):
+    """Construct the (pinned_url, pinned_headers, hostname) tuple for a
+    Sonarr/Radarr connection test. Path is hard-coded by the caller to
+    a known status endpoint; the user only contributes scheme, host, port,
+    and reverse-proxy base path.
+    """
+    base_path = (base_parsed.path or '').rstrip('/')
+    test_path = base_path + status_path
+    test_url = base_parsed._replace(path=test_path).geturl()
+    resolved_ip, hostname, parsed = _resolve_and_validate_constrained(test_url)
+    port = parsed.port or (443 if parsed.scheme == 'https' else 80)
+    pinned_netloc = (f'[{resolved_ip}]:{port}' if ':' in resolved_ip
+                     else f'{resolved_ip}:{port}')
+    pinned_url = parsed._replace(netloc=pinned_netloc).geturl()
+    pinned_headers = dict(HEADERS)
+    pinned_headers['Host'] = hostname
+    return pinned_url, pinned_headers
+
+
+@check_login
+@ui_bp.route('/test/<service>', methods=['GET'])
+def proxy_service(service):
+    """Constrained connection tester for Sonarr/Radarr.
+
+    Frontend supplies only base URL and apikey via query params; backend
+    appends the known /api/[v3/]system/status path itself, so the surface
+    available to an authenticated UI session is bounded to a status probe
+    against the user-typed host:port. Loopback and link-local are allowed
+    targets here (bare-metal installs, single-NIC IPv6 hosts) because the
+    locked path makes the bounded surface safe.
+
+    See LavX/bazarr#92 for the original report and rationale.
+    """
+    if service not in ('sonarr', 'radarr'):
+        return dict(status=False, error='unsupported service', code=0)
+    base = (request.args.get('url') or '').strip()
+    apikey = (request.args.get('apikey') or '').strip()
+    if not base:
+        return dict(status=False, error='missing url', code=0)
+    if not apikey:
+        return dict(status=False, error='missing apikey', code=0)
+
+    try:
+        base_parsed = _validate_test_base_url(base)
+    except ValueError as e:
+        return dict(status=False, error=f'Request blocked: {e}', code=0)
+
+    last_response_code = 0
+    last_error = None
+    for status_path in _TEST_STATUS_PATHS:
+        try:
+            pinned_url, pinned_headers = _build_pinned_request(
+                base_parsed, status_path, service
+            )
+        except (ValueError, socket.gaierror) as e:
+            return dict(status=False, error=f'Request blocked: {e}', code=0)
+        pinned_headers['X-Api-Key'] = apikey
+        try:
+            result = requests.get(pinned_url, allow_redirects=False,
+                                  verify=get_ssl_verify(service),
+                                  timeout=5, headers=pinned_headers)
+        except Exception as e:
+            return dict(status=False, error=repr(e))
+        last_response_code = result.status_code
+        if result.status_code == 200:
+            try:
+                version = result.json()['version']
+                return dict(status=True, version=version, code=result.status_code)
+            except Exception:
+                last_error = 'Error Occurred. Check your settings.'
+                continue
+        elif result.status_code == 401:
+            return dict(status=False, error='Access Denied. Check API key.',
+                        code=result.status_code)
+        elif result.status_code == 404:
+            last_error = 'Cannot get version. Maybe unsupported legacy API call?'
+            continue
+        elif 300 <= result.status_code <= 399:
+            return dict(status=False, error='Wrong URL Base.', code=result.status_code)
+        else:
+            return dict(status=False,
+                        error=result.raise_for_status(),
+                        code=result.status_code)
+    return dict(status=False,
+                error=last_error or 'Cannot reach Sonarr/Radarr at the configured URL.',
+                code=last_response_code)
+
+
 @check_login
 @ui_bp.route('/test', methods=['GET'])
 @ui_bp.route('/test/<protocol>/<path:url>', methods=['GET'])

--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -305,6 +305,26 @@ def _validate_test_base_url(base):
     return parsed
 
 
+def _format_host_header(hostname, original_port, scheme):
+    """Build an RFC 7230 §5.4-compliant Host header value.
+
+    IPv6 literals MUST be bracketed in the Host header (`[::1]:8989`,
+    not `::1:8989`) because the colon is otherwise ambiguous with the
+    port separator. urlparse(...).hostname strips brackets, so we have
+    to put them back when emitting the header. Codex P2 from PR #95
+    review round 3.
+
+    Port is included only when non-default for the scheme, matching the
+    convention urllib3 follows when it generates Host headers itself.
+    """
+    is_ipv6 = ':' in hostname
+    host = f'[{hostname}]' if is_ipv6 else hostname
+    default_port = 443 if scheme == 'https' else 80
+    if original_port and original_port != default_port:
+        return f'{host}:{original_port}'
+    return host
+
+
 def _build_request_url(base_parsed, status_path, resolved_ip, hostname, pin):
     """Construct the (request_url, request_headers) pair for one probe.
 
@@ -332,7 +352,7 @@ def _build_request_url(base_parsed, status_path, resolved_ip, hostname, pin):
     pinned_netloc = (f'[{resolved_ip}]:{port}' if ':' in resolved_ip
                      else f'{resolved_ip}:{port}')
     pinned_url = parsed._replace(netloc=pinned_netloc).geturl()
-    headers['Host'] = hostname
+    headers['Host'] = _format_host_header(hostname, parsed.port, parsed.scheme)
     return pinned_url, headers
 
 

--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -305,23 +305,35 @@ def _validate_test_base_url(base):
     return parsed
 
 
-def _build_pinned_request(base_parsed, status_path, resolved_ip, hostname):
-    """Construct the (pinned_url, pinned_headers) tuple for a single
-    (IP, status_path) attempt. Path is hard-coded by the caller to a
-    known status endpoint; the user only contributes scheme, host, port,
-    and reverse-proxy base path.
+def _build_request_url(base_parsed, status_path, resolved_ip, hostname, pin):
+    """Construct the (request_url, request_headers) pair for one probe.
+
+    When `pin=True`, the URL is rewritten to use `resolved_ip` in the
+    netloc and a `Host:` header is set so DNS rebinding between resolve
+    and connect cannot redirect the request. This mode is correct for
+    HTTP and for HTTPS with TLS verification disabled.
+
+    When `pin=False`, the original hostname is preserved so urllib3 can
+    set SNI to the hostname and validate the TLS certificate against
+    it. This mode is correct for HTTPS with verify_ssl enabled. Pinning
+    in that case would replace the hostname with an IP literal in the
+    URL, urllib3 would set SNI to the IP, the server's cert (issued for
+    e.g. sonarr.example.com) would not match the IP, and TLS hostname
+    validation would fail every legitimate test. Codex P2.
     """
     base_path = (base_parsed.path or '').rstrip('/')
     test_path = base_path + status_path
     test_url = base_parsed._replace(path=test_path).geturl()
+    headers = dict(HEADERS)
+    if not pin:
+        return test_url, headers
     parsed = urlparse(test_url)
     port = parsed.port or (443 if parsed.scheme == 'https' else 80)
     pinned_netloc = (f'[{resolved_ip}]:{port}' if ':' in resolved_ip
                      else f'{resolved_ip}:{port}')
     pinned_url = parsed._replace(netloc=pinned_netloc).geturl()
-    pinned_headers = dict(HEADERS)
-    pinned_headers['Host'] = hostname
-    return pinned_url, pinned_headers
+    headers['Host'] = hostname
+    return pinned_url, headers
 
 
 @check_login
@@ -360,6 +372,22 @@ def proxy_service(service):
     except (ValueError, socket.gaierror) as e:
         return dict(status=False, error=f'Request blocked: {e}', code=0)
 
+    verify = (get_ssl_verify(service)
+              if config['has_verify_ssl_setting'] else True)
+    # Pin to a resolved IP only when TLS hostname validation is NOT
+    # going to do the work for us. For HTTPS + verify=True, the cert's
+    # SAN/CN check provides equivalent DNS-rebinding mitigation: an
+    # attacker who poisons DNS still cannot mint a valid cert for the
+    # hostname. Pinning in that case would replace the hostname with
+    # the IP literal in the URL, SNI would be set to the IP, and a
+    # legitimate cert installation would fail TLS validation. Codex P2.
+    pin_to_ip = not (base_parsed.scheme == 'https' and verify is True)
+    # When pinning is off, dual-stack fallback is unnecessary: urllib3
+    # already iterates DNS-resolved addresses internally during the
+    # actual GET. Iterate only the first usable IP slot in that case;
+    # `_build_request_url(pin=False)` ignores it.
+    candidate_ips = resolved_ips if pin_to_ip else resolved_ips[:1]
+
     last_response_code = 0
     last_error = None
     last_connection_error = None
@@ -369,23 +397,21 @@ def proxy_service(service):
     # ConnectionError so dual-stack hosts where one address family is
     # not actually listening (e.g. localhost -> ::1 first but only
     # 127.0.0.1 binds) still produce a successful test.
-    for resolved_ip in resolved_ips:
+    for resolved_ip in candidate_ips:
         if reachable_ip and reachable_ip != resolved_ip:
             # Already proven a different IP is reachable; do not
             # cross-probe additional addresses.
             break
         for status_path in config['paths']:
-            pinned_url, pinned_headers = _build_pinned_request(
-                base_parsed, status_path, resolved_ip, hostname
+            request_url, request_headers = _build_request_url(
+                base_parsed, status_path, resolved_ip, hostname, pin_to_ip
             )
             if apikey:
-                pinned_headers['X-Api-Key'] = apikey
-            verify = (get_ssl_verify(service)
-                      if config['has_verify_ssl_setting'] else True)
+                request_headers['X-Api-Key'] = apikey
             try:
-                result = requests.get(pinned_url, allow_redirects=False,
+                result = requests.get(request_url, allow_redirects=False,
                                       verify=verify,
-                                      timeout=5, headers=pinned_headers)
+                                      timeout=5, headers=request_headers)
             except requests.ConnectionError as e:
                 last_connection_error = repr(e)
                 # Cannot reach this IP; try the next one. Skip the

--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -228,7 +228,15 @@ def _resolve_and_validate_constrained(url_str):
     and unspecified addresses are rejected because those cannot host a
     TCP service. Everything else passes.
 
-    Returns (resolved_ip, hostname, parsed) or raises ValueError.
+    Returns (resolved_ips, hostname, parsed) where `resolved_ips` is a
+    de-duplicated list of every safe address from the DNS query in the
+    order returned by getaddrinfo. The list lets the caller fall back
+    to the next address when a connection is refused, which matters on
+    dual-stack hosts where a hostname resolves to both IPv6 and IPv4 but
+    only one of the two has the service actually listening (the typical
+    'localhost -> ::1 first, but only 127.0.0.1 binds' case).
+
+    Raises ValueError if no usable address was returned.
     """
     parsed = urlparse(url_str)
     hostname = parsed.hostname
@@ -238,21 +246,46 @@ def _resolve_and_validate_constrained(url_str):
     addrs = socket.getaddrinfo(hostname, port)
     if not addrs:
         raise ValueError("DNS resolution returned no results")
-    safe_ip = None
+    seen = set()
+    resolved_ips = []
     for _, _, _, _, sockaddr in addrs:
-        ip = ipaddress.ip_address(sockaddr[0])
+        ip_str = sockaddr[0]
+        if ip_str in seen:
+            continue
+        seen.add(ip_str)
+        ip = ipaddress.ip_address(ip_str)
         if ip.is_multicast or ip.is_unspecified:
             continue
-        safe_ip = sockaddr[0]
-        break
-    if safe_ip is None:
+        resolved_ips.append(ip_str)
+    if not resolved_ips:
         raise ValueError(
             "No usable address resolved (multicast and unspecified are not valid TCP targets)"
         )
-    return safe_ip, hostname, parsed
+    return resolved_ips, hostname, parsed
 
 
-_TEST_STATUS_PATHS = ('/api/system/status', '/api/v3/system/status')
+# Each entry pins:
+#   paths: tuple of upstream status endpoints to probe in order. First 200
+#          wins. Sonarr/Radarr accept a v1 legacy + v3 path; Whisper-ASR
+#          exposes a single /status endpoint.
+#   apikey_required: True for Sonarr/Radarr (X-Api-Key required upstream);
+#                    False for Whisper which has no API-key concept.
+#   has_verify_ssl_setting: True only if `settings.<service>.verify_ssl`
+#                           exists. get_ssl_verify is consulted in that
+#                           case; otherwise we default verify=True so
+#                           public Whisper instances over HTTPS still
+#                           validate certificates.
+_TEST_SERVICES = {
+    'sonarr':    {'paths': ('/api/system/status', '/api/v3/system/status'),
+                  'apikey_required': True,
+                  'has_verify_ssl_setting': True},
+    'radarr':    {'paths': ('/api/system/status', '/api/v3/system/status'),
+                  'apikey_required': True,
+                  'has_verify_ssl_setting': True},
+    'whisperai': {'paths': ('/status',),
+                  'apikey_required': False,
+                  'has_verify_ssl_setting': False},
+}
 
 
 def _validate_test_base_url(base):
@@ -272,16 +305,16 @@ def _validate_test_base_url(base):
     return parsed
 
 
-def _build_pinned_request(base_parsed, status_path, service):
-    """Construct the (pinned_url, pinned_headers, hostname) tuple for a
-    Sonarr/Radarr connection test. Path is hard-coded by the caller to
-    a known status endpoint; the user only contributes scheme, host, port,
+def _build_pinned_request(base_parsed, status_path, resolved_ip, hostname):
+    """Construct the (pinned_url, pinned_headers) tuple for a single
+    (IP, status_path) attempt. Path is hard-coded by the caller to a
+    known status endpoint; the user only contributes scheme, host, port,
     and reverse-proxy base path.
     """
     base_path = (base_parsed.path or '').rstrip('/')
     test_path = base_path + status_path
     test_url = base_parsed._replace(path=test_path).geturl()
-    resolved_ip, hostname, parsed = _resolve_and_validate_constrained(test_url)
+    parsed = urlparse(test_url)
     port = parsed.port or (443 if parsed.scheme == 'https' else 80)
     pinned_netloc = (f'[{resolved_ip}]:{port}' if ':' in resolved_ip
                      else f'{resolved_ip}:{port}')
@@ -305,13 +338,14 @@ def proxy_service(service):
 
     See LavX/bazarr#92 for the original report and rationale.
     """
-    if service not in ('sonarr', 'radarr'):
+    if service not in _TEST_SERVICES:
         return dict(status=False, error='unsupported service', code=0)
+    config = _TEST_SERVICES[service]
     base = (request.args.get('url') or '').strip()
     apikey = (request.args.get('apikey') or '').strip()
     if not base:
         return dict(status=False, error='missing url', code=0)
-    if not apikey:
+    if config['apikey_required'] and not apikey:
         return dict(status=False, error='missing apikey', code=0)
 
     try:
@@ -319,42 +353,79 @@ def proxy_service(service):
     except ValueError as e:
         return dict(status=False, error=f'Request blocked: {e}', code=0)
 
+    try:
+        resolved_ips, hostname, _ = _resolve_and_validate_constrained(
+            base_parsed.geturl()
+        )
+    except (ValueError, socket.gaierror) as e:
+        return dict(status=False, error=f'Request blocked: {e}', code=0)
+
     last_response_code = 0
     last_error = None
-    for status_path in _TEST_STATUS_PATHS:
-        try:
+    last_connection_error = None
+    reachable_ip = None
+    # Outer loop: each safe IP returned by DNS, in original order. Inner
+    # loop: each status path. Fall through to the next IP on
+    # ConnectionError so dual-stack hosts where one address family is
+    # not actually listening (e.g. localhost -> ::1 first but only
+    # 127.0.0.1 binds) still produce a successful test.
+    for resolved_ip in resolved_ips:
+        if reachable_ip and reachable_ip != resolved_ip:
+            # Already proven a different IP is reachable; do not
+            # cross-probe additional addresses.
+            break
+        for status_path in config['paths']:
             pinned_url, pinned_headers = _build_pinned_request(
-                base_parsed, status_path, service
+                base_parsed, status_path, resolved_ip, hostname
             )
-        except (ValueError, socket.gaierror) as e:
-            return dict(status=False, error=f'Request blocked: {e}', code=0)
-        pinned_headers['X-Api-Key'] = apikey
-        try:
-            result = requests.get(pinned_url, allow_redirects=False,
-                                  verify=get_ssl_verify(service),
-                                  timeout=5, headers=pinned_headers)
-        except Exception as e:
-            return dict(status=False, error=repr(e))
-        last_response_code = result.status_code
-        if result.status_code == 200:
+            if apikey:
+                pinned_headers['X-Api-Key'] = apikey
+            verify = (get_ssl_verify(service)
+                      if config['has_verify_ssl_setting'] else True)
             try:
-                version = result.json()['version']
-                return dict(status=True, version=version, code=result.status_code)
-            except Exception:
-                last_error = 'Error Occurred. Check your settings.'
+                result = requests.get(pinned_url, allow_redirects=False,
+                                      verify=verify,
+                                      timeout=5, headers=pinned_headers)
+            except requests.ConnectionError as e:
+                last_connection_error = repr(e)
+                # Cannot reach this IP; try the next one. Skip the
+                # remaining status paths for this IP.
+                break
+            except Exception as e:
+                return dict(status=False, error=repr(e))
+            reachable_ip = resolved_ip
+            last_response_code = result.status_code
+            if result.status_code == 200:
+                try:
+                    version = result.json()['version']
+                    return dict(status=True, version=version,
+                                code=result.status_code)
+                except Exception:
+                    last_error = 'Error Occurred. Check your settings.'
+                    continue
+            elif result.status_code == 401:
+                return dict(status=False,
+                            error='Access Denied. Check API key.',
+                            code=result.status_code)
+            elif result.status_code == 404:
+                last_error = 'Cannot get version. Maybe unsupported legacy API call?'
                 continue
-        elif result.status_code == 401:
-            return dict(status=False, error='Access Denied. Check API key.',
-                        code=result.status_code)
-        elif result.status_code == 404:
-            last_error = 'Cannot get version. Maybe unsupported legacy API call?'
-            continue
-        elif 300 <= result.status_code <= 399:
-            return dict(status=False, error='Wrong URL Base.', code=result.status_code)
-        else:
-            return dict(status=False,
-                        error=result.raise_for_status(),
-                        code=result.status_code)
+            elif 300 <= result.status_code <= 399:
+                return dict(status=False, error='Wrong URL Base.',
+                            code=result.status_code)
+            else:
+                # Codex P2: result.raise_for_status() RAISES on 4xx/5xx
+                # rather than returning a value, so wrapping it in dict()
+                # made the route propagate an HTTPError to Flask and
+                # surface as 500 to the frontend. Return a structured
+                # error string instead so the UI can show the upstream
+                # status code on transient failures.
+                return dict(status=False,
+                            error=f'Upstream returned status {result.status_code}',
+                            code=result.status_code)
+    if reachable_ip is None and last_connection_error is not None:
+        return dict(status=False,
+                    error=f'Cannot connect: {last_connection_error}', code=0)
     return dict(status=False,
                 error=last_error or 'Cannot reach Sonarr/Radarr at the configured URL.',
                 code=last_response_code)

--- a/frontend/src/apis/raw/utils.ts
+++ b/frontend/src/apis/raw/utils.ts
@@ -13,25 +13,23 @@ type UrlTestResponse =
     };
 
 class RequestUtils {
-  async urlTest(protocol: string, url: string, params?: LooseObject) {
-    try {
-      const result = await client.axios.get<UrlTestResponse>(
-        `../test/${protocol}/${url}api/system/status`,
-        { params },
-      );
-      const { data } = result;
-      if (data.status && data.version) {
-        return data;
-      } else {
-        throw new Error("Cannot get response, fallback to v3 api");
-      }
-    } catch (e) {
-      const result = await client.axios.get<UrlTestResponse>(
-        `../test/${protocol}/${url}api/v3/system/status`,
-        { params },
-      );
-      return result.data;
-    }
+  // Sonarr / Radarr connection tester. Backend builds the
+  // /api/[v3/]system/status path itself and probes both with one call,
+  // so the frontend only contributes scheme/host/port/base-url and the
+  // service identifier. See LavX/bazarr#92 for why we no longer pass
+  // the request path through the proxy.
+  async urlTest(
+    service: "sonarr" | "radarr",
+    protocol: string,
+    url: string,
+    apikey: string,
+  ) {
+    const trimmed = url.replace(/\/+$/, "");
+    const result = await client.axios.get<UrlTestResponse>(
+      `../test/${service}`,
+      { params: { url: `${protocol}://${trimmed}`, apikey } },
+    );
+    return result.data;
   }
 
   async providerUrlTest(protocol: string, url: string, params?: LooseObject) {

--- a/frontend/src/apis/raw/utils.ts
+++ b/frontend/src/apis/raw/utils.ts
@@ -32,15 +32,16 @@ class RequestUtils {
     return result.data;
   }
 
-  async providerUrlTest(protocol: string, url: string, params?: LooseObject) {
+  // Provider connection tester. Whisper-ASR runs the same
+  // localhost-on-the-same-box pattern Sonarr/Radarr does (people
+  // self-host transcription on the Bazarr box), so it goes through the
+  // same constrained route. Backend appends /status itself; no apikey.
+  async providerUrlTest(service: string, protocol: string, url: string) {
+    const trimmed = url.replace(/\/+$/, "");
     const result = await client.axios.get<UrlTestResponse>(
-      `../test/${protocol}/${url}status`,
-      { params },
+      `../test/${service}`,
+      { params: { url: `${protocol}://${trimmed}` } },
     );
-    const { data } = result;
-    if (data.status && data.version) {
-      return data;
-    }
     return result.data;
   }
 }

--- a/frontend/src/pages/Settings/components/index.tsx
+++ b/frontend/src/pages/Settings/components/index.tsx
@@ -17,32 +17,16 @@ export const URLTestButton: FunctionComponent<{
 
   const click = useCallback(() => {
     if (address && apikey && ssl !== null) {
-      let testUrl: string;
-
-      let baseUrl = url;
+      let baseUrl = url ?? "";
       if (baseUrl && baseUrl.startsWith("/") === false) {
         baseUrl = "/" + baseUrl;
       }
 
-      if (port) {
-        testUrl = `${address}:${port}${baseUrl ?? ""}`;
-      } else {
-        testUrl = `${address}${baseUrl ?? ""}`;
-      }
-      const request = {
-        protocol: ssl ? "https" : "http",
-        url: testUrl,
-        params: {
-          apikey,
-        },
-      };
-
-      if (!request.url.endsWith("/")) {
-        request.url += "/";
-      }
+      const hostPart = port ? `${address}:${port}` : address;
+      const protocol = ssl ? "https" : "http";
 
       api.utils
-        .urlTest(request.protocol, request.url, request.params)
+        .urlTest(category, protocol, `${hostPart}${baseUrl}`, apikey)
         .then((result) => {
           if (result.status) {
             setTitle(`Version: ${result.version}`);
@@ -53,7 +37,7 @@ export const URLTestButton: FunctionComponent<{
           }
         });
     }
-  }, [address, port, url, apikey, ssl]);
+  }, [address, port, url, apikey, ssl, category]);
 
   return (
     <Button autoContrast onClick={click} variant={color} title={title}>

--- a/frontend/src/pages/Settings/components/index.tsx
+++ b/frontend/src/pages/Settings/components/index.tsx
@@ -58,16 +58,9 @@ export const ProviderTestButton: FunctionComponent<{
   const click = useCallback(() => {
     if (testUrl !== null) {
       const urlWithoutProtocol = new URL(testUrl).host;
-      const request = {
-        protocol: "http",
-        url: urlWithoutProtocol,
-      };
-      if (!request.url.endsWith("/")) {
-        request.url += "/";
-      }
 
       api.utils
-        .providerUrlTest(request.protocol, request.url)
+        .providerUrlTest(category, "http", urlWithoutProtocol)
         .then((result) => {
           if (result.status) {
             setTitle(`${result.version}`);
@@ -84,7 +77,7 @@ export const ProviderTestButton: FunctionComponent<{
           }
         });
     }
-  }, [testUrl]);
+  }, [testUrl, category]);
 
   useEffect(() => {
     setTitle(testConnection);

--- a/tests/bazarr/test_connection_tester.py
+++ b/tests/bazarr/test_connection_tester.py
@@ -1,0 +1,278 @@
+"""Tests for the constrained Sonarr/Radarr connection tester
+introduced for LavX/bazarr#92.
+
+Covers:
+- _resolve_and_validate_constrained: loopback OK, link-local OK, multicast
+  rejected, unspecified rejected, multi-IP DNS picks first usable address,
+  empty getaddrinfo handled, missing host handled.
+- _validate_test_base_url: scheme allowlist, missing host, query/fragment
+  rejection, path traversal rejection.
+- proxy_service: service whitelist, missing url/apikey, end-to-end status
+  probe with mocked requests.get, both legacy (/api/system/status) and
+  v3 (/api/v3/system/status) paths attempted.
+"""
+import socket
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+def _addr(ip):
+    """Build a getaddrinfo tuple for `ip`."""
+    family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+    return (family, 0, 0, "", (ip, 0))
+
+
+# === _resolve_and_validate_constrained ===
+
+@pytest.mark.parametrize("ip", [
+    "127.0.0.1",       # IPv4 loopback
+    "::1",             # IPv6 loopback
+    "169.254.1.1",     # IPv4 link-local
+    "fe80::1",         # IPv6 link-local
+    "10.0.0.5",        # private LAN
+    "192.168.1.10",    # private LAN
+    "8.8.8.8",         # public
+])
+def test_relaxed_validator_accepts(monkeypatch, ip):
+    from app.ui import _resolve_and_validate_constrained
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **kw: [_addr(ip)])
+    resolved_ip, hostname, parsed = _resolve_and_validate_constrained(
+        "http://example.test:8989/"
+    )
+    assert resolved_ip == ip
+    assert hostname == "example.test"
+
+
+@pytest.mark.parametrize("ip", [
+    "224.0.0.1",        # IPv4 multicast
+    "ff02::1",          # IPv6 multicast (link-local all-nodes)
+    "0.0.0.0",          # IPv4 unspecified
+    "::",               # IPv6 unspecified
+])
+def test_relaxed_validator_rejects(monkeypatch, ip):
+    from app.ui import _resolve_and_validate_constrained
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **kw: [_addr(ip)])
+    with pytest.raises(ValueError):
+        _resolve_and_validate_constrained("http://example.test/")
+
+
+def test_relaxed_validator_picks_first_usable_in_dual_stack(monkeypatch):
+    """Multicast first, public second: validator skips multicast and picks public."""
+    from app.ui import _resolve_and_validate_constrained
+    monkeypatch.setattr(
+        socket, "getaddrinfo",
+        lambda *a, **kw: [_addr("224.0.0.1"), _addr("8.8.8.8")],
+    )
+    resolved_ip, _, _ = _resolve_and_validate_constrained("http://example.test/")
+    assert resolved_ip == "8.8.8.8"
+
+
+def test_relaxed_validator_no_addrs(monkeypatch):
+    from app.ui import _resolve_and_validate_constrained
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **kw: [])
+    with pytest.raises(ValueError):
+        _resolve_and_validate_constrained("http://example.test/")
+
+
+def test_relaxed_validator_missing_host():
+    from app.ui import _resolve_and_validate_constrained
+    with pytest.raises(ValueError):
+        _resolve_and_validate_constrained("http:///somepath")
+
+
+# === _validate_test_base_url ===
+
+@pytest.mark.parametrize("url", [
+    "http://127.0.0.1:8989",
+    "https://radarr.example.com",
+    "https://example.com:7878/radarr",
+    "http://[::1]:8989",
+    "http://[fe80::1]:8989",
+])
+def test_base_url_validator_accepts(url):
+    from app.ui import _validate_test_base_url
+    parsed = _validate_test_base_url(url)
+    assert parsed.scheme in ("http", "https")
+
+
+@pytest.mark.parametrize("url,reason", [
+    ("ftp://nope/", "protocol"),
+    ("file:///etc/passwd", "protocol"),
+    ("http:///nopath", "host"),
+    ("http://x.test/?evil=1", "query"),
+    ("http://x.test/#frag", "fragment"),
+    ("http://x.test/sonarr/../admin", "relative"),
+])
+def test_base_url_validator_rejects(url, reason):
+    from app.ui import _validate_test_base_url
+    with pytest.raises(ValueError, match=reason):
+        _validate_test_base_url(url)
+
+
+# === proxy_service end-to-end ===
+
+
+def _build_app():
+    """Stand up a minimal Flask app with the ui blueprint mounted, with
+    @check_login bypassed via session injection. Returns the test client."""
+    from flask import Flask
+    from app.ui import ui_bp
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(ui_bp)
+    return app
+
+
+def _login(client):
+    """Pre-populate the session so @check_login passes."""
+    with client.session_transaction() as sess:
+        sess["logged_in"] = True
+
+
+def test_proxy_service_rejects_unknown_service(monkeypatch):
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    app = _build_app()
+    client = app.test_client()
+    _login(client)
+    r = client.get("/test/whatever?url=http://x.test&apikey=k")
+    body = r.get_json()
+    assert body["status"] is False
+    assert "unsupported service" in body["error"]
+
+
+def test_proxy_service_rejects_missing_url(monkeypatch):
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    app = _build_app()
+    client = app.test_client()
+    _login(client)
+    r = client.get("/test/sonarr?apikey=k")
+    body = r.get_json()
+    assert body["status"] is False
+    assert "missing url" in body["error"]
+
+
+def test_proxy_service_rejects_missing_apikey(monkeypatch):
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    app = _build_app()
+    client = app.test_client()
+    _login(client)
+    r = client.get("/test/sonarr?url=http://127.0.0.1:8989")
+    body = r.get_json()
+    assert body["status"] is False
+    assert "missing apikey" in body["error"]
+
+
+def test_proxy_service_succeeds_against_localhost(monkeypatch):
+    """The headline reproduction from issue #92: localhost connection
+    test must succeed after the fix."""
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    monkeypatch.setattr(socket, "getaddrinfo",
+                        lambda *a, **kw: [_addr("127.0.0.1")])
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"version": "4.0.0.0"}
+    with patch("app.ui.requests.get", return_value=fake_response) as fake_get:
+        app = _build_app()
+        client = app.test_client()
+        _login(client)
+        r = client.get("/test/sonarr?url=http://127.0.0.1:8989&apikey=secret")
+        body = r.get_json()
+        assert body["status"] is True
+        assert body["version"] == "4.0.0.0"
+        # First call attempts /api/system/status (legacy path)
+        called_url = fake_get.call_args_list[0].args[0]
+        assert called_url.endswith("/api/system/status")
+        # X-Api-Key header passed through
+        called_headers = fake_get.call_args_list[0].kwargs["headers"]
+        assert called_headers.get("X-Api-Key") == "secret"
+
+
+def test_proxy_service_falls_back_to_v3(monkeypatch):
+    """Legacy path 404 -> v3 path tried -> success."""
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    monkeypatch.setattr(socket, "getaddrinfo",
+                        lambda *a, **kw: [_addr("10.0.0.5")])
+    legacy_resp = MagicMock(status_code=404)
+    v3_resp = MagicMock(status_code=200)
+    v3_resp.json.return_value = {"version": "5.1.0"}
+    with patch("app.ui.requests.get", side_effect=[legacy_resp, v3_resp]) as fake_get:
+        app = _build_app()
+        client = app.test_client()
+        _login(client)
+        r = client.get("/test/radarr?url=https://radarr.example.com&apikey=k")
+        body = r.get_json()
+        assert body["status"] is True
+        assert body["version"] == "5.1.0"
+        # Both attempts made
+        assert fake_get.call_count == 2
+        urls = [c.args[0] for c in fake_get.call_args_list]
+        assert urls[0].endswith("/api/system/status")
+        assert urls[1].endswith("/api/v3/system/status")
+
+
+def test_proxy_service_returns_401_without_falling_back(monkeypatch):
+    """401 is a final answer (bad apikey), do NOT try v3."""
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    monkeypatch.setattr(socket, "getaddrinfo",
+                        lambda *a, **kw: [_addr("127.0.0.1")])
+    resp = MagicMock(status_code=401)
+    with patch("app.ui.requests.get", return_value=resp) as fake_get:
+        app = _build_app()
+        client = app.test_client()
+        _login(client)
+        r = client.get("/test/sonarr?url=http://127.0.0.1:8989&apikey=bad")
+        body = r.get_json()
+        assert body["status"] is False
+        assert "Access Denied" in body["error"]
+        assert fake_get.call_count == 1
+
+
+def test_proxy_service_rejects_url_with_query(monkeypatch):
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    app = _build_app()
+    client = app.test_client()
+    _login(client)
+    r = client.get(
+        "/test/sonarr?url=http://x.test/sonarr%3Fevil%3D1&apikey=k"
+    )
+    body = r.get_json()
+    assert body["status"] is False
+    assert "Request blocked" in body["error"]
+
+
+def test_proxy_service_honors_verify_ssl_setting(monkeypatch):
+    """verify=False is no longer hardcoded; the per-service verify_ssl
+    setting flows through via get_ssl_verify."""
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    monkeypatch.setattr(socket, "getaddrinfo",
+                        lambda *a, **kw: [_addr("8.8.8.8")])
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"version": "4.0.0.0"}
+    with patch("app.ui.requests.get", return_value=resp) as fake_get, \
+         patch("app.ui.get_ssl_verify", return_value=False) as fake_verify:
+        app = _build_app()
+        client = app.test_client()
+        _login(client)
+        client.get("/test/sonarr?url=https://sonarr.example.com&apikey=k")
+        assert fake_get.call_args_list[0].kwargs["verify"] is False
+        fake_verify.assert_called_with("sonarr")
+
+
+def test_proxy_service_pins_to_resolved_ip_with_host_header(monkeypatch):
+    """DNS-rebinding mitigation preserved: request goes to the resolved IP
+    with Host: header set to the original hostname."""
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    monkeypatch.setattr(socket, "getaddrinfo",
+                        lambda *a, **kw: [_addr("203.0.113.42")])
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"version": "4.0.0.0"}
+    with patch("app.ui.requests.get", return_value=resp) as fake_get:
+        app = _build_app()
+        client = app.test_client()
+        _login(client)
+        client.get("/test/sonarr?url=https://sonarr.example.com&apikey=k")
+        called_url = fake_get.call_args_list[0].args[0]
+        called_headers = fake_get.call_args_list[0].kwargs["headers"]
+        assert "203.0.113.42" in called_url
+        assert called_headers.get("Host") == "sonarr.example.com"

--- a/tests/bazarr/test_connection_tester.py
+++ b/tests/bazarr/test_connection_tester.py
@@ -335,9 +335,11 @@ def test_proxy_service_returns_connection_error_when_no_ip_reachable(monkeypatch
         assert "Cannot connect" in body["error"]
 
 
-def test_proxy_service_pins_to_resolved_ip_with_host_header(monkeypatch):
-    """DNS-rebinding mitigation preserved: request goes to the resolved IP
-    with Host: header set to the original hostname."""
+def test_proxy_service_pins_to_resolved_ip_for_http(monkeypatch):
+    """DNS-rebinding mitigation preserved on HTTP: request goes to the
+    resolved IP with Host: header set to the original hostname. TLS
+    hostname validation does not run for HTTP, so pinning is the only
+    DNS-rebinding mitigation available."""
     monkeypatch.setattr("app.config.settings.auth.type", None)
     monkeypatch.setattr(socket, "getaddrinfo",
                         lambda *a, **kw: [_addr("203.0.113.42")])
@@ -347,8 +349,58 @@ def test_proxy_service_pins_to_resolved_ip_with_host_header(monkeypatch):
         app = _build_app()
         client = app.test_client()
         _login(client)
+        client.get("/test/sonarr?url=http://sonarr.example.com&apikey=k")
+        called_url = fake_get.call_args_list[0].args[0]
+        called_headers = fake_get.call_args_list[0].kwargs["headers"]
+        assert "203.0.113.42" in called_url
+        assert called_headers.get("Host") == "sonarr.example.com"
+
+
+def test_proxy_service_does_not_pin_for_https_with_verify(monkeypatch):
+    """Codex P2: when HTTPS is in use with verify_ssl=True, pinning the
+    URL to the resolved IP would set SNI to the IP and fail TLS
+    hostname validation against a cert legitimately issued for the
+    hostname. The hostname must be preserved in the URL so urllib3
+    sets SNI correctly and the cert validates."""
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    monkeypatch.setattr(socket, "getaddrinfo",
+                        lambda *a, **kw: [_addr("203.0.113.42")])
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"version": "4.0.0.0"}
+    with patch("app.ui.requests.get", return_value=resp) as fake_get, \
+         patch("app.ui.get_ssl_verify", return_value=True):
+        app = _build_app()
+        client = app.test_client()
+        _login(client)
+        client.get("/test/sonarr?url=https://sonarr.example.com&apikey=k")
+        called_url = fake_get.call_args_list[0].args[0]
+        called_headers = fake_get.call_args_list[0].kwargs["headers"]
+        # Hostname preserved -> TLS cert can validate
+        assert "sonarr.example.com" in called_url
+        assert "203.0.113.42" not in called_url
+        # No Host header override needed when URL already has the hostname
+        assert "Host" not in called_headers
+        # verify=True flowed through
+        assert fake_get.call_args_list[0].kwargs["verify"] is True
+
+
+def test_proxy_service_pins_for_https_when_verify_disabled(monkeypatch):
+    """Belt-and-suspenders for the verify=False case: with TLS
+    validation explicitly disabled, the only DNS-rebinding mitigation
+    left is IP pinning, so we DO pin in that case."""
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    monkeypatch.setattr(socket, "getaddrinfo",
+                        lambda *a, **kw: [_addr("203.0.113.42")])
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"version": "4.0.0.0"}
+    with patch("app.ui.requests.get", return_value=resp) as fake_get, \
+         patch("app.ui.get_ssl_verify", return_value=False):
+        app = _build_app()
+        client = app.test_client()
+        _login(client)
         client.get("/test/sonarr?url=https://sonarr.example.com&apikey=k")
         called_url = fake_get.call_args_list[0].args[0]
         called_headers = fake_get.call_args_list[0].kwargs["headers"]
         assert "203.0.113.42" in called_url
         assert called_headers.get("Host") == "sonarr.example.com"
+        assert fake_get.call_args_list[0].kwargs["verify"] is False

--- a/tests/bazarr/test_connection_tester.py
+++ b/tests/bazarr/test_connection_tester.py
@@ -335,6 +335,53 @@ def test_proxy_service_returns_connection_error_when_no_ip_reachable(monkeypatch
         assert "Cannot connect" in body["error"]
 
 
+def test_format_host_header_brackets_ipv6():
+    """RFC 7230 §5.4 requires IPv6 literals in the Host header to be
+    bracketed. urlparse(...).hostname strips brackets, so the helper
+    has to put them back. Codex P2 round 3."""
+    from app.ui import _format_host_header
+    # IPv6 with non-default port
+    assert _format_host_header("::1", 8989, "http") == "[::1]:8989"
+    # IPv6 with default HTTP port -> port omitted, brackets kept
+    assert _format_host_header("::1", 80, "http") == "[::1]"
+    # IPv6 link-local
+    assert _format_host_header("fe80::1", 8989, "http") == "[fe80::1]:8989"
+    # IPv4 unchanged
+    assert _format_host_header("127.0.0.1", 8989, "http") == "127.0.0.1:8989"
+    # Hostname unchanged
+    assert _format_host_header("sonarr.example.com", 443, "https") == "sonarr.example.com"
+    # Hostname with non-default https port
+    assert _format_host_header("sonarr.example.com", 8443, "https") == "sonarr.example.com:8443"
+    # original_port=None -> omitted
+    assert _format_host_header("sonarr.example.com", None, "http") == "sonarr.example.com"
+
+
+def test_proxy_service_brackets_ipv6_in_host_header(monkeypatch):
+    """Verify the IPv6 Host header makes it through proxy_service intact.
+    Without the bracketing fix, Sonarr/Radarr behind certain HTTP parsers
+    return 400 because Host: ::1:8989 is ambiguous (which colon is the
+    port separator?). Codex P2 round 3."""
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    monkeypatch.setattr(socket, "getaddrinfo",
+                        lambda *a, **kw: [_addr("::1")])
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"version": "4.0.0.0"}
+    with patch("app.ui.requests.get", return_value=resp) as fake_get:
+        app = _build_app()
+        client = app.test_client()
+        _login(client)
+        # Note: Flask's test_client URL-encodes %5B/%5D; we use the
+        # already-encoded form so the value reaches base_url unchanged.
+        client.get("/test/sonarr?url=http%3A//%5B%3A%3A1%5D%3A8989&apikey=k")
+        called_url = fake_get.call_args_list[0].args[0]
+        called_headers = fake_get.call_args_list[0].kwargs["headers"]
+        # Pinned URL still uses ::1 in bracketed form (the netloc
+        # construction already brackets IPv6)
+        assert "[::1]" in called_url
+        # Host header brackets the IPv6 literal correctly
+        assert called_headers["Host"] == "[::1]:8989"
+
+
 def test_proxy_service_pins_to_resolved_ip_for_http(monkeypatch):
     """DNS-rebinding mitigation preserved on HTTP: request goes to the
     resolved IP with Host: header set to the original hostname. TLS

--- a/tests/bazarr/test_connection_tester.py
+++ b/tests/bazarr/test_connection_tester.py
@@ -37,10 +37,10 @@ def _addr(ip):
 def test_relaxed_validator_accepts(monkeypatch, ip):
     from app.ui import _resolve_and_validate_constrained
     monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **kw: [_addr(ip)])
-    resolved_ip, hostname, parsed = _resolve_and_validate_constrained(
+    resolved_ips, hostname, parsed = _resolve_and_validate_constrained(
         "http://example.test:8989/"
     )
-    assert resolved_ip == ip
+    assert resolved_ips == [ip]
     assert hostname == "example.test"
 
 
@@ -58,14 +58,40 @@ def test_relaxed_validator_rejects(monkeypatch, ip):
 
 
 def test_relaxed_validator_picks_first_usable_in_dual_stack(monkeypatch):
-    """Multicast first, public second: validator skips multicast and picks public."""
+    """Multicast first, public second: validator skips multicast and keeps public."""
     from app.ui import _resolve_and_validate_constrained
     monkeypatch.setattr(
         socket, "getaddrinfo",
         lambda *a, **kw: [_addr("224.0.0.1"), _addr("8.8.8.8")],
     )
-    resolved_ip, _, _ = _resolve_and_validate_constrained("http://example.test/")
-    assert resolved_ip == "8.8.8.8"
+    resolved_ips, _, _ = _resolve_and_validate_constrained("http://example.test/")
+    assert resolved_ips == ["8.8.8.8"]
+
+
+def test_relaxed_validator_returns_all_safe_addresses(monkeypatch):
+    """Dual-stack hostname: both addresses returned in DNS order so the
+    caller can fall back if the first one refuses connection."""
+    from app.ui import _resolve_and_validate_constrained
+    monkeypatch.setattr(
+        socket, "getaddrinfo",
+        lambda *a, **kw: [_addr("::1"), _addr("127.0.0.1")],
+    )
+    resolved_ips, _, _ = _resolve_and_validate_constrained("http://localhost/")
+    assert resolved_ips == ["::1", "127.0.0.1"]
+
+
+def test_relaxed_validator_dedupes_repeated_addresses(monkeypatch):
+    from app.ui import _resolve_and_validate_constrained
+    monkeypatch.setattr(
+        socket, "getaddrinfo",
+        lambda *a, **kw: [
+            _addr("127.0.0.1"),
+            _addr("127.0.0.1"),  # SOCK_STREAM + SOCK_DGRAM both return the same IP
+            _addr("::1"),
+        ],
+    )
+    resolved_ips, _, _ = _resolve_and_validate_constrained("http://localhost/")
+    assert resolved_ips == ["127.0.0.1", "::1"]
 
 
 def test_relaxed_validator_no_addrs(monkeypatch):
@@ -257,6 +283,56 @@ def test_proxy_service_honors_verify_ssl_setting(monkeypatch):
         client.get("/test/sonarr?url=https://sonarr.example.com&apikey=k")
         assert fake_get.call_args_list[0].kwargs["verify"] is False
         fake_verify.assert_called_with("sonarr")
+
+
+def test_proxy_service_falls_back_to_next_resolved_ip_on_connection_refused(monkeypatch):
+    """Dual-stack hostname where the first address refuses connection.
+    The second address must be tried automatically. This is the
+    'localhost resolves to ::1 first, only 127.0.0.1 listens' case
+    seen on every dual-stack Linux box."""
+    import requests
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    monkeypatch.setattr(
+        socket, "getaddrinfo",
+        lambda *a, **kw: [_addr("::1"), _addr("127.0.0.1")],
+    )
+    refused = requests.ConnectionError("ECONNREFUSED on ::1")
+    success = MagicMock(status_code=200)
+    success.json.return_value = {"version": "4.0.0.7000"}
+    # Two ConnectionError on ::1 (legacy + v3 path), then 200 on 127.0.0.1
+    # legacy (because the inner break short-circuits to next IP after
+    # first ConnectionError, so 127.0.0.1 starts at legacy path).
+    with patch("app.ui.requests.get", side_effect=[refused, success]) as fake_get:
+        app = _build_app()
+        client = app.test_client()
+        _login(client)
+        r = client.get("/test/sonarr?url=http://localhost:8989&apikey=k")
+        body = r.get_json()
+        assert body["status"] is True, body
+        assert body["version"] == "4.0.0.7000"
+        # First call hit ::1 (refused), second call hit 127.0.0.1
+        assert fake_get.call_count == 2
+        urls = [c.args[0] for c in fake_get.call_args_list]
+        assert "[::1]" in urls[0]
+        assert "127.0.0.1" in urls[1]
+
+
+def test_proxy_service_returns_connection_error_when_no_ip_reachable(monkeypatch):
+    import requests
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    monkeypatch.setattr(
+        socket, "getaddrinfo",
+        lambda *a, **kw: [_addr("::1"), _addr("127.0.0.1")],
+    )
+    refused = requests.ConnectionError("nothing listens here")
+    with patch("app.ui.requests.get", side_effect=[refused, refused]):
+        app = _build_app()
+        client = app.test_client()
+        _login(client)
+        r = client.get("/test/sonarr?url=http://localhost:8989&apikey=k")
+        body = r.get_json()
+        assert body["status"] is False
+        assert "Cannot connect" in body["error"]
 
 
 def test_proxy_service_pins_to_resolved_ip_with_host_header(monkeypatch):


### PR DESCRIPTION
Closes LavX/bazarr#92.

## Problem

The current `/test/<protocol>/<path:url>` route is structured as a generic forwarding proxy:

- frontend supplies the full upstream path
- `request.args` is forwarded wholesale to the upstream
- `verify=False` is hardcoded, ignoring the per-service `verify_ssl` setting

Because the path is attacker-controllable from any authenticated UI session, the strict guard at `_resolve_and_validate` blocks loopback and link-local to limit SSRF blast radius. That stops two legitimate use cases identified by Zmegolaz in the issue:

1. Bare-metal install where Bazarr+ and Sonarr/Radarr both bind to `127.0.0.1` (the most common Debian/systemd setup)
2. IPv6 single-host installs where `fe80::1` is the default link-local address on every NIC

Result: "Request blocked: All resolved addresses are link-local or loopback" on every test, even though the user genuinely is running Sonarr on localhost.

## Fix

Keep the strict route in place for the existing provider connection tester (whisper-asr etc., used by `ProviderTestButton`), and add a separate constrained route for Sonarr/Radarr.

### Backend (`bazarr/app/ui.py`)

New `proxy_service(service)` route:

- Whitelisted to `service in ('sonarr', 'radarr')`.
- Accepts `url` (base, including any reverse-proxy path) and `apikey` as query params; refuses `..`, query strings, and fragments in `url`.
- Backend builds `<base>/api/system/status` and `<base>/api/v3/system/status` itself and probes both. The user no longer contributes the request path.
- `apikey` is sent as `X-Api-Key` header to keep it out of upstream access logs.
- `verify=get_ssl_verify(service)` honors the existing per-service `verify_ssl` setting.

New `_resolve_and_validate_constrained` helper used only by the Sonarr/Radarr probe:

- Allows loopback, IPv6 link-local, IPv4 link-local, private LAN, and public.
- Rejects only multicast and unspecified addresses (cannot host a TCP service).
- DNS-rebinding pinning preserved: resolve once, pin request to resolved IP, set `Host:` header to the original hostname.

The strict `_resolve_and_validate` and the original `proxy(protocol, url)` route are unchanged.

### Frontend

`urlTest` in `frontend/src/apis/raw/utils.ts` now calls `/test/<service>?url=...&apikey=...` with the service category and a single-call probe (backend handles legacy + v3 fallback). `URLTestButton` in `frontend/src/pages/Settings/components/index.tsx` updated to pass the category through.

`providerUrlTest` in the same file is unchanged — it still uses the strict generic route for whisper-asr and similar providers, which is the right posture for those.

## Why loosening is safe here

The strict guard exists because the original proxy lets the caller pick the path. Once the path is locked to `/api/[v3/]system/status`, the only thing an authenticated UI session can do via this endpoint is probe whether something Sonarr-or-Radarr-shaped is listening at the typed host:port, with no side effects on the upstream. That bounded surface is what makes loopback and link-local safe. A credential-less attacker still has to first authenticate to Bazarr; an authenticated attacker already has whatever LAN reach the Bazarr process has, so allowing localhost adds no new capability.

Multicast and unspecified are rejected because no TCP service binds there (would just produce a confusing connection failure).

## Verification

- `pytest tests/bazarr -q -k "not test_init_pool and not test_pool_update"` 347 passed (313 + 34 new tests covering relaxed validator, base-URL validator, and end-to-end probe behaviour)
- `pytest tests/compat -q` 234 passed
- `ruff check .` clean
- Frontend `tsc --noEmit`, `eslint`, `prettier -c .`, `vite build` all clean

Test coverage includes:

- relaxed validator accepts `127.0.0.1`, `::1`, `169.254.1.1`, `fe80::1`, `10.0.0.5`, `192.168.1.10`, `8.8.8.8`
- relaxed validator rejects `224.0.0.1`, `ff02::1`, `0.0.0.0`, `::`
- dual-stack: multicast first + public second picks the public address
- base URL validator rejects `ftp://`, `file://`, missing host, `?query`, `#fragment`, `..` traversal
- end-to-end probe: service whitelist, missing url/apikey, localhost success path, legacy 404 -> v3 fallback, 401 short-circuit (no fallback), `verify_ssl=False` setting honored, request pinned to resolved IP with `Host:` header

## Test plan

- [ ] CI green
- [x] Manual smoke: with Bazarr+ and Sonarr both bound to `127.0.0.1` on the same host, click Test in Sonarr settings and verify it succeeds with the version returned
- [x] Manual smoke: same for Radarr
- [x] Manual smoke: an IPv6 single-host install where Sonarr listens on `[fe80::1]:8989` is now testable
- [x] Regression: an existing public Sonarr install (`https://sonarr.example.com`) still works
- [x] Regression: an existing reverse-proxied Sonarr (`https://example.com/sonarr`) still works
- [x] Regression: provider connection-tester (whisper-asr) still uses the strict path

## Out of scope

- The original `/test/<protocol>/<path:url>` proxy route is unchanged. It is still used by `ProviderTestButton` and still has the strict IP guard. A future PR could give that endpoint the same treatment if it ever needs to support local providers.