### PR TITLE
Scope mass-op TableShows join to translate action

### DIFF
--- a/bazarr/subtitles/mass_operations.py
+++ b/bazarr/subtitles/mass_operations.py
@@ -146,16 +146,26 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
                       force_resync=False, max_offset='60', gss=True, no_fix_framerate=True,
                       target_lang=None, source_lang=None):
     """Collect episode subtitles from the database."""
-    query = select(
+    columns = [
         TableEpisodes.sonarrEpisodeId,
         TableEpisodes.sonarrSeriesId,
         TableEpisodes.path,
         TableEpisodes.subtitles,
-        TableEpisodes.season,
-        TableEpisodes.episode,
-        TableShows.imdbId,
-        TableShows.tvdbId
-    ).join(TableShows)
+    ]
+    if action == 'translate':
+        # translate_subtitles_file consumes show-level metadata (imdbId, tvdbId,
+        # season, episode) via postprocess_subtitles. Other actions do not, so
+        # the join to TableShows is scoped to translate to avoid dropping
+        # orphaned episodes from sync/mods batches.
+        columns.extend([
+            TableEpisodes.season,
+            TableEpisodes.episode,
+            TableShows.imdbId,
+            TableShows.tvdbId,
+        ])
+        query = select(*columns).join(TableShows)
+    else:
+        query = select(*columns)
 
     filters = []
     if episode_ids:
@@ -210,7 +220,7 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
                     skipped += 1
                     continue
 
-            items.append({
+            item = {
                 'video_path': video_path,
                 'srt_path': mapped_sub_path,
                 'srt_lang': sub_lang,
@@ -222,8 +232,10 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
                 'max_offset_seconds': max_offset,
                 'no_fix_framerate': no_fix_framerate,
                 'gss': gss,
-                'metadata': ep,
-            })
+            }
+            if action == 'translate':
+                item['metadata'] = ep
+            items.append(item)
 
     return items, skipped
 
@@ -232,13 +244,18 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
                     max_offset='60', gss=True, no_fix_framerate=True,
                     target_lang=None, source_lang=None):
     """Collect movie subtitles from the database."""
-    query = select(
+    columns = [
         TableMovies.radarrId,
         TableMovies.path,
         TableMovies.subtitles,
-        TableMovies.imdbId,
-        TableMovies.tmdbId
-    )
+    ]
+    if action == 'translate':
+        # See _collect_episodes for why metadata columns are translate-only.
+        columns.extend([
+            TableMovies.imdbId,
+            TableMovies.tmdbId,
+        ])
+    query = select(*columns)
 
     if movie_ids:
         query = query.where(TableMovies.radarrId.in_(movie_ids))
@@ -288,7 +305,7 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
                     skipped += 1
                     continue
 
-            items.append({
+            item = {
                 'video_path': video_path,
                 'srt_path': mapped_sub_path,
                 'srt_lang': sub_lang,
@@ -300,8 +317,10 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
                 'max_offset_seconds': max_offset,
                 'no_fix_framerate': no_fix_framerate,
                 'gss': gss,
-                'metadata': movie,
-            })
+            }
+            if action == 'translate':
+                item['metadata'] = movie
+            items.append(item)
 
     return items, skipped
 


### PR DESCRIPTION
## Summary

Follow-up to PR #124. That fix correctly wired the required `metadata` argument through to `translate_subtitles_file`, but it did so by widening the database query for every batch action:

- `_collect_episodes` now does an inner join to `TableShows` and pulls `season`, `episode`, `imdbId`, `tvdbId` regardless of the action.
- `_collect_movies` always pulls `imdbId` and `tmdbId`.
- Every item dict carries a `metadata` key even when the consumer ignores it.

Only the `translate` action actually consumes those fields (via `translate_subtitles_file` to `postprocess_subtitles` in `api/subtitles/subtitles.py`). The `sync` action and the mod actions read `item['video_path']`, `item['srt_path']`, etc. and never touch `item['metadata']`.

The unconditional inner join also silently filters out any episode whose parent show row is missing from `TableShows`, which the previous implementation would have included. In practice that should never happen, but it is a behavioural change for sync and mods that does not need to ship together with the translate fix.

## Change

`bazarr/subtitles/mass_operations.py`:

- Build the episode/movie column lists conditionally and only add the extra columns plus `.join(TableShows)` when `action == 'translate'`.
- Only set `item['metadata']` when `action == 'translate'`.

No call-site changes; `_process_subtitle_item` already reads `item['metadata']` only in the translate branch.

## Test plan

- [x] `ruff check .`
- [x] `pytest tests/bazarr/test_mass_operations.py` (53 passed, unchanged)
- [x] `pytest tests/compat/ tests/bazarr/test_pretty_date.py tests/bazarr/test_dependency_loading.py tests/bazarr/test_signalrcore_compat.py tests/bazarr/test_app_get_providers.py tests/bazarr/test_mass_operations.py` (395 passed)