### PR TITLE
fix(docker): proxy /system/backup/download to backend

### DIFF
--- a/docker/supervisor.py
+++ b/docker/supervisor.py
@@ -104,7 +104,7 @@ BACKEND_PORT = 6768  # internal port for bazarr backend
 DEFAULT_PORT = 6767  # external port users connect to
 
 # Paths that get proxied to the backend
-PROXY_PREFIXES = ("/api/", "/images/", "/test/", "/bazarr.log")
+PROXY_PREFIXES = ("/api/", "/images/", "/test/", "/system/backup/download/", "/bazarr.log")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/bazarr/test_supervisor_proxy.py
+++ b/tests/bazarr/test_supervisor_proxy.py
@@ -1,0 +1,41 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+
+
+_SUPERVISOR_PATH = Path(__file__).resolve().parents[2] / "docker" / "supervisor.py"
+_SPEC = importlib.util.spec_from_file_location("bazarr_docker_supervisor", _SUPERVISOR_PATH)
+supervisor = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(supervisor)
+
+
+class _Backend:
+    def get_status(self):
+        return {"state": "running", "stage_index": 0}
+
+
+async def _proxy_marker(request):
+    return None
+
+
+async def _static_marker(request):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_backup_download_path_is_proxied_to_backend(monkeypatch, tmp_path):
+    monkeypatch.setattr(supervisor, "proxy_handler", _proxy_marker)
+    monkeypatch.setattr(supervisor, "create_static_handler", lambda config_dir: _static_marker)
+
+    app = supervisor.create_app(str(tmp_path), _Backend())
+    request = make_mocked_request(
+        "GET",
+        "/system/backup/download/bazarr_backup_vlatest_2026.05.03_03.00.00.zip",
+        app=app,
+    )
+
+    match_info = await app.router.resolve(request)
+
+    assert match_info.handler is _proxy_marker


### PR DESCRIPTION
## Summary
Backup downloads via `/system/backup/download/<file>.zip` returned 404 in Docker because `docker/supervisor.py` only proxied `/api/`, `/images/`, `/test/`, and `/bazarr.log` to the bazarr backend. Everything else fell through to the SPA/static handler, so the Flask `backup_download()` route was never reached, even though the backup files existed in `/config/backup`.

## Changes
- `docker/supervisor.py`: add `/system/backup/download/` to `PROXY_PREFIXES`
- `tests/bazarr/test_supervisor_proxy.py`: regression test verifying the exact path pattern that was failing (`bazarr_backup_v*.zip`) routes to the backend proxy

## Test plan
- [x] `ruff check docker/supervisor.py tests/bazarr/test_supervisor_proxy.py`
- [x] `pytest tests/bazarr/test_supervisor_proxy.py` (1 passed)
- [x] `npm run build`
- [x] Docker image build
- [x] Deployed to test server
- [x] Verify a backup `.zip` downloads in the browser via `/system/backup/download/...`