### PR TITLE
chore: bump python deps and switch base image to debian trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG VCS_REF
 # =============================================================================
 # Stage 1: Install Python Dependencies (cached heavily)
 # =============================================================================
-FROM python:3.14-slim-bookworm AS python-builder
+FROM python:3.14-slim-trixie AS python-builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -36,7 +36,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # =============================================================================
 # Stage 2: Production Image
 # =============================================================================
-FROM python:3.14-slim-bookworm AS production
+FROM python:3.14-slim-trixie AS production
 
 ARG BAZARR_VERSION
 ARG BUILD_DATE
@@ -52,11 +52,10 @@ LABEL org.opencontainers.image.title="Bazarr+" \
       org.opencontainers.image.vendor="LavX" \
       org.opencontainers.image.licenses="GPL-3.0"
 
-# Enable non-free repository for unrar and install runtime dependencies
-# Use apt cache mount to speed up repeated builds
+# Install runtime dependencies. RAR archives from subtitle providers are
+# extracted via p7zip's 7z binary, so no non-free repo or unrar package needed.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    sed -i 's/Components: main/Components: main non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources && \
     apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     libxml2 \
@@ -64,7 +63,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libpq5 \
     mediainfo \
     p7zip-full \
-    unrar \
     bash \
     gosu \
     curl \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-setuptools
-aiohttp>=3.9.0
-cachetools>=5.3.0
-lxml>=4.3.0
-numpy>=1.12.0,<2.4.0  # prevent segfault on hold hardware caused by new CPU requirements introduced in 2.4.0
-webrtcvad-wheels>=2.0.10
-Pillow>=9.0.0 --only-binary=Pillow
-cryptography>=41.0.0
-PyJWT>=2.8.0
-pywin32; platform_system == "Windows"
+setuptools>=82.0.1
+aiohttp>=3.13.5
+cachetools>=7.1.1
+lxml>=6.1.0  # XXE fix in iterparse / ETCompatXMLParser
+numpy>=2.0.0,<2.4.0  # cap excludes entire 2.4.x line: it raised the x86-64 baseline to v2, crashing pre-2009 CPUs (SIGILL on import). 2.4.0 itself is also yanked for an unrelated BC bug.
+webrtcvad-wheels>=2.0.14
+Pillow>=12.2.0 --only-binary=Pillow
+cryptography>=48.0.0
+PyJWT>=2.12.1  # CVE-2026-32597 fix for unknown crit headers
+pywin32>=311; platform_system == "Windows"


### PR DESCRIPTION
## Summary

- Switch base image from `python:3.14-slim-bookworm` to `python:3.14-slim-trixie`. Trixie ships newer ffmpeg (7.1), libsqlite3 (3.46.1 vs bookworm's ~3.40), libxml2/libxslt with current CVE backports.
- Drop the non-free repo enable and the apt `unrar` package. Bazarr's `binaries.json` already pulls a portable `unrar` at first run, and `p7zip-full`'s `7z` remains as the existing fallback in `bazarr/init.py`. Smaller image, no non-free licensing surface.
- Bump Python deps in `requirements.txt` to current latest. Notable security bumps:
  - `lxml>=6.1.0`: fixes XXE in `iterparse()` and `ETCompatXMLParser` (relevant since several subtitle providers feed us third-party XML).
  - `PyJWT>=2.12.1`: fixes CVE-2026-32597 (unknown `crit` header acceptance) on the JWT validate path used by `bazarr/compat/auth.py`.
  - `cryptography>=48.0.0`: OpenSSL 3.5.5, AEAD hardening on the `Fernet` / `AESGCM` paths in `secret_store/crypto.py` and `subtitles/tools/translate/services/encryption.py`.
  - `Pillow>=12.2.0`: picks up the 10.x `Image.open` CVE patches.
  - `aiohttp>=3.13.5`, `cachetools>=7.1.1`, `webrtcvad-wheels>=2.0.14`, `setuptools>=82.0.1`, `pywin32>=311` for hygiene and Python 3.14 wheel coverage.
- `numpy` stays capped at `<2.4.0`. The 2.4 series raised the x86-64 wheel baseline to v2, which crashes pre-2009 CPUs with `SIGILL` on `import numpy`. 2.4.0 itself was also yanked on PyPI for an unrelated BC bug. Floor moved from `>=1.12.0` to `>=2.0.0` to make the actual resolution explicit, and the comment is rewritten to reference the whole 2.4 line, not just 2.4.0.

## Test plan

- [x] `docker build -f Dockerfile .` succeeds on the new trixie base
- [x] Image deployed to test server, container healthy on first start
- [x] `pip list` inside the container shows every dep at the pinned floor (Python 3.14.4)
- [x] No tracebacks or import errors on boot; subtitle-sync (ffsubsync) and Sonarr/Radarr sync paths verified live
- [x] JIT base image (`xomoxcc/python314-jit:trixie`) trialed and rejected: ~5% on synthetic CPU loops, ~0% on Bazarr-relevant workloads, with 4x image size and a stale Python 3.14.2 build. Not worth swapping for.