### PR TITLE
Add guarded SQLite runtime maintenance

### DIFF
--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -4,6 +4,7 @@ import atexit
 import json
 import logging
 import os
+import sqlite3
 import flask_migrate
 
 from dogpile.cache import make_region
@@ -38,6 +39,41 @@ region = make_region().configure(
 )
 
 migrations_directory = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'migrations')
+
+
+def configure_sqlite_connection(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA synchronous=FULL")
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.execute("PRAGMA busy_timeout=60000")
+    finally:
+        cursor.close()
+
+
+def optimize_sqlite_database(engine_to_optimize):
+    if engine_to_optimize.dialect.name != 'sqlite':
+        return False
+    if sqlite3.sqlite_version_info < (3, 46, 0):
+        logger.debug("Skipping PRAGMA optimize on SQLite %s", sqlite3.sqlite_version)
+        return False
+
+    try:
+        with engine_to_optimize.connect() as connection:
+            connection.execute(text("PRAGMA optimize"))
+    except Exception:
+        logger.exception("Unable to run SQLite PRAGMA optimize.")
+        return False
+    return True
+
+
+def log_sqlite_runtime_version(engine_to_log):
+    if engine_to_log.dialect.name != 'sqlite':
+        return False
+    logging.info("SQLite runtime version: %s", sqlite3.sqlite_version)
+    return True
+
 
 if postgresql:
     # insert is different between database types
@@ -108,15 +144,7 @@ else:
     from sqlalchemy.engine import Engine
     from sqlalchemy import event
 
-    @event.listens_for(Engine, "connect")
-    def set_sqlite_pragma(dbapi_connection, connection_record):
-        cursor = dbapi_connection.cursor()
-        cursor.execute("PRAGMA journal_mode=WAL")
-        cursor.execute("PRAGMA synchronous=FULL")
-        cursor.execute("PRAGMA foreign_keys=ON")
-        cursor.execute("PRAGMA journal_mode=WAL")
-        cursor.execute("PRAGMA busy_timeout=60000")
-        cursor.close()
+    event.listen(Engine, "connect", configure_sqlite_connection)
 
 # Dev-only slow-query log. Gated by BAZARR_SQL_PROFILE env var; this
 # is a cheap function call and a hard early-return when disabled, so
@@ -419,6 +447,7 @@ def create_db_revision(app):
 
 
 def migrate_db(app):
+    log_sqlite_runtime_version(engine)
     logging.debug("Upgrading database schema")
     app.config["SQLALCHEMY_DATABASE_URI"] = url
     db = SQLAlchemy(app, metadata=metadata)
@@ -440,6 +469,7 @@ def migrate_db(app):
         database.execute(
             insert(System)
             .values(configured='0', updated='0'))
+    optimize_sqlite_database(engine)
 
 
 def get_exclusion_clause(exclusion_type):

--- a/tests/bazarr/test_database_sqlite_maintenance.py
+++ b/tests/bazarr/test_database_sqlite_maintenance.py
@@ -1,0 +1,116 @@
+class _Cursor:
+    def __init__(self):
+        self.statements = []
+        self.closed = False
+
+    def execute(self, statement):
+        self.statements.append(str(statement))
+
+    def close(self):
+        self.closed = True
+
+
+class _DbapiConnection:
+    def __init__(self):
+        self.cursor_obj = _Cursor()
+
+    def cursor(self):
+        return self.cursor_obj
+
+
+class _Dialect:
+    def __init__(self, name):
+        self.name = name
+
+
+class _SqlConnection:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, statement):
+        self.calls.append(str(statement))
+
+
+class _Engine:
+    def __init__(self, name="sqlite"):
+        self.dialect = _Dialect(name)
+        self.calls = []
+        self.connect_count = 0
+
+    def connect(self):
+        self.connect_count += 1
+        return _SqlConnection(self.calls)
+
+
+def test_log_sqlite_runtime_version_logs_for_sqlite(monkeypatch, caplog):
+    from app import database as db_module
+
+    monkeypatch.setattr(db_module.sqlite3, "sqlite_version", "3.46.1")
+
+    with caplog.at_level("INFO"):
+        assert db_module.log_sqlite_runtime_version(_Engine()) is True
+
+    assert "SQLite runtime version: 3.46.1" in caplog.text
+
+
+def test_log_sqlite_runtime_version_skips_non_sqlite(caplog):
+    from app import database as db_module
+
+    with caplog.at_level("INFO"):
+        assert db_module.log_sqlite_runtime_version(_Engine(name="postgresql")) is False
+
+    assert "SQLite runtime version" not in caplog.text
+
+
+def test_configure_sqlite_connection_sets_wal_once():
+    from app import database as db_module
+
+    dbapi_connection = _DbapiConnection()
+
+    db_module.configure_sqlite_connection(dbapi_connection, None)
+
+    assert dbapi_connection.cursor_obj.statements == [
+        "PRAGMA journal_mode=WAL",
+        "PRAGMA synchronous=FULL",
+        "PRAGMA foreign_keys=ON",
+        "PRAGMA busy_timeout=60000",
+    ]
+    assert dbapi_connection.cursor_obj.closed is True
+
+
+def test_optimize_sqlite_database_is_skipped_for_non_sqlite(monkeypatch):
+    from app import database as db_module
+
+    monkeypatch.setattr(db_module.sqlite3, "sqlite_version_info", (3, 46, 0))
+    engine = _Engine(name="postgresql")
+
+    assert db_module.optimize_sqlite_database(engine) is False
+    assert engine.connect_count == 0
+    assert engine.calls == []
+
+
+def test_optimize_sqlite_database_is_skipped_before_sqlite_346(monkeypatch):
+    from app import database as db_module
+
+    monkeypatch.setattr(db_module.sqlite3, "sqlite_version_info", (3, 45, 3))
+    engine = _Engine()
+
+    assert db_module.optimize_sqlite_database(engine) is False
+    assert engine.connect_count == 0
+    assert engine.calls == []
+
+
+def test_optimize_sqlite_database_runs_on_sqlite_346_or_newer(monkeypatch):
+    from app import database as db_module
+
+    monkeypatch.setattr(db_module.sqlite3, "sqlite_version_info", (3, 46, 0))
+    engine = _Engine()
+
+    assert db_module.optimize_sqlite_database(engine) is True
+    assert engine.calls == ["PRAGMA optimize"]


### PR DESCRIPTION
## Summary
- log the SQLite runtime version during database migration startup
- keep the existing SQLite connection pragmas while removing the duplicate WAL pragma
- run `PRAGMA optimize` only on SQLite 3.46.0 or newer, with a safe skip path for older runtimes
- add focused tests for the SQLite maintenance helpers

## Validation
- `ruff check bazarr/app/database.py tests/bazarr/test_database_sqlite_maintenance.py`
- `pytest tests/bazarr/test_database_sqlite_maintenance.py tests/bazarr/test_sql_profiler.py`
- `pytest tests/compat/`
- `npm run build`
- deployed to the test server and verified the container is healthy with SQLite 3.46.1