### PR TITLE
fix: resolve manual download cache miss caused by dual sys.path import

### DIFF
--- a/bazarr/subtitles/cache.py
+++ b/bazarr/subtitles/cache.py
@@ -78,9 +78,12 @@ class _SubtitleCache:
 
     def _purge_expired(self):
         now = time.monotonic()
-        expired = [k for k, (_, expiry) in self._cache.items() if now >= expiry]
+        expired = [k for k, (_, expiry) in list(self._cache.items()) if now >= expiry]
         for k in expired:
-            del self._cache[k]
+            try:
+                del self._cache[k]
+            except KeyError:
+                pass  # already deleted by another instance's concurrent purge
 
     def store(self, subtitle):
         """Store a subtitle object and return its cache key (UUID string).
@@ -97,10 +100,8 @@ class _SubtitleCache:
         with self._lock:
             self._purge_expired()
             self._cache[key] = (subtitle, expiry)
-        log.debug(
-            "CACHE store key=%s total_keys=%d id(cache)=%s module=%s",
-            key, len(self._cache), id(self._cache), __name__,
-        )
+            log.debug("CACHE store key=%s total_keys=%d id(cache)=%s module=%s",
+                      key, len(self._cache), id(self._cache), __name__)
         return key
 
     def get(self, key):

--- a/bazarr/subtitles/cache.py
+++ b/bazarr/subtitles/cache.py
@@ -50,11 +50,7 @@ def _get_shared_store():
     Test: Import this module twice under different names and assert that
     ``_get_shared_store() is _get_shared_store()`` (same id).
     """
-    store = sys.modules.get(_SHARED_STORE_KEY)
-    if store is None:
-        store = {}
-        sys.modules[_SHARED_STORE_KEY] = store
-    return store
+    return sys.modules.setdefault(_SHARED_STORE_KEY, {})
 
 
 class _SubtitleCache:
@@ -74,7 +70,7 @@ class _SubtitleCache:
         # Use the module-level shared dict so every _SubtitleCache instance
         # in this process operates on the same storage.
         self._cache = _get_shared_store()
-        self._lock = threading.Lock()
+        self._lock = sys.modules.setdefault("_bazarr_subtitle_cache_shared_lock", threading.Lock())
 
     def _purge_expired(self):
         now = time.monotonic()

--- a/bazarr/subtitles/cache.py
+++ b/bazarr/subtitles/cache.py
@@ -1,16 +1,79 @@
 # coding=utf-8
 
+import logging
+import sys
 import time
 import threading
 import uuid
 
 
+log = logging.getLogger("subtitle_cache")
+
+
 _TTL_SECONDS = 3600  # 1 hour
 
 
+# ---------------------------------------------------------------------------
+# Shared backing store
+# ---------------------------------------------------------------------------
+# The bazarr process puts BOTH ``/app/bazarr`` (script dir) and
+# ``/app`` (the parent, added by ``bazarr/app/libs.py`` so jobs_queue can
+# ``importlib.import_module('bazarr.<x>')``) onto ``sys.path``. As a result
+# Python may resolve this module under two different dotted names:
+#
+#   * ``subtitles.cache``         — imported from the Flask request thread
+#                                   (api/providers/* → subtitles.manual)
+#   * ``bazarr.subtitles.cache``  — imported by ``jobs_queue._run_job`` via
+#                                   ``importlib.import_module('bazarr.<x>')``
+#
+# Each dotted name produces a separate module object with its own
+# ``subtitle_cache = _SubtitleCache()`` singleton, so the UUID stored during
+# manual_search() is never found during the queued download job → the user
+# sees "Subtitle not found in cache" every time.
+#
+# Solution: stash the actual storage dict on ``sys.modules`` under a stable
+# key. Both module copies hand out ``_SubtitleCache`` instances that share
+# that single dict, so .store() and .get() always agree.
+
+_SHARED_STORE_KEY = "_bazarr_subtitle_cache_shared_store"
+
+
+def _get_shared_store():
+    """Return the process-global dict that backs every _SubtitleCache instance.
+
+    Why: ``sys.modules`` is the only object guaranteed to be unique per
+    interpreter regardless of how many times this module is re-imported under
+    different dotted names. Storing the dict here makes the cache truly
+    singleton across import paths.
+    What: Lazily creates ``sys.modules[_SHARED_STORE_KEY]`` as ``{}`` and
+    returns it.
+    Test: Import this module twice under different names and assert that
+    ``_get_shared_store() is _get_shared_store()`` (same id).
+    """
+    store = sys.modules.get(_SHARED_STORE_KEY)
+    if store is None:
+        store = {}
+        sys.modules[_SHARED_STORE_KEY] = store
+    return store
+
+
 class _SubtitleCache:
+    """Thread-safe TTL cache for subliminal subtitle objects keyed by UUID.
+
+    Why: Manual search returns subtitle objects to the UI as opaque UUIDs;
+    the follow-up download request must resolve the UUID back to the original
+    object. Storage MUST survive across the two distinct import paths the
+    process uses (see module docstring above).
+    What: Wraps a shared dict (via :func:`_get_shared_store`) with a lock and
+    TTL-based expiry.
+    Test: ``c = _SubtitleCache(); k = c.store(obj); assert c.get(k) is obj``;
+    instantiate a second ``_SubtitleCache`` and assert it sees the same key.
+    """
+
     def __init__(self):
-        self._cache = {}
+        # Use the module-level shared dict so every _SubtitleCache instance
+        # in this process operates on the same storage.
+        self._cache = _get_shared_store()
         self._lock = threading.Lock()
 
     def _purge_expired(self):
@@ -20,18 +83,43 @@ class _SubtitleCache:
             del self._cache[k]
 
     def store(self, subtitle):
-        """Store a subtitle object and return its cache key (UUID string)."""
+        """Store a subtitle object and return its cache key (UUID string).
+
+        Why: Hands the UI an opaque token so it can ask us to download a
+        specific result later without round-tripping the full subtitle object.
+        What: Generates a UUID4, stores ``(subtitle, expiry)`` under it, and
+        returns the UUID.
+        Test: Store any object, assert the returned key is a UUID string, and
+        assert ``get(key)`` returns the same object.
+        """
         key = str(uuid.uuid4())
         expiry = time.monotonic() + _TTL_SECONDS
         with self._lock:
             self._purge_expired()
             self._cache[key] = (subtitle, expiry)
+        log.debug(
+            "CACHE store key=%s total_keys=%d id(cache)=%s module=%s",
+            key, len(self._cache), id(self._cache), __name__,
+        )
         return key
 
     def get(self, key):
-        """Return the subtitle object for the given key, or None if not found/expired."""
+        """Return the subtitle object for the given key, or None if not found/expired.
+
+        Why: Resolves the opaque UUID handed to the UI back into the original
+        subtitle object so the download path can act on it.
+        What: Looks up ``key`` in the shared store, returns the subtitle if
+        non-expired, otherwise deletes the entry and returns ``None``.
+        Test: ``c.get(c.store(obj)) is obj``; with TTL set to 0,
+        ``c.get(c.store(obj))`` returns ``None``.
+        """
         with self._lock:
             entry = self._cache.get(key)
+            found = entry is not None
+            log.debug(
+                "CACHE get key=%s found=%s total_keys=%d id(cache)=%s module=%s",
+                key, found, len(self._cache), id(self._cache), __name__,
+            )
             if entry is None:
                 return None
             subtitle, expiry = entry


### PR DESCRIPTION
## Summary

Fixes #135 — manual subtitle download always failing with `BAZARR Subtitle not found in cache (expired or invalid ID)`.

## Root Cause

Both `/app/bazarr/bin` and `/app/bazarr/bin/bazarr` are on `sys.path`. This causes `subtitles/cache.py` to be imported under two different dotted module names:

- `subtitles.cache` — Flask API thread (search, via `api/providers/providers_movies.py`)
- `bazarr.subtitles.cache` — jobs queue worker (download, via `importlib.import_module` in `add_job_from_function`, which prefixes the `bazarr.` namespace)

Python creates **two separate module objects**, each with its own `_SubtitleCache` instance and its own empty `self._cache = {}`. The UUID stored during search is invisible to the download worker — every manual download fails.

## Fix

Use `sys.modules` as a shared backing store under a neutral key (`_bazarr_subtitle_cache_shared_store`). Both module instances' `_SubtitleCache` objects point at the same dict, so `.store()` and `.get()` always agree regardless of import path.

```python
_SHARED_STORE_KEY = "_bazarr_subtitle_cache_shared_store"

def _get_shared_store():
    store = sys.modules.get(_SHARED_STORE_KEY)
    if store is None:
        store = {}
        sys.modules[_SHARED_STORE_KEY] = store
    return store

class _SubtitleCache:
    def __init__(self):
        self._cache = _get_shared_store()  # shared across both import paths
        self._lock = threading.Lock()
```

Also adds DEBUG logging on `store()`/`get()` to make any future regression immediately visible in logs.

## Test

- Verified in running container: store via `subtitles.cache.subtitle_cache`, retrieve via `bazarr.subtitles.cache.subtitle_cache` → returns correct object
- Manual search → Download flow now completes successfully (no more cache miss error in log)