### PR TITLE
ci: auto-deploy gh-pages + stop the create-release clobber

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -208,33 +208,10 @@ jobs:
           echo "- **Platforms:** linux/amd64, linux/arm64" >> $GITHUB_STEP_SUMMARY
           echo "- **Cache Status:** GHA cache enabled" >> $GITHUB_STEP_SUMMARY
 
-  # ==========================================================================
-  # Create GitHub Release for tagged versions
-  # ==========================================================================
-  create-release:
-    needs: build-and-push
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v3
-        with:
-          generate_release_notes: true
-          body: |
-            ## 🐳 Docker Images
-            
-            ```bash
-            docker pull ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            ```
-            
-            ## 📝 Changes
-            
-            This release is based on upstream Bazarr with the following custom modifications:
-            - OpenSubtitles.org web scraper provider (no VIP API needed)
-            
-            See the auto-generated release notes below for detailed changes.
+  # Release-body management is intentionally NOT done from this workflow.
+  # Releases for the Bazarr+ fork are drafted by hand with a pandoc GFM
+  # pre-publish render check; an earlier softprops/action-gh-release step
+  # here ran on every refs/tags/v* push and clobbered the hand-authored
+  # body of the existing release (notably v2.2.0 Synapse on 2026-05-13).
+  # If post-tag automation is ever needed again, gate it so it only fills
+  # release bodies that are currently empty.

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,58 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'site/**'
+      - '.github/workflows/deploy-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: deploy-pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          path: src
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: pages
+
+      - name: Sync site/ to gh-pages
+        run: |
+          set -euo pipefail
+          # site/hero/ is a developer-side p5.js generator (release artwork
+          # source), not referenced from any deployed page. Everything else
+          # under site/ ships as-is, including .nojekyll.
+          rsync -a --delete \
+            --exclude '.git/' \
+            --exclude 'hero/' \
+            src/site/ pages/
+
+      - name: Commit and push if changed
+        working-directory: pages
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No changes to deploy."
+            exit 0
+          fi
+          COMMIT_SHA=$(git -C ../src rev-parse --short HEAD)
+          git commit -m "deploy: site/ from ${COMMIT_SHA}"
+          git push origin gh-pages


### PR DESCRIPTION
## Summary

- **Add `.github/workflows/deploy-pages.yml`**: auto-syncs `site/` to `gh-pages` on every master push that touches `site/**` (plus `workflow_dispatch`). The landing page at https://lavx.github.io/bazarr/ had drifted to v2.1.0-rc1 content while master shipped v2.2.0; this stops that from happening again.
- **Remove `create-release` job from `build-docker.yml`**: `softprops/action-gh-release@v3` was clobbering the hand-authored body of the existing release on every `refs/tags/v*` push. It hit v2.2.0 Synapse today (body dropped from 26,344 → 4,675 chars). Releases for this fork are drafted by hand with a pandoc GFM render check, so the auto-managed body was never doing useful work, only overwriting good work.

## Test plan

- [x] `yaml.safe_load` succeeds on both workflow files
- [x] After merge, manually trigger `Deploy Pages` workflow once via `workflow_dispatch` (or push something to `site/` on master) and confirm `gh-pages` updates to current `site/` contents
- [x] Next release tag does not overwrite the hand-authored body

The one-shot manual sync of `site/` → `gh-pages` for v2.2.0 is being done out-of-band so the landing page reflects v2.2.0 today without waiting on this PR.