### PR TITLE
chore(sync): cherry-pick 9 commits from upstream development (2026-05-10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,9 +462,11 @@ Includes all upstream providers plus fork additions:
 - Nekur
 - OpenSubtitles.com
 - **OpenSubtitles.org (Bazarr+ web scraper, no API needed)**
+- Pipocas.tv
 - Podnapisi
 - RegieLive
 - Sous-Titres.eu
+- SubClub.eu
 - SubX
 - subf2m.co
 - Subs.sab.bz

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -931,31 +931,31 @@ def save_settings(settings_items):
 
         if key in ['settings-sonarr-excluded_tags', 'settings-sonarr-only_monitored',
                    'settings-sonarr-excluded_series_types', 'settings-sonarr-exclude_season_zero',
-                   'settings.radarr.excluded_tags', 'settings-radarr-only_monitored']:
+                   'settings-radarr-excluded_tags', 'settings-radarr-only_monitored']:
             exclusion_updated = True
 
         if key in ['settings-sonarr-excluded_tags', 'settings-sonarr-only_monitored',
                    'settings-sonarr-excluded_series_types', 'settings-sonarr-exclude_season_zero']:
             sonarr_exclusion_updated = True
 
-        if key in ['settings.radarr.excluded_tags', 'settings-radarr-only_monitored']:
+        if key in ['settings-radarr-excluded_tags', 'settings-radarr-only_monitored']:
             radarr_exclusion_updated = True
 
         if key == 'settings-addic7ed-username':
-            if key != settings.addic7ed.username:
+            if value != settings.addic7ed.username:
                 reset_providers = True
                 region.delete('addic7ed_data')
         elif key == 'settings-addic7ed-password':
-            if key != settings.addic7ed.password:
+            if value != settings.addic7ed.password:
                 reset_providers = True
                 region.delete('addic7ed_data')
 
         if key == 'settings-legendasdivx-username':
-            if key != settings.legendasdivx.username:
+            if value != settings.legendasdivx.username:
                 reset_providers = True
                 region.delete('legendasdivx_cookies2')
         elif key == 'settings-legendasdivx-password':
-            if key != settings.legendasdivx.password:
+            if value != settings.legendasdivx.password:
                 reset_providers = True
                 region.delete('legendasdivx_cookies2')
 
@@ -977,25 +977,25 @@ def save_settings(settings_items):
 
 
         if key == 'settings-opensubtitlescom-username':
-            if key != settings.opensubtitlescom.username:
+            if value != settings.opensubtitlescom.username:
                 reset_providers = True
                 region.delete('oscom_token')
         elif key == 'settings-opensubtitlescom-password':
-            if key != settings.opensubtitlescom.password:
+            if value != settings.opensubtitlescom.password:
                 reset_providers = True
                 region.delete('oscom_token')
 
         if key == 'settings-titlovi-username':
-            if key != settings.titlovi.username:
+            if value != settings.titlovi.username:
                 reset_providers = True
                 region.delete('titlovi_token')
         elif key == 'settings-titlovi-password':
-            if key != settings.titlovi.password:
+            if value != settings.titlovi.password:
                 reset_providers = True
                 region.delete('titlovi_token')
 
         if key == 'settings-subsource-apikey':
-            if key != settings.subsource.apikey:
+            if value != settings.subsource.apikey:
                 reset_providers = True
 
         if key == 'settings-general-enabled_providers':

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -407,6 +407,10 @@ validators = [
     Validator('legendasnet.username', must_exist=True, default='', is_type_of=str, cast=str),
     Validator('legendasnet.password', must_exist=True, default='', is_type_of=str, cast=str),
 
+    # pipocas section
+    Validator('pipocas.username', must_exist=True, default='', is_type_of=str, cast=str),
+    Validator('pipocas.password', must_exist=True, default='', is_type_of=str, cast=str),
+
     # ktuvit section
     Validator('ktuvit.email', must_exist=True, default='', is_type_of=str),
     Validator('ktuvit.hashed_password', must_exist=True, default='', is_type_of=str, cast=str),

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -156,6 +156,8 @@ validators = [
     Validator('general.chmod', must_exist=True, default='0640', is_type_of=str),
     Validator('general.subfolder', must_exist=True, default='current', is_type_of=str),
     Validator('general.subfolder_custom', must_exist=True, default='', is_type_of=str),
+    Validator('general.use_whisper_fallback', must_exist=True, default=False, is_type_of=bool),
+    Validator('general.use_whisper_fallback_series', must_exist=True, default=False, is_type_of=bool),
     Validator('general.upgrade_subs', must_exist=True, default=True, is_type_of=bool),
     Validator('general.upgrade_frequency', must_exist=True, default=12, is_type_of=int,
               is_in=[6, 12, 24, 168, ONE_HUNDRED_YEARS_IN_HOURS]),

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -303,6 +303,10 @@ def get_providers_auth():
             'username': settings.legendasnet.username,
             'password': settings.legendasnet.password,
         },
+        'pipocas': {
+            'username': settings.pipocas.username,
+            'password': settings.pipocas.password,
+        },
         'xsubs': {
             'username': settings.xsubs.username,
             'password': settings.xsubs.password,

--- a/bazarr/app/jobs_queue.py
+++ b/bazarr/app/jobs_queue.py
@@ -152,17 +152,21 @@ class JobsQueue:
         :param progress_max: Maximum value of the job's progress, initialized to 0.
         :type progress_max: int
         :return: The unique job ID assigned to the newly queued job.
-        :rtype: int
+        :rtype: int | bool
         """
         if args is None:
             args = []
         if kwargs is None:
             kwargs = {}
 
-        with self._job_id_lock:
-            new_job_id = self.current_job_id = self.current_job_id + 1
-        
         with self._queue_lock:
+            if self._is_an_existing_job(module, func, args, kwargs):
+                logging.debug(f"Task {job_name} already exists in pending and running queue")
+                return False
+
+            with self._job_id_lock:
+                new_job_id = self.current_job_id = self.current_job_id + 1
+
             self.jobs_pending_queue.append(
                 Job(job_id=new_job_id,
                     job_name=job_name,
@@ -174,7 +178,7 @@ class JobsQueue:
                     is_signalr=is_signalr,
                     progress_max=progress_max,)
             )
-        
+
         logging.debug(f"Task {job_name} ({new_job_id}) added to queue")  # noqa: G004
         event_stream(type='jobs', action='update', payload={"job_id": new_job_id, "progress_value": None,
                                                             "status": "pending"})
@@ -369,7 +373,7 @@ class JobsQueue:
         return False
 
     def add_job_from_function(self, job_name: str, is_progress: bool, progress_max: int = 0,
-                              wait_for_completion: bool = False) -> int:
+                              wait_for_completion: bool = False) -> int | bool:
         """
         Adds a job to the pending queue using the details of the calling function. The job is then executed.
 
@@ -382,7 +386,7 @@ class JobsQueue:
         :param wait_for_completion: Flag indicating whether to wait for the job to complete before returning.
         :type wait_for_completion: bool
         :return: ID of the added job.
-        :rtype: int
+        :rtype: int | bool
         """
         # Get the current frame
         current_frame = inspect.currentframe()
@@ -416,9 +420,12 @@ class JobsQueue:
         job_id = self.feed_jobs_pending_queue(job_name=job_name, module=parent_function_path, func=parent_function_name,
                                               kwargs=arguments, is_progress=is_progress, progress_max=progress_max)
 
+        if not job_id:
+            return False
+
         if wait_for_completion:
             time.sleep(1)
-            while jobs_queue.get_job_status(job_id) in ['queued', 'running']:
+            while jobs_queue.get_job_status(job_id) in ['pending', 'running']:
                 time.sleep(1)
 
         return job_id
@@ -670,6 +677,36 @@ class JobsQueue:
                 event_stream(type='jobs', action='update', payload=payload)
             except Exception as e:
                 logging.exception(f"Exception raised while sending event: {e}")  # noqa: G004
+
+    def _is_an_existing_job(self, module, func, args, kwargs):
+        """
+        Checks if a job with matching attributes already exists in pending or running queues.
+
+        :param module: Module name of the job to check.
+        :type module: str
+        :param func: Function name of the job to check.
+        :type func: str
+        :param args: Positional arguments of the job to check.
+        :type args: list
+        :param kwargs: Keyword arguments of the job to check.
+        :type kwargs: dict
+        :return: True if a matching job exists in pending or running queues, False otherwise.
+        :rtype: bool
+        """
+        cleaned_kwargs = kwargs.copy()
+        cleaned_kwargs.pop('job_id', None)
+        with (self._queue_lock):
+            queues_to_check = list(self.jobs_pending_queue) + list(self.jobs_running_queue)
+
+            for job in queues_to_check:
+                cleaned_job_kwargs = job.kwargs.copy()
+                cleaned_job_kwargs.pop('job_id', None)
+                if (job.module == module and
+                        job.func == func and
+                        job.args == args and
+                        cleaned_job_kwargs == cleaned_kwargs):
+                    return True
+            return False
 
 
 jobs_queue = JobsQueue()

--- a/bazarr/app/jobs_queue.py
+++ b/bazarr/app/jobs_queue.py
@@ -161,7 +161,7 @@ class JobsQueue:
 
         with self._queue_lock:
             if self._is_an_existing_job(module, func, args, kwargs):
-                logging.debug(f"Task {job_name} already exists in pending and running queue")
+                logging.debug(f"Task {job_name} already exists in pending and running queue")  # noqa: G004
                 return False
 
             with self._job_id_lock:

--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -64,7 +64,7 @@ def check_login(actual_method):
                 })
         elif settings.auth.type == 'form':
             if 'logged_in' not in session:
-                return abort(401, message="Unauthorized")
+                return abort(401)
         return actual_method(*args, **kwargs)
     return wrapper
 
@@ -128,14 +128,14 @@ def catch_all(path):
     return render_template("index.html", BAZARR_SERVER_INJECT=inject, baseUrl=template_url)
 
 
-@check_login
 @ui_bp.route('/' + FILE_LOG)
+@check_login
 def download_log():
     return send_file(get_log_file_path(), max_age=0, as_attachment=True)
 
 
-@check_login
 @ui_bp.route('/images/series/<path:url>', methods=['GET'])
+@check_login
 def series_images(url):
     url = url.strip("/")
     apikey = settings.sonarr.apikey
@@ -149,8 +149,8 @@ def series_images(url):
         return Response(stream_with_context(req.iter_content(2048)), content_type=req.headers['content-type'])
 
 
-@check_login
 @ui_bp.route('/images/movies/<path:url>', methods=['GET'])
+@check_login
 def movies_images(url):
     apikey = settings.radarr.apikey
     baseUrl = settings.radarr.base_url
@@ -163,8 +163,8 @@ def movies_images(url):
         return Response(stream_with_context(req.iter_content(2048)), content_type=req.headers['content-type'])
 
 
-@check_login
 @ui_bp.route('/system/backup/download/<path:filename>', methods=['GET'])
+@check_login
 def backup_download(filename):
     fullpath = os.path.normpath(os.path.join(settings.backup.folder, filename))
     if not fullpath.startswith(settings.backup.folder):
@@ -356,8 +356,8 @@ def _build_request_url(base_parsed, status_path, resolved_ip, hostname, pin):
     return pinned_url, headers
 
 
-@check_login
 @ui_bp.route('/test/<service>', methods=['GET'])
+@check_login
 def proxy_service(service):
     """Constrained connection tester for Sonarr/Radarr.
 
@@ -477,9 +477,9 @@ def proxy_service(service):
                 code=last_response_code)
 
 
-@check_login
 @ui_bp.route('/test', methods=['GET'])
 @ui_bp.route('/test/<protocol>/<path:url>', methods=['GET'])
+@check_login
 def proxy(protocol, url):
     if protocol.lower() not in ['http', 'https']:
         return dict(status=False, error='Unsupported protocol', code=0)

--- a/bazarr/radarr/sync/movies.py
+++ b/bazarr/radarr/sync/movies.py
@@ -69,10 +69,10 @@ def update_movie(updated_movie):
         if (previous_movie_file_id != updated_movie['movie_file_id'] or
                 previous_movie_path != updated_movie['path']):
             # Store subtitles for updated movie where path or movie_file_id changed
-            logging.debug(f'BAZARR updating subtitles for movie {updated_movie["path"]}')
+            logging.debug(f'BAZARR updating subtitles for movie {updated_movie["path"]}')  # noqa: G004
             store_subtitles_movie(updated_movie['path'], path_mappings.path_replace_movie(updated_movie['path']))
         else:
-            logging.debug(f'BAZARR skipping subtitle update for movie {updated_movie["path"]} as path '
+            logging.debug(f'BAZARR skipping subtitle update for movie {updated_movie["path"]} as path '  # noqa: G004
                           f'and movie_file_id unchanged')
 
         event_stream(type='movie', action='update', payload=previous_movie_id)

--- a/bazarr/radarr/sync/movies.py
+++ b/bazarr/radarr/sync/movies.py
@@ -50,6 +50,15 @@ def get_movie_file_size_from_db(movie_path):
 # Update movies in DB
 def update_movie(updated_movie):
     try:
+        previous_movie_data = database.execute(
+            select(TableMovies.movie_file_id, TableMovies.path)
+            .where(TableMovies.radarrId == updated_movie['radarrId'])
+        ).first()
+
+        previous_movie_id = updated_movie['radarrId']
+        previous_movie_file_id = previous_movie_data.movie_file_id
+        previous_movie_path = previous_movie_data.path
+
         updated_movie['updated_at_timestamp'] = datetime.now()
         database.execute(
             update(TableMovies).values(updated_movie)
@@ -57,8 +66,16 @@ def update_movie(updated_movie):
     except IntegrityError as e:
         logging.error(f"BAZARR cannot update movie {updated_movie['path']} because of {e}")  # noqa: G004
     else:
-        store_subtitles_movie(updated_movie['path'], path_mappings.path_replace_movie(updated_movie['path']))
-        event_stream(type='movie', action='update', payload=updated_movie['radarrId'])
+        if (previous_movie_file_id != updated_movie['movie_file_id'] or
+                previous_movie_path != updated_movie['path']):
+            # Store subtitles for updated movie where path or movie_file_id changed
+            logging.debug(f'BAZARR updating subtitles for movie {updated_movie["path"]}')
+            store_subtitles_movie(updated_movie['path'], path_mappings.path_replace_movie(updated_movie['path']))
+        else:
+            logging.debug(f'BAZARR skipping subtitle update for movie {updated_movie["path"]} as path '
+                          f'and movie_file_id unchanged')
+
+        event_stream(type='movie', action='update', payload=previous_movie_id)
 
 
 def get_movie_monitored_status(movie_id):

--- a/bazarr/secret_store/registry.py
+++ b/bazarr/secret_store/registry.py
@@ -83,6 +83,8 @@ USER_VISIBLE_SECRETS = frozenset({
     "legendasdivx.password",
     "legendasnet.username",
     "legendasnet.password",
+    "pipocas.username",
+    "pipocas.password",
     "xsubs.username",
     "xsubs.password",
     "deathbycaptcha.username",

--- a/bazarr/subtitles/download.py
+++ b/bazarr/subtitles/download.py
@@ -25,7 +25,7 @@ from .processing import process_subtitle
 @update_pools
 def generate_subtitles(path, languages, audio_language, sceneName, title, media_type, profile_id,
                        forced_minimum_score=None, is_upgrade=False, check_if_still_required=False,
-                       previous_subtitles_to_delete=None, job_id=None):
+                       previous_subtitles_to_delete=None, job_id=None, fallback_allowed=False):
     if not languages:
         return None
 
@@ -94,7 +94,8 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
                                                                        min_score=int(min_score),
                                                                        hearing_impaired=hi_required,
                                                                        use_original_format=original_format in (1, "1", "True", True),
-                                                                       use_provider_priority=settings.general.use_provider_priority)
+                                                                       use_provider_priority=settings.general.use_provider_priority,
+                                                                       fallback_allowed=fallback_allowed)
                     except Exception as e:
                         logging.exception(f'BAZARR Error downloading Subtitles for this file {path}: {repr(e)}')  # noqa: G004
                         return None

--- a/bazarr/subtitles/mass_download/series.py
+++ b/bazarr/subtitles/mass_download/series.py
@@ -17,6 +17,7 @@ from app.database import (get_exclusion_clause, get_audio_profile_languages, Tab
                           select, get_profile_id)
 from app.jobs_queue import jobs_queue
 from app.event_handler import event_stream
+from app.config import settings
 
 from ..download import generate_subtitles
 
@@ -64,10 +65,10 @@ def series_download_subtitles(no, job_id=None, job_sub_function=False):
                                                             f'{episode.episode:02d} - {episode.episodeTitle}')
 
             providers_list = get_providers()
-
+            fallback_allowed = settings.general.use_whisper_fallback and settings.general.use_whisper_fallback_series
             if providers_list:
                 episode_download_subtitles(no=episode.sonarrEpisodeId, job_id=job_id, job_sub_function=True,
-                                           providers_list=providers_list)
+                                           providers_list=providers_list, fallback_allowed=fallback_allowed)
             else:
                 jobs_queue.update_job_progress(job_id=job_id, progress_value=count_episodes_details)
                 logging.info("BAZARR All providers are throttled")
@@ -80,7 +81,7 @@ def series_download_subtitles(no, job_id=None, job_sub_function=False):
     jobs_queue.update_job_name(job_id=job_id, new_job_name=f"Downloaded missing subtitles for {series_row.title}")
 
 
-def episode_download_subtitles(no, job_id=None, job_sub_function=False, providers_list=None):
+def episode_download_subtitles(no, job_id=None, job_sub_function=False, providers_list=None, fallback_allowed=False):
     if not job_sub_function and not job_id:
         jobs_queue.add_job_from_function(f"""Downloading missing subtitles for {database.scalar(
             select(TableShows.title).where(TableShows.sonarrSeriesId == no)) or 'Unknown Series'}""", is_progress=True)
@@ -161,7 +162,8 @@ def episode_download_subtitles(no, job_id=None, job_sub_function=False, provider
                                              'series',
                                              episode.profileId,
                                              check_if_still_required=True,
-                                             job_id=job_id):
+                                             job_id=job_id,
+                                             fallback_allowed=fallback_allowed):
                 if result:
                     if isinstance(result, tuple) and len(result):
                         result = result[0]

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -15,6 +15,7 @@ from app.get_providers import get_providers
 from app.database import get_exclusion_clause, get_audio_profile_languages, TableMovies, database, update, select
 from app.event_handler import event_stream
 from app.jobs_queue import jobs_queue
+from app.config import settings
 
 from ..adaptive_searching import is_search_active, updateFailedAttempts
 from ..download import generate_subtitles
@@ -50,7 +51,8 @@ def _wanted_movie(movie, providers_list, job_id=None):
                                      'movie',
                                      movie.profileId,
                                      check_if_still_required=True,
-                                     job_id=job_id):
+                                     job_id=job_id,
+                                     fallback_allowed=settings.general.use_whisper_fallback):
 
         if result:
             found_any = True

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -18,6 +18,7 @@ from app.database import get_exclusion_clause, get_audio_profile_languages, Tabl
     update, select
 from app.event_handler import event_stream
 from app.jobs_queue import jobs_queue
+from app.config import settings
 
 from ..adaptive_searching import is_search_active, updateFailedAttempts
 from ..download import generate_subtitles
@@ -53,7 +54,8 @@ def _wanted_episode(episode, providers_list, job_id=None):
                                      'series',
                                      episode.profileId,
                                      check_if_still_required=True,
-                                     job_id=job_id):
+                                     job_id=job_id,
+                                     fallback_allowed=settings.general.use_whisper_fallback):
         if result:
             found_any = True
             if isinstance(result, tuple) and len(result):

--- a/bazarr/utilities/backup.py
+++ b/bazarr/utilities/backup.py
@@ -4,6 +4,7 @@ import os
 import sqlite3
 import shutil
 import logging
+import re
 
 from datetime import datetime, timedelta, timezone
 from zipfile import ZipFile, BadZipFile, ZIP_DEFLATED
@@ -14,6 +15,30 @@ from app.config import settings
 from app.event_handler import event_stream
 from app.jobs_queue import jobs_queue
 from utilities.central import restart_bazarr
+
+_BACKUP_FILENAME_RE = re.compile(r'^bazarr_backup_v[\w.\-]+\.zip$')
+
+
+def _validate_backup_filename(filename):
+    """Return a safe filename if `filename` is a plain backup file name, else None."""
+    if not filename:
+        return None
+    safe_name = os.path.basename(filename)
+    if safe_name != filename:
+        return None
+    if not _BACKUP_FILENAME_RE.match(safe_name):
+        return None
+    return safe_name
+
+
+def _safe_extract(zip_obj, dest_path):
+    """Extract a ZIP archive while rejecting entries that escape `dest_path`."""
+    dest_real = os.path.realpath(dest_path)
+    for member in zip_obj.namelist():
+        member_real = os.path.realpath(os.path.join(dest_real, member))
+        if member_real != dest_real and not member_real.startswith(dest_real + os.sep):
+            raise BadZipFile(f'Unsafe path in backup archive: {member}')
+    zip_obj.extractall(path=dest_path)
 
 
 def get_backup_path():
@@ -162,6 +187,10 @@ def restore_from_backup():
 
 
 def prepare_restore(filename):
+    filename = _validate_backup_filename(filename)
+    if filename is None:
+        logging.error('Invalid backup filename refused for restore.')
+        return False
     src_zip_file_path = os.path.join(get_backup_path(), filename)
     dest_zip_file_path = os.path.join(get_restore_path(), filename)
     success = False
@@ -172,7 +201,7 @@ def prepare_restore(filename):
     else:
         try:
             with ZipFile(dest_zip_file_path, 'r') as zipObj:
-                zipObj.extractall(path=get_restore_path())
+                _safe_extract(zipObj, get_restore_path())
         except BadZipFile:
             logging.exception(f'Unable to extract files from backup archive {dest_zip_file_path}')  # noqa: G004
         else:
@@ -216,6 +245,10 @@ def backup_rotation():
 
 
 def delete_backup_file(filename):
+    filename = _validate_backup_filename(filename)
+    if filename is None:
+        logging.error('Invalid backup filename refused for deletion.')
+        return False
     backup_file_path = os.path.join(get_backup_path(), filename)
     try:
         os.remove(backup_file_path)

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -613,7 +613,7 @@ class SZProviderPool(ProviderPool):
         return True
 
     def download_best_subtitles(self, subtitles, video, languages, min_score=0, hearing_impaired=False, only_one=False,
-                                use_original_format=False):
+                                use_original_format=False, fallback_allowed=False):
         """Download the best matching subtitles.
 
         patch:
@@ -723,6 +723,24 @@ class SZProviderPool(ProviderPool):
             if only_one:
                 logger.debug('Only one subtitle downloaded')
                 break
+
+        # --- WHISPER FALLBACK PRECONDITIONS ---
+        # 1. No regular provider results with at least minimum score
+        # 2. We are in a Bulk Task or Single Series search
+        # 3. User enabled the Whisper fallback setting
+        # 4. Whisper is actually in the active providers list
+        if (not downloaded_subtitles and 
+            fallback_allowed and 
+            'whisperai' in self.providers):
+            
+            for subtitle, score, score_without_hash, matches, orig_matches in scored_subtitles:
+                if subtitle.provider_name == 'whisperai':
+                    logger.info('BAZARR Bulk Task: Falling back to Whisper for %r', video.name)
+                    subtitle.use_original_format = use_original_format
+                    if self.download_subtitle(subtitle):
+                        subtitle.score = score
+                        downloaded_subtitles.append(subtitle)
+                        break
 
         return downloaded_subtitles
 

--- a/custom_libs/subliminal_patch/core_persistent.py
+++ b/custom_libs/subliminal_patch/core_persistent.py
@@ -59,6 +59,7 @@ def download_best_subtitles(
     only_one=False,
     use_original_format=False,
     use_provider_priority=True,
+    fallback_allowed=False,
     **kwargs
 ):
     downloaded_subtitles = defaultdict(list)
@@ -90,6 +91,7 @@ def download_best_subtitles(
             hearing_impaired=hearing_impaired,
             only_one=only_one,
             use_original_format=use_original_format,
+            fallback_allowed=fallback_allowed,
         )
         logger.info("Downloaded %d subtitle(s)", len(subtitles))
         downloaded_subtitles[video].extend(subtitles)

--- a/custom_libs/subliminal_patch/providers/opensubtitlescom.py
+++ b/custom_libs/subliminal_patch/providers/opensubtitlescom.py
@@ -541,11 +541,11 @@ class OpenSubtitlesComProvider(ProviderRetryMixin, Provider):
             subtitle_content = r.content
             subtitle.content = fix_line_ending(subtitle_content)
 
-    @staticmethod
-    def reset_token():
+    def reset_token(self):
         logger.debug('Authentication failed: clearing cache and attempting to login.')
         region.delete("oscom_token")
         region.delete("oscom_server")
+        self.session.headers.pop('Authorization', None)
         return
 
     def checked(self, fn, raise_api_limit=False, validate_json=False, json_key_name=None, validate_content=False,

--- a/custom_libs/subliminal_patch/providers/pipocas.py
+++ b/custom_libs/subliminal_patch/providers/pipocas.py
@@ -1,0 +1,390 @@
+# coding=utf-8
+
+from __future__ import absolute_import, unicode_literals
+
+import io
+import logging
+import os
+import re
+from time import sleep
+from zipfile import ZipFile, is_zipfile
+from rarfile import RarFile, is_rarfile
+from bs4 import BeautifulSoup
+from guessit import guessit
+from requests.exceptions import HTTPError, RequestException
+
+from subzero.language import Language
+from subliminal.exceptions import (
+    AuthenticationError,
+    ConfigurationError,
+    ProviderError,
+    ServiceUnavailable,
+)
+from subliminal.subtitle import fix_line_ending
+from subliminal.video import Episode, Movie
+
+from subliminal_patch.providers.mixins import ProviderSubtitleArchiveMixin
+from subliminal_patch.subtitle import Subtitle, guess_matches
+
+from . import Provider, reinitialize_on_error
+
+logger = logging.getLogger(__name__)
+
+SITE = "https://pipocas.tv"
+LOGIN_URL = SITE + "/login"
+SEARCH_URL = SITE + "/legendas"
+DOWNLOAD_URL = SITE + "/legendas/download/{id}"
+
+TOKEN_RE = re.compile(r'<meta name="csrf-token" content="(.+?)">', re.IGNORECASE)
+
+
+# Mapping between Language objects and pipocas.tv language names
+PIPOCAS_LANGUAGE_MAP = {
+    # Portuguese (Portugal)
+    ("por", None): "portugues",
+    ("por", "PT"): "portugues",
+    # Portuguese (Brazil)
+    ("por", "BR"): "brasileiro",
+    # English
+    ("eng", None): "ingles",
+    ("eng", "US"): "ingles",
+    ("eng", "GB"): "ingles",
+    # Spanish
+    ("spa", None): "espanhol",
+    ("spa", "ES"): "espanhol",
+    ("spa", "MX"): "espanhol",
+}
+
+
+def get_pipocas_language(language):
+    """Map a Language to pipocas.tv internal language string."""
+    key = (language.alpha3, language.country)
+    if key in PIPOCAS_LANGUAGE_MAP:
+        return PIPOCAS_LANGUAGE_MAP[key]
+
+    key = (language.alpha3, None)
+    return PIPOCAS_LANGUAGE_MAP.get(key)
+
+
+class PipocasSubtitle(Subtitle):
+    """Single subtitle entry from pipocas.tv."""
+
+    provider_name = "pipocas"
+    hash_verifiable = False
+
+    def __init__(self, language, video, sub_id, release, hits, uploader, score_stars):
+        super(PipocasSubtitle, self).__init__(language)
+        self.video = video
+        self.sub_id = sub_id
+        self.release = release or ""
+        self.releases = self.release_info = self.release
+        self.matches = set()
+
+        if isinstance(video, Episode):
+            self.season = video.season
+            self.episode = video.episode
+            self.asked_for_episode = video.episode
+        else:
+            self.season = None
+            self.episode = None
+            self.asked_for_episode = None
+
+        self.asked_for_release_group = getattr(video, "release_group", None)
+        self.is_pack = False
+        self.hits = hits or 0
+        self.uploader = uploader or "pipocas-bot"
+        self.user_score = score_stars or 0
+        self.page_link = DOWNLOAD_URL.format(id=sub_id)
+
+    @property
+    def id(self):
+        # Stable internal ID for caching/history
+        return f"{self.provider_name}_{self.sub_id}"
+
+    def get_matches(self, video):
+        """Compute match set for scoring."""
+        matches = set()
+
+        # Basic movie/episode matching on name/year
+        if isinstance(video, Episode):
+            if video.series and video.series.lower() in self.release.lower():
+                matches.add("series")
+            if video.season and f"s{video.season:02d}".lower() in self.release.lower():
+                matches.add("season")
+            if video.episode and f"e{video.episode:02d}".lower() in self.release.lower():
+                matches.add("episode")
+        else:
+            if video.title and video.title.lower() in self.release.lower():
+                matches.add("title")
+
+        if video.year and str(video.year) in self.release:
+            matches.add("year")
+
+        # Let guessit refine matches
+        try:
+            guessed = guessit(self.release, {"type": "episode" if isinstance(video, Episode) else "movie"})
+            matches |= guess_matches(video, guessed)
+        except Exception:
+            pass
+
+        self.matches = matches
+        return matches
+
+
+class PipocasProvider(Provider, ProviderSubtitleArchiveMixin):
+    """pipocas.tv provider for subliminal_patch."""
+
+    languages = {
+        Language("por"),          # Portuguese (Portugal)
+        Language("por", "BR"),    # Portuguese (Brazil)
+        Language("eng"),          # English
+        Language("spa"),          # Spanish
+    }
+
+    video_types = (Episode, Movie)
+    subtitle_class = PipocasSubtitle
+    SEARCH_DELAY = 5
+
+    headers = {
+        "User-Agent": os.environ.get("SZ_USER_AGENT", "Sub-Zero/2"),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Origin": SITE,
+        "Referer": SITE,
+        "Connection": "keep-alive",
+    }
+
+    def __init__(self, username=None, password=None):
+        if any((username, password)) and not all((username, password)):
+            raise ConfigurationError("Pipocas.tv :: username and password must both be set")
+
+        self.username = username
+        self.password = password
+        self.session = None
+
+    def initialize(self):
+        """Create HTTP session and log in."""
+        if not self.username or not self.password:
+            raise ConfigurationError("Pipocas.tv :: username/password not configured")
+
+        # Session is injected to this module as Session by providers/__init__.py
+        self.session = Session()
+        self.session.headers.update(self.headers)
+
+        self._login()
+
+    def terminate(self):
+        if self.session:
+            self.session.close()
+
+    def _login(self):
+        """Perform CSRF-based login."""
+        logger.debug("Pipocas.tv :: requesting login page")
+        res = self.session.get(LOGIN_URL)
+        res.raise_for_status()
+
+        token_match = TOKEN_RE.search(res.text)
+        if not token_match:
+            raise ServiceUnavailable("Pipocas.tv :: unable to find CSRF token on login page")
+
+        token = token_match.group(1)
+        payload = {
+            "username": self.username,
+            "password": self.password,
+            "_token": token,
+        }
+
+        logger.debug("Pipocas.tv :: posting login form")
+        res = self.session.post(LOGIN_URL, data=payload)
+        res.raise_for_status()
+
+        if "Cria uma conta" in res.text:
+            raise AuthenticationError("Pipocas.tv :: login failed, check credentials")
+
+        logger.info("Pipocas.tv :: login successful")
+
+    # ------------------------------------------------------------------ search
+
+    def _build_search_query(self, video):
+        """Build search string from video metadata."""
+        if isinstance(video, Episode):
+            if video.series and video.season and video.episode:
+                return f"{video.series} S{video.season:02d}E{video.episode:02d}"
+            if video.series:
+                return video.series
+        else:
+            if video.title:
+                return video.title
+
+        if video.name:
+            return os.path.splitext(os.path.basename(video.name))[0]
+
+        return ""
+
+    def _parse_details_page(self, video, url, language):
+        """Parse /legendas/info/<id> page into a PipocasSubtitle."""
+        res = self.session.get(url)
+        res.raise_for_status()
+
+        soup = BeautifulSoup(res.text, "html.parser")
+
+        # Release name
+        release = ""
+        title_h3 = soup.find("h3", class_="title")
+        if title_h3:
+            span = title_h3.find("span", class_="font-normal")
+            if span and span.text:
+                release = span.text.strip()
+
+        # Subtitle ID
+        sub_id = None
+        for a in soup.find_all("a", href=True):
+            m = re.search(r"/legendas/download/([^\"']+)", a["href"])
+            if m:
+                sub_id = m.group(1)
+                break
+
+        if not sub_id:
+            return None
+
+        # Hits
+        hits = 0
+        hits_span = soup.find("span", class_="hits hits-pd")
+        if hits_span:
+            div = hits_span.find("div")
+            if div and div.text:
+                try:
+                    hits = int(div.text.strip())
+                except ValueError:
+                    hits = 0
+
+        # Uploader
+        uploader = None
+        span_color = soup.find("span", style=re.compile(r"color:\s*#[0-9A-Fa-f]{3,6}"))
+        if span_color and span_color.text:
+            uploader = span_color.text.strip()
+
+        # Rating X/Y
+        rating_val = 0
+        rating_h2 = soup.find("h2", class_="mt-3 text-center")
+        if rating_h2 and rating_h2.text:
+            m = re.search(r"(\d+)\s*/\s*\d+", rating_h2.text)
+            if m:
+                try:
+                    rating_val = int(m.group(1))
+                except ValueError:
+                    rating_val = 0
+
+        # Convert rating + hits to 0–5 stars (similar to Kodi addon)
+        if rating_val == 0:
+            hit_factor = 0
+        else:
+            hit_factor = min(hits / 100.0, 5.0)
+        score_stars = round((rating_val + hit_factor) / 2.0)
+
+        return PipocasSubtitle(
+            language=language,
+            video=video,
+            sub_id=sub_id,
+            release=release,
+            hits=hits,
+            uploader=uploader,
+            score_stars=score_stars,
+        )
+
+    def _search_language(self, video, language):
+        """Search for one language and return a list of PipocasSubtitle."""
+        site_lang = get_pipocas_language(language)
+        if not site_lang:
+            logger.debug("Pipocas.tv :: language %s not supported by site", language)
+            return []
+
+        query = self._build_search_query(video)
+        if not query:
+            return []
+
+        params = {
+            "t": "rel",
+            "l": site_lang,
+            "page": 1,
+            "s": query,
+        }
+
+        logger.debug("Pipocas.tv :: searching '%s' [%s]", query, site_lang)
+        sleep(self.SEARCH_DELAY)
+
+        res = self.session.get(SEARCH_URL, params=params)
+        res.raise_for_status()
+
+        if "Cria uma conta" in res.text:
+            raise AuthenticationError("Pipocas.tv :: not authenticated during search")
+
+        soup = BeautifulSoup(res.text, "html.parser")
+        results = []
+
+        for a in soup.find_all("a", href=True, class_="text-dark no-decoration"):
+            if "/legendas/info/" not in a["href"]:
+                continue
+
+            details_href = a["href"]
+            if not details_href.startswith("http"):
+                details_href = SITE.rstrip("/") + details_href
+
+            sub = self._parse_details_page(video, details_href, language)
+            if sub:
+                results.append(sub)
+
+        return results
+
+    def list_subtitles(self, video, languages):
+        """Main entry point used by subliminal."""
+        all_subs = []
+        for lang in languages:
+            try:
+                subs = self._search_language(video, lang)
+                all_subs.extend(subs)
+            except (HTTPError, RequestException, AuthenticationError, ServiceUnavailable):
+                raise
+            except Exception as e:
+                logger.error("Pipocas.tv :: error searching %s: %r", lang, e)
+
+        all_subs.sort(key=lambda s: (s.user_score, s.hits), reverse=True)
+        return all_subs
+
+    # ---------------------------------------------------------------- download
+
+    @reinitialize_on_error((RequestException,), attempts=1)
+    def download_subtitle(self, subtitle):
+        """Download subtitle and fill subtitle.content."""
+        logger.info("Pipocas.tv :: downloading %s", subtitle.page_link)
+
+        res = self.session.get(subtitle.page_link, timeout=10)
+        res.raise_for_status()
+
+        if "Cria uma conta" in res.text:
+            raise AuthenticationError("Pipocas.tv :: not authenticated during download")
+
+        data = res.content
+        if not data:
+            raise ServiceUnavailable("Pipocas.tv :: empty download response")
+
+        archive_stream = io.BytesIO(data)
+
+        if is_rarfile(archive_stream):
+            archive = RarFile(archive_stream)
+        elif is_zipfile(archive_stream):
+            archive = ZipFile(archive_stream)
+        else:
+            subtitle.content = fix_line_ending(data)
+
+            if subtitle.is_valid():
+                return subtitle
+
+            subtitle.content = None
+            raise ProviderError("Pipocas.tv :: unidentified archive type")
+
+        subtitle.content = self.get_subtitle_from_archive(subtitle, archive)
+
+        if not subtitle.content:
+            raise ServiceUnavailable("Pipocas.tv :: no suitable subtitle file in archive")
+
+        return subtitle

--- a/custom_libs/subliminal_patch/providers/pipocas.py
+++ b/custom_libs/subliminal_patch/providers/pipocas.py
@@ -58,7 +58,12 @@ PIPOCAS_LANGUAGE_MAP = {
 
 def get_pipocas_language(language):
     """Map a Language to pipocas.tv internal language string."""
-    key = (language.alpha3, language.country)
+    # language.country is a babelfish.Country object (or None); the map
+    # uses alpha2 strings, so coerce before lookup. Without this,
+    # Brazilian Portuguese ('por', Country('BR')) misses the ('por','BR')
+    # entry and falls through to generic Portuguese.
+    country_code = language.country.alpha2 if language.country else None
+    key = (language.alpha3, country_code)
     if key in PIPOCAS_LANGUAGE_MAP:
         return PIPOCAS_LANGUAGE_MAP[key]
 

--- a/custom_libs/subliminal_patch/providers/subclub.py
+++ b/custom_libs/subliminal_patch/providers/subclub.py
@@ -1,0 +1,329 @@
+# -*- coding: utf-8 -*-
+import io
+import logging
+import re
+from random import randint
+from zipfile import ZipFile, is_zipfile
+
+from rarfile import RarFile, is_rarfile
+
+from guessit import guessit
+from requests import Session
+from subliminal.exceptions import ProviderError
+from subliminal.providers import ParserBeautifulSoup
+from subliminal.subtitle import SUBTITLE_EXTENSIONS, fix_line_ending, sanitize
+from subliminal.video import Episode, Movie
+from subzero.language import Language
+
+from subliminal_patch.providers import Provider
+from subliminal_patch.subtitle import Subtitle, guess_matches
+
+from .utils import FIRST_THOUSAND_OR_SO_USER_AGENTS as AGENT_LIST
+
+logger = logging.getLogger(__name__)
+
+# Anchor text shapes: "Inception (2010)" or "Game of Thrones (2011) [01x01]".
+TITLE_RE = re.compile(
+    r'^(?P<title>.+?)\s*\((?P<year>\d{4})\)'
+    r'(?:\s*\[(?P<season>\d+)x(?P<episode>\d+)\])?\s*$'
+)
+IMDB_ID_RE = re.compile(r'(tt\d+)')
+DOWN_ID_RE = re.compile(r'down\.php\?id=(\d+)')
+
+
+class SubclubSubtitle(Subtitle):
+    provider_name = 'subclub'
+
+    def __init__(self, language, page_link, download_link, archive_id, filename,
+                 title, year, season, episode, imdb_id, fps, rating, uploader):
+        super().__init__(language, page_link=page_link)
+        self.download_link = download_link
+        self.archive_id = archive_id
+        self.filename = filename
+        self.title = title
+        self.year = year
+        self.season = season
+        self.episode = episode
+        self.imdb_id = imdb_id
+        self.fps = fps
+        self.rating = rating
+        self.uploader = uploader
+        self.release_info = filename
+        self.matches = set()
+
+    @property
+    def id(self):
+        return '{}/{}'.format(self.archive_id, self.filename)
+
+    def get_fps(self):
+        return self.fps
+
+    def get_matches(self, video):
+        matches = set()
+        type_ = 'episode' if isinstance(video, Episode) else 'movie'
+
+        if isinstance(video, Movie):
+            if video.title and sanitize(self.title) == sanitize(video.title):
+                matches.add('title')
+        else:
+            if video.series and sanitize(self.title) == sanitize(video.series):
+                matches.add('series')
+            if video.season is not None and self.season == video.season:
+                matches.add('season')
+            if video.episode is not None and self.episode == video.episode:
+                matches.add('episode')
+
+        if video.year and self.year == video.year:
+            matches.add('year')
+
+        if self.imdb_id:
+            if isinstance(video, Movie) and video.imdb_id == self.imdb_id:
+                matches.add('imdb_id')
+            elif isinstance(video, Episode) and video.series_imdb_id == self.imdb_id:
+                matches.add('series_imdb_id')
+
+        matches |= guess_matches(video, guessit(self.filename, {'type': type_}))
+
+        self.matches = matches
+        return matches
+
+
+class SubclubProvider(Provider):
+    subtitle_class = SubclubSubtitle
+    languages = {Language('est')}
+    video_types = (Episode, Movie)
+    server_url = 'https://www.subclub.eu'
+    search_url = server_url + '/jutud.php'
+    archive_content_url = server_url + '/subtitles_archivecontent.php'
+    download_url = server_url + '/down.php'
+
+    def __init__(self):
+        self.session = None
+
+    def initialize(self):
+        self.session = Session()
+        self.session.headers['User-Agent'] = AGENT_LIST[randint(0, len(AGENT_LIST) - 1)]
+        self.session.headers['Referer'] = self.server_url + '/'
+
+    def terminate(self):
+        self.session.close()
+
+    @staticmethod
+    def _parse_float(text):
+        if not text:
+            return None
+        try:
+            return float(text.strip().replace(',', '.').split()[0])
+        except (ValueError, IndexError):
+            return None
+
+    def _search(self, title):
+        r = self.session.get(self.search_url, params={'otsing': title}, timeout=30)
+        r.raise_for_status()
+
+        soup = ParserBeautifulSoup(r.content.decode('utf-8', 'ignore'),
+                                   ['lxml', 'html.parser'])
+        table = soup.find('table', id='tale_list')
+        if table is None:
+            return []
+
+        results = []
+        for row in table.select('tbody > tr'):
+            tds = row.find_all('td', recursive=False)
+            if len(tds) < 9:
+                continue
+
+            link_el = tds[1].find('a', class_='sc_link', href=DOWN_ID_RE)
+            if link_el is None:
+                continue
+
+            archive_id = DOWN_ID_RE.search(link_el['href']).group(1)
+            anchor_text = ' '.join(link_el.get_text(' ', strip=True).split())
+            m = TITLE_RE.match(anchor_text)
+            if not m:
+                logger.debug('subclub: skipping unparsable title %r', anchor_text)
+                continue
+
+            imdb_id = None
+            imdb_a = tds[3].find('a', href=True)
+            if imdb_a:
+                im = IMDB_ID_RE.search(imdb_a['href'])
+                if im:
+                    imdb_id = im.group(1)
+
+            rating_span = tds[7].find('span')
+            rating_text = rating_span.get_text() if rating_span else tds[7].get_text()
+
+            results.append({
+                'archive_id': archive_id,
+                'page_link': '{}?id={}'.format(self.download_url, archive_id),
+                'title': m.group('title').strip(),
+                'year': int(m.group('year')),
+                'season': int(m.group('season')) if m.group('season') else None,
+                'episode': int(m.group('episode')) if m.group('episode') else None,
+                'imdb_id': imdb_id,
+                'fps': self._parse_float(tds[6].get_text()),
+                'rating': self._parse_float(rating_text),
+                'uploader': tds[8].get_text(strip=True) or None,
+            })
+
+        results.sort(key=lambda h: -(h['rating'] or 0.0))
+        return results
+
+    def _archive_files(self, archive_id):
+        """Return [(filename, direct download url)] from the site's listing,
+        or [] when the listing is empty (caller falls back to extraction)."""
+        r = self.session.get(self.archive_content_url,
+                             params={'id': archive_id}, timeout=30)
+        r.raise_for_status()
+
+        soup = ParserBeautifulSoup(r.content.decode('utf-8', 'ignore'),
+                                   ['lxml', 'html.parser'])
+        files = []
+        for a in soup.select('a[href*="down.php"]'):
+            href = a.get('href') or ''
+            if 'filename=' not in href:
+                continue
+            filename = a.get_text(strip=True)
+            if not filename.lower().endswith(tuple(SUBTITLE_EXTENSIONS)):
+                continue
+            # Site emits "../down.php?id=N&filename=B64".
+            files.append((filename, self.server_url + '/' + href.lstrip('./')))
+        return files
+
+    def _extract_archive(self, archive_id):
+        """Download and unpack the whole archive; return [(filename, bytes)]
+        for each subtitle member. Used when the listing endpoint is empty."""
+        r = self.session.get(self.download_url,
+                             params={'id': archive_id}, timeout=60)
+        r.raise_for_status()
+
+        stream = io.BytesIO(r.content)
+        if is_zipfile(stream):
+            archive = ZipFile(stream)
+        elif is_rarfile(stream):
+            archive = RarFile(stream)
+        else:
+            raise ProviderError(
+                'subclub: unsupported archive format for id=%s' % archive_id
+            )
+
+        out = []
+        for name in archive.namelist():
+            base = name.rsplit('/', 1)[-1]
+            if not base or base.startswith('.'):
+                continue
+            if not base.lower().endswith(tuple(SUBTITLE_EXTENSIONS)):
+                continue
+            try:
+                data = archive.read(name)
+            except Exception as e:
+                logger.warning('subclub: failed to read %r from archive %s: %s',
+                               name, archive_id, e)
+                continue
+            out.append((base, data))
+        return out
+
+    def _hit_matches_video(self, hit, video):
+        if isinstance(video, Episode):
+            if hit['season'] is None or hit['episode'] is None:
+                return False
+            if video.season is not None and hit['season'] != video.season:
+                return False
+            if video.episode is not None and hit['episode'] != video.episode:
+                return False
+            if video.series and sanitize(hit['title']) != sanitize(video.series):
+                return False
+        else:
+            if hit['season'] is not None or hit['episode'] is not None:
+                return False
+            if video.title and sanitize(hit['title']) != sanitize(video.title):
+                return False
+            if video.year and hit['year'] != video.year:
+                return False
+        return True
+
+    def query(self, video):
+        if isinstance(video, Episode):
+            search_titles = [video.series] + list(getattr(video, 'alternative_series', []) or [])
+        else:
+            search_titles = [video.title] + list(getattr(video, 'alternative_titles', []) or [])
+
+        seen_archive_ids = set()
+        subtitles = []
+
+        for search_title in search_titles:
+            if not search_title:
+                continue
+            try:
+                hits = self._search(search_title)
+            except Exception as e:
+                logger.warning('subclub: search for %r failed: %s', search_title, e)
+                continue
+
+            for hit in hits:
+                if hit['archive_id'] in seen_archive_ids:
+                    continue
+                if not self._hit_matches_video(hit, video):
+                    continue
+                seen_archive_ids.add(hit['archive_id'])
+
+                try:
+                    files = self._archive_files(hit['archive_id'])
+                except Exception as e:
+                    logger.warning('subclub: archive list for id=%s failed: %s',
+                                   hit['archive_id'], e)
+                    continue
+
+                extracted = []
+                if not files:
+                    try:
+                        extracted = self._extract_archive(hit['archive_id'])
+                    except Exception as e:
+                        logger.warning('subclub: archive unpack for id=%s failed: %s',
+                                       hit['archive_id'], e)
+                        continue
+                    if not extracted:
+                        continue
+
+                pairs = files or [(name, None) for name, _ in extracted]
+                contents = dict(extracted)
+
+                for filename, download_link in pairs:
+                    subtitle = self.subtitle_class(
+                        language=Language('est'),
+                        page_link=hit['page_link'],
+                        download_link=download_link,
+                        archive_id=hit['archive_id'],
+                        filename=filename,
+                        title=hit['title'],
+                        year=hit['year'],
+                        season=hit['season'],
+                        episode=hit['episode'],
+                        imdb_id=hit['imdb_id'],
+                        fps=hit['fps'],
+                        rating=hit['rating'],
+                        uploader=hit['uploader'],
+                    )
+                    if filename in contents:
+                        subtitle.content = fix_line_ending(contents[filename])
+                    subtitles.append(subtitle)
+
+        return subtitles
+
+    def list_subtitles(self, video, languages):
+        if not any(lang.alpha3 == 'est' for lang in languages):
+            return []
+        return self.query(video)
+
+    def download_subtitle(self, subtitle):
+        # Fallback path pre-populates content during query().
+        if subtitle.content:
+            return
+
+        r = self.session.get(subtitle.download_link, timeout=30)
+        r.raise_for_status()
+        if not r.content:
+            raise ProviderError('subclub: empty response for id=%s file=%s' % (
+                subtitle.archive_id, subtitle.filename))
+        subtitle.content = fix_line_ending(r.content)

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -305,6 +305,24 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
     ],
   },
   {
+    key: "pipocas",
+    name: "Pipocas.tv",
+    description:
+      "Portuguese / Brazilian / English / Spanish Subtitles Provider",
+    inputs: [
+      {
+        type: "text",
+        key: "username",
+        name: "Username",
+      },
+      {
+        type: "password",
+        key: "password",
+        name: "Password",
+      },
+    ],
+  },
+  {
     key: "legendasdivx",
     name: "LegendasDivx",
     description: "Brazilian / Portuguese Subtitles Provider",

--- a/frontend/src/pages/Settings/Providers/list.ts
+++ b/frontend/src/pages/Settings/Providers/list.ts
@@ -465,6 +465,11 @@ export const ProviderList: Readonly<ProviderInfo[]> = [
     description: "Mostly French Subtitles Provider",
   },
   {
+    key: "subclub",
+    name: "SubClub.eu",
+    description: "Estonian Subtitles Provider",
+  },
+  {
     key: "subdl",
     inputs: [
       {

--- a/frontend/src/pages/Settings/Subtitles/index.tsx
+++ b/frontend/src/pages/Settings/Subtitles/index.tsx
@@ -229,6 +229,39 @@ const SettingsSubtitlesView: FunctionComponent = () => {
           </Message>
         </CollapseBox>
       </Section>
+      <Section header="Whisper As Fallback">
+        <Check
+          label="Use Whisper as Fallback for Automated Searches"
+          settingKey="settings-general-use_whisper_fallback"
+        ></Check>
+        <CollapseBox settingKey={"settings-general-use_whisper_fallback"}>
+          <Message>
+            When enabled, Bazarr will ignore the Radarr/Sonarr minimum score and
+            fall back to a Whisper generated subtitle when no provider reaches
+            that minimum score. To avoid overloading Whisper, this fallback is
+            used only during automated tasks like Search for Missing Movie
+            Subtitles and Search for Missing Series Subtitles, or by invoking
+            Search from the Wanted menu. You are responsible for ensuring that
+            only one Whisper transcription or translation runs at a time, unless
+            your hardware can handle more.
+          </Message>
+        </CollapseBox>
+        <CollapseBox settingKey={"settings-general-use_whisper_fallback"}>
+          <Check
+            label="Use Whisper as Fallback for Single Series Searches"
+            settingKey="settings-general-use_whisper_fallback_series"
+          ></Check>
+          <CollapseBox
+            settingKey={"settings-general-use_whisper_fallback_series"}
+          >
+            <Message>
+              When enabled, Bazarr will also use Whisper fallback for single
+              series subtitle searches. All of the warnings about overloading
+              Whisper from the previous setting also apply to this one.
+            </Message>
+          </CollapseBox>
+        </CollapseBox>
+      </Section>
       <Section header="Upgrading Subtitles">
         <Check
           label="Upgrade Previously Downloaded Subtitles"

--- a/tests/subliminal_patch/test_subclub.py
+++ b/tests/subliminal_patch/test_subclub.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from subliminal_patch.core import Episode, Movie
+from subliminal_patch.providers.subclub import (
+    SubclubProvider,
+    SubclubSubtitle,
+    TITLE_RE,
+)
+from subzero.language import Language
+
+
+@pytest.mark.parametrize(
+    "anchor_text,expected",
+    [
+        (
+            "Inception (2010)",
+            {"title": "Inception", "year": "2010", "season": None, "episode": None},
+        ),
+        (
+            "Game of Thrones (2011) [01x02]",
+            {"title": "Game of Thrones", "year": "2011", "season": "01", "episode": "02"},
+        ),
+        (
+            "House M.D. (2004) [03x12]",
+            {"title": "House M.D.", "year": "2004", "season": "03", "episode": "12"},
+        ),
+        (
+            "The Simpsons Movie (2007)",
+            {"title": "The Simpsons Movie", "year": "2007", "season": None, "episode": None},
+        ),
+    ],
+)
+def test_title_regex(anchor_text, expected):
+    m = TITLE_RE.match(anchor_text)
+    assert m is not None, anchor_text
+    assert m.groupdict() == expected
+
+
+def test_subtitle_movie_matches():
+    sub = SubclubSubtitle(
+        language=Language("est"),
+        page_link="https://www.subclub.eu/down.php?id=10100",
+        download_link="https://www.subclub.eu/down.php?id=10100&filename=X",
+        archive_id="10100",
+        filename="Inception.720p.BluRay.x264-CROSSBOW.srt",
+        title="Inception",
+        year=2010,
+        season=None,
+        episode=None,
+        imdb_id="tt1375666",
+        fps=23.976,
+        rating=5.0,
+        uploader="schnappi",
+    )
+    movie = Movie(
+        "Inception.2010.720p.BluRay.x264-CROSSBOW.mkv",
+        "Inception",
+        year=2010,
+        imdb_id="tt1375666",
+    )
+    matches = sub.get_matches(movie)
+    assert {"title", "year", "imdb_id"} <= matches
+
+
+def test_subtitle_episode_matches():
+    sub = SubclubSubtitle(
+        language=Language("est"),
+        page_link="https://www.subclub.eu/down.php?id=11232",
+        download_link="https://www.subclub.eu/down.php?id=11232&filename=X",
+        archive_id="11232",
+        filename="Game.of.Thrones.S01E01.720p.BluRay.X264-REWARD.srt",
+        title="Game of Thrones",
+        year=2011,
+        season=1,
+        episode=1,
+        imdb_id="tt0944947",
+        fps=23.976,
+        rating=5.0,
+        uploader="Orav",
+    )
+    ep = Episode(
+        "Game.of.Thrones.S01E01.720p.BluRay.X264-REWARD.mkv",
+        "Game of Thrones",
+        1,
+        1,
+        series_imdb_id="tt0944947",
+        year=2011,
+    )
+    matches = sub.get_matches(ep)
+    assert {"series", "season", "episode", "year", "series_imdb_id"} <= matches
+
+
+def test_list_subtitles_skips_when_no_estonian():
+    with SubclubProvider() as provider:
+        # English-only request must short-circuit without hitting the network.
+        result = provider.list_subtitles(
+            Movie("Inception.mkv", "Inception", year=2010), [Language("eng")]
+        )
+        assert result == []
+
+
+@pytest.mark.vcr
+def test_list_subtitles_movie_inception():
+    """Inception has a working per-file listing; expect direct download URLs."""
+    movie = Movie(
+        "Inception.2010.720p.BluRay.x264-CROSSBOW.mkv",
+        "Inception",
+        year=2010,
+        imdb_id="tt1375666",
+    )
+    with SubclubProvider() as provider:
+        subs = provider.list_subtitles(movie, [Language("est")])
+    assert subs, "expected at least one Inception subtitle"
+    # Every returned sub references the same archive id.
+    assert {s.archive_id for s in subs} == {"10100"}
+    # The site exposes per-file URLs; nothing should be pre-extracted here.
+    assert all(s.download_link and not s.content for s in subs)
+    assert any("CROSSBOW" in s.filename for s in subs)
+
+
+@pytest.mark.vcr
+def test_list_subtitles_movie_shrek2_archive_fallback():
+    """Shrek 2 has an empty per-file listing — must fall back to whole-archive
+    extraction so the user still gets the individual releases."""
+    movie = Movie(
+        "Shrek.2.2004.WS.XviD.AC3-FOO.mkv",
+        "Shrek 2",
+        year=2004,
+        imdb_id="tt0298148",
+    )
+    with SubclubProvider() as provider:
+        subs = provider.list_subtitles(movie, [Language("est")])
+    assert subs, "expected fallback to extract Shrek 2 subtitles"
+    # Fallback path always pre-populates content during query().
+    assert all(s.content for s in subs)
+    # Filenames come from inside the archive — release-named entries should
+    # be present alongside any plain CD splits.
+    assert any("BRUTUS" in s.filename or "ShareConnector" in s.filename for s in subs)
+
+
+@pytest.mark.vcr
+def test_list_subtitles_movie_simpsons_movie_mixed():
+    """The Simpsons Movie has two archives uploaded:
+    - id=5270 has a working per-file listing (rar, but listed)
+    - id=5159 has an empty listing (zip) and needs the archive fallback
+    Both should be returned as a single combined result set.
+    """
+    movie = Movie(
+        "The.Simpsons.Movie.2007.720p.BluRay.x264.mkv",
+        "The Simpsons Movie",
+        year=2007,
+        imdb_id="tt0462538",
+    )
+    with SubclubProvider() as provider:
+        subs = provider.list_subtitles(movie, [Language("est")])
+    assert subs, "expected Simpsons Movie subtitles"
+    archives = {s.archive_id for s in subs}
+    assert {"5270", "5159"} <= archives, archives
+    # The fallback archive should have its content pre-populated.
+    fallback_subs = [s for s in subs if s.archive_id == "5159"]
+    assert fallback_subs and all(s.content for s in fallback_subs)
+
+
+@pytest.mark.vcr
+def test_list_subtitles_episode_got_s01e01():
+    ep = Episode(
+        "Game.of.Thrones.S01E01.720p.BluRay.X264-REWARD.mkv",
+        "Game of Thrones",
+        1,
+        1,
+        series_imdb_id="tt0944947",
+        year=2011,
+    )
+    with SubclubProvider() as provider:
+        subs = provider.list_subtitles(ep, [Language("est")])
+    assert subs
+    # Filtering by season/episode keeps only the matching archive.
+    assert {s.archive_id for s in subs} == {"11232"}
+    assert any("REWARD" in s.filename for s in subs)


### PR DESCRIPTION
Upstream sync of the 14 commits added to `morpheus65535/bazarr@development` since our last sync window (2026-04-26). Each commit was committee-reviewed by three independent agents (code, security, fork-fit). Of the 14, 3 were trivial no-log items (README/test fix) skipped; 1 was rejected (fork already has stronger fix); 1 was deferred (fork restructured the target code, needs manual port). The remaining 9 are picked here.

## Picked

In chronological order, with verdicts:

| Hash | Message | Severity / Note |
|---|---|---|
| `ee4a51fd7` | Fix unauthenticated route access by fixing decorator ordering | **HIGH security** (auth bypass on download_log/series_images/movies_images/backup_download/proxy; fork's proxy_service had the same bug, fixed in the same commit) |
| `250aa90cb` | Add Whisper fallback implementation | Opt-in (default off); kwarg merge with our `use_provider_priority` |
| `6ab768445` | Fix ensubtitles.com `reset_token` Authorization header clear | Credential hygiene |
| `2635f7d46` | Movie sync: only re-index subtitles when path or movie_file_id changed | Bug fix (perf) |
| `9aeadf3a1` | Add Pipocas.tv provider | New provider (Portuguese) |
| `611c633f8` | Add SubClub.eu Estonian subtitles provider | New provider (no auth) |
| `864622120` | Fix settings change detection on save | Logic bug (`key !=` vs `value !=`) and a typo in the radarr-excluded-tags key |
| `bddec5e67` | Backup filename validation + Zip Slip fix | **HIGH security** (authenticated path traversal in delete/restore + Zip Slip on extract) |
| `306ac2ff5` | Duplicate job entries prevention `#3322` | Bug fix; also fixes a `'queued'` vs `'pending'` status string mismatch |

Plus one fork follow-up commit (`aeedcebd9`):
- Register `pipocas.username` / `pipocas.password` in `secret_store/registry.py` so the new provider's credentials are encrypted at rest like every other provider login pair.
- Add `# noqa: G004` to two new `logging.debug(f'...')` lines in `bazarr/radarr/sync/movies.py` to match the fork's existing G004 ruff baseline.
- Advertise Pipocas.tv and SubClub.eu in the supported-providers list in `README.md`.

## Skipped

| Hash | Message | Reason |
|---|---|---|
| `9846c7b40` | Improve password verification to use constant-time comparison | Fork already PBKDF2-SHA256 + `hmac.compare_digest`; cherry-pick would regress to MD5-only |
| `4f6554c08` | Subtitle upgrade safeguards #3235 | Fork restructured `max_id_timestamp` and `query_actions` ordering; needs manual port + regression test, deferred |
| `77b007938` | Refresh README layout/wording | Upstream-branding-only restructure; not applicable to the fork's Bazarr+ README |
| `e04eb0b2a` | Fix abort mock in unit test | Internal test scaffolding only |
| `72a1876ac` | Update README copyright | Our copyright line is already current (`2025-2026`) |

## Conflicts resolved

- `bazarr/app/ui.py`: kept all fork-only routes (`_resolve_and_validate`, `_resolve_and_validate_constrained`, `proxy_service`, etc.) and applied the upstream decorator-order fix to both `proxy` (upstream's target) and `proxy_service` (fork-only route with the identical bug).
- `bazarr/subtitles/download.py` and `custom_libs/subliminal_patch/core_persistent.py`: kwarg merge, both `use_provider_priority` and `fallback_allowed` co-exist.
- `README.md`: kept ours.
- `bazarr/app/jobs_queue.py`: kept fork's `# noqa: G004` annotations on the `logging.debug` lines.

## Test plan

- [x] All files compile (`python -m py_compile` on every touched module)
- [x] Frontend test suite passes (433 / 3 skipped)
- [x] No new ruff errors in non-submodule code
- [x] CodeQL: deferred to GitHub-side scan (no local resources for the run)