### PR TITLE
Promote PR 117 follow-up hotfix

### DIFF
--- a/custom_libs/subliminal_patch/providers/prijevodionline.py
+++ b/custom_libs/subliminal_patch/providers/prijevodionline.py
@@ -25,8 +25,22 @@ except ImportError:
 # We match only the dot-notation assignment so we don't accidentally match
 # the empty-string initialiser in the object literal.
 _KEY_RE = re.compile(r"epizode\.key\s*=\s*['\"]([0-9a-f]{32})['\"]")
+_LANGUAGE_BY_URL_SEGMENT = {
+    'hr': Language('hrv'),
+    'sr': Language('srp'),
+    'cg': Language('mne'),
+}
 
 logger = logging.getLogger(__name__)
+
+
+def _language_from_href(href):
+    slug = href.rsplit('/', 1)[-1].lower()
+    for segment in reversed(slug.split('-')):
+        language = _LANGUAGE_BY_URL_SEGMENT.get(segment)
+        if language:
+            return language
+    return None
 
 
 class PrijevodiOnlineSubtitle(Subtitle):
@@ -183,15 +197,8 @@ class PrijevodiOnlineProvider(Provider):
                 continue
             href = link['href']
 
-            # Detect language from URL suffix (-hr = Croatian, -sr = Serbian, -cg = Montenegrin)
-            href_lower = href.lower()
-            if href_lower.endswith('-hr'):
-                sub_lang = Language('hrv')
-            elif href_lower.endswith('-sr'):
-                sub_lang = Language('srp')
-            elif href_lower.endswith('-cg'):
-                sub_lang = Language('mne')
-            else:
+            sub_lang = _language_from_href(href)
+            if not sub_lang:
                 continue
 
             if sub_lang not in languages and Language('hbs') not in languages:
@@ -272,4 +279,3 @@ class PrijevodiOnlineProvider(Provider):
                 subtitle.content = fix_line_ending(zf.read(names[0]))
         else:
             raise ProviderError('Unrecognized archive format for subtitle {}'.format(subtitle.id))
-

--- a/docker/supervisor.py
+++ b/docker/supervisor.py
@@ -16,6 +16,7 @@ Usage:
 """
 
 import asyncio
+import html
 import json
 import mimetypes
 import os
@@ -332,6 +333,54 @@ def _get_index_html(config_dir: str) -> str:
     return content
 
 
+def _get_startup_html(status: dict) -> str:
+    """Return a tiny startup page that reloads without booting the SPA."""
+    stage = html.escape(str(status.get("stage", "Starting backend")))
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="refresh" content="2">
+  <title>Bazarr+ is starting up</title>
+  <style>
+    body {{
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: #111827;
+      color: #f9fafb;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }}
+    main {{
+      width: min(28rem, calc(100vw - 2rem));
+      text-align: center;
+    }}
+    h1 {{
+      margin: 0 0 0.75rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }}
+    p {{
+      margin: 0;
+      color: #cbd5e1;
+      line-height: 1.5;
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Bazarr+ is starting up</h1>
+    <p>{stage}. This page will reload automatically.</p>
+  </main>
+  <script>
+    setTimeout(function () {{ window.location.reload(); }}, 2000);
+  </script>
+</body>
+</html>"""
+
+
 STATIC_FILE_EXTENSIONS = {
     ".js", ".css", ".map", ".json", ".webmanifest",
     ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".webp",
@@ -390,7 +439,16 @@ def create_static_handler(config_dir: str, backend: BackendManager | None = None
         if backend and backend.get_status().get("state") == BackendManager.STATE_RUNNING:
             return await proxy_handler(request)
 
-        # Serve patched index.html for SPA routing
+        status = backend.get_status() if backend else {}
+        if backend:
+            return web.Response(
+                status=503,
+                text=_get_startup_html(status),
+                content_type="text/html",
+                headers={"Cache-Control": "no-store"},
+            )
+
+        # Serve patched index.html for SPA routing when no backend manager is wired.
         return web.Response(
             text=_get_index_html(config_dir),
             content_type="text/html",

--- a/docker/supervisor.py
+++ b/docker/supervisor.py
@@ -436,11 +436,13 @@ def create_static_handler(config_dir: str, backend: BackendManager | None = None
         if ext in STATIC_FILE_EXTENSIONS:
             return web.Response(status=404, text="Not found")
 
-        if backend and backend.get_status().get("state") == BackendManager.STATE_RUNNING:
+        status = backend.get_status() if backend else {}
+        state = status.get("state")
+
+        if backend and state == BackendManager.STATE_RUNNING:
             return await proxy_handler(request)
 
-        status = backend.get_status() if backend else {}
-        if backend:
+        if backend and state == BackendManager.STATE_STARTING:
             return web.Response(
                 status=503,
                 text=_get_startup_html(status),

--- a/tests/bazarr/test_supervisor_proxy.py
+++ b/tests/bazarr/test_supervisor_proxy.py
@@ -75,3 +75,17 @@ async def test_spa_routes_do_not_boot_app_while_backend_is_starting(monkeypatch,
     assert "Bazarr+ is starting up" in response.text
     assert "window.Bazarr" not in response.text
     assert "/assets/app.js" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_crashed_backend_serves_app_for_reconnection_flow(monkeypatch, tmp_path):
+    app_shell = '<script>window.Bazarr = {"apiKey": ""}</script><script src="/assets/app.js"></script>'
+    monkeypatch.setattr(supervisor, "_get_index_html", lambda config_dir: app_shell)
+
+    handler = supervisor.create_static_handler(str(tmp_path), _Backend(state="crashed"))
+    request = make_mocked_request("GET", "/system/releases")
+
+    response = await handler(request)
+
+    assert response.status == 200
+    assert response.text == app_shell

--- a/tests/bazarr/test_supervisor_proxy.py
+++ b/tests/bazarr/test_supervisor_proxy.py
@@ -56,3 +56,22 @@ async def test_spa_routes_are_proxied_when_backend_is_running(monkeypatch, tmp_p
     response = await match_info.handler(request)
 
     assert response.text == "proxied"
+
+
+@pytest.mark.asyncio
+async def test_spa_routes_do_not_boot_app_while_backend_is_starting(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        supervisor,
+        "_get_index_html",
+        lambda config_dir: '<script>window.Bazarr = {"apiKey": ""}</script><script src="/assets/app.js"></script>',
+    )
+
+    handler = supervisor.create_static_handler(str(tmp_path), _Backend(state="starting"))
+    request = make_mocked_request("GET", "/system/releases")
+
+    response = await handler(request)
+
+    assert response.status == 503
+    assert "Bazarr+ is starting up" in response.text
+    assert "window.Bazarr" not in response.text
+    assert "/assets/app.js" not in response.text

--- a/tests/subliminal_patch/test_prijevodi.py
+++ b/tests/subliminal_patch/test_prijevodi.py
@@ -68,7 +68,8 @@ def test_list_subtitles_sr(region, got_s01e06, requests_mock, data):
     with PrijevodiOnlineProvider() as provider:
         subtitles = provider.list_subtitles(got_s01e06, {Language('srp')})
 
-    assert len(subtitles) == 4
+    assert len(subtitles) == 6
+    assert {s.subtitle_id for s in subtitles} == {21710, 21728, 21748, 21757, 22259, 37142}
     assert all(s.language == Language('srp') for s in subtitles)
     assert all(s.season == 1 for s in subtitles)
     assert all(s.episode == 6 for s in subtitles)


### PR DESCRIPTION
## Summary
- Promote the verified PR #118 follow-up fixes to the release branch without carrying unrelated development-only changes.
- Keep the Docker startup shell limited to backend startup only, while preserving the SPA reconnection path for crashed backends.
- Include Prijevodi-Online SR/HR/CG subtitle links whose language marker is followed by uploader or release suffixes.

## Validation
- pytest tests/subliminal_patch/test_prijevodi.py tests/bazarr/test_supervisor_proxy.py
- ruff check custom_libs/subliminal_patch/providers/prijevodionline.py docker/supervisor.py tests/subliminal_patch/test_prijevodi.py tests/bazarr/test_supervisor_proxy.py