### PR TITLE
chore: drop em dash + G004 noqa baseline in adaptive_searching

### DIFF
--- a/bazarr/subtitles/adaptive_searching.py
+++ b/bazarr/subtitles/adaptive_searching.py
@@ -153,12 +153,12 @@ def is_search_given_up(desired_language, attempt_string):
     elif max_age.endswith('d'):
         threshold = timedelta(days=int(max_age[:-1]))
     else:
-        logging.debug(f"Adaptive searching: cannot parse adaptive_searching_max_age from config: {max_age}")
+        logging.debug(f"Adaptive searching: cannot parse adaptive_searching_max_age from config: {max_age}")  # noqa: G004
         return False
 
     given_up = (last_ts - first_ts) >= threshold
     if given_up:
-        logging.debug(f"Adaptive searching: giving up on {desired_language} — span between first and last attempt "
+        logging.debug(f"Adaptive searching: giving up on {desired_language}: span between first and last attempt "  # noqa: G004
                       f"({last_ts - first_ts}) exceeds threshold ({threshold})")
     return given_up
 


### PR DESCRIPTION
Two cleanups for code that just merged via PR #87, plus a noqa baseline for the new ruff PERF/G ruleset enabled by PR #93.

## Em dash removal

PR #87 added `is_search_given_up` with this debug log line:

```python
logging.debug(f"Adaptive searching: giving up on {desired_language} — span between first and last attempt ...")
```

Project policy disallows em dashes everywhere in source. Replaced with a colon, message semantics unchanged.

## G004 noqa baseline

The G rule family was enabled in `ruff.toml` as part of PR #93 (perf-consolidated audit) with `--add-noqa` applied to all then-existing offenders. PR #87 introduced two new f-string `logging.debug` call sites in `is_search_given_up` that the rule now flags. Added `# noqa: G004` to each, keeping ruff in CI green without disturbing the logging idiom of the surrounding file: every other `logging.debug` call in `adaptive_searching.py` is already an f-string with a noqa baseline. A separate cleanup PR can convert the whole file to lazy `%s` formatting in one pass when someone gets to it.

## Verification

- `ruff check .` clean
- `pytest tests/bazarr -q` 355 passed (2 pre-existing SQLite env deselects)

## Test plan

- [x] CI green