### PR TITLE
compat: serve locally-available SRTs alongside provider results

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -547,6 +547,8 @@ validators = [
               default=1000, cast=int, gte=1, lte=1000000),
     Validator('compat_endpoint.downloads_window_seconds',
               default=86400, cast=int, gte=60, lte=2592000),
+    Validator('compat_endpoint.serve_local_subs',
+              default=True, is_type_of=bool),
     # OMDB: optional title/year resolution for movies that aren't in the
     # local library. Free tier at omdbapi.com (1000 req/day). Empty = skip.
     Validator('omdb.apikey', default='', cast=str),

--- a/bazarr/compat/auth.py
+++ b/bazarr/compat/auth.py
@@ -122,15 +122,20 @@ def mint_file_id(provider: str, native_id: str, language: str, release_info: str
 
 def mint_local_file_id(*, path: str, lang: str, modifier: str | None,
                        fmt: str, media_type: str, media_id: int,
-                       media_dir: str) -> int:
+                       media_dir: str,
+                       allowed_roots: list[str] | None = None) -> int:
     """Allocate a server-side-mapped int file_id for a locally-stored subtitle.
 
-    Stash the resolved path + format + media-dir anchor so /download/stream
-    can validate and serve without re-resolving from the DB. The `kind`
-    discriminator key lets the stream handler branch on payload type.
+    Stash the resolved path + format + allowed-roots list so /download/stream
+    can validate and serve without re-resolving from the DB. `allowed_roots`
+    is the union of the media file's directory and any configured target
+    folder (general.subfolder=='absolute'); serve_local rejects any path
+    outside this list at stream time. Falls back to [media_dir] if the
+    caller doesn't pre-compute the list (back-compat).
     """
     from .file_id_store import get_store
     ttl = int(settings.compat_endpoint.file_id_ttl_seconds)
+    roots = [str(r) for r in (allowed_roots or [media_dir])]
     payload = {
         "kind": "local",
         "path": str(path),
@@ -140,6 +145,7 @@ def mint_local_file_id(*, path: str, lang: str, modifier: str | None,
         "media_type": str(media_type),
         "media_id": int(media_id),
         "media_dir": str(media_dir),
+        "allowed_roots": roots,
     }
     return get_store().put(payload, ttl)
 

--- a/bazarr/compat/auth.py
+++ b/bazarr/compat/auth.py
@@ -120,6 +120,30 @@ def mint_file_id(provider: str, native_id: str, language: str, release_info: str
     return get_store().put(payload, ttl)
 
 
+def mint_local_file_id(*, path: str, lang: str, modifier: str | None,
+                       fmt: str, media_type: str, media_id: int,
+                       media_dir: str) -> int:
+    """Allocate a server-side-mapped int file_id for a locally-stored subtitle.
+
+    Stash the resolved path + format + media-dir anchor so /download/stream
+    can validate and serve without re-resolving from the DB. The `kind`
+    discriminator key lets the stream handler branch on payload type.
+    """
+    from .file_id_store import get_store
+    ttl = int(settings.compat_endpoint.file_id_ttl_seconds)
+    payload = {
+        "kind": "local",
+        "path": str(path),
+        "lang": str(lang),
+        "modifier": modifier,
+        "fmt": str(fmt),
+        "media_type": str(media_type),
+        "media_id": int(media_id),
+        "media_dir": str(media_dir),
+    }
+    return get_store().put(payload, ttl)
+
+
 def parse_file_id(fid) -> Tuple[bool, dict]:
     """Resolve an int (or digit string) file_id to its stored payload."""
     from .file_id_store import get_store

--- a/bazarr/compat/cache.py
+++ b/bazarr/compat/cache.py
@@ -44,8 +44,15 @@ def build_key(media_type: str, imdb_id: str, season: int | None,
         ",".join(sorted(enabled_providers or [])).encode()
     ).hexdigest()[:16]
     req_langs = ",".join(sorted(requested_languages or []))
+    # Local-sub merging changes envelope shape (locals are pinned to the
+    # top), so it must influence the cache key. Without this, toggling the
+    # serve_local_subs flag would keep returning the previous cached
+    # envelope until natural TTL expiry.
+    from app.config import settings as _cfg
+    local_flag = int(bool(_cfg.compat_endpoint.serve_local_subs))
     extras = hashlib.sha256(
-        f"{query or ''}|{moviehash or ''}|{moviehash_match or ''}|{req_langs}".encode()
+        f"{query or ''}|{moviehash or ''}|{moviehash_match or ''}"
+        f"|{req_langs}|local={local_flag}".encode()
     ).hexdigest()[:16]
     return (
         f"compat:v2:{media_type}:{imdb_id}:{season or 0}:{episode or 0}"

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -7,11 +7,20 @@ DB lookup and path-safety logic it needs inline.
 """
 from __future__ import annotations
 
+import ast as _ast
+import logging
 import os
 import struct
 import threading
 from collections import OrderedDict
 
+
+# Bound through a local name so the call site reads `_parse_literal(raw)`,
+# matching the same safe-parse contract Bazarr uses elsewhere
+# (see bazarr/api/utils.py for the same pattern on `subtitles` / `tags`).
+_parse_literal = _ast.literal_eval
+
+logger = logging.getLogger("bazarr.compat.local_subs")
 
 _CHUNK_SIZE = 64 * 1024  # 64 KB - OpenSubtitles algorithm constant
 
@@ -80,11 +89,6 @@ class _HashCache:
 
 
 _hash_cache = _HashCache()
-
-
-import logging
-
-logger = logging.getLogger("bazarr.compat.local_subs")
 
 
 def _tt(imdb_id: str | None) -> str:
@@ -246,14 +250,6 @@ def _resolve_media(imdb_id: str | None, season: int | None,
         if hit:
             return hit
     return None
-
-
-import ast as _ast
-
-# Bound through a local name so the call site is `_parse_literal(raw)`,
-# matching the same safe-parse contract Bazarr uses elsewhere
-# (see bazarr/api/utils.py for the same pattern on `subtitles` / `tags`).
-_parse_literal = _ast.literal_eval
 
 
 _CONVERTIBLE_FORMATS = frozenset({"srt", "ass", "ssa", "vtt", "sub", "smi", "ttml", "dfxp"})

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -102,17 +102,36 @@ def _tt(imdb_id: str | None) -> str:
     return f"tt{s}" if s.lstrip("0").isdigit() or s.isdigit() else ""
 
 
+def _imdb_candidates(imdb_id: str | None) -> list[str]:
+    """Build the set of plausible IMDb id strings the DB might store.
+
+    Jellyfin/OS-compat clients commonly strip leading zeros (sending
+    `481369` for `tt0481369`); Sonarr/Radarr keep them. So we generate
+    candidates: the as-supplied form, plus zero-padded widths 7, 8, 9
+    that cover historical and current IMDb id lengths. Empty list when
+    the input has no digits.
+    """
+    norm = _tt(imdb_id)
+    if not norm:
+        return []
+    digits = norm[2:].lstrip("0") or "0"
+    candidates = {norm, f"tt{digits}"}
+    for width in (7, 8, 9):
+        candidates.add(f"tt{digits.zfill(width)}")
+    return sorted(candidates)
+
+
 def _resolve_by_imdb(imdb_id: str, season: int | None, episode: int | None,
                     media_type: str) -> tuple[str, int] | None:
     from app.database import select, TableMovies, TableShows, TableEpisodes
-    imdb = _tt(imdb_id)
-    if not imdb:
+    candidates = _imdb_candidates(imdb_id)
+    if not candidates:
         return None
     try:
         if media_type == "episode":
             show = database.execute(
                 select(TableShows.sonarrSeriesId)
-                .where(TableShows.imdbId == imdb)
+                .where(TableShows.imdbId.in_(candidates))
             ).first()
             if not show:
                 return None
@@ -126,7 +145,7 @@ def _resolve_by_imdb(imdb_id: str, season: int | None, episode: int | None,
         else:
             row = database.execute(
                 select(TableMovies.radarrId)
-                .where(TableMovies.imdbId == imdb)
+                .where(TableMovies.imdbId.in_(candidates))
             ).first()
             return ("movie", int(row.radarrId)) if row else None
     except Exception as e:

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -248,6 +248,70 @@ def _resolve_media(imdb_id: str | None, season: int | None,
     return None
 
 
+import ast as _ast
+
+# Bound through a local name so the call site is `_parse_literal(raw)`,
+# matching the same safe-parse contract Bazarr uses elsewhere
+# (see bazarr/api/utils.py for the same pattern on `subtitles` / `tags`).
+_parse_literal = _ast.literal_eval
+
+
+_CONVERTIBLE_FORMATS = frozenset({"srt", "ass", "ssa", "vtt", "sub", "smi", "ttml", "dfxp"})
+
+
+def _parse_subtitles_blob(raw) -> list:
+    """Parse Bazarr's repr-encoded `subtitles` column. Returns [] on any
+    failure. Wrapper exists so tests can mock the parser at one place."""
+    if not raw:
+        return []
+    try:
+        items = _parse_literal(raw)
+    except (ValueError, SyntaxError):
+        return []
+    return items if isinstance(items, list) else []
+
+
+def _parse_lang_code(code: str) -> tuple[str, str | None]:
+    """Parse a Bazarr lang code into (base, modifier).
+
+    "en"           -> ("en", None)
+    "en:hi"        -> ("en", "hi")
+    "pt-BR:forced" -> ("pt-BR", "forced")
+    """
+    if ":" in code:
+        base, mod = code.split(":", 1)
+    else:
+        base, mod = code, None
+    if mod and mod not in ("hi", "forced"):
+        mod = None
+    return base, mod
+
+
+def _parse_request_bcp47(code: str) -> tuple[str, str | None]:
+    """Split a BCP-47 request code into (base_alpha2, region)."""
+    if "-" in code:
+        base, region = code.split("-", 1)
+        return base.lower(), region.upper()
+    return code.lower(), None
+
+
+def _lang_matches(entry_base: str, request_base: str,
+                  request_region: str | None) -> bool:
+    e_parts = entry_base.split("-", 1)
+    e_base = e_parts[0].lower()
+    e_region = e_parts[1].upper() if len(e_parts) > 1 else None
+    if e_base != request_base.lower():
+        return False
+    if request_region is None:
+        return True
+    return e_region == request_region.upper()
+
+
+def _resolve_format(path: str) -> str | None:
+    ext = os.path.splitext(path)[1].lower().lstrip(".")
+    return ext if ext in _CONVERTIBLE_FORMATS else None
+
+
 # Module-level `database` symbol so tests can patch via
 # `compat.local_subs.database`. Real reference imported lazily.
 try:

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -191,6 +191,45 @@ def _resolve_by_query(query: str, media_type: str) -> tuple[str, int] | None:
         return None
 
 
+try:
+    from utilities.path_mappings import path_mappings
+except Exception:
+    path_mappings = None
+
+
+def _resolve_by_moviehash(moviehash: str, media_type: str) -> tuple[str, int] | None:
+    if not moviehash:
+        return None
+    target = str(moviehash).strip().lower()
+    if not target or len(target) != 16:
+        return None
+    from app.database import select, TableMovies, TableEpisodes
+    try:
+        if media_type == "episode":
+            rows = database.execute(
+                select(TableEpisodes.sonarrEpisodeId, TableEpisodes.path)
+            ).all()
+            for r in rows:
+                local = path_mappings.path_replace(r.path) if path_mappings else r.path
+                h = _hash_cache.get(local)
+                if h and h.lower() == target:
+                    return ("episode", int(r.sonarrEpisodeId))
+            return None
+        else:
+            rows = database.execute(
+                select(TableMovies.radarrId, TableMovies.path)
+            ).all()
+            for r in rows:
+                local = path_mappings.path_replace_movie(r.path) if path_mappings else r.path
+                h = _hash_cache.get(local)
+                if h and h.lower() == target:
+                    return ("movie", int(r.radarrId))
+            return None
+    except Exception as e:
+        logger.debug("compat local: moviehash resolve failed: %s", e)
+        return None
+
+
 def _resolve_media(imdb_id: str | None, season: int | None,
                    episode: int | None, media_type: str,
                    query: str | None, moviehash: str | None) -> tuple[str, int] | None:
@@ -200,6 +239,10 @@ def _resolve_media(imdb_id: str | None, season: int | None,
             return hit
     if query:
         hit = _resolve_by_query(query, media_type)
+        if hit:
+            return hit
+    if moviehash:
+        hit = _resolve_by_moviehash(moviehash, media_type)
         if hit:
             return hit
     return None

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -521,10 +521,17 @@ def search_local(
     languages: list[str],
     query: str | None = None,
     moviehash: str | None = None,
+    moviehash_match: str | None = None,
 ) -> list[dict]:
     """OS.com-shaped entries for locally-available subtitles.
 
     Empty list on resolve miss or no matches. Never raises.
+
+    `moviehash_match="only"` honors the OS.com perfect-match contract:
+    only return locals when the media row was resolved via the moviehash
+    path (which proves the on-disk file matches the client's hash).
+    Locals resolved via imdb/query are NOT hash-validated and would
+    silently break the strict-hash workflow if surfaced under "only".
     """
     if not languages:
         return []
@@ -532,8 +539,16 @@ def search_local(
         from .response_mapper import local_to_os_entry
         from . import auth as _auth
 
-        resolved = _resolve_media(imdb_id, season, episode, media_type,
-                                   query, moviehash)
+        if moviehash_match == "only":
+            # Strict hash mode: only the moviehash resolution path can
+            # certify that the local file actually matches the client's
+            # hash. Skip imdb/query — they'd produce false positives.
+            if not moviehash:
+                return []
+            resolved = _resolve_by_moviehash(moviehash, media_type)
+        else:
+            resolved = _resolve_media(imdb_id, season, episode, media_type,
+                                       query, moviehash)
         if resolved is None:
             return []
         media_type_resolved, media_id = resolved

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -130,11 +130,76 @@ def _resolve_by_imdb(imdb_id: str, season: int | None, episode: int | None,
         return None
 
 
+def _guessit_filename(filename: str) -> dict:
+    """Run guessit; return plain dict (never raises)."""
+    if not filename:
+        return {}
+    try:
+        from subliminal_patch.core import guessit as _g
+        return dict(_g(filename) or {})
+    except Exception as e:
+        logger.debug("compat local: guessit failed on %r: %s", filename, e)
+        return {}
+
+
+def _resolve_by_query(query: str, media_type: str) -> tuple[str, int] | None:
+    from app.database import select, TableMovies, TableShows, TableEpisodes
+    g = _guessit_filename(query)
+    title = (g.get("title") or "").strip()
+    if not title:
+        return None
+    try:
+        if media_type == "episode":
+            season = g.get("season")
+            episode = g.get("episode")
+            if season is None or episode is None:
+                return None
+            show = database.execute(
+                select(TableShows.sonarrSeriesId)
+                .where(TableShows.title.ilike(title))
+            ).first()
+            if not show:
+                show = database.execute(
+                    select(TableShows.sonarrSeriesId)
+                    .where(TableShows.alternativeTitles.ilike(f"%{title}%"))
+                ).first()
+            if not show:
+                return None
+            ep = database.execute(
+                select(TableEpisodes.sonarrEpisodeId)
+                .where(TableEpisodes.sonarrSeriesId == show.sonarrSeriesId)
+                .where(TableEpisodes.season == int(season))
+                .where(TableEpisodes.episode == int(episode))
+            ).first()
+            return ("episode", int(ep.sonarrEpisodeId)) if ep else None
+        else:
+            year = g.get("year")
+            rows = database.execute(
+                select(TableMovies.radarrId, TableMovies.year)
+                .where(TableMovies.title.ilike(title))
+            ).all()
+            if not rows:
+                return None
+            if year is not None:
+                year_str = str(year)
+                for r in rows:
+                    if str(r.year) == year_str:
+                        return ("movie", int(r.radarrId))
+            return ("movie", int(rows[0].radarrId))
+    except Exception as e:
+        logger.debug("compat local: query resolve failed: %s", e)
+        return None
+
+
 def _resolve_media(imdb_id: str | None, season: int | None,
                    episode: int | None, media_type: str,
                    query: str | None, moviehash: str | None) -> tuple[str, int] | None:
     if imdb_id:
         hit = _resolve_by_imdb(imdb_id, season, episode, media_type)
+        if hit:
+            return hit
+    if query:
+        hit = _resolve_by_query(query, media_type)
         if hit:
             return hit
     return None

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -312,6 +312,77 @@ def _resolve_format(path: str) -> str | None:
     return ext if ext in _CONVERTIBLE_FORMATS else None
 
 
+def _select_local_subs(raw_subtitles, media_dir: str,
+                      requested_languages: list[str]) -> list[dict]:
+    """Filter Bazarr's `subtitles` column entries by requested languages
+    and surviving on-disk files.
+
+    Returns a list of intermediate dicts (NOT yet OS.com-shaped). Each:
+      {"lang": str, "modifier": "hi"|"forced"|None, "fmt": str,
+       "path": str (realpath inside media_dir), "filename": str,
+       "size": int, "mtime": float}
+
+    Path safety: each entry is realpath'd and required to live inside
+    realpath(media_dir). The caller is responsible for path-mapping the
+    raw subtitle paths *before* passing them in (the raw `subtitles`
+    column stores Sonarr/Radarr-side paths).
+    """
+    items = _parse_subtitles_blob(raw_subtitles)
+    if not items:
+        return []
+    requests = [_parse_request_bcp47(c) for c in requested_languages if c]
+    if not requests:
+        return []
+
+    media_dir_real = os.path.realpath(media_dir)
+    out: list[dict] = []
+    for item in items:
+        if not (isinstance(item, list) and len(item) >= 2):
+            continue
+        lang_code, raw_path = item[0], item[1]
+        if not (isinstance(lang_code, str) and isinstance(raw_path, str)
+                and raw_path):
+            continue
+
+        entry_base, modifier = _parse_lang_code(lang_code)
+
+        if not any(_lang_matches(entry_base, rb, rr) for rb, rr in requests):
+            continue
+
+        try:
+            real = os.path.realpath(raw_path)
+        except (OSError, ValueError):
+            continue
+        try:
+            common = os.path.commonpath([real, media_dir_real])
+        except ValueError:
+            continue
+        if common != media_dir_real:
+            continue
+        if not os.path.isfile(real):
+            continue
+
+        fmt = _resolve_format(real)
+        if fmt is None:
+            continue
+
+        try:
+            st = os.stat(real)
+        except OSError:
+            continue
+
+        out.append({
+            "lang": entry_base,
+            "modifier": modifier,
+            "fmt": fmt,
+            "path": real,
+            "filename": os.path.basename(real),
+            "size": st.st_size,
+            "mtime": st.st_mtime,
+        })
+    return out
+
+
 # Module-level `database` symbol so tests can patch via
 # `compat.local_subs.database`. Real reference imported lazily.
 try:

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -358,6 +358,48 @@ def _convert_to_srt(raw: bytes, fmt: str) -> bytes:
         return b""
 
 
+_MAX_SUB_BYTES = 5 * 1024 * 1024
+
+
+def serve_local(payload: dict) -> tuple[bytes, str]:
+    """Validate, read, and (if needed) convert a local subtitle to SRT.
+
+    Returns (bytes, "application/x-subrip"). Empty bytes is a valid
+    response: it's the plugin signal for "broken sub, blocklist".
+    """
+    path = payload.get("path") or ""
+    media_dir = payload.get("media_dir") or ""
+    fmt = payload.get("fmt") or "srt"
+
+    try:
+        real = os.path.realpath(path)
+    except (OSError, ValueError):
+        raise FileNotFoundError("invalid path")
+    try:
+        media_dir_real = os.path.realpath(media_dir)
+        if os.path.commonpath([real, media_dir_real]) != media_dir_real:
+            raise FileNotFoundError("subtitle moved outside media dir")
+    except ValueError:
+        raise FileNotFoundError("invalid media dir")
+
+    if not os.path.isfile(real):
+        raise FileNotFoundError("subtitle missing on disk")
+
+    try:
+        size = os.path.getsize(real)
+    except OSError:
+        raise FileNotFoundError("subtitle stat failed")
+    if size > _MAX_SUB_BYTES:
+        raise FileNotFoundError(f"subtitle file too large ({size} bytes)")
+
+    with open(real, "rb") as f:
+        raw = f.read()
+
+    if fmt == "srt":
+        return _normalize_srt(raw), "application/x-subrip"
+    return _convert_to_srt(raw, fmt), "application/x-subrip"
+
+
 def _fetch_media_row(media_type: str, media_id: int):
     """Fetch the row needed to enumerate subtitles + media path."""
     from app.database import select, TableMovies, TableEpisodes

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -416,17 +416,31 @@ def serve_local(payload: dict) -> tuple[bytes, str]:
 
 
 def _fetch_media_row(media_type: str, media_id: int):
-    """Fetch the row needed to enumerate subtitles + media path."""
-    from app.database import select, TableMovies, TableEpisodes
+    """Fetch the row needed to enumerate subtitles, media path, and the
+    metadata that goes into `feature_details` (title/year/imdb/season/
+    episode). Episodes need a join to TableShows for series-level fields.
+    """
+    from app.database import select, TableMovies, TableEpisodes, TableShows
     try:
         if media_type == "episode":
             return database.execute(
-                select(TableEpisodes.subtitles, TableEpisodes.path)
+                select(
+                    TableEpisodes.subtitles, TableEpisodes.path,
+                    TableEpisodes.season, TableEpisodes.episode,
+                    TableEpisodes.title.label("episode_title"),
+                    TableShows.title.label("series_title"),
+                    TableShows.year, TableShows.imdbId,
+                )
+                .join(TableShows,
+                      TableEpisodes.sonarrSeriesId == TableShows.sonarrSeriesId)
                 .where(TableEpisodes.sonarrEpisodeId == int(media_id))
             ).first()
         else:
             return database.execute(
-                select(TableMovies.subtitles, TableMovies.path)
+                select(
+                    TableMovies.subtitles, TableMovies.path,
+                    TableMovies.title, TableMovies.year, TableMovies.imdbId,
+                )
                 .where(TableMovies.radarrId == int(media_id))
             ).first()
     except Exception as e:
@@ -602,6 +616,28 @@ def search_local(
         if not candidates:
             return []
 
+        # Pull metadata for feature_details (Jellyfin's plugin filters
+        # entries lacking it). Episodes use series_title; movies use
+        # title.
+        if media_type_resolved == "episode":
+            md_title = getattr(row, "series_title", "") or ""
+            md_episode_title = getattr(row, "episode_title", "") or ""
+            md_year_raw = getattr(row, "year", None)
+            md_imdb = getattr(row, "imdbId", "") or ""
+            md_season = getattr(row, "season", None)
+            md_episode = getattr(row, "episode", None)
+        else:
+            md_title = getattr(row, "title", "") or ""
+            md_episode_title = ""
+            md_year_raw = getattr(row, "year", None)
+            md_imdb = getattr(row, "imdbId", "") or ""
+            md_season = None
+            md_episode = None
+        try:
+            md_year = int(str(md_year_raw)[:4]) if md_year_raw else 0
+        except (TypeError, ValueError):
+            md_year = 0
+
         req_lang_map = _build_request_to_lang_map(languages)
         out: list[dict] = []
         for c in candidates:
@@ -625,6 +661,13 @@ def search_local(
                 media_type=media_type_resolved,
                 media_id=media_id,
                 requested_language=requested_language,
+                imdb_id=md_imdb,
+                title=md_title,
+                year=md_year,
+                season=md_season,
+                episode=md_episode,
+                episode_title=md_episode_title,
+                hash_matched=bool(moviehash) and moviehash_match == "only",
             ))
         return out
     except Exception as e:

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -255,19 +255,30 @@ def _resolve_by_moviehash(moviehash: str, media_type: str) -> tuple[str, int] | 
 
 def _resolve_media(imdb_id: str | None, season: int | None,
                    episode: int | None, media_type: str,
-                   query: str | None, moviehash: str | None) -> tuple[str, int] | None:
+                   query: str | None, moviehash: str | None
+                   ) -> tuple[str, int, str] | None:
+    """Return (media_type, media_id, source) on hit, None on miss.
+
+    `source` records which resolver path produced the hit:
+      - "imdb"      : imdb_id + season/episode lookup
+      - "query"     : guessit-on-filename lookup
+      - "moviehash" : library scan + OS hash match
+    Callers use `source == "moviehash"` to set attributes.moviehash_match
+    on the response entry: hash-resolved rows are hash-validated by
+    construction, regardless of the request's moviehash_match mode.
+    """
     if imdb_id:
         hit = _resolve_by_imdb(imdb_id, season, episode, media_type)
         if hit:
-            return hit
+            return (*hit, "imdb")
     if query:
         hit = _resolve_by_query(query, media_type)
         if hit:
-            return hit
+            return (*hit, "query")
     if moviehash:
         hit = _resolve_by_moviehash(moviehash, media_type)
         if hit:
-            return hit
+            return (*hit, "moviehash")
     return None
 
 
@@ -629,13 +640,14 @@ def search_local(
             # hash. Skip imdb/query — they'd produce false positives.
             if not moviehash:
                 return []
-            resolved = _resolve_by_moviehash(moviehash, media_type)
+            hit = _resolve_by_moviehash(moviehash, media_type)
+            resolved = (*hit, "moviehash") if hit else None
         else:
             resolved = _resolve_media(imdb_id, season, episode, media_type,
                                        query, moviehash)
         if resolved is None:
             return []
-        media_type_resolved, media_id = resolved
+        media_type_resolved, media_id, resolve_source = resolved
 
         row = _fetch_media_row(media_type_resolved, media_id)
         if row is None:
@@ -726,7 +738,11 @@ def search_local(
                 season=md_season,
                 episode=md_episode,
                 episode_title=md_episode_title,
-                hash_matched=bool(moviehash) and moviehash_match == "only",
+                # Hash-match flag reflects how the row was resolved, not
+                # the request mode: a moviehash-resolved row is
+                # hash-validated regardless of moviehash_match=include vs
+                # only. Codex P2.
+                hash_matched=resolve_source == "moviehash",
             ))
         return out
     except Exception as e:

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -312,6 +312,52 @@ def _resolve_format(path: str) -> str | None:
     return ext if ext in _CONVERTIBLE_FORMATS else None
 
 
+def _decode_subtitle_bytes(raw: bytes) -> str:
+    """BOM check -> UTF-8 -> charset_normalizer -> cp1252 fallback.
+
+    Mirrors bazarr/api/subtitles/content.py:read_subtitle_file.
+    """
+    if raw.startswith(b"\xef\xbb\xbf"):
+        return raw[3:].decode("utf-8")
+    if raw.startswith(b"\xff\xfe"):
+        return raw[2:].decode("utf-16-le")
+    if raw.startswith(b"\xfe\xff"):
+        return raw[2:].decode("utf-16-be")
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        pass
+    try:
+        import charset_normalizer
+        result = charset_normalizer.from_bytes(raw).best()
+        if result is not None:
+            return str(result)
+    except Exception:
+        pass
+    return raw.decode("cp1252", errors="replace")
+
+
+def _normalize_srt(raw: bytes) -> bytes:
+    """Decode any incoming SRT bytes, re-emit UTF-8 without BOM."""
+    return _decode_subtitle_bytes(raw).encode("utf-8")
+
+
+def _convert_to_srt(raw: bytes, fmt: str) -> bytes:
+    """Convert ass/ssa/vtt/sub/smi/ttml/dfxp source to SRT bytes via pysubs2.
+
+    Returns b"" on any conversion failure (preserves the plugin's
+    "broken sub, blocklist this file_id" contract -- 200 + empty body).
+    """
+    try:
+        import pysubs2
+        text = _decode_subtitle_bytes(raw)
+        sub = pysubs2.SSAFile.from_string(text, format_=fmt)
+        return sub.to_string("srt").encode("utf-8")
+    except Exception as e:
+        logger.debug("compat local: convert %s -> srt failed: %s", fmt, e)
+        return b""
+
+
 def _fetch_media_row(media_type: str, media_id: int):
     """Fetch the row needed to enumerate subtitles + media path."""
     from app.database import select, TableMovies, TableEpisodes

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -1,0 +1,36 @@
+"""Library-side subtitle resolution and serving for the compat endpoint.
+
+DO NOT import from bazarr.subtitles.manual, bazarr.subtitles.indexer, or
+bazarr/api/subtitles/*. The compat surface is isolated by design (see
+bazarr/compat/__init__.py); this module re-implements the small slice of
+DB lookup and path-safety logic it needs inline.
+"""
+from __future__ import annotations
+
+import os
+import struct
+
+
+_CHUNK_SIZE = 64 * 1024  # 64 KB - OpenSubtitles algorithm constant
+
+
+def _opensubtitles_hash(path: str) -> str:
+    """Compute the OpenSubtitles file hash.
+
+    Algorithm: read first 64KB and last 64KB, sum as little-endian uint64
+    chunks plus the file size, mod 2^64. Returns 16-char lowercase hex.
+    """
+    size = os.path.getsize(path)
+    h = size & 0xFFFFFFFFFFFFFFFF
+
+    with open(path, "rb") as f:
+        head = f.read(min(_CHUNK_SIZE, size))
+        for i in range(0, len(head) - 7, 8):
+            h = (h + struct.unpack_from("<Q", head, i)[0]) & 0xFFFFFFFFFFFFFFFF
+        if size > _CHUNK_SIZE:
+            f.seek(max(0, size - _CHUNK_SIZE))
+            tail = f.read(_CHUNK_SIZE)
+            for i in range(0, len(tail) - 7, 8):
+                h = (h + struct.unpack_from("<Q", tail, i)[0]) & 0xFFFFFFFFFFFFFFFF
+
+    return f"{h:016x}"

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -312,6 +312,44 @@ def _resolve_format(path: str) -> str | None:
     return ext if ext in _CONVERTIBLE_FORMATS else None
 
 
+def _fetch_media_row(media_type: str, media_id: int):
+    """Fetch the row needed to enumerate subtitles + media path."""
+    from app.database import select, TableMovies, TableEpisodes
+    try:
+        if media_type == "episode":
+            return database.execute(
+                select(TableEpisodes.subtitles, TableEpisodes.path)
+                .where(TableEpisodes.sonarrEpisodeId == int(media_id))
+            ).first()
+        else:
+            return database.execute(
+                select(TableMovies.subtitles, TableMovies.path)
+                .where(TableMovies.radarrId == int(media_id))
+            ).first()
+    except Exception as e:
+        logger.debug("compat local: media row fetch failed: %s", e)
+        return None
+
+
+def _build_request_to_lang_map(requested: list[str]) -> dict[str, str]:
+    """Map "en" / "pt" / "zh" -> the original BCP-47 string when there's
+    exactly one variant per base, so the mapper can preserve the region
+    subtag (zh-CN / pt-BR)."""
+    by_base: dict[str, list[str]] = {}
+    for code in requested or []:
+        base = code.split("-", 1)[0].lower()
+        by_base.setdefault(base, []).append(code)
+    return {b: codes[0] for b, codes in by_base.items() if len(codes) == 1}
+
+
+def _path_replace_for(media_type: str):
+    if path_mappings is None:
+        return lambda p: p
+    return (path_mappings.path_replace
+            if media_type == "episode"
+            else path_mappings.path_replace_movie)
+
+
 def _select_local_subs(raw_subtitles, media_dir: str,
                       requested_languages: list[str]) -> list[dict]:
     """Filter Bazarr's `subtitles` column entries by requested languages
@@ -389,3 +427,88 @@ try:
     from app.database import database
 except Exception:
     database = None
+
+
+def search_local(
+    imdb_id: str | None,
+    season: int | None,
+    episode: int | None,
+    media_type: str,
+    languages: list[str],
+    query: str | None = None,
+    moviehash: str | None = None,
+) -> list[dict]:
+    """OS.com-shaped entries for locally-available subtitles.
+
+    Empty list on resolve miss or no matches. Never raises.
+    """
+    if not languages:
+        return []
+    try:
+        from .response_mapper import local_to_os_entry
+        from . import auth as _auth
+
+        resolved = _resolve_media(imdb_id, season, episode, media_type,
+                                   query, moviehash)
+        if resolved is None:
+            return []
+        media_type_resolved, media_id = resolved
+
+        row = _fetch_media_row(media_type_resolved, media_id)
+        if row is None:
+            return []
+
+        path_replace = _path_replace_for(media_type_resolved)
+        media_local = path_replace(row.path)
+
+        try:
+            media_dir_real = os.path.realpath(os.path.dirname(media_local))
+        except (OSError, ValueError):
+            return []
+
+        # Path-replace each subtitle path before selection so the realpath
+        # barrier in _select_local_subs sees local-filesystem paths.
+        items = _parse_subtitles_blob(row.subtitles)
+        mapped = [
+            [it[0], path_replace(it[1])]
+            for it in items
+            if isinstance(it, list) and len(it) >= 2
+        ]
+        raw_remapped = repr(mapped)
+
+        candidates = _select_local_subs(
+            raw_subtitles=raw_remapped,
+            media_dir=media_dir_real,
+            requested_languages=languages,
+        )
+        if not candidates:
+            return []
+
+        req_lang_map = _build_request_to_lang_map(languages)
+        out: list[dict] = []
+        for c in candidates:
+            file_id = _auth.mint_local_file_id(
+                path=c["path"],
+                lang=c["lang"],
+                modifier=c["modifier"],
+                fmt=c["fmt"],
+                media_type=media_type_resolved,
+                media_id=media_id,
+                media_dir=media_dir_real,
+            )
+            base_alpha2 = c["lang"].split("-", 1)[0].lower()
+            requested_language = req_lang_map.get(base_alpha2)
+            out.append(local_to_os_entry(
+                file_id=file_id,
+                lang=c["lang"],
+                modifier=c["modifier"],
+                filename=c["filename"],
+                upload_mtime=c["mtime"],
+                media_type=media_type_resolved,
+                media_id=media_id,
+                requested_language=requested_language,
+            ))
+        return out
+    except Exception as e:
+        logger.warning("compat local: search_local crashed (returning []): %s", e)
+        return []

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -467,8 +467,42 @@ def _path_replace_for(media_type: str):
             else path_mappings.path_replace_movie)
 
 
+def _allowed_subtitle_roots(media_dir_real: str, media_path_real: str) -> list[str]:
+    """Compose the allowed subtitle roots: the media file's directory
+    plus any configured target folder (relative or absolute).
+
+    `general.subfolder == "absolute"` users keep subs in a dedicated
+    library that has no path overlap with the video file, so a strict
+    media-dir-only check would silently filter every local entry out of
+    the compat response. Mirrors the pattern in
+    `bazarr/api/subtitles/content.py:resolve_subtitle_path`.
+    """
+    roots = [media_dir_real]
+    try:
+        from utilities.helper import get_target_folder
+        target = get_target_folder(media_path_real)
+        if target:
+            target_real = os.path.realpath(target)
+            if target_real and target_real not in roots:
+                roots.append(target_real)
+    except Exception as e:
+        logger.debug("compat local: get_target_folder lookup failed: %s", e)
+    return roots
+
+
+def _path_under_any_root(real_path: str, roots: list[str]) -> bool:
+    for root in roots:
+        try:
+            if os.path.commonpath([real_path, root]) == root:
+                return True
+        except ValueError:
+            continue
+    return False
+
+
 def _select_local_subs(raw_subtitles, media_dir: str,
-                      requested_languages: list[str]) -> list[dict]:
+                      requested_languages: list[str],
+                      media_path: str | None = None) -> list[dict]:
     """Filter Bazarr's `subtitles` column entries by requested languages
     and surviving on-disk files.
 
@@ -478,9 +512,11 @@ def _select_local_subs(raw_subtitles, media_dir: str,
        "size": int, "mtime": float}
 
     Path safety: each entry is realpath'd and required to live inside
-    realpath(media_dir). The caller is responsible for path-mapping the
-    raw subtitle paths *before* passing them in (the raw `subtitles`
-    column stores Sonarr/Radarr-side paths).
+    `media_dir` OR the configured `general.subfolder` target. The caller
+    is responsible for path-mapping the raw subtitle paths *before*
+    passing them in (the raw `subtitles` column stores Sonarr/Radarr-
+    side paths). Files larger than `_MAX_SUB_BYTES` are dropped at
+    selection time so they never appear as broken download links.
     """
     items = _parse_subtitles_blob(raw_subtitles)
     if not items:
@@ -490,6 +526,9 @@ def _select_local_subs(raw_subtitles, media_dir: str,
         return []
 
     media_dir_real = os.path.realpath(media_dir)
+    media_path_real = os.path.realpath(media_path) if media_path else media_dir_real
+    allowed_roots = _allowed_subtitle_roots(media_dir_real, media_path_real)
+
     out: list[dict] = []
     for item in items:
         if not (isinstance(item, list) and len(item) >= 2):
@@ -508,11 +547,7 @@ def _select_local_subs(raw_subtitles, media_dir: str,
             real = os.path.realpath(raw_path)
         except (OSError, ValueError):
             continue
-        try:
-            common = os.path.commonpath([real, media_dir_real])
-        except ValueError:
-            continue
-        if common != media_dir_real:
+        if not _path_under_any_root(real, allowed_roots):
             continue
         if not os.path.isfile(real):
             continue
@@ -524,6 +559,12 @@ def _select_local_subs(raw_subtitles, media_dir: str,
         try:
             st = os.stat(real)
         except OSError:
+            continue
+        # Drop oversized files at selection time so they never appear as
+        # broken download links: serve_local would 404 them anyway, but
+        # surfacing them in the picker just produces a guaranteed-fail
+        # download. Keep the picker honest.
+        if st.st_size > _MAX_SUB_BYTES:
             continue
 
         out.append({
@@ -612,6 +653,7 @@ def search_local(
             raw_subtitles=raw_remapped,
             media_dir=media_dir_real,
             requested_languages=languages,
+            media_path=media_local,
         )
         if not candidates:
             return []

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -381,21 +381,31 @@ def serve_local(payload: dict) -> tuple[bytes, str]:
 
     Returns (bytes, "application/x-subrip"). Empty bytes is a valid
     response: it's the plugin signal for "broken sub, blocklist".
+
+    Path-safety: the file must still live inside one of the
+    `allowed_roots` recorded at mint time. Older payloads (pre-migration)
+    only have `media_dir` — fall back to that single root.
     """
     path = payload.get("path") or ""
     media_dir = payload.get("media_dir") or ""
     fmt = payload.get("fmt") or "srt"
+    raw_roots = payload.get("allowed_roots") or [media_dir]
 
     try:
         real = os.path.realpath(path)
     except (OSError, ValueError):
         raise FileNotFoundError("invalid path")
-    try:
-        media_dir_real = os.path.realpath(media_dir)
-        if os.path.commonpath([real, media_dir_real]) != media_dir_real:
-            raise FileNotFoundError("subtitle moved outside media dir")
-    except ValueError:
+
+    real_roots: list[str] = []
+    for r in raw_roots:
+        try:
+            real_roots.append(os.path.realpath(r))
+        except (OSError, ValueError):
+            continue
+    if not real_roots:
         raise FileNotFoundError("invalid media dir")
+    if not _path_under_any_root(real, real_roots):
+        raise FileNotFoundError("subtitle moved outside allowed roots")
 
     if not os.path.isfile(real):
         raise FileNotFoundError("subtitle missing on disk")
@@ -658,6 +668,12 @@ def search_local(
         if not candidates:
             return []
 
+        # The same roots list the selector used to validate paths; carry
+        # it into each minted file_id so serve_local can re-validate at
+        # stream time, including subs in the absolute target folder.
+        allowed_roots = _allowed_subtitle_roots(media_dir_real,
+                                                 os.path.realpath(media_local))
+
         # Pull metadata for feature_details (Jellyfin's plugin filters
         # entries lacking it). Episodes use series_title; movies use
         # title.
@@ -691,6 +707,7 @@ def search_local(
                 media_type=media_type_resolved,
                 media_id=media_id,
                 media_dir=media_dir_real,
+                allowed_roots=allowed_roots,
             )
             base_alpha2 = c["lang"].split("-", 1)[0].lower()
             requested_language = req_lang_map.get(base_alpha2)

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import os
 import struct
+import threading
+from collections import OrderedDict
 
 
 _CHUNK_SIZE = 64 * 1024  # 64 KB - OpenSubtitles algorithm constant
@@ -34,3 +36,47 @@ def _opensubtitles_hash(path: str) -> str:
                 h = (h + struct.unpack_from("<Q", tail, i)[0]) & 0xFFFFFFFFFFFFFFFF
 
     return f"{h:016x}"
+
+
+class _HashCache:
+    """In-memory LRU: (realpath, mtime_ns, size) -> oshash hex string.
+
+    Stat-on-every-get auto-invalidates when (mtime_ns, size) drift. Bounded
+    LRU; lifetime = process; restart flushes (acceptable, first cold lookup
+    recomputes).
+    """
+
+    def __init__(self, max_entries: int = 5000):
+        self._lock = threading.Lock()
+        self._max = max_entries
+        self._store: "OrderedDict[tuple, str]" = OrderedDict()
+
+    def get(self, path: str) -> str | None:
+        try:
+            real = os.path.realpath(path)
+            st = os.stat(real)
+        except (OSError, ValueError):
+            return None
+        key = (real, st.st_mtime_ns, st.st_size)
+        with self._lock:
+            cached = self._store.get(key)
+            if cached is not None:
+                self._store.move_to_end(key)
+                return cached
+        try:
+            h = _opensubtitles_hash(real)
+        except OSError:
+            return None
+        with self._lock:
+            self._store[key] = h
+            self._store.move_to_end(key)
+            while len(self._store) > self._max:
+                self._store.popitem(last=False)
+        return h
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._store)
+
+
+_hash_cache = _HashCache()

--- a/bazarr/compat/local_subs.py
+++ b/bazarr/compat/local_subs.py
@@ -80,3 +80,69 @@ class _HashCache:
 
 
 _hash_cache = _HashCache()
+
+
+import logging
+
+logger = logging.getLogger("bazarr.compat.local_subs")
+
+
+def _tt(imdb_id: str | None) -> str:
+    if not imdb_id:
+        return ""
+    s = str(imdb_id).strip().lower()
+    if not s:
+        return ""
+    if s.startswith("tt"):
+        return s
+    return f"tt{s}" if s.lstrip("0").isdigit() or s.isdigit() else ""
+
+
+def _resolve_by_imdb(imdb_id: str, season: int | None, episode: int | None,
+                    media_type: str) -> tuple[str, int] | None:
+    from app.database import select, TableMovies, TableShows, TableEpisodes
+    imdb = _tt(imdb_id)
+    if not imdb:
+        return None
+    try:
+        if media_type == "episode":
+            show = database.execute(
+                select(TableShows.sonarrSeriesId)
+                .where(TableShows.imdbId == imdb)
+            ).first()
+            if not show:
+                return None
+            ep = database.execute(
+                select(TableEpisodes.sonarrEpisodeId)
+                .where(TableEpisodes.sonarrSeriesId == show.sonarrSeriesId)
+                .where(TableEpisodes.season == int(season or 0))
+                .where(TableEpisodes.episode == int(episode or 0))
+            ).first()
+            return ("episode", int(ep.sonarrEpisodeId)) if ep else None
+        else:
+            row = database.execute(
+                select(TableMovies.radarrId)
+                .where(TableMovies.imdbId == imdb)
+            ).first()
+            return ("movie", int(row.radarrId)) if row else None
+    except Exception as e:
+        logger.debug("compat local: imdb resolve failed: %s", e)
+        return None
+
+
+def _resolve_media(imdb_id: str | None, season: int | None,
+                   episode: int | None, media_type: str,
+                   query: str | None, moviehash: str | None) -> tuple[str, int] | None:
+    if imdb_id:
+        hit = _resolve_by_imdb(imdb_id, season, episode, media_type)
+        if hit:
+            return hit
+    return None
+
+
+# Module-level `database` symbol so tests can patch via
+# `compat.local_subs.database`. Real reference imported lazily.
+try:
+    from app.database import database
+except Exception:
+    database = None

--- a/bazarr/compat/response_mapper.py
+++ b/bazarr/compat/response_mapper.py
@@ -339,10 +339,19 @@ def languages_response() -> dict:
 def local_to_os_entry(*, file_id: int, lang: str, modifier: str | None,
                       filename: str, upload_mtime: float,
                       media_type: str, media_id: int,
-                      requested_language: str | None) -> dict:
-    """OS.com-shaped entry for a locally-stored subtitle. Synthetic high
-    download_count pins locals above provider entries via the existing
-    single-key sort in service._do_fanout."""
+                      requested_language: str | None,
+                      imdb_id: str = "", title: str = "",
+                      year: int = 0,
+                      season: int | None = None,
+                      episode: int | None = None,
+                      episode_title: str = "",
+                      hash_matched: bool = False) -> dict:
+    """OS.com-shaped entry for a locally-stored subtitle.
+
+    Schema parity with `subtitle_to_os_entry` is required: the Jellyfin
+    plugin (and other OS-compat clients) silently drop entries missing
+    expected fields like `feature_details`, `uploader`, `fps`, etc.
+    """
     upload_iso = (
         dt.datetime.fromtimestamp(int(upload_mtime), dt.timezone.utc)
           .strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -352,6 +361,15 @@ def local_to_os_entry(*, file_id: int, lang: str, modifier: str | None,
     subtitle_id = f"local-{media_type}-{int(media_id)}-{lang}"
     if modifier:
         subtitle_id = f"{subtitle_id}:{modifier}"
+
+    feat_type = "Episode" if media_type == "episode" else "Movie"
+    if media_type == "episode":
+        movie_name = episode_title or title
+    elif year and title:
+        movie_name = f"{year} - {title}"
+    else:
+        movie_name = title
+
     return {
         "id": f"subtitle-{int(file_id)}",
         "type": "subtitle",
@@ -359,12 +377,30 @@ def local_to_os_entry(*, file_id: int, lang: str, modifier: str | None,
             "subtitle_id": subtitle_id,
             "language": language_out,
             "release": filename,
-            "hearing_impaired": modifier == "hi",
-            "foreign_parts_only": modifier == "forced",
-            "from_trusted": True,
-            "ratings": 10.0,
+            "comments": filename,
             "download_count": 999_999,
+            "ratings": 10.0,
+            "votes": 0,
+            "from_trusted": True,
+            "hd": False,
+            "hearing_impaired": modifier == "hi",
+            "moviehash_match": bool(hash_matched),
+            "ai_translated": False,
+            "machine_translated": False,
+            "foreign_parts_only": modifier == "forced",
+            "fps": 0.0,
             "upload_date": upload_iso,
+            "uploader": {"name": "bazarr:local"},
+            "feature_details": {
+                "feature_type": feat_type,
+                "imdb_id": _imdb_to_int(imdb_id),
+                "season_number": int(season) if season is not None else 0,
+                "episode_number": int(episode) if episode is not None else 0,
+                "title": title,
+                "movie_name": movie_name,
+                "year": int(year) if year else 0,
+            },
+            "url": "",
             "files": [{"file_id": int(file_id), "file_name": filename}],
         },
     }

--- a/bazarr/compat/response_mapper.py
+++ b/bazarr/compat/response_mapper.py
@@ -370,6 +370,11 @@ def local_to_os_entry(*, file_id: int, lang: str, modifier: str | None,
     else:
         movie_name = title
 
+    # Append the per-file id so two locals with the same lang+modifier
+    # (e.g. two distinct on-disk `.en.srt` files) don't collide on
+    # subtitle_id and get de-duplicated by the client. Codex P2.
+    subtitle_id = f"{subtitle_id}-{int(file_id)}"
+
     return {
         "id": f"subtitle-{int(file_id)}",
         "type": "subtitle",

--- a/bazarr/compat/response_mapper.py
+++ b/bazarr/compat/response_mapper.py
@@ -334,3 +334,37 @@ def languages_response() -> dict:
     ]
     return {"data": [{"language_code": c, "language_name": c.upper()}
                      for c in codes]}
+
+
+def local_to_os_entry(*, file_id: int, lang: str, modifier: str | None,
+                      filename: str, upload_mtime: float,
+                      media_type: str, media_id: int,
+                      requested_language: str | None) -> dict:
+    """OS.com-shaped entry for a locally-stored subtitle. Synthetic high
+    download_count pins locals above provider entries via the existing
+    single-key sort in service._do_fanout."""
+    upload_iso = (
+        dt.datetime.fromtimestamp(int(upload_mtime), dt.timezone.utc)
+          .strftime("%Y-%m-%dT%H:%M:%SZ")
+        if upload_mtime else _EPOCH_ISO
+    )
+    language_out = requested_language or lang
+    subtitle_id = f"local-{media_type}-{int(media_id)}-{lang}"
+    if modifier:
+        subtitle_id = f"{subtitle_id}:{modifier}"
+    return {
+        "id": f"subtitle-{int(file_id)}",
+        "type": "subtitle",
+        "attributes": {
+            "subtitle_id": subtitle_id,
+            "language": language_out,
+            "release": filename,
+            "hearing_impaired": modifier == "hi",
+            "foreign_parts_only": modifier == "forced",
+            "from_trusted": True,
+            "ratings": 10.0,
+            "download_count": 999_999,
+            "upload_date": upload_iso,
+            "files": [{"file_id": int(file_id), "file_name": filename}],
+        },
+    }

--- a/bazarr/compat/service.py
+++ b/bazarr/compat/service.py
@@ -712,6 +712,7 @@ def _do_fanout(imdb_id, season, episode, languages, media_type,
                 media_type=media_type,
                 languages=requested_languages or [],
                 query=query, moviehash=moviehash,
+                moviehash_match=moviehash_match,
             )
         except Exception as e:
             logger.warning("compat: search_local failed (continuing without locals): %s", e)

--- a/bazarr/compat/service.py
+++ b/bazarr/compat/service.py
@@ -851,6 +851,14 @@ def serve_subtitle_content(stream_token: str) -> tuple[bytes, str]:
     ok, fpayload = auth.parse_file_id(fid)
     if not ok:
         raise FileNotFoundError("file_id expired or not found")
+
+    # Local-library payloads carry an explicit kind discriminator; serve
+    # them from disk (with on-the-fly format conversion) instead of the
+    # provider fanout pool.
+    if fpayload.get("kind") == "local":
+        from .local_subs import serve_local
+        return serve_local(fpayload)
+
     sub = fpayload.get("sub")
     # Surface the guard symbol so tests can patch it.
     _ = assert_safe_outbound

--- a/bazarr/compat/service.py
+++ b/bazarr/compat/service.py
@@ -11,6 +11,7 @@ from subliminal_patch.core_persistent import list_all_subtitles_parallel
 from app.config import settings
 from app.get_providers import get_providers_sorted, get_providers_auth
 from . import auth, cache as C, response_mapper as M
+from .local_subs import search_local
 from utilities.url_guard import assert_safe_outbound, resolve_safe_url, UnsafeURLError  # noqa: F401
 
 logger = logging.getLogger("bazarr.compat.service")
@@ -700,6 +701,23 @@ def _do_fanout(imdb_id, season, episode, languages, media_type,
             score=(int(score), int(max_score)),
             requested_language=req_lang,
         ))
+    # Surface locally-stored subtitles alongside provider results when the
+    # operator hasn't disabled the feature. Locals carry a synthetic high
+    # download_count, so the existing single-key sort below pins them to
+    # the top of the list naturally.
+    if bool(settings.compat_endpoint.serve_local_subs):
+        try:
+            local_entries = search_local(
+                imdb_id=imdb_id, season=season, episode=episode,
+                media_type=media_type,
+                languages=requested_languages or [],
+                query=query, moviehash=moviehash,
+            )
+        except Exception as e:
+            logger.warning("compat: search_local failed (continuing without locals): %s", e)
+            local_entries = []
+        if local_entries:
+            entries = local_entries + entries
     entries.sort(key=lambda e: -int(e["attributes"].get("download_count", 0)))
     return M.search_envelope(entries, per_page=50, page=1)
 

--- a/tests/compat/integration/test_local_e2e.py
+++ b/tests/compat/integration/test_local_e2e.py
@@ -31,6 +31,7 @@ def test_e2e_search_then_download_then_stream(app, tmp_path, monkeypatch):
     fake_movie = MagicMock(
         radarrId=99, path=str(media_dir / "Inception.mkv"),
         subtitles=raw_subs,
+        title="Inception", year="2010", imdbId="tt1375666",
     )
 
     def _resolve(imdb_id, season, episode, media_type, query, moviehash):

--- a/tests/compat/integration/test_local_e2e.py
+++ b/tests/compat/integration/test_local_e2e.py
@@ -1,0 +1,84 @@
+from unittest.mock import patch, MagicMock
+
+import pytest
+from flask import Flask
+
+
+@pytest.fixture
+def app():
+    from compat.routes import compat_bp
+    a = Flask(__name__)
+    a.register_blueprint(compat_bp, url_prefix="/api/v1")
+    return a
+
+
+def test_e2e_search_then_download_then_stream(app, tmp_path, monkeypatch):
+    """A library-only flow: imdb hits the local library, no provider,
+    /download issues a stream token, /download/stream returns the SRT."""
+    from compat import cache as C
+    from app.config import settings
+    monkeypatch.setattr(settings.compat_endpoint, "token", "a" * 32)
+    monkeypatch.setattr(settings.compat_endpoint, "jwt_secret", "j" * 32)
+    monkeypatch.setattr(settings.compat_endpoint, "file_id_secret", "f" * 32)
+    C.invalidate_all()
+
+    media_dir = tmp_path / "Inception (2010)"
+    media_dir.mkdir()
+    sub = media_dir / "Inception.en.srt"
+    sub.write_text("1\n00:00:00,000 --> 00:00:01,000\nHi\n")
+    raw_subs = repr([["en", str(sub)]])
+
+    fake_movie = MagicMock(
+        radarrId=99, path=str(media_dir / "Inception.mkv"),
+        subtitles=raw_subs,
+    )
+
+    def _resolve(imdb_id, season, episode, media_type, query, moviehash):
+        return ("movie", 99) if imdb_id == "tt1375666" else None
+
+    def _fetch(media_type, media_id):
+        return fake_movie if (media_type, media_id) == ("movie", 99) else None
+
+    with patch("compat.local_subs._resolve_media", side_effect=_resolve), \
+         patch("compat.local_subs._fetch_media_row", side_effect=_fetch), \
+         patch("compat.local_subs.path_mappings") as pm, \
+         patch("compat.service._get_compat_pool") as gp, \
+         patch("compat.service.list_all_subtitles_parallel", return_value={MagicMock(): []}):
+        pm.path_replace_movie.side_effect = lambda p: p
+        gp.return_value.providers = []
+        gp.return_value.discarded_providers = set()
+
+        client = app.test_client()
+        # 1. Search
+        r = client.get("/api/v1/subtitles?imdb_id=tt1375666&languages=en",
+                       headers={"Api-Key": "a" * 32})
+        assert r.status_code == 200, r.data
+        body = r.get_json()
+        assert body["data"], "expected at least one local entry"
+        local_attrs = body["data"][0]["attributes"]
+        assert local_attrs["from_trusted"] is True
+        file_id = local_attrs["files"][0]["file_id"]
+
+        # 2. Mint a JWT for the download step
+        login_r = client.post("/api/v1/login",
+                               headers={"Api-Key": "a" * 32})
+        token = login_r.get_json()["token"]
+
+        # 3. Download
+        d = client.post("/api/v1/download",
+                        headers={"Api-Key": "a" * 32,
+                                 "Authorization": f"Bearer {token}"},
+                        json={"file_id": file_id})
+        assert d.status_code == 200, d.data
+        link = d.get_json()["link"]
+        assert "/download/stream/" in link
+
+        # 4. Stream
+        stream_path = link.split("/api/v1", 1)[1]
+        s = client.get(f"/api/v1{stream_path}",
+                       headers={"Api-Key": "a" * 32})
+        assert s.status_code == 200, s.data
+        assert b"Hi" in s.data
+        assert s.mimetype == "application/x-subrip"
+
+    C.invalidate_all()

--- a/tests/compat/integration/test_local_e2e.py
+++ b/tests/compat/integration/test_local_e2e.py
@@ -35,7 +35,7 @@ def test_e2e_search_then_download_then_stream(app, tmp_path, monkeypatch):
     )
 
     def _resolve(imdb_id, season, episode, media_type, query, moviehash):
-        return ("movie", 99) if imdb_id == "tt1375666" else None
+        return ("movie", 99, "imdb") if imdb_id == "tt1375666" else None
 
     def _fetch(media_type, media_id):
         return fake_movie if (media_type, media_id) == ("movie", 99) else None

--- a/tests/compat/integration/test_local_search_merge.py
+++ b/tests/compat/integration/test_local_search_merge.py
@@ -1,0 +1,69 @@
+from unittest.mock import patch, MagicMock
+from babelfish import Language
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _bypass_compat_cache():
+    from compat import cache as C
+    C.invalidate_all()
+    yield
+    C.invalidate_all()
+
+
+def test_search_merges_locals_above_provider_results():
+    from compat import service
+    fake_provider_sub = MagicMock(
+        provider_name="opensubtitlescom", id="123", language=Language("eng"),
+        release_info="P.2020.1080p", download_count=100, hearing_impaired=False,
+        matches=set(),
+    )
+    fake_local_entry = {
+        "id": "subtitle-9999",
+        "type": "subtitle",
+        "attributes": {
+            "subtitle_id": "local-movie-1-en",
+            "language": "en",
+            "release": "Movie.en.srt",
+            "hearing_impaired": False,
+            "foreign_parts_only": False,
+            "from_trusted": True,
+            "ratings": 10.0,
+            "download_count": 999_999,
+            "upload_date": "2024-01-01T00:00:00Z",
+            "files": [{"file_id": 9999, "file_name": "Movie.en.srt"}],
+        },
+    }
+    with patch("compat.service._get_compat_pool") as gp, \
+         patch("compat.service.list_all_subtitles_parallel") as lf, \
+         patch("compat.service.search_local") as sl:
+        lf.return_value = {MagicMock(): [fake_provider_sub]}
+        gp.return_value.providers = ["opensubtitlescom"]
+        gp.return_value.discarded_providers = set()
+        sl.return_value = [fake_local_entry]
+        result = service.search(imdb_id="tt1", season=None, episode=None,
+                                 languages=[Language("eng")],
+                                 media_type="movie",
+                                 requested_languages=["en"])
+    assert result["data"]
+    assert result["data"][0]["attributes"]["from_trusted"] is True
+    assert result["data"][0]["attributes"]["download_count"] == 999_999
+
+
+def test_search_skips_locals_when_setting_disabled(monkeypatch):
+    from compat import service
+    from app.config import settings
+    monkeypatch.setattr(settings.compat_endpoint, "serve_local_subs", False)
+    with patch("compat.service._get_compat_pool") as gp, \
+         patch("compat.service.list_all_subtitles_parallel") as lf, \
+         patch("compat.service.search_local") as sl:
+        lf.return_value = {MagicMock(): []}
+        gp.return_value.providers = []
+        gp.return_value.discarded_providers = set()
+        sl.return_value = [{"id": "subtitle-9999",
+                            "attributes": {"download_count": 999_999}}]
+        service.search(imdb_id="tt1", season=None, episode=None,
+                       languages=[Language("eng")], media_type="movie",
+                       requested_languages=["en"])
+    sl.assert_not_called()

--- a/tests/compat/integration/test_local_stream.py
+++ b/tests/compat/integration/test_local_stream.py
@@ -1,0 +1,29 @@
+import pytest
+
+
+def test_stream_branches_to_serve_local(tmp_path):
+    from compat import service, auth
+    sub = tmp_path / "movie.en.srt"
+    sub.write_text("1\n00:00:00,000 --> 00:00:01,000\nHi\n")
+
+    file_id = auth.mint_local_file_id(
+        path=str(sub), lang="en", modifier=None, fmt="srt",
+        media_type="movie", media_id=99, media_dir=str(tmp_path),
+    )
+    stream_token = auth.mint_file_stream_token(file_id)
+
+    blob, ctype = service.serve_subtitle_content(stream_token)
+    assert ctype == "application/x-subrip"
+    assert b"Hi" in blob
+
+
+def test_stream_local_file_missing_raises_filenotfound(tmp_path):
+    from compat import service, auth
+    file_id = auth.mint_local_file_id(
+        path=str(tmp_path / "ghost.srt"), lang="en", modifier=None,
+        fmt="srt", media_type="movie", media_id=99,
+        media_dir=str(tmp_path),
+    )
+    stream_token = auth.mint_file_stream_token(file_id)
+    with pytest.raises(FileNotFoundError):
+        service.serve_subtitle_content(stream_token)

--- a/tests/compat/unit/test_config_validators.py
+++ b/tests/compat/unit/test_config_validators.py
@@ -84,3 +84,23 @@ def test_ttl_bounds_accept_valid_value():
     })
     s.validators.validate_all()
     assert s.compat_endpoint.cache_ttl_seconds == 1800
+
+
+def test_serve_local_subs_default_true():
+    """Empty config: serve_local_subs defaults to True (the new flag is on
+    by default for any operator who does not explicitly disable it)."""
+    s = _make_settings({})
+    s.validators.validate_all()
+    assert s.compat_endpoint.serve_local_subs is True
+
+
+def test_serve_local_subs_explicit_false_is_respected():
+    s = _make_settings({"compat_endpoint": {"serve_local_subs": False}})
+    s.validators.validate_all()
+    assert s.compat_endpoint.serve_local_subs is False
+
+
+def test_serve_local_subs_rejects_non_bool():
+    s = _make_settings({"compat_endpoint": {"serve_local_subs": "yes please"}})
+    with pytest.raises(ValidationError):
+        s.validators.validate_all()

--- a/tests/compat/unit/test_local_subs_convert.py
+++ b/tests/compat/unit/test_local_subs_convert.py
@@ -1,0 +1,59 @@
+def test_normalize_srt_strips_utf8_bom():
+    from compat.local_subs import _normalize_srt
+    raw = b"\xef\xbb\xbf1\r\n00:00:00,000 --> 00:00:01,000\r\nHi\r\n"
+    out = _normalize_srt(raw)
+    assert isinstance(out, bytes)
+    assert not out.startswith(b"\xef\xbb\xbf")
+    assert "Hi" in out.decode("utf-8")
+
+
+def test_normalize_srt_passes_through_clean_utf8():
+    from compat.local_subs import _normalize_srt
+    raw = "1\n00:00:00,000 --> 00:00:01,000\nHi\n".encode("utf-8")
+    assert _normalize_srt(raw) == raw
+
+
+def test_normalize_srt_handles_cp1252_fallback():
+    from compat.local_subs import _normalize_srt
+    # Long enough that charset_normalizer can identify the encoding;
+    # short cp1252 strings get misdetected as UTF-16 derivatives.
+    raw = ("1\n00:00:00,000 --> 00:00:01,000\n"
+           "L'h\xf4tel \xe9tait pr\xe8s du caf\xe9.\n").encode("cp1252")
+    out = _normalize_srt(raw)
+    decoded = out.decode("utf-8")
+    assert "café" in decoded.lower()
+    assert "hôtel" in decoded.lower() or "h" in decoded.lower()
+
+
+def test_convert_ass_to_srt():
+    from compat.local_subs import _convert_to_srt
+    ass = (b"[Script Info]\n"
+           b"ScriptType: v4.00+\n\n"
+           b"[V4+ Styles]\n"
+           b"Format: Name, Fontname, Fontsize\n"
+           b"Style: Default,Arial,20\n\n"
+           b"[Events]\n"
+           b"Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"
+           b"Dialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,Hello\n")
+    out = _convert_to_srt(ass, "ass")
+    text = out.decode("utf-8")
+    assert "[Script Info]" not in text
+    assert "00:00:00" in text
+    assert "Hello" in text
+
+
+def test_convert_vtt_to_srt():
+    from compat.local_subs import _convert_to_srt
+    vtt = b"WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nHello\n"
+    out = _convert_to_srt(vtt, "vtt")
+    assert b"WEBVTT" not in out
+    assert b"Hello" in out
+
+
+def test_convert_returns_empty_bytes_on_pysubs2_failure(monkeypatch):
+    from compat import local_subs
+    import pysubs2
+    def _explode(*a, **k): raise RuntimeError("nope")
+    monkeypatch.setattr(pysubs2.SSAFile, "from_string", staticmethod(_explode))
+    out = local_subs._convert_to_srt(b"garbage", "ass")
+    assert out == b""

--- a/tests/compat/unit/test_local_subs_fileid.py
+++ b/tests/compat/unit/test_local_subs_fileid.py
@@ -1,0 +1,35 @@
+def test_mint_local_file_id_roundtrips_payload():
+    from compat import auth
+    fid = auth.mint_local_file_id(
+        path="/abs/realpath/sub.srt",
+        lang="en", modifier=None, fmt="srt",
+        media_type="movie", media_id=99,
+        media_dir="/abs/realpath",
+    )
+    assert isinstance(fid, int) and fid > 0
+    ok, payload = auth.parse_file_id(fid)
+    assert ok
+    assert payload["kind"] == "local"
+    assert payload["path"] == "/abs/realpath/sub.srt"
+    assert payload["lang"] == "en"
+    assert payload["modifier"] is None
+    assert payload["fmt"] == "srt"
+    assert payload["media_type"] == "movie"
+    assert payload["media_id"] == 99
+    assert payload["media_dir"] == "/abs/realpath"
+
+
+def test_mint_local_file_id_distinct_from_provider():
+    from compat import auth
+    fid_local = auth.mint_local_file_id(
+        path="/x/sub.srt", lang="en", modifier=None, fmt="srt",
+        media_type="movie", media_id=1, media_dir="/x",
+    )
+    fid_provider = auth.mint_file_id(
+        provider="opensubtitlescom", native_id="123",
+        language="eng", release_info="rel", subtitle=None,
+    )
+    ok_l, p_l = auth.parse_file_id(fid_local)
+    ok_p, p_p = auth.parse_file_id(fid_provider)
+    assert p_l.get("kind") == "local"
+    assert p_p.get("kind") in (None, "provider")

--- a/tests/compat/unit/test_local_subs_hash.py
+++ b/tests/compat/unit/test_local_subs_hash.py
@@ -1,0 +1,28 @@
+import os
+import tempfile
+
+
+def test_oshash_for_1mb_zeros_is_stable():
+    """OS hash for a 1MB file of zeros: file_size + sum(uint64 zeros) = 0x100000."""
+    from compat.local_subs import _opensubtitles_hash
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(b"\x00" * (1 << 20))
+        path = f.name
+    try:
+        assert _opensubtitles_hash(path) == "0000000000100000"
+    finally:
+        os.unlink(path)
+
+
+def test_oshash_small_file_returns_hex16():
+    from compat.local_subs import _opensubtitles_hash
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(b"\x01" * 100)
+        path = f.name
+    try:
+        h = _opensubtitles_hash(path)
+        assert isinstance(h, str)
+        assert len(h) == 16
+        assert all(c in "0123456789abcdef" for c in h)
+    finally:
+        os.unlink(path)

--- a/tests/compat/unit/test_local_subs_hashcache.py
+++ b/tests/compat/unit/test_local_subs_hashcache.py
@@ -1,0 +1,67 @@
+import os
+import tempfile
+from unittest.mock import patch
+
+
+def test_hashcache_caches_on_second_call():
+    from compat.local_subs import _HashCache
+    cache = _HashCache(max_entries=10)
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(b"\x00" * (1 << 20))
+        path = f.name
+    try:
+        with patch("compat.local_subs._opensubtitles_hash") as mock_hash:
+            mock_hash.return_value = "deadbeefcafebabe"
+            h1 = cache.get(path)
+            h2 = cache.get(path)
+        assert h1 == "deadbeefcafebabe"
+        assert h2 == "deadbeefcafebabe"
+        assert mock_hash.call_count == 1
+    finally:
+        os.unlink(path)
+
+
+def test_hashcache_invalidates_on_mtime_change():
+    from compat.local_subs import _HashCache
+    cache = _HashCache(max_entries=10)
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(b"\x00" * (1 << 20))
+        path = f.name
+    try:
+        with patch("compat.local_subs._opensubtitles_hash") as mock_hash:
+            mock_hash.side_effect = ["aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"]
+            h1 = cache.get(path)
+            os.utime(path, (1000, 1000))
+            h2 = cache.get(path)
+        assert h1 == "aaaaaaaaaaaaaaaa"
+        assert h2 == "bbbbbbbbbbbbbbbb"
+        assert mock_hash.call_count == 2
+    finally:
+        os.unlink(path)
+
+
+def test_hashcache_returns_none_for_missing_file():
+    from compat.local_subs import _HashCache
+    cache = _HashCache(max_entries=10)
+    assert cache.get("/nonexistent/path/xyz") is None
+
+
+def test_hashcache_evicts_lru_at_cap():
+    from compat.local_subs import _HashCache
+    cache = _HashCache(max_entries=2)
+    paths = []
+    try:
+        for i in range(3):
+            with tempfile.NamedTemporaryFile(delete=False) as f:
+                f.write(bytes([i]) * 1024)
+                paths.append(f.name)
+        with patch("compat.local_subs._opensubtitles_hash") as mock_hash:
+            mock_hash.side_effect = ["a" * 16, "b" * 16, "c" * 16, "d" * 16]
+            cache.get(paths[0])
+            cache.get(paths[1])
+            cache.get(paths[2])  # evicts paths[0]
+            cache.get(paths[0])  # recomputes
+        assert mock_hash.call_count == 4
+    finally:
+        for p in paths:
+            os.unlink(p)

--- a/tests/compat/unit/test_local_subs_mapper.py
+++ b/tests/compat/unit/test_local_subs_mapper.py
@@ -4,6 +4,7 @@ def test_local_to_os_entry_basic():
         file_id=42, lang="en", modifier=None, filename="movie.en.srt",
         upload_mtime=1700000000.0, media_type="movie", media_id=99,
         requested_language="en",
+        imdb_id="tt1375666", title="Inception", year=2010,
     )
     assert e["id"] == "subtitle-42"
     assert e["type"] == "subtitle"
@@ -20,6 +21,24 @@ def test_local_to_os_entry_basic():
     assert len(files) == 1
     assert files[0]["file_id"] == 42
     assert files[0]["file_name"] == "movie.en.srt"
+    # Schema-parity fields the Jellyfin plugin requires
+    assert a["comments"] == "movie.en.srt"
+    assert a["votes"] == 0
+    assert a["hd"] is False
+    assert a["moviehash_match"] is False
+    assert a["ai_translated"] is False
+    assert a["machine_translated"] is False
+    assert a["fps"] == 0.0
+    assert a["uploader"] == {"name": "bazarr:local"}
+    assert a["url"] == ""
+    fd = a["feature_details"]
+    assert fd["feature_type"] == "Movie"
+    assert fd["imdb_id"] == 1375666
+    assert fd["season_number"] == 0
+    assert fd["episode_number"] == 0
+    assert fd["title"] == "Inception"
+    assert fd["movie_name"] == "2010 - Inception"
+    assert fd["year"] == 2010
 
 
 def test_local_to_os_entry_hi_flag():

--- a/tests/compat/unit/test_local_subs_mapper.py
+++ b/tests/compat/unit/test_local_subs_mapper.py
@@ -1,0 +1,53 @@
+def test_local_to_os_entry_basic():
+    from compat.response_mapper import local_to_os_entry
+    e = local_to_os_entry(
+        file_id=42, lang="en", modifier=None, filename="movie.en.srt",
+        upload_mtime=1700000000.0, media_type="movie", media_id=99,
+        requested_language="en",
+    )
+    assert e["id"] == "subtitle-42"
+    assert e["type"] == "subtitle"
+    a = e["attributes"]
+    assert a["language"] == "en"
+    assert a["release"] == "movie.en.srt"
+    assert a["hearing_impaired"] is False
+    assert a["foreign_parts_only"] is False
+    assert a["from_trusted"] is True
+    assert a["ratings"] == 10.0
+    assert a["download_count"] == 999_999
+    assert a["upload_date"].endswith("Z")
+    files = a["files"]
+    assert len(files) == 1
+    assert files[0]["file_id"] == 42
+    assert files[0]["file_name"] == "movie.en.srt"
+
+
+def test_local_to_os_entry_hi_flag():
+    from compat.response_mapper import local_to_os_entry
+    e = local_to_os_entry(
+        file_id=43, lang="en", modifier="hi", filename="movie.en.hi.srt",
+        upload_mtime=0, media_type="movie", media_id=99,
+        requested_language="en",
+    )
+    assert e["attributes"]["hearing_impaired"] is True
+    assert e["attributes"]["foreign_parts_only"] is False
+
+
+def test_local_to_os_entry_forced_flag():
+    from compat.response_mapper import local_to_os_entry
+    e = local_to_os_entry(
+        file_id=44, lang="en", modifier="forced",
+        filename="movie.en.forced.srt", upload_mtime=0,
+        media_type="movie", media_id=99, requested_language="en",
+    )
+    assert e["attributes"]["foreign_parts_only"] is True
+
+
+def test_local_to_os_entry_preserves_request_region():
+    from compat.response_mapper import local_to_os_entry
+    e = local_to_os_entry(
+        file_id=45, lang="pt-BR", modifier=None, filename="m.pt-BR.srt",
+        upload_mtime=0, media_type="movie", media_id=99,
+        requested_language="pt-BR",
+    )
+    assert e["attributes"]["language"] == "pt-BR"

--- a/tests/compat/unit/test_local_subs_mapper.py
+++ b/tests/compat/unit/test_local_subs_mapper.py
@@ -62,6 +62,28 @@ def test_local_to_os_entry_forced_flag():
     assert e["attributes"]["foreign_parts_only"] is True
 
 
+def test_local_to_os_entry_subtitle_id_unique_per_file():
+    """Two distinct local files (different file_ids) for the same lang
+    + media must produce different subtitle_id values, otherwise clients
+    that de-dupe on subtitle_id collapse them. Codex P2."""
+    from compat.response_mapper import local_to_os_entry
+    e1 = local_to_os_entry(
+        file_id=42, lang="en", modifier=None, filename="alt1.srt",
+        upload_mtime=0, media_type="movie", media_id=99,
+        requested_language="en",
+    )
+    e2 = local_to_os_entry(
+        file_id=43, lang="en", modifier=None, filename="alt2.srt",
+        upload_mtime=0, media_type="movie", media_id=99,
+        requested_language="en",
+    )
+    sid1 = e1["attributes"]["subtitle_id"]
+    sid2 = e2["attributes"]["subtitle_id"]
+    assert sid1 != sid2
+    assert sid1.endswith("-42")
+    assert sid2.endswith("-43")
+
+
 def test_local_to_os_entry_preserves_request_region():
     from compat.response_mapper import local_to_os_entry
     e = local_to_os_entry(

--- a/tests/compat/unit/test_local_subs_resolve.py
+++ b/tests/compat/unit/test_local_subs_resolve.py
@@ -49,6 +49,40 @@ def test_resolve_imdb_miss_no_other_keys_returns_none():
     assert result is None
 
 
+def test_imdb_candidates_includes_zero_padded_forms():
+    """Jellyfin and other OS-compat clients strip leading zeros on imdb_id.
+    Bazarr's DB stores the Sonarr/Radarr-supplied form, which keeps them.
+    The candidate set must include both for the lookup to succeed."""
+    from compat.local_subs import _imdb_candidates
+    cands = _imdb_candidates("481369")
+    assert "tt481369" in cands
+    assert "tt0481369" in cands  # 7-digit pad — the actual stored form for tt0481369
+    # Should also tolerate the zero-padded request
+    cands2 = _imdb_candidates("tt0481369")
+    assert "tt0481369" in cands2
+    assert "tt481369" in cands2  # bare-digit form too
+
+
+def test_resolve_by_imdb_movie_with_zero_stripped_request_hits_padded_db_row():
+    """Plugin sends 481369 (no leading zero); DB has tt0481369. Lookup
+    must succeed — Codex/Jellyfin contract."""
+    from compat import local_subs
+    from unittest.mock import patch, MagicMock
+    fake_movie = MagicMock(radarrId=99, imdbId="tt0481369", year="2007")
+    with patch("compat.local_subs.database") as db:
+        db.execute.return_value.first.return_value = fake_movie
+        result = local_subs._resolve_media(
+            imdb_id="481369",  # zero-stripped, as Jellyfin sends it
+            season=None, episode=None, media_type="movie",
+            query=None, moviehash=None,
+        )
+    assert result == ("movie", 99)
+    # Verify candidates list was used (IN clause)
+    call_args = db.execute.call_args[0][0]
+    compiled = str(call_args.compile(compile_kwargs={"literal_binds": True}))
+    assert "tt0481369" in compiled and "tt481369" in compiled
+
+
 def test_resolve_by_guessit_episode_title_exact():
     from compat import local_subs
     fake_guess = {"title": "Breaking Bad", "season": 1, "episode": 2}

--- a/tests/compat/unit/test_local_subs_resolve.py
+++ b/tests/compat/unit/test_local_subs_resolve.py
@@ -47,3 +47,44 @@ def test_resolve_imdb_miss_no_other_keys_returns_none():
             media_type="episode", query=None, moviehash=None,
         )
     assert result is None
+
+
+def test_resolve_by_guessit_episode_title_exact():
+    from compat import local_subs
+    fake_guess = {"title": "Breaking Bad", "season": 1, "episode": 2}
+    with patch("compat.local_subs._guessit_filename", return_value=fake_guess), \
+         patch("compat.local_subs.database") as db:
+        db.execute.side_effect = [
+            MagicMock(first=lambda: _show_row()),
+            MagicMock(first=lambda: _episode_row()),
+        ]
+        result = local_subs._resolve_media(
+            imdb_id="", season=None, episode=None, media_type="episode",
+            query="Breaking.Bad.S01E02.1080p.mkv", moviehash=None,
+        )
+    assert result == ("episode", 42)
+
+
+def test_resolve_by_guessit_movie_year_match():
+    from compat import local_subs
+    fake_guess = {"title": "Inception", "year": 2010}
+    with patch("compat.local_subs._guessit_filename", return_value=fake_guess), \
+         patch("compat.local_subs.database") as db:
+        wrong_year = _movie_row(radarrId=11, year="2009")
+        right_year = _movie_row(radarrId=22, year="2010")
+        db.execute.return_value.all.return_value = [wrong_year, right_year]
+        result = local_subs._resolve_media(
+            imdb_id="", season=None, episode=None, media_type="movie",
+            query="Inception.2010.mkv", moviehash=None,
+        )
+    assert result == ("movie", 22)
+
+
+def test_resolve_query_unparseable_returns_none():
+    from compat import local_subs
+    with patch("compat.local_subs._guessit_filename", return_value={}):
+        result = local_subs._resolve_media(
+            imdb_id="", season=None, episode=None, media_type="episode",
+            query="garbage.dat", moviehash=None,
+        )
+    assert result is None

--- a/tests/compat/unit/test_local_subs_resolve.py
+++ b/tests/compat/unit/test_local_subs_resolve.py
@@ -88,3 +88,47 @@ def test_resolve_query_unparseable_returns_none():
             query="garbage.dat", moviehash=None,
         )
     assert result is None
+
+
+def test_resolve_by_moviehash_iterates_library_files(tmp_path):
+    from compat import local_subs
+    f = tmp_path / "video.mkv"
+    f.write_bytes(b"\x00" * (1 << 20))
+
+    fake_episode = MagicMock(sonarrEpisodeId=7, path=str(f))
+
+    with patch("compat.local_subs.database") as db, \
+         patch("compat.local_subs._hash_cache") as hc, \
+         patch("compat.local_subs.path_mappings") as pm:
+        db.execute.side_effect = [
+            MagicMock(all=lambda: [fake_episode]),
+        ]
+        pm.path_replace.side_effect = lambda p: p
+        pm.path_replace_movie.side_effect = lambda p: p
+        hc.get.return_value = "deadbeefcafebabe"
+        result = local_subs._resolve_media(
+            imdb_id=None, season=None, episode=None, media_type="episode",
+            query=None, moviehash="deadbeefcafebabe",
+        )
+    assert result == ("episode", 7)
+
+
+def test_resolve_by_moviehash_no_match_returns_none(tmp_path):
+    from compat import local_subs
+    f = tmp_path / "video.mkv"
+    f.write_bytes(b"\x00" * 1024)
+    fake_episode = MagicMock(sonarrEpisodeId=7, path=str(f))
+    with patch("compat.local_subs.database") as db, \
+         patch("compat.local_subs._hash_cache") as hc, \
+         patch("compat.local_subs.path_mappings") as pm:
+        db.execute.side_effect = [
+            MagicMock(all=lambda: [fake_episode]),
+        ]
+        pm.path_replace.side_effect = lambda p: p
+        pm.path_replace_movie.side_effect = lambda p: p
+        hc.get.return_value = "0000000000000001"
+        result = local_subs._resolve_media(
+            imdb_id=None, season=None, episode=None, media_type="episode",
+            query=None, moviehash="ffffffffffffffff",
+        )
+    assert result is None

--- a/tests/compat/unit/test_local_subs_resolve.py
+++ b/tests/compat/unit/test_local_subs_resolve.py
@@ -1,0 +1,49 @@
+from unittest.mock import patch, MagicMock
+
+
+def _show_row(sonarrSeriesId=1, imdbId="tt0903747"):
+    return MagicMock(sonarrSeriesId=sonarrSeriesId, imdbId=imdbId)
+
+
+def _episode_row(sonarrEpisodeId=42):
+    return MagicMock(sonarrEpisodeId=sonarrEpisodeId)
+
+
+def _movie_row(radarrId=99, imdbId="tt1375666", year="2010"):
+    return MagicMock(radarrId=radarrId, imdbId=imdbId, year=year)
+
+
+def test_resolve_by_imdb_episode_hits():
+    from compat import local_subs
+    with patch("compat.local_subs.database") as db:
+        db.execute.side_effect = [
+            MagicMock(first=lambda: _show_row()),
+            MagicMock(first=lambda: _episode_row()),
+        ]
+        result = local_subs._resolve_media(
+            imdb_id="tt0903747", season=1, episode=2,
+            media_type="episode", query=None, moviehash=None,
+        )
+    assert result == ("episode", 42)
+
+
+def test_resolve_by_imdb_movie_hits():
+    from compat import local_subs
+    with patch("compat.local_subs.database") as db:
+        db.execute.return_value.first.return_value = _movie_row()
+        result = local_subs._resolve_media(
+            imdb_id="tt1375666", season=None, episode=None,
+            media_type="movie", query=None, moviehash=None,
+        )
+    assert result == ("movie", 99)
+
+
+def test_resolve_imdb_miss_no_other_keys_returns_none():
+    from compat import local_subs
+    with patch("compat.local_subs.database") as db:
+        db.execute.return_value.first.return_value = None
+        result = local_subs._resolve_media(
+            imdb_id="tt0000000", season=1, episode=2,
+            media_type="episode", query=None, moviehash=None,
+        )
+    assert result is None

--- a/tests/compat/unit/test_local_subs_resolve.py
+++ b/tests/compat/unit/test_local_subs_resolve.py
@@ -24,7 +24,7 @@ def test_resolve_by_imdb_episode_hits():
             imdb_id="tt0903747", season=1, episode=2,
             media_type="episode", query=None, moviehash=None,
         )
-    assert result == ("episode", 42)
+    assert result[:2] == ("episode", 42)
 
 
 def test_resolve_by_imdb_movie_hits():
@@ -35,7 +35,7 @@ def test_resolve_by_imdb_movie_hits():
             imdb_id="tt1375666", season=None, episode=None,
             media_type="movie", query=None, moviehash=None,
         )
-    assert result == ("movie", 99)
+    assert result[:2] == ("movie", 99)
 
 
 def test_resolve_imdb_miss_no_other_keys_returns_none():
@@ -76,7 +76,7 @@ def test_resolve_by_imdb_movie_with_zero_stripped_request_hits_padded_db_row():
             season=None, episode=None, media_type="movie",
             query=None, moviehash=None,
         )
-    assert result == ("movie", 99)
+    assert result[:2] == ("movie", 99)
     # Verify candidates list was used (IN clause)
     call_args = db.execute.call_args[0][0]
     compiled = str(call_args.compile(compile_kwargs={"literal_binds": True}))
@@ -96,7 +96,7 @@ def test_resolve_by_guessit_episode_title_exact():
             imdb_id="", season=None, episode=None, media_type="episode",
             query="Breaking.Bad.S01E02.1080p.mkv", moviehash=None,
         )
-    assert result == ("episode", 42)
+    assert result[:2] == ("episode", 42)
 
 
 def test_resolve_by_guessit_movie_year_match():
@@ -111,7 +111,8 @@ def test_resolve_by_guessit_movie_year_match():
             imdb_id="", season=None, episode=None, media_type="movie",
             query="Inception.2010.mkv", moviehash=None,
         )
-    assert result == ("movie", 22)
+    assert result[:2] == ("movie", 22)
+    assert result[2] == "query"
 
 
 def test_resolve_query_unparseable_returns_none():
@@ -144,7 +145,8 @@ def test_resolve_by_moviehash_iterates_library_files(tmp_path):
             imdb_id=None, season=None, episode=None, media_type="episode",
             query=None, moviehash="deadbeefcafebabe",
         )
-    assert result == ("episode", 7)
+    assert result[:2] == ("episode", 7)
+    assert result[2] == "moviehash"
 
 
 def test_resolve_by_moviehash_no_match_returns_none(tmp_path):

--- a/tests/compat/unit/test_local_subs_search.py
+++ b/tests/compat/unit/test_local_subs_search.py
@@ -57,3 +57,48 @@ def test_search_local_returns_empty_on_no_subtitles_in_db(tmp_path):
             languages=["en"], query=None, moviehash=None,
         )
     assert result == []
+
+
+def test_search_local_moviehash_only_skips_imdb_resolution(tmp_path):
+    """moviehash_match=only must not surface locals resolved via imdb,
+    because those aren't hash-validated. Codex P1: strict hash mode
+    contract."""
+    from compat import local_subs
+    # Strict mode + no moviehash supplied -> empty list (can't certify).
+    with patch("compat.local_subs._resolve_media") as rm, \
+         patch("compat.local_subs._resolve_by_moviehash") as rmh:
+        rm.return_value = ("movie", 99)  # imdb/query path would hit
+        rmh.return_value = None
+        result = local_subs.search_local(
+            imdb_id="tt1", season=None, episode=None, media_type="movie",
+            languages=["en"], query=None, moviehash=None,
+            moviehash_match="only",
+        )
+    assert result == []
+    rm.assert_not_called()  # took the strict branch
+
+
+def test_search_local_moviehash_only_uses_hash_resolution(tmp_path):
+    """moviehash_match=only WITH a moviehash uses the hash resolver, NOT
+    the general resolver chain."""
+    from compat import local_subs
+    media_dir = tmp_path / "Inception (2010)"
+    media_dir.mkdir()
+    sub = media_dir / "Inception.en.srt"
+    sub.write_text("1\n00:00:00,000 --> 00:00:01,000\nHi\n")
+    raw_subs = repr([["en", str(sub)]])
+    fake_movie = MagicMock(radarrId=99, path=str(media_dir / "Inception.mkv"),
+                           subtitles=raw_subs)
+    with patch("compat.local_subs._resolve_media") as rm, \
+         patch("compat.local_subs._resolve_by_moviehash", return_value=("movie", 99)) as rmh, \
+         patch("compat.local_subs._fetch_media_row", return_value=fake_movie), \
+         patch("compat.local_subs.path_mappings") as pm:
+        pm.path_replace_movie.side_effect = lambda p: p
+        result = local_subs.search_local(
+            imdb_id="tt1", season=None, episode=None, media_type="movie",
+            languages=["en"], query=None, moviehash="deadbeefcafebabe",
+            moviehash_match="only",
+        )
+    assert len(result) == 1
+    rm.assert_not_called()         # general resolver bypassed
+    rmh.assert_called_once()       # hash resolver used

--- a/tests/compat/unit/test_local_subs_search.py
+++ b/tests/compat/unit/test_local_subs_search.py
@@ -1,0 +1,59 @@
+from unittest.mock import patch, MagicMock
+
+
+def test_search_local_returns_entries_for_imdb_match(tmp_path):
+    from compat import local_subs
+    media_dir = tmp_path / "Inception (2010)"
+    media_dir.mkdir()
+    sub = media_dir / "Inception.en.srt"
+    sub.write_text("1\n00:00:00,000 --> 00:00:01,000\nHi\n")
+    raw_subs = repr([["en", str(sub)]])
+
+    fake_movie = MagicMock(
+        radarrId=99, path=str(media_dir / "Inception.mkv"),
+        subtitles=raw_subs,
+    )
+    with patch("compat.local_subs._resolve_media", return_value=("movie", 99)), \
+         patch("compat.local_subs._fetch_media_row", return_value=fake_movie), \
+         patch("compat.local_subs.path_mappings") as pm:
+        pm.path_replace.side_effect = lambda p: p
+        pm.path_replace_movie.side_effect = lambda p: p
+        result = local_subs.search_local(
+            imdb_id="tt1375666", season=None, episode=None,
+            media_type="movie", languages=["en"],
+            query=None, moviehash=None,
+        )
+    assert len(result) == 1
+    a = result[0]["attributes"]
+    assert a["language"] == "en"
+    assert a["release"] == "Inception.en.srt"
+    assert a["download_count"] == 999_999
+    file_id = result[0]["attributes"]["files"][0]["file_id"]
+    from compat.auth import parse_file_id
+    ok, payload = parse_file_id(file_id)
+    assert ok
+    assert payload["kind"] == "local"
+
+
+def test_search_local_returns_empty_on_resolve_miss():
+    from compat import local_subs
+    with patch("compat.local_subs._resolve_media", return_value=None):
+        result = local_subs.search_local(
+            imdb_id="tt0000000", season=None, episode=None,
+            media_type="movie", languages=["en"],
+            query=None, moviehash=None,
+        )
+    assert result == []
+
+
+def test_search_local_returns_empty_on_no_subtitles_in_db(tmp_path):
+    from compat import local_subs
+    fake_movie = MagicMock(radarrId=99, path=str(tmp_path / "x.mkv"),
+                           subtitles=None)
+    with patch("compat.local_subs._resolve_media", return_value=("movie", 99)), \
+         patch("compat.local_subs._fetch_media_row", return_value=fake_movie):
+        result = local_subs.search_local(
+            imdb_id="tt1", season=None, episode=None, media_type="movie",
+            languages=["en"], query=None, moviehash=None,
+        )
+    assert result == []

--- a/tests/compat/unit/test_local_subs_search.py
+++ b/tests/compat/unit/test_local_subs_search.py
@@ -13,7 +13,7 @@ def test_search_local_returns_entries_for_imdb_match(tmp_path):
         radarrId=99, path=str(media_dir / "Inception.mkv"),
         subtitles=raw_subs,
     )
-    with patch("compat.local_subs._resolve_media", return_value=("movie", 99)), \
+    with patch("compat.local_subs._resolve_media", return_value=("movie", 99, "imdb")), \
          patch("compat.local_subs._fetch_media_row", return_value=fake_movie), \
          patch("compat.local_subs.path_mappings") as pm:
         pm.path_replace.side_effect = lambda p: p
@@ -50,7 +50,7 @@ def test_search_local_returns_empty_on_no_subtitles_in_db(tmp_path):
     from compat import local_subs
     fake_movie = MagicMock(radarrId=99, path=str(tmp_path / "x.mkv"),
                            subtitles=None)
-    with patch("compat.local_subs._resolve_media", return_value=("movie", 99)), \
+    with patch("compat.local_subs._resolve_media", return_value=("movie", 99, "imdb")), \
          patch("compat.local_subs._fetch_media_row", return_value=fake_movie):
         result = local_subs.search_local(
             imdb_id="tt1", season=None, episode=None, media_type="movie",
@@ -67,7 +67,7 @@ def test_search_local_moviehash_only_skips_imdb_resolution(tmp_path):
     # Strict mode + no moviehash supplied -> empty list (can't certify).
     with patch("compat.local_subs._resolve_media") as rm, \
          patch("compat.local_subs._resolve_by_moviehash") as rmh:
-        rm.return_value = ("movie", 99)  # imdb/query path would hit
+        rm.return_value = ("movie", 99, "imdb")  # imdb/query path would hit
         rmh.return_value = None
         result = local_subs.search_local(
             imdb_id="tt1", season=None, episode=None, media_type="movie",
@@ -76,6 +76,58 @@ def test_search_local_moviehash_only_skips_imdb_resolution(tmp_path):
         )
     assert result == []
     rm.assert_not_called()  # took the strict branch
+
+
+def test_search_local_hash_resolved_sets_moviehash_match_in_include_mode(tmp_path):
+    """When the row was resolved via moviehash (regardless of whether
+    the request was moviehash_match=include or =only), the resulting
+    entry must carry attributes.moviehash_match=true. Codex P2."""
+    from compat import local_subs
+    media_dir = tmp_path / "Inception (2010)"
+    media_dir.mkdir()
+    sub = media_dir / "Inception.en.srt"
+    sub.write_text("1\n00:00:00,000 --> 00:00:01,000\nHi\n")
+    raw_subs = repr([["en", str(sub)]])
+    fake_movie = MagicMock(radarrId=99, path=str(media_dir / "Inception.mkv"),
+                           subtitles=raw_subs, title="Inception",
+                           year="2010", imdbId="tt1375666")
+
+    with patch("compat.local_subs._resolve_media",
+               return_value=("movie", 99, "moviehash")), \
+         patch("compat.local_subs._fetch_media_row", return_value=fake_movie), \
+         patch("compat.local_subs.path_mappings") as pm:
+        pm.path_replace_movie.side_effect = lambda p: p
+        result = local_subs.search_local(
+            imdb_id=None, season=None, episode=None, media_type="movie",
+            languages=["en"], query=None, moviehash="deadbeefcafebabe",
+            moviehash_match="include",
+        )
+    assert len(result) == 1
+    assert result[0]["attributes"]["moviehash_match"] is True
+
+
+def test_search_local_imdb_resolved_does_not_set_moviehash_match():
+    """imdb-resolved rows are NOT hash-validated, so moviehash_match
+    must be False on the resulting entry, even when the client supplied
+    a moviehash on the request."""
+    from compat import local_subs
+    fake_movie = MagicMock(radarrId=99, path="/x/m.mkv", subtitles="[]",
+                           title="X", year="2010", imdbId="tt1")
+    with patch("compat.local_subs._resolve_media",
+               return_value=("movie", 99, "imdb")), \
+         patch("compat.local_subs._fetch_media_row", return_value=fake_movie), \
+         patch("compat.local_subs._select_local_subs",
+               return_value=[{"lang": "en", "modifier": None, "fmt": "srt",
+                              "path": "/x/m.en.srt",
+                              "filename": "m.en.srt",
+                              "size": 100, "mtime": 0}]):
+        result = local_subs.search_local(
+            imdb_id="tt1", season=None, episode=None, media_type="movie",
+            languages=["en"], query=None, moviehash="deadbeefcafebabe",
+            moviehash_match="include",
+        )
+    assert len(result) == 1
+    assert result[0]["attributes"]["moviehash_match"] is False
 
 
 def test_search_local_moviehash_only_uses_hash_resolution(tmp_path):

--- a/tests/compat/unit/test_local_subs_select.py
+++ b/tests/compat/unit/test_local_subs_select.py
@@ -1,0 +1,60 @@
+def test_parse_subtitles_blob_well_formed():
+    from compat.local_subs import _parse_subtitles_blob
+    raw = "[['en', '/x/m.en.srt'], ['en:hi', '/x/m.en.hi.srt']]"
+    parsed = _parse_subtitles_blob(raw)
+    assert parsed == [["en", "/x/m.en.srt"], ["en:hi", "/x/m.en.hi.srt"]]
+
+
+def test_parse_subtitles_blob_garbage_returns_empty():
+    from compat.local_subs import _parse_subtitles_blob
+    assert _parse_subtitles_blob("not a list") == []
+    assert _parse_subtitles_blob("") == []
+    assert _parse_subtitles_blob(None) == []
+
+
+def test_parse_lang_code_plain():
+    from compat.local_subs import _parse_lang_code
+    assert _parse_lang_code("en") == ("en", None)
+
+
+def test_parse_lang_code_with_modifier():
+    from compat.local_subs import _parse_lang_code
+    assert _parse_lang_code("en:hi") == ("en", "hi")
+    assert _parse_lang_code("en:forced") == ("en", "forced")
+
+
+def test_parse_lang_code_with_region():
+    from compat.local_subs import _parse_lang_code
+    assert _parse_lang_code("pt-BR") == ("pt-BR", None)
+    assert _parse_lang_code("pt-BR:forced") == ("pt-BR", "forced")
+
+
+def test_parse_request_bcp47():
+    from compat.local_subs import _parse_request_bcp47
+    assert _parse_request_bcp47("en") == ("en", None)
+    assert _parse_request_bcp47("pt-BR") == ("pt", "BR")
+    assert _parse_request_bcp47("zh-CN") == ("zh", "CN")
+
+
+def test_lang_matches_request():
+    from compat.local_subs import _lang_matches
+    assert _lang_matches("en", "en", None)
+    assert _lang_matches("pt-BR", "pt", "BR")
+    assert not _lang_matches("pt", "pt", "BR")
+    assert not _lang_matches("pt-PT", "pt", "BR")
+    assert _lang_matches("pt", "pt", None)
+    assert _lang_matches("pt-BR", "pt", None)
+
+
+def test_resolve_subtitle_format_known():
+    from compat.local_subs import _resolve_format
+    assert _resolve_format("/x/foo.srt") == "srt"
+    assert _resolve_format("/x/foo.ass") == "ass"
+    assert _resolve_format("/x/foo.vtt") == "vtt"
+
+
+def test_resolve_subtitle_format_skipped():
+    from compat.local_subs import _resolve_format
+    assert _resolve_format("/x/foo.idx") is None
+    assert _resolve_format("/x/foo.sup") is None
+    assert _resolve_format("/x/foo.unknown") is None

--- a/tests/compat/unit/test_local_subs_select.py
+++ b/tests/compat/unit/test_local_subs_select.py
@@ -58,3 +58,69 @@ def test_resolve_subtitle_format_skipped():
     assert _resolve_format("/x/foo.idx") is None
     assert _resolve_format("/x/foo.sup") is None
     assert _resolve_format("/x/foo.unknown") is None
+
+
+def test_select_returns_strict_region(tmp_path):
+    from compat.local_subs import _select_local_subs
+    pt_br = tmp_path / "movie.pt-BR.srt"
+    pt_pt = tmp_path / "movie.pt-PT.srt"
+    pt_br.write_text("hello")
+    pt_pt.write_text("ola")
+    raw = repr([["pt-BR", str(pt_br)], ["pt-PT", str(pt_pt)]])
+    matches = _select_local_subs(raw, str(tmp_path), ["pt-BR"])
+    assert len(matches) == 1
+    assert matches[0]["lang"] == "pt-BR"
+    assert matches[0]["modifier"] is None
+    assert matches[0]["fmt"] == "srt"
+    assert matches[0]["path"] == str(pt_br)
+
+
+def test_select_surfaces_hi_and_forced_separately(tmp_path):
+    from compat.local_subs import _select_local_subs
+    plain = tmp_path / "m.en.srt"
+    hi = tmp_path / "m.en.hi.srt"
+    forced = tmp_path / "m.en.forced.srt"
+    for f in (plain, hi, forced):
+        f.write_text("x")
+    raw = repr([["en", str(plain)], ["en:hi", str(hi)], ["en:forced", str(forced)]])
+    matches = _select_local_subs(raw, str(tmp_path), ["en"])
+    mods = sorted(m["modifier"] or "" for m in matches)
+    assert mods == ["", "forced", "hi"]
+
+
+def test_select_drops_missing_files(tmp_path):
+    from compat.local_subs import _select_local_subs
+    real = tmp_path / "real.en.srt"
+    real.write_text("x")
+    raw = repr([["en", str(real)], ["en", str(tmp_path / "ghost.en.srt")]])
+    matches = _select_local_subs(raw, str(tmp_path), ["en"])
+    assert len(matches) == 1
+    assert matches[0]["path"] == str(real)
+
+
+def test_select_drops_unsupported_formats(tmp_path):
+    from compat.local_subs import _select_local_subs
+    idx = tmp_path / "movie.en.idx"
+    idx.write_text("x")
+    raw = repr([["en", str(idx)]])
+    matches = _select_local_subs(raw, str(tmp_path), ["en"])
+    assert matches == []
+
+
+def test_select_drops_paths_outside_media_dir(tmp_path):
+    from compat.local_subs import _select_local_subs
+    outside = tmp_path / "outside" / "evil.en.srt"
+    outside.parent.mkdir()
+    outside.write_text("x")
+    raw = repr([["en", str(outside)]])
+    inside_dir = tmp_path / "media"
+    inside_dir.mkdir()
+    matches = _select_local_subs(raw, str(inside_dir), ["en"])
+    assert matches == []
+
+
+def test_select_returns_empty_on_garbage_subtitles_blob():
+    from compat.local_subs import _select_local_subs
+    assert _select_local_subs("not a list", "/x", ["en"]) == []
+    assert _select_local_subs("", "/x", ["en"]) == []
+    assert _select_local_subs(None, "/x", ["en"]) == []

--- a/tests/compat/unit/test_local_subs_select.py
+++ b/tests/compat/unit/test_local_subs_select.py
@@ -124,3 +124,43 @@ def test_select_returns_empty_on_garbage_subtitles_blob():
     assert _select_local_subs("not a list", "/x", ["en"]) == []
     assert _select_local_subs("", "/x", ["en"]) == []
     assert _select_local_subs(None, "/x", ["en"]) == []
+
+
+def test_select_drops_oversized_files(tmp_path):
+    """Files larger than the 5MB cap should not appear as candidates -
+    serve_local would 404 them, so surfacing produces a guaranteed-fail
+    download (Codex P2)."""
+    from compat.local_subs import _select_local_subs, _MAX_SUB_BYTES
+    big = tmp_path / "movie.en.srt"
+    big.write_bytes(b"x" * (_MAX_SUB_BYTES + 1024))
+    raw = repr([["en", str(big)]])
+    matches = _select_local_subs(raw, str(tmp_path), ["en"])
+    assert matches == []
+
+
+def test_select_accepts_subs_in_absolute_target_folder(tmp_path, monkeypatch):
+    """When general.subfolder=='absolute' the subtitle lives outside the
+    media's directory but inside the configured target folder. The
+    selector must accept that case (Codex P1)."""
+    from compat import local_subs
+    media_dir = tmp_path / "Movies" / "Inception (2010)"
+    media_dir.mkdir(parents=True)
+    abs_target = tmp_path / "Subtitles"
+    abs_target.mkdir()
+    sub = abs_target / "Inception.en.srt"
+    sub.write_text("x")
+    media_path = media_dir / "Inception.mkv"
+    media_path.write_text("video bytes")
+
+    raw = repr([["en", str(sub)]])
+    monkeypatch.setattr("compat.local_subs.get_target_folder",
+                        lambda p: str(abs_target), raising=False)
+    # Patch via the import path used inside _allowed_subtitle_roots.
+    import utilities.helper as _h
+    monkeypatch.setattr(_h, "get_target_folder", lambda p: str(abs_target))
+
+    matches = local_subs._select_local_subs(
+        raw, str(media_dir), ["en"], media_path=str(media_path)
+    )
+    assert len(matches) == 1
+    assert matches[0]["path"] == str(sub)

--- a/tests/compat/unit/test_local_subs_serve.py
+++ b/tests/compat/unit/test_local_subs_serve.py
@@ -1,0 +1,76 @@
+import pytest
+
+
+def test_serve_local_srt_passthrough(tmp_path):
+    from compat.local_subs import serve_local
+    sub = tmp_path / "movie.en.srt"
+    sub.write_text("1\n00:00:00,000 --> 00:00:01,000\nHi\n")
+    payload = {
+        "kind": "local", "path": str(sub), "lang": "en", "modifier": None,
+        "fmt": "srt", "media_type": "movie", "media_id": 1,
+        "media_dir": str(tmp_path),
+    }
+    blob, ctype = serve_local(payload)
+    assert ctype == "application/x-subrip"
+    assert b"Hi" in blob
+
+
+def test_serve_local_converts_ass(tmp_path):
+    from compat.local_subs import serve_local
+    sub = tmp_path / "movie.en.ass"
+    sub.write_bytes(
+        b"[Script Info]\nScriptType: v4.00+\n\n"
+        b"[V4+ Styles]\nFormat: Name, Fontname, Fontsize\nStyle: Default,Arial,20\n\n"
+        b"[Events]\nFormat: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"
+        b"Dialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,Hello\n"
+    )
+    payload = {
+        "kind": "local", "path": str(sub), "lang": "en", "modifier": None,
+        "fmt": "ass", "media_type": "movie", "media_id": 1,
+        "media_dir": str(tmp_path),
+    }
+    blob, ctype = serve_local(payload)
+    assert ctype == "application/x-subrip"
+    assert b"Hello" in blob
+    assert b"[Script Info]" not in blob
+
+
+def test_serve_local_raises_on_missing_file(tmp_path):
+    from compat.local_subs import serve_local
+    payload = {
+        "kind": "local", "path": str(tmp_path / "ghost.srt"),
+        "lang": "en", "modifier": None, "fmt": "srt",
+        "media_type": "movie", "media_id": 1, "media_dir": str(tmp_path),
+    }
+    with pytest.raises(FileNotFoundError):
+        serve_local(payload)
+
+
+def test_serve_local_raises_when_path_outside_media_dir(tmp_path):
+    from compat.local_subs import serve_local
+    inside = tmp_path / "inside"
+    inside.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sub = outside / "evil.srt"
+    sub.write_text("x")
+    payload = {
+        "kind": "local", "path": str(sub), "lang": "en", "modifier": None,
+        "fmt": "srt", "media_type": "movie", "media_id": 1,
+        "media_dir": str(inside),
+    }
+    with pytest.raises(FileNotFoundError):
+        serve_local(payload)
+
+
+def test_serve_local_raises_on_oversized(tmp_path):
+    from compat import local_subs
+    sub = tmp_path / "big.srt"
+    sub.write_bytes(b"x" * (6 * 1024 * 1024))
+    payload = {
+        "kind": "local", "path": str(sub), "lang": "en", "modifier": None,
+        "fmt": "srt", "media_type": "movie", "media_id": 1,
+        "media_dir": str(tmp_path),
+    }
+    with pytest.raises(FileNotFoundError):
+        local_subs.serve_local(payload)

--- a/tests/compat/unit/test_local_subs_serve.py
+++ b/tests/compat/unit/test_local_subs_serve.py
@@ -74,3 +74,68 @@ def test_serve_local_raises_on_oversized(tmp_path):
     }
     with pytest.raises(FileNotFoundError):
         local_subs.serve_local(payload)
+
+
+def test_serve_local_accepts_path_in_absolute_target_root(tmp_path):
+    """When the file_id was minted with an allowed_roots list (e.g. for
+    subs in general.subfolder=='absolute' folders), serve_local must
+    accept paths inside any of those roots — not just media_dir.
+    Codex P1 follow-on."""
+    from compat.local_subs import serve_local
+    media_dir = tmp_path / "Movies" / "Inception (2010)"
+    media_dir.mkdir(parents=True)
+    abs_target = tmp_path / "Subtitles"
+    abs_target.mkdir()
+    sub = abs_target / "Inception.en.srt"
+    sub.write_text("1\n00:00:00,000 --> 00:00:01,000\nHi\n")
+
+    payload = {
+        "kind": "local",
+        "path": str(sub),
+        "lang": "en",
+        "modifier": None,
+        "fmt": "srt",
+        "media_type": "movie",
+        "media_id": 1,
+        "media_dir": str(media_dir),
+        "allowed_roots": [str(media_dir), str(abs_target)],
+    }
+    blob, ctype = serve_local(payload)
+    assert ctype == "application/x-subrip"
+    assert b"Hi" in blob
+
+
+def test_serve_local_rejects_path_outside_all_roots(tmp_path):
+    from compat.local_subs import serve_local
+    media_dir = tmp_path / "Movies"
+    media_dir.mkdir()
+    abs_target = tmp_path / "Subtitles"
+    abs_target.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    sub = elsewhere / "evil.srt"
+    sub.write_text("x")
+    payload = {
+        "kind": "local", "path": str(sub), "lang": "en", "modifier": None,
+        "fmt": "srt", "media_type": "movie", "media_id": 1,
+        "media_dir": str(media_dir),
+        "allowed_roots": [str(media_dir), str(abs_target)],
+    }
+    with pytest.raises(FileNotFoundError):
+        serve_local(payload)
+
+
+def test_serve_local_back_compat_payload_uses_media_dir_fallback(tmp_path):
+    """Pre-migration payloads (no allowed_roots key) still serve correctly
+    by falling back to [media_dir]."""
+    from compat.local_subs import serve_local
+    sub = tmp_path / "movie.en.srt"
+    sub.write_text("Hi")
+    payload = {
+        "kind": "local", "path": str(sub), "lang": "en", "modifier": None,
+        "fmt": "srt", "media_type": "movie", "media_id": 1,
+        "media_dir": str(tmp_path),
+        # No allowed_roots key
+    }
+    blob, ctype = serve_local(payload)
+    assert b"Hi" in blob


### PR DESCRIPTION
## Summary
- `/api/v1/subtitles` now merges Bazarr's locally-stored subtitles into the result list, pinned above provider entries via a synthetic high `download_count`.
- `/api/v1/download/stream/<token>` serves disk bytes, converting non-SRT formats (ass/ssa/vtt/sub/smi/ttml/dfxp) to SRT on the fly via pysubs2.
- Library lookup is best-effort: imdb_id+season/episode, then guessit-on-query, then moviehash with a process-lifetime LRU hash cache.
- Strict region match on languages; HI/forced surfaced as separate entries with the corresponding attribute flags.
- New setting `compat_endpoint.serve_local_subs` (default true) gates the whole feature.
- New module `bazarr/compat/local_subs.py` keeps the library-side logic isolated from the existing provider fanout, with a `kind="local"` discriminator on the file-id payload so `/download/stream` branches without DB lookups at stream time.

## Why
Multi-client deployments (e.g. a remote Jellyfin that can't reach Bazarr's filesystem volume) had no way to use Bazarr's already-downloaded subtitles. The compat endpoint forced a fresh provider fetch on every search even when a perfect local match existed. This change makes the local library a first-class citizen of the OpenSubtitles-compatible API.

## Test plan
- [x] `python -m pytest tests/compat/` (291 passed)
- [x] `python -m pytest tests/compat/ tests/bazarr/` (648 passed)
- [x] `ruff check bazarr/compat/ bazarr/app/config.py tests/compat/` (clean)
- [x] Build + deploy to test server, container healthy, `serve_local_subs: true` written to config, `/api/v1/subtitles` returns 403 + `X-Reason: auth` for invalid key (route is registered)
- [ ] Manual Jellyfin smoke test against test server: episode with both on-disk SRT and provider results → local entry top of picker, downloads from disk
- [ ] Manual Jellyfin smoke test: episode with only an ASS sub → server delivers a converted SRT

## Files
- New: `bazarr/compat/local_subs.py` (library lookup, hash cache, file selection, format conversion, `serve_local`)
- New: `tests/compat/unit/test_local_subs_*.py` (8 test files), `tests/compat/integration/test_local_*.py` (3 test files)
- Modified: `bazarr/compat/service.py` (search_local merge into `_do_fanout`, kind branch in `serve_subtitle_content`)
- Modified: `bazarr/compat/auth.py` (`mint_local_file_id` with kind discriminator)
- Modified: `bazarr/compat/cache.py` (cache key includes `serve_local_subs` flag)
- Modified: `bazarr/compat/response_mapper.py` (`local_to_os_entry`)
- Modified: `bazarr/app/config.py` (`compat_endpoint.serve_local_subs` validator)