### PR TITLE
fix(translator): pass missing metadata to batch translation callers

### DIFF
--- a/bazarr/subtitles/mass_operations.py
+++ b/bazarr/subtitles/mass_operations.py
@@ -5,7 +5,7 @@ import logging
 import os
 
 from app.config import settings
-from app.database import TableEpisodes, TableMovies, TableHistory, TableHistoryMovie, database, select
+from app.database import TableEpisodes, TableMovies, TableHistory, TableHistoryMovie, TableShows, database, select
 from app.jobs_queue import jobs_queue
 from subtitles.sync import sync_subtitles
 from subtitles.tools.mods import subtitles_apply_mods
@@ -151,7 +151,11 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
         TableEpisodes.sonarrSeriesId,
         TableEpisodes.path,
         TableEpisodes.subtitles,
-    )
+        TableEpisodes.season,
+        TableEpisodes.episode,
+        TableShows.imdbId,
+        TableShows.tvdbId
+    ).join(TableShows)
 
     filters = []
     if episode_ids:
@@ -218,6 +222,7 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
                 'max_offset_seconds': max_offset,
                 'no_fix_framerate': no_fix_framerate,
                 'gss': gss,
+                'metadata': ep,
             })
 
     return items, skipped
@@ -231,6 +236,8 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
         TableMovies.radarrId,
         TableMovies.path,
         TableMovies.subtitles,
+        TableMovies.imdbId,
+        TableMovies.tmdbId
     )
 
     if movie_ids:
@@ -293,6 +300,7 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
                 'max_offset_seconds': max_offset,
                 'no_fix_framerate': no_fix_framerate,
                 'gss': gss,
+                'metadata': movie,
             })
 
     return items, skipped
@@ -337,6 +345,7 @@ def _process_subtitle_item(item, action, options, job_id):
             sonarr_series_id=item['sonarr_series_id'],
             sonarr_episode_id=item['sonarr_episode_id'],
             radarr_id=item['radarr_id'],
+            metadata=item['metadata'],
         )
         return True
     elif action in MOD_ACTIONS:

--- a/bazarr/subtitles/tools/translate/batch.py
+++ b/bazarr/subtitles/tools/translate/batch.py
@@ -83,6 +83,7 @@ def process_episode_translation(item, source_language, target_language, forced, 
             sonarr_series_id=sonarr_series_id,
             sonarr_episode_id=sonarr_episode_id,
             radarr_id=None,
+            metadata=episode,
             job_id=job_id
         )
         # Re-index subtitles so Bazarr's DB knows about the new translated file
@@ -151,6 +152,7 @@ def process_movie_translation(item, source_language, target_language, forced, hi
             sonarr_series_id=None,
             sonarr_episode_id=None,
             radarr_id=radarr_id,
+            metadata=movie,
             job_id=job_id
         )
         # Re-index subtitles so Bazarr's DB knows about the new translated file

--- a/tests/bazarr/test_mass_operations.py
+++ b/tests/bazarr/test_mass_operations.py
@@ -55,6 +55,7 @@ class TestProcessSubtitleItem:
             'max_offset_seconds': '60',
             'no_fix_framerate': True,
             'gss': True,
+            'metadata': MagicMock(),
         }
 
     @patch('subtitles.mass_operations.sync_subtitles', return_value=True)
@@ -114,6 +115,7 @@ class TestProcessSubtitleItem:
             sonarr_series_id=10,
             sonarr_episode_id=1,
             radarr_id=None,
+            metadata=item['metadata'],
         )
 
     @patch('subtitles.tools.translate.main.translate_subtitles_file', return_value=True)
@@ -126,6 +128,7 @@ class TestProcessSubtitleItem:
         call_kwargs = mock_translate.call_args[1]
         assert call_kwargs['media_type'] == 'movies'
         assert call_kwargs['radarr_id'] == 5
+        assert call_kwargs['metadata'] == item['metadata']
         assert 'job_id' not in call_kwargs
 
     def test_unknown_action_returns_false(self):
@@ -877,6 +880,7 @@ class TestTranslateDefaultOptions:
             'max_offset_seconds': '60',
             'no_fix_framerate': True,
             'gss': True,
+            'metadata': MagicMock(),
         }
         result = _process_subtitle_item(item, 'translate', {}, 'test_job')
         assert result is True


### PR DESCRIPTION
### Summary
Fixed an issue where `translate_subtitles_file()` failed during batch operations (mass edit, wanted-based translate) due to a missing required `metadata` argument.

### Changes
- **Batch Logic**: Updated `bazarr/subtitles/tools/translate/batch.py` to pass the `episode` or `movie` metadata objects to the translation function.
- **Mass Operations**: Modified `bazarr/subtitles/mass_operations.py` to fetch full metadata objects (including joining `TableShows` for episodes) and thread them through to the translation caller.
- **Database**: Fixed a `NameError` in `mass_operations.py` by importing `TableShows`.
- **Tests**: Updated `tests/bazarr/test_mass_operations.py` to include `metadata` in mock items and verified its presence in translation calls.

### Verification
- Ran backend tests: `pytest tests/bazarr/test_mass_operations.py`
- Result: 53 passed, 2 warnings (datetime/SQLAlchemy deprecations unrelated to changes).
- Confirmed manually that `translate_subtitles_file` now receives the correct metadata object, enabling downstream post-processing (notifications/library refreshes) to function correctly.