### PR TITLE
feat: automatic subtitle translation via language profile (Translate From)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-added-large-files
+        args: ['--maxkb=500']
+      - id: debug-statements
+      - id: check-merge-conflict
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ['--baseline', '.secrets.baseline']
+        exclude: '(\.lock|requirements.*\.txt|frontend/)$'

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,1350 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "frontend/.*",
+        ".*\\.lock",
+        "requirements.*\\.txt"
+      ]
+    }
+  ],
+  "results": {
+    "bazarr/app/get_providers.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "bazarr/app/get_providers.py",
+        "hashed_secret": "0eb5f9640aa5892237e50301e4646bcbe19a7834",
+        "is_verified": false,
+        "line_number": 341
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "bazarr/app/get_providers.py",
+        "hashed_secret": "0eb5f9640aa5892237e50301e4646bcbe19a7834",
+        "is_verified": false,
+        "line_number": 341
+      }
+    ],
+    "bazarr/secret_store/crypto.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "bazarr/secret_store/crypto.py",
+        "hashed_secret": "cc8625519ca2129f824d74d18d919e42fbaa87e3",
+        "is_verified": false,
+        "line_number": 53
+      }
+    ],
+    "bazarr/utilities/binaries.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "5b704a4bc385ad79f7662594582e564030454015",
+        "is_verified": false,
+        "line_number": 7
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "8343c1b27e7c7adf5176054d9308821bbbe6f2a4",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "f179b82048fab2ebde0a270aa69cf4e761951da3",
+        "is_verified": false,
+        "line_number": 23
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "b58e94f11a2925721a29e9d1f91cf2efe09de153",
+        "is_verified": false,
+        "line_number": 31
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "14e4f79df319063f26bb21658436e553161c3e23",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "4f9d09920dfc1fb209f7de2ee66648746e442e28",
+        "is_verified": false,
+        "line_number": 47
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "fd55c486ba7b10fb0d828724b506804de6830774",
+        "is_verified": false,
+        "line_number": 55
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "16146291e733869cc322ba3615060d3dc5eb27e6",
+        "is_verified": false,
+        "line_number": 63
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "127bf281df49d6fd9624b88a8754fa7f043a3271",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "ac189de5396d7a37d9fc476b3db29647c98c9ba3",
+        "is_verified": false,
+        "line_number": 79
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "6cf2aeef07979ecd2f40b1319c17de109b8af915",
+        "is_verified": false,
+        "line_number": 87
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "efe96485276e11f02c83a2e6c37f6c80191fcb5f",
+        "is_verified": false,
+        "line_number": 111
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "92cd4f3141c900d1cf3fda0cbcb2b9790b9b47ab",
+        "is_verified": false,
+        "line_number": 143
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "1188bc1644cc57cd20217ac12a2e88ba9c77a83a",
+        "is_verified": false,
+        "line_number": 151
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "bazarr/utilities/binaries.json",
+        "hashed_secret": "07a94d7bef205b9ca4e79fc32bc76b0a4b0e4df0",
+        "is_verified": false,
+        "line_number": 159
+      }
+    ],
+    "custom_libs/subliminal_patch/providers/karagarga.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "custom_libs/subliminal_patch/providers/karagarga.py",
+        "hashed_secret": "b6017d75865498ff6ac2ab8eea4e3bbd9ea2d0d4",
+        "is_verified": false,
+        "line_number": 106
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_libs/subliminal_patch/providers/karagarga.py",
+        "hashed_secret": "b6017d75865498ff6ac2ab8eea4e3bbd9ea2d0d4",
+        "is_verified": false,
+        "line_number": 106
+      }
+    ],
+    "custom_libs/subliminal_patch/providers/ktuvit.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "custom_libs/subliminal_patch/providers/ktuvit.py",
+        "hashed_secret": "be8439cd93f1796f23d4ffd7f2e75a399b502044",
+        "is_verified": false,
+        "line_number": 122
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_libs/subliminal_patch/providers/ktuvit.py",
+        "hashed_secret": "be8439cd93f1796f23d4ffd7f2e75a399b502044",
+        "is_verified": false,
+        "line_number": 122
+      }
+    ],
+    "custom_libs/subliminal_patch/providers/napisy24.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_libs/subliminal_patch/providers/napisy24.py",
+        "hashed_secret": "77f0ef97ceba0f0460846acf84bacc3b16b0e5e7",
+        "is_verified": false,
+        "line_number": 61
+      }
+    ],
+    "custom_libs/subliminal_patch/providers/opensubtitlescom.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_libs/subliminal_patch/providers/opensubtitlescom.py",
+        "hashed_secret": "0f674908b6342fcf2a9842d04699cb008d57d399",
+        "is_verified": false,
+        "line_number": 668
+      }
+    ],
+    "custom_libs/subliminal_patch/providers/wizdom.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "custom_libs/subliminal_patch/providers/wizdom.py",
+        "hashed_secret": "be8439cd93f1796f23d4ffd7f2e75a399b502044",
+        "is_verified": false,
+        "line_number": 82
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_libs/subliminal_patch/providers/wizdom.py",
+        "hashed_secret": "be8439cd93f1796f23d4ffd7f2e75a399b502044",
+        "is_verified": false,
+        "line_number": 82
+      }
+    ],
+    "dev-setup/README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "dev-setup/README.md",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "dev-setup/README.md",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 37
+      }
+    ],
+    "dev-setup/setup-dev.sh": [
+      {
+        "type": "Secret Keyword",
+        "filename": "dev-setup/setup-dev.sh",
+        "hashed_secret": "085f0b437f9bf9c98bb68b745c8dcf323a7e0499",
+        "is_verified": false,
+        "line_number": 79
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "dev-setup/setup-dev.sh",
+        "hashed_secret": "90b9aa7e25f80cf4f64e990b78a9fc5ebd6cecad",
+        "is_verified": false,
+        "line_number": 81
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "dev-setup/setup-dev.sh",
+        "hashed_secret": "90b9aa7e25f80cf4f64e990b78a9fc5ebd6cecad",
+        "is_verified": false,
+        "line_number": 81
+      }
+    ],
+    "migrations/versions/195144da1f7e_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/195144da1f7e_.py",
+        "hashed_secret": "1f2479069221b66eb61f1982ee61ac954c3b644c",
+        "is_verified": false,
+        "line_number": 22
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/195144da1f7e_.py",
+        "hashed_secret": "1415422f9f8a50e0aa9222e96f961b6d75faa4fb",
+        "is_verified": false,
+        "line_number": 23
+      }
+    ],
+    "migrations/versions/1e38aa77a491_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/1e38aa77a491_.py",
+        "hashed_secret": "e26259868551adf201f236e5954a5d00db20b514",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "migrations/versions/309dc062d2e4_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/309dc062d2e4_.py",
+        "hashed_secret": "d72c6b4ffc39e05a16e4368cf82df21ee6059a7b",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "migrations/versions/4274a5dfc4ad_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/4274a5dfc4ad_.py",
+        "hashed_secret": "972bb69677960adc51658c0299b5761761d1aafa",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "migrations/versions/452dd0f0b578_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/452dd0f0b578_.py",
+        "hashed_secret": "e26259868551adf201f236e5954a5d00db20b514",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/452dd0f0b578_.py",
+        "hashed_secret": "f3952d069f94ee0f85d59402a137b9d5f60ae0d6",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "migrations/versions/4bb94a033f93_add_hot_path_indexes.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/4bb94a033f93_add_hot_path_indexes.py",
+        "hashed_secret": "d72c6b4ffc39e05a16e4368cf82df21ee6059a7b",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "migrations/versions/8baf97427327_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/8baf97427327_.py",
+        "hashed_secret": "972bb69677960adc51658c0299b5761761d1aafa",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "migrations/versions/95cd4cf40d7a_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/95cd4cf40d7a_.py",
+        "hashed_secret": "1415422f9f8a50e0aa9222e96f961b6d75faa4fb",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/95cd4cf40d7a_.py",
+        "hashed_secret": "55141c4dc11b0231e8c523a58333b9f9102ce642",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "migrations/versions/b183a2ac0dd1_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/b183a2ac0dd1_.py",
+        "hashed_secret": "f3952d069f94ee0f85d59402a137b9d5f60ae0d6",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "migrations/versions/c00d40af333c_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/c00d40af333c_.py",
+        "hashed_secret": "871fc0262b799e8f1bd90f98e995430f94796963",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
+    "migrations/versions/cee6a710cb71_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/cee6a710cb71_.py",
+        "hashed_secret": "1f2479069221b66eb61f1982ee61ac954c3b644c",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "migrations/versions/dc09994b7e65_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/dc09994b7e65_.py",
+        "hashed_secret": "55141c4dc11b0231e8c523a58333b9f9102ce642",
+        "is_verified": false,
+        "line_number": 33
+      }
+    ],
+    "migrations/versions/df76a4410347_.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "migrations/versions/df76a4410347_.py",
+        "hashed_secret": "871fc0262b799e8f1bd90f98e995430f94796963",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "tests/bazarr/test_connection_tester.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_connection_tester.py",
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_verified": false,
+        "line_number": 176
+      }
+    ],
+    "tests/bazarr/test_encryption.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/bazarr/test_encryption.py",
+        "hashed_secret": "03007ff9206a94bed5b9751b15b9005e2957c88e",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_encryption.py",
+        "hashed_secret": "8467e8d31a7db8398c8c439cc0a8d0734259e489",
+        "is_verified": false,
+        "line_number": 40
+      }
+    ],
+    "tests/bazarr/test_gemini_translator.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_gemini_translator.py",
+        "hashed_secret": "9e52503a0984e613e6ed5f6f9a3cf0b93b2d826b",
+        "is_verified": false,
+        "line_number": 112
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_gemini_translator.py",
+        "hashed_secret": "a90dff8ba6472d733cb0a37734fe28a8078f8444",
+        "is_verified": false,
+        "line_number": 117
+      }
+    ],
+    "tests/bazarr/test_jellyfin_operations.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_jellyfin_operations.py",
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_verified": false,
+        "line_number": 102
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_jellyfin_operations.py",
+        "hashed_secret": "2904d22406e0b8a92da17ea24726ef61865c7f80",
+        "is_verified": false,
+        "line_number": 177
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_jellyfin_operations.py",
+        "hashed_secret": "ae3422b2863eb3f39d4d9f0265ffcfe353ce3ca0",
+        "is_verified": false,
+        "line_number": 187
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_jellyfin_operations.py",
+        "hashed_secret": "d94932271c53ac9735fee7053d78d372e2260d7d",
+        "is_verified": false,
+        "line_number": 481
+      }
+    ],
+    "tests/bazarr/test_secret_store_crypto.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_crypto.py",
+        "hashed_secret": "4d1dd9aefc1ab6da9b18913be2b4c7f27d67dabb",
+        "is_verified": false,
+        "line_number": 49
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/bazarr/test_secret_store_crypto.py",
+        "hashed_secret": "3f6e2e0ab91e6d5873b659ded44334f47e60c6af",
+        "is_verified": false,
+        "line_number": 64
+      }
+    ],
+    "tests/bazarr/test_secret_store_e2e.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_e2e.py",
+        "hashed_secret": "4e4854b9fc40ace976964b890b585b64190a15bd",
+        "is_verified": false,
+        "line_number": 115
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_e2e.py",
+        "hashed_secret": "fa56a5c5af352993a044d646ab38c47c0ee4b18a",
+        "is_verified": false,
+        "line_number": 116
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_e2e.py",
+        "hashed_secret": "317f1e761f2faa8da781a4762b9dcc2c5cad209a",
+        "is_verified": false,
+        "line_number": 117
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_e2e.py",
+        "hashed_secret": "794fe540705dde5c04e2e1a4b8bfc5db4881818d",
+        "is_verified": false,
+        "line_number": 165
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_e2e.py",
+        "hashed_secret": "2e74a5cf4364ad331d19296de7ea90d502c9b9ea",
+        "is_verified": false,
+        "line_number": 196
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_e2e.py",
+        "hashed_secret": "b42b4b719c270e6ead062c23766455ec04b7aace",
+        "is_verified": false,
+        "line_number": 299
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_e2e.py",
+        "hashed_secret": "8a13e70f85c7a14a26b0b322091d1c5189d11c80",
+        "is_verified": false,
+        "line_number": 312
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_e2e.py",
+        "hashed_secret": "62d546f784359c18dcb9cdca4fc2461f154d6ea4",
+        "is_verified": false,
+        "line_number": 313
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_e2e.py",
+        "hashed_secret": "ec4795a199eb7bff85027d0465b977b34d0a2b47",
+        "is_verified": false,
+        "line_number": 316
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_e2e.py",
+        "hashed_secret": "f0755bad43b4bf0d104086efc94c7045e1920164",
+        "is_verified": false,
+        "line_number": 320
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_e2e.py",
+        "hashed_secret": "709b897bd12df161f3487db7435eff24561b3b10",
+        "is_verified": false,
+        "line_number": 321
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_e2e.py",
+        "hashed_secret": "4e62024973941727f50ef902c50c355703a77488",
+        "is_verified": false,
+        "line_number": 375
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_e2e.py",
+        "hashed_secret": "e616373d738f1cc5a4df8ab3dee8603fa1394343",
+        "is_verified": false,
+        "line_number": 410
+      }
+    ],
+    "tests/bazarr/test_secret_store_migration.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_migration.py",
+        "hashed_secret": "317f1e761f2faa8da781a4762b9dcc2c5cad209a",
+        "is_verified": false,
+        "line_number": 47
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_migration.py",
+        "hashed_secret": "c72906dc6cfe296fe56daea7d2c32bf90612ed78",
+        "is_verified": false,
+        "line_number": 49
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_migration.py",
+        "hashed_secret": "17777770638ff48088aa775590017be22e64bf65",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_migration.py",
+        "hashed_secret": "30380dbc806a624373c31c2728a19562ab1174b8",
+        "is_verified": false,
+        "line_number": 52
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_migration.py",
+        "hashed_secret": "582f533393f4e0c660cd11290dc5b32ed05cdf9a",
+        "is_verified": false,
+        "line_number": 55
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_migration.py",
+        "hashed_secret": "e379d0b90f90193ffd68bc36e4fc6a7af5161810",
+        "is_verified": false,
+        "line_number": 59
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_migration.py",
+        "hashed_secret": "1b723d129dbd917b362ab954773600a068749956",
+        "is_verified": false,
+        "line_number": 158
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_migration.py",
+        "hashed_secret": "794fe540705dde5c04e2e1a4b8bfc5db4881818d",
+        "is_verified": false,
+        "line_number": 189
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_secret_store_migration.py",
+        "hashed_secret": "6013d7e960cc55bdf007e7bba0f210e9a548fbb2",
+        "is_verified": false,
+        "line_number": 235
+      }
+    ],
+    "tests/bazarr/test_translator_auth.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/bazarr/test_translator_auth.py",
+        "hashed_secret": "03007ff9206a94bed5b9751b15b9005e2957c88e",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "tests/bazarr/test_ui.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/bazarr/test_ui.py",
+        "hashed_secret": "72cb70dbbafe97e5ea13ad88acd65d08389439b0",
+        "is_verified": false,
+        "line_number": 157
+      }
+    ],
+    "tests/compat/contract/test_plugin_contract.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/compat/contract/test_plugin_contract.py",
+        "hashed_secret": "34e319633255b44803ecc732f24727edf67fce86",
+        "is_verified": false,
+        "line_number": 74
+      }
+    ],
+    "tests/compat/unit/test_build_video.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/compat/unit/test_build_video.py",
+        "hashed_secret": "d21458f98258c8e15b302aec58fbe2a2206f8c64",
+        "is_verified": false,
+        "line_number": 93
+      }
+    ],
+    "tests/compat/unit/test_omdb_apikey.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/compat/unit/test_omdb_apikey.py",
+        "hashed_secret": "a7b7ebcff485c336a11220f52b6fda4436b6adb9",
+        "is_verified": false,
+        "line_number": 35
+      }
+    ],
+    "tests/subliminal_patch/cassettes/test_animesubinfo/test_download_subtitle.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_animesubinfo/test_download_subtitle.yaml",
+        "hashed_secret": "ff981c41bb309402945db76315b27b961bb564f0",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_animesubinfo/test_download_subtitle.yaml",
+        "hashed_secret": "a6311fbc2aa3e37aecd74f2d3aa6f7bba2a31f67",
+        "is_verified": false,
+        "line_number": 158
+      }
+    ],
+    "tests/subliminal_patch/cassettes/test_animesubinfo/test_list_subtitles_english_title.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_animesubinfo/test_list_subtitles_english_title.yaml",
+        "hashed_secret": "474a905a33d0722e06b282c5f3ac36c8d7a23224",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_animesubinfo/test_list_subtitles_english_title.yaml",
+        "hashed_secret": "c423954c5d891ccccb675aaaae78d082f036d5c0",
+        "is_verified": false,
+        "line_number": 125
+      }
+    ],
+    "tests/subliminal_patch/cassettes/test_animesubinfo/test_list_subtitles_japanese_title.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_animesubinfo/test_list_subtitles_japanese_title.yaml",
+        "hashed_secret": "c731a489779066c1336c2cc5b6e2e33940bbf11e",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "tests/subliminal_patch/cassettes/test_animesubinfo/test_list_subtitles_polish_language.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_animesubinfo/test_list_subtitles_polish_language.yaml",
+        "hashed_secret": "474a905a33d0722e06b282c5f3ac36c8d7a23224",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_animesubinfo/test_list_subtitles_polish_language.yaml",
+        "hashed_secret": "7ed1be51a7a22896c38c5f3c01fca8f3b7dfcb27",
+        "is_verified": false,
+        "line_number": 125
+      }
+    ],
+    "tests/subliminal_patch/cassettes/test_animesubinfo/test_subtitle_attributes.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_animesubinfo/test_subtitle_attributes.yaml",
+        "hashed_secret": "aba2395c9f8f02829aded7d064eb9ff2ae4a0c0f",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "tests/subliminal_patch/cassettes/test_hosszupuska/test_download_subtitle_episode.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_hosszupuska/test_download_subtitle_episode.yaml",
+        "hashed_secret": "8d7d6d5fa3514c3196fd8ce0828bb6d5ce0b66c4",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_hosszupuska/test_download_subtitle_episode.yaml",
+        "hashed_secret": "3824ebd3557b98c3570842010e67f1fe0483e175",
+        "is_verified": false,
+        "line_number": 951
+      }
+    ],
+    "tests/subliminal_patch/cassettes/test_hosszupuska/test_list_subtitles_episode.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_hosszupuska/test_list_subtitles_episode.yaml",
+        "hashed_secret": "3f0814470fbe3ee42b8d80b7fb3562cce6791c5f",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ],
+    "tests/subliminal_patch/cassettes/test_napiprojekt/test_list_subtitles_episode.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_napiprojekt/test_list_subtitles_episode.yaml",
+        "hashed_secret": "2dd681469e13b8fe222181308415fbeb14273da3",
+        "is_verified": false,
+        "line_number": 17
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_napiprojekt/test_list_subtitles_episode.yaml",
+        "hashed_secret": "5166ad97e8a55292a65ee6325796695a21d0edfe",
+        "is_verified": false,
+        "line_number": 156
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_napiprojekt/test_list_subtitles_episode.yaml",
+        "hashed_secret": "3e921d122aababb0743f667353548e395a3e408b",
+        "is_verified": false,
+        "line_number": 247
+      }
+    ],
+    "tests/subliminal_patch/cassettes/test_napiprojekt/test_list_subtitles_movie.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_napiprojekt/test_list_subtitles_movie.yaml",
+        "hashed_secret": "b01c7c6c83af21d010807b185c5ee35af18d32cb",
+        "is_verified": false,
+        "line_number": 17
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_napiprojekt/test_list_subtitles_movie.yaml",
+        "hashed_secret": "8b97470edd0e944616fcabd510b204a67c4f53d9",
+        "is_verified": false,
+        "line_number": 389
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/cassettes/test_napiprojekt/test_list_subtitles_movie.yaml",
+        "hashed_secret": "56af47d43cb91f549cbe1d53e39b88853eb5bcc3",
+        "is_verified": false,
+        "line_number": 446
+      }
+    ],
+    "tests/subliminal_patch/conftest.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/conftest.py",
+        "hashed_secret": "0940c8bf8f0bfa51f29edee2c1a0195da2186242",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/conftest.py",
+        "hashed_secret": "b8a5f9b3d81451aedf4d8c8fdb49db852743880e",
+        "is_verified": false,
+        "line_number": 52
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/conftest.py",
+        "hashed_secret": "13d38c8b2fe85d976a11d261f03ed1e8207976ac",
+        "is_verified": false,
+        "line_number": 55
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/conftest.py",
+        "hashed_secret": "f6d2c2a64a0d2a4c77357125155e9543493112f5",
+        "is_verified": false,
+        "line_number": 114
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/conftest.py",
+        "hashed_secret": "cfc320df8cdb46ded9e9dd6a2de55e11d7505f86",
+        "is_verified": false,
+        "line_number": 117
+      }
+    ],
+    "tests/subliminal_patch/data/animetosho_episode_response.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "f39c05b302c67a8644aae7167a8131fec887ed55",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "48a306b0ffeef5c4732c9d40bf166d8f6f0d6a45",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "f29c1ff2be3f4a8094add3b5417310c43f1d9fc3",
+        "is_verified": false,
+        "line_number": 72
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "926b196e0315d266f0ed3449296cdde8b7e54e30",
+        "is_verified": false,
+        "line_number": 101
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "9f9f4278253e374a47ce9b2d53e83345610f19d1",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "fc823b751c0d546d277b44114e962824eeef5491",
+        "is_verified": false,
+        "line_number": 159
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "6bb53a2f69adee18e057382276504151c3b5d1d5",
+        "is_verified": false,
+        "line_number": 188
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "6e7dfc5a75f4bc8b3ed5374bf9c8d8caad1d03aa",
+        "is_verified": false,
+        "line_number": 217
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "179e0cfbeff8cf7ca44446d7a23e5c75bc1676c4",
+        "is_verified": false,
+        "line_number": 246
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "38e388b3c64caf1a27ec98dc1236635b5d5eec95",
+        "is_verified": false,
+        "line_number": 275
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "38cb4e9872c8f24cc97a5ad1eb737d934931a890",
+        "is_verified": false,
+        "line_number": 304
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "c7e53aa795af8cc61ba10eeabb8aacaa3cda8cce",
+        "is_verified": false,
+        "line_number": 333
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "51d4fdee247ec6049fd66726c819edea91b376bc",
+        "is_verified": false,
+        "line_number": 362
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "2eec3d2646068bf4d24b9bac17c7d37daa036d51",
+        "is_verified": false,
+        "line_number": 391
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "0cd87c67b5b85ad078fc2fc62389bc359e4f5cce",
+        "is_verified": false,
+        "line_number": 420
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "54cf05663b0ce83d9f63e4c505e0add04855970f",
+        "is_verified": false,
+        "line_number": 449
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "38076cf6ff745b7cabaf8c907bae8d2727426065",
+        "is_verified": false,
+        "line_number": 478
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "d2adad6d23dd49e7d52ae7d1d902fc4dbed6d3d0",
+        "is_verified": false,
+        "line_number": 507
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "ccefa14dffad19b0ac5f20e7000ee9599c6d14c9",
+        "is_verified": false,
+        "line_number": 536
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "e626c73922f03df370c47bedf2238267f0710df0",
+        "is_verified": false,
+        "line_number": 565
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "79575c020dc797806f4e335e588119c22ddb3895",
+        "is_verified": false,
+        "line_number": 594
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "ede457f05eac3989b363fce0bd135930606facc4",
+        "is_verified": false,
+        "line_number": 623
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "e31bdfcc1f4003b4d85344fe0c10253c00e1dbae",
+        "is_verified": false,
+        "line_number": 652
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "52aa1a662880b011a671d4f0defbb51f31e53b0f",
+        "is_verified": false,
+        "line_number": 681
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "3107e59b932d6bdcde674208c483c1b9b478a8f2",
+        "is_verified": false,
+        "line_number": 710
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_episode_response.json",
+        "hashed_secret": "0062ce63f08f16d5219a57b9f66cc9321372b56b",
+        "is_verified": false,
+        "line_number": 739
+      }
+    ],
+    "tests/subliminal_patch/data/animetosho_series_response.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_series_response.json",
+        "hashed_secret": "f39c05b302c67a8644aae7167a8131fec887ed55",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_series_response.json",
+        "hashed_secret": "1ceb8882c344ddbbe55d98c0208bfc614f86441b",
+        "is_verified": false,
+        "line_number": 35
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_series_response.json",
+        "hashed_secret": "2c030eee2572fc7cab8e31993d2b3e5ddab02e61",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_series_response.json",
+        "hashed_secret": "371186875ae24578c4b536eb161cedb7f6b2f350",
+        "is_verified": false,
+        "line_number": 37
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_series_response.json",
+        "hashed_secret": "022068bd80906fe582e48309ee6ff68ddc0b939a",
+        "is_verified": false,
+        "line_number": 38
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/animetosho_series_response.json",
+        "hashed_secret": "03f2f4d0b6378b0a9aee48d2f97906563597f372",
+        "is_verified": false,
+        "line_number": 39
+      }
+    ],
+    "tests/subliminal_patch/data/prijevodi_ep34272.html": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_ep34272.html",
+        "hashed_secret": "5de54fb64826db547ae49b80912c3670ac350918",
+        "is_verified": false,
+        "line_number": 6
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_ep34272.html",
+        "hashed_secret": "b5eb0175c963afd1ac2d338ef18c433f9c4f8da5",
+        "is_verified": false,
+        "line_number": 22
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_ep34272.html",
+        "hashed_secret": "c8c342e2cfcf9c9ea8c4c90684a8ab0bc663501d",
+        "is_verified": false,
+        "line_number": 38
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_ep34272.html",
+        "hashed_secret": "72590f6ce993c8589296f02eeb88cf2a213a6749",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_ep34272.html",
+        "hashed_secret": "a01d2bc1c41f89cf2deceb9c92ad2ce3bbeb429b",
+        "is_verified": false,
+        "line_number": 70
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_ep34272.html",
+        "hashed_secret": "d06e0cd88de16bab003e32460defaac4475036eb",
+        "is_verified": false,
+        "line_number": 86
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_ep34272.html",
+        "hashed_secret": "35d0f1d58e5cfb3d6dcd40022e3ce92733ecce94",
+        "is_verified": false,
+        "line_number": 102
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_ep34272.html",
+        "hashed_secret": "350048db96059e562a386861e7aa99b04e803a61",
+        "is_verified": false,
+        "line_number": 118
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_ep34272.html",
+        "hashed_secret": "852b42cc4ffcdb8f5b60da6fa8d45283339177ab",
+        "is_verified": false,
+        "line_number": 134
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_ep34272.html",
+        "hashed_secret": "c7d7ea7d7942a30f36d07dc315a72103a5e6964b",
+        "is_verified": false,
+        "line_number": 150
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_ep34272.html",
+        "hashed_secret": "c9826cd8cf4b5d69e3923fd14a6cc049422c9b52",
+        "is_verified": false,
+        "line_number": 166
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_ep34272.html",
+        "hashed_secret": "80e0bb36d36d52c9e7c6d8a1c40be51330c43dc6",
+        "is_verified": false,
+        "line_number": 182
+      }
+    ],
+    "tests/subliminal_patch/data/prijevodi_got.html": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_got.html",
+        "hashed_secret": "d83816251f9707ce2b5b1b2037a850a676369bc5",
+        "is_verified": false,
+        "line_number": 28
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_got.html",
+        "hashed_secret": "ff6dadcef14482a0550fc52ebc1279ad8db7608f",
+        "is_verified": false,
+        "line_number": 1660
+      }
+    ],
+    "tests/subliminal_patch/data/prijevodi_index_g.html": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/data/prijevodi_index_g.html",
+        "hashed_secret": "d83816251f9707ce2b5b1b2037a850a676369bc5",
+        "is_verified": false,
+        "line_number": 28
+      }
+    ],
+    "tests/subliminal_patch/test_animesubinfo.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/test_animesubinfo.py",
+        "hashed_secret": "24497c2ec36e7278f91d60dc516440c0edacbcc0",
+        "is_verified": false,
+        "line_number": 57
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/test_animesubinfo.py",
+        "hashed_secret": "10c872cc94c0f1508301bddaba9c2de9d66ef6dd",
+        "is_verified": false,
+        "line_number": 116
+      }
+    ],
+    "tests/subliminal_patch/test_napiprojekt.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/test_napiprojekt.py",
+        "hashed_secret": "34b2b9daf04f601390a26b8836cfdbd1195d5d0e",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/subliminal_patch/test_napiprojekt.py",
+        "hashed_secret": "eb09d0d33a495660316d15c4fdbb4c3c88a03568",
+        "is_verified": false,
+        "line_number": 29
+      }
+    ]
+  },
+  "generated_at": "2026-05-23T11:59:05Z"
+}

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -209,6 +209,7 @@ validators = [
     Validator('backup.hour', must_exist=True, default=3, is_type_of=int, gte=0, lte=23),
 
     # translating section
+    Validator('translator.min_source_score', must_exist=True, default=90, is_type_of=int, gte=0, lte=100),
     Validator('translator.default_score', must_exist=True, default=50, is_type_of=int, gte=0),
     Validator('translator.gemini_keys', must_exist=True, default=[], is_type_of=list),
     Validator('translator.gemini_model', must_exist=True, default='gemini-2.0-flash', is_type_of=str, cast=str),

--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -679,6 +679,9 @@ def upgrade_languages_profile_values():
 
             if 'audio_only_include' not in language:
                 language['audio_only_include'] = "False"
+
+            if "translate_from" not in language:
+                language["translate_from"] = None
         database.execute(
             update(TableLanguagesProfiles)
             .values({"items": json.dumps(items)})

--- a/bazarr/subtitles/processing.py
+++ b/bazarr/subtitles/processing.py
@@ -70,7 +70,7 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
         if source_score_percent is not None and source_score_percent < min_score:
             logging.info(
                 'BAZARR auto-translate skipped: source score %.1f%% '
-                'below threshold %s%% for %s',
+                'below threshold %.1f%% for %s',
                 source_score_percent, min_score, video_path,
             )
             return
@@ -258,7 +258,7 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
         if settings.general.use_plex is True:
             if settings.plex.update_series_library is True:
                 # Use specific item refresh instead of full library scan
-                plex_refresh_item(episode_metadata.imdbId, is_movie=False, 
+                plex_refresh_item(episode_metadata.imdbId, is_movie=False,
                                 season=episode_metadata.season, episode=episode_metadata.episode)
             if settings.plex.set_episode_added is True:
                 plex_set_episode_added_date_now(episode_metadata)

--- a/bazarr/subtitles/processing.py
+++ b/bazarr/subtitles/processing.py
@@ -42,7 +42,7 @@ class ProcessSubtitlesResult:
 
 def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_type,
                               series_id=None, episode_id=None, radarr_id=None,
-                              source_score_percent=None):
+                              source_score_percent=None, forced=False):
     """
     After a subtitle is downloaded, check if any profile language is configured to
     auto-translate from the just-downloaded language. If so, queue translation.
@@ -50,6 +50,10 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
     source_score_percent: 0-100 score of the just-downloaded source subtitle. If
     provided and below settings.translator.min_source_score, translation is
     skipped (poorly-matched sources shouldn't seed translations).
+
+    forced: True when the just-downloaded subtitle is a forced track. Forced
+    subtitles cover only foreign-language inserts and are not a valid
+    translation seed, so we skip auto-translate for them.
     """
     try:
         from app.database import get_profile_id, get_profiles_list
@@ -59,7 +63,7 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
         if not subtitle_path or not downloaded_lang:
             return
 
-        if subtitle_path and ':forced' in str(downloaded_lang):
+        if forced:
             return
 
         min_score = settings.translator.min_source_score
@@ -84,6 +88,26 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
         if not profile:
             return
 
+        # Hoisted out of the loop: check_missing_languages is independent of the
+        # profile item being considered, so calling it once per profile item
+        # (potentially N database/indexer queries) is wasteful. Compute the
+        # missing-codes set once and reuse for every item.
+        missing = check_missing_languages(path=video_path, media_type=media_type)
+        missing_codes = set()
+        for lang_obj in missing or []:
+            try:
+                code2 = alpha2_from_alpha3(lang_obj.alpha3)
+            except Exception:
+                code2 = None
+            if not code2:
+                continue
+            if getattr(lang_obj, 'hi', False):
+                missing_codes.add(f'{code2}:hi')
+            elif getattr(lang_obj, 'forced', False):
+                missing_codes.add(f'{code2}:forced')
+            else:
+                missing_codes.add(code2)
+
         for item in profile.get('items', []):
             target_lang = item.get('language')
             translate_from = item.get('translate_from')
@@ -92,22 +116,6 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
                 continue
             if target_lang == downloaded_lang:
                 continue
-
-            missing = check_missing_languages(path=video_path, media_type=media_type)
-            missing_codes = set()
-            for lang_obj in missing or []:
-                try:
-                    code2 = alpha2_from_alpha3(lang_obj.alpha3)
-                except Exception:
-                    code2 = None
-                if not code2:
-                    continue
-                if getattr(lang_obj, 'hi', False):
-                    missing_codes.add(f'{code2}:hi')
-                elif getattr(lang_obj, 'forced', False):
-                    missing_codes.add(f'{code2}:forced')
-                else:
-                    missing_codes.add(code2)
 
             target_codes = {target_lang, f'{target_lang}:hi', f'{target_lang}:forced'}
             if not (missing_codes & target_codes):
@@ -287,6 +295,7 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
         episode_id=episode_id if media_type == 'series' else None,
         radarr_id=movie_metadata.radarrId if media_type != 'series' else None,
         source_score_percent=percent_score,
+        forced=subtitle.language.forced,
     )
 
     return ProcessSubtitlesResult(message=message,

--- a/bazarr/subtitles/processing.py
+++ b/bazarr/subtitles/processing.py
@@ -40,6 +40,99 @@ class ProcessSubtitlesResult:
             self.language_code = downloaded_language_code2
 
 
+def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_type,
+                              series_id=None, episode_id=None, radarr_id=None,
+                              source_score_percent=None):
+    """
+    After a subtitle is downloaded, check if any profile language is configured to
+    auto-translate from the just-downloaded language. If so, queue translation.
+
+    source_score_percent: 0-100 score of the just-downloaded source subtitle. If
+    provided and below settings.translator.min_source_score, translation is
+    skipped (poorly-matched sources shouldn't seed translations).
+    """
+    try:
+        from app.database import get_profile_id, get_profiles_list
+        from subtitles.tools.translate.main import translate_subtitles_file
+        from subtitles.download import check_missing_languages
+
+        if not subtitle_path or not downloaded_lang:
+            return
+
+        if subtitle_path and ':forced' in str(downloaded_lang):
+            return
+
+        min_score = settings.translator.min_source_score
+        if source_score_percent is not None and source_score_percent < min_score:
+            logging.info(
+                f'BAZARR auto-translate skipped: source score {source_score_percent:.1f}% '
+                f'below threshold {min_score}% for {video_path}'
+            )
+            return
+
+        if media_type == 'series' and episode_id:
+            profile_id = get_profile_id(episode_id=episode_id)
+        elif media_type == 'series' and series_id:
+            profile_id = get_profile_id(series_id=series_id)
+        else:
+            profile_id = get_profile_id(movie_id=radarr_id)
+
+        if not profile_id:
+            return
+
+        profile = get_profiles_list(profile_id=profile_id)
+        if not profile:
+            return
+
+        for item in profile.get('items', []):
+            target_lang = item.get('language')
+            translate_from = item.get('translate_from')
+
+            if not translate_from or translate_from != downloaded_lang:
+                continue
+            if target_lang == downloaded_lang:
+                continue
+
+            missing = check_missing_languages(path=video_path, media_type=media_type)
+            missing_codes = set()
+            for lang_obj in missing or []:
+                try:
+                    code2 = alpha2_from_alpha3(lang_obj.alpha3)
+                except Exception:
+                    code2 = None
+                if not code2:
+                    continue
+                if getattr(lang_obj, 'hi', False):
+                    missing_codes.add(f'{code2}:hi')
+                elif getattr(lang_obj, 'forced', False):
+                    missing_codes.add(f'{code2}:forced')
+                else:
+                    missing_codes.add(code2)
+
+            target_codes = {target_lang, f'{target_lang}:hi', f'{target_lang}:forced'}
+            if not (missing_codes & target_codes):
+                logging.debug(f'BAZARR auto-translate skipped: {target_lang} already satisfied for {video_path}')
+                continue
+
+            logging.info(f'BAZARR auto-translate queuing {downloaded_lang} -> {target_lang} for {video_path}')
+            translate_media_type = 'series' if media_type == 'series' else 'movies'
+            translate_subtitles_file(
+                video_path=video_path,
+                source_srt_file=subtitle_path,
+                from_lang=downloaded_lang,
+                to_lang=target_lang,
+                forced=item.get('forced') == 'True',
+                hi=item.get('hi') == 'True',
+                media_type=translate_media_type,
+                sonarr_series_id=series_id,
+                sonarr_episode_id=episode_id,
+                radarr_id=radarr_id,
+                metadata=None,
+            )
+    except Exception:
+        logging.exception('BAZARR error in _trigger_auto_translation')
+
+
 def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_upgrade=False, is_manual=False,
                      job_id=None):
     use_postprocessing = settings.general.use_postprocessing
@@ -182,6 +275,18 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
         media_path=path,
         language=downloaded_language,
         media_type=media_type
+    )
+
+    # Auto-translate: trigger translation to any profile language configured with translate_from
+    _trigger_auto_translation(
+        downloaded_lang=downloaded_language_code2,
+        subtitle_path=downloaded_path,
+        video_path=path,
+        media_type=media_type,
+        series_id=series_id if media_type == 'series' else None,
+        episode_id=episode_id if media_type == 'series' else None,
+        radarr_id=movie_metadata.radarrId if media_type != 'series' else None,
+        source_score_percent=percent_score,
     )
 
     return ProcessSubtitlesResult(message=message,

--- a/bazarr/subtitles/processing.py
+++ b/bazarr/subtitles/processing.py
@@ -69,8 +69,9 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
         min_score = settings.translator.min_source_score
         if source_score_percent is not None and source_score_percent < min_score:
             logging.info(
-                f'BAZARR auto-translate skipped: source score {source_score_percent:.1f}% '
-                f'below threshold {min_score}% for {video_path}'
+                'BAZARR auto-translate skipped: source score %.1f%% '
+                'below threshold %s%% for %s',
+                source_score_percent, min_score, video_path,
             )
             return
 
@@ -119,10 +120,16 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
 
             target_codes = {target_lang, f'{target_lang}:hi', f'{target_lang}:forced'}
             if not (missing_codes & target_codes):
-                logging.debug(f'BAZARR auto-translate skipped: {target_lang} already satisfied for {video_path}')
+                logging.debug(
+                    'BAZARR auto-translate skipped: %s already satisfied for %s',
+                    target_lang, video_path,
+                )
                 continue
 
-            logging.info(f'BAZARR auto-translate queuing {downloaded_lang} -> {target_lang} for {video_path}')
+            logging.info(
+                'BAZARR auto-translate queuing %s -> %s for %s',
+                downloaded_lang, target_lang, video_path,
+            )
             translate_media_type = 'series' if media_type == 'series' else 'movies'
             translate_subtitles_file(
                 video_path=video_path,

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -78,6 +78,20 @@ def _wanted_movie(movie, providers_list, job_id=None):
                         f"(falling back to provider search)"
                     )
                 else:
+                    # Guard: skip if we already have a translate history entry
+                    # for this target language. Why: the previous translate
+                    # history_log write is what blocks re-queuing after a
+                    # restart while the queued job hasn't run yet. Without this
+                    # check, the wanted-scan would re-queue every cycle.
+                    already_translated = database.execute(
+                        select(TableHistoryMovie.id)
+                        .where(TableHistoryMovie.radarrId == movie.radarrId)
+                        .where(TableHistoryMovie.language == lang_code)
+                        .where(TableHistoryMovie.action == 6)
+                        .limit(1)
+                    ).first()
+                    if already_translated:
+                        continue
                     try:
                         from subtitles.tools.translate.main import translate_subtitles_file
                         from subtitles.tools.translate.core.translator_utils import create_process_result

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -99,11 +99,7 @@ def _wanted_movie(movie, providers_list, job_id=None):
                         continue
                     try:
                         from subtitles.tools.translate.main import translate_subtitles_file
-                        logging.info(
-                            "BAZARR auto-translate (wanted-scan) queuing %s -> %s for %s",
-                            translate_cfg['from'], lang_code, video_path,
-                        )
-                        translate_subtitles_file(
+                        translate_kwargs = dict(
                             video_path=video_path,
                             source_srt_file=source_srt,
                             from_lang=translate_cfg['from'],
@@ -116,12 +112,30 @@ def _wanted_movie(movie, providers_list, job_id=None):
                             radarr_id=movie.radarrId,
                             metadata=None,
                         )
-                        continue
-                    except Exception as e:
-                        logging.exception(
-                            "BAZARR failed to queue auto-translate for %s: %s",
-                            video_path, str(e),
+                        # Guard: skip if an identical translate job is already
+                        # pending or running. Why: history guard (action=6) only
+                        # blocks re-queue after successful completion; without
+                        # this check, every wanted-scan tick during a pending
+                        # translation would enqueue a duplicate job.
+                        if jobs_queue._is_an_existing_job(
+                            module='subtitles.tools.translate.main',
+                            func='translate_subtitles_file',
+                            args=[],
+                            kwargs=translate_kwargs,
+                        ):
+                            continue
+                        logging.info(
+                            "BAZARR auto-translate (wanted-scan) queuing %s -> %s for %s",
+                            translate_cfg['from'], lang_code, video_path,
                         )
+                        translate_subtitles_file(**translate_kwargs)
+                        continue
+                    except Exception:
+                        logging.exception(
+                            "BAZARR failed to queue auto-translate for %s",
+                            video_path,
+                        )
+                        # Fall through to normal provider search on queuing failure
 
         if is_search_active(desired_language=language, attempt_string=movie.failedAttempts):
             hi_ = "True" if language.endswith(':hi') else "False"

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -92,10 +92,14 @@ def _wanted_movie(movie, providers_list, job_id=None):
                     .order_by(TableHistoryMovie.timestamp.desc())
                     .limit(1)
                 ).first()
-                source_score_pct = (
-                    round((history.score / MAX_SCORES['movie']) * 100, 1)
-                    if history and history.score else 0
-                )
+                if history and history.score:
+                    source_score_pct = round((history.score / MAX_SCORES['movie']) * 100, 1)
+                else:
+                    # No history record — subtitle may have been manually placed or
+                    # predates history tracking. Treat as exactly at threshold so
+                    # we proceed with translation instead of silently falling
+                    # back to provider search.
+                    source_score_pct = min_score
                 if source_score_pct < min_score:
                     logging.debug(
                         f"BAZARR auto-translate (wanted-scan) skipped for {video_path}: "

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -4,7 +4,6 @@
 import ast
 import logging
 import operator
-import os
 
 from functools import reduce
 
@@ -22,35 +21,7 @@ from subliminal_patch.score import MAX_SCORES
 
 from ..adaptive_searching import is_search_active, updateFailedAttempts
 from ..download import generate_subtitles
-
-
-def _find_existing_subtitle_path(subtitles_field, source_lang):
-    """Return on-disk path of an existing external subtitle for source_lang
-    (ignoring :hi / :forced variants), or None. subtitles_field is the raw
-    DB value (a python-literal list of [code, path, length] tuples)."""
-    if not subtitles_field:
-        return None
-    try:
-        entries = ast.literal_eval(subtitles_field)
-    except (ValueError, SyntaxError):
-        return None
-    # First pass: prefer plain (non-HI, non-forced) source language
-    for entry in entries:
-        if not entry or len(entry) < 2:
-            continue
-        code = (entry[0] or '')
-        path = entry[1]
-        if code == source_lang and path and os.path.exists(path):
-            return path
-    # Fallback: accept any source-language variant
-    for entry in entries:
-        if not entry or len(entry) < 2:
-            continue
-        code = (entry[0] or '').split(':')[0]
-        path = entry[1]
-        if code == source_lang and path and os.path.exists(path):
-            return path
-    return None
+from .utils import _find_existing_subtitle_path
 
 
 def _wanted_movie(movie, providers_list, job_id=None):
@@ -109,8 +80,26 @@ def _wanted_movie(movie, providers_list, job_id=None):
                 else:
                     try:
                         from subtitles.tools.translate.main import translate_subtitles_file
+                        from subtitles.tools.translate.core.translator_utils import create_process_result
                         logging.info(f"BAZARR auto-translate (wanted-scan) queuing "
                                      f"{translate_cfg['from']} -> {lang_code} for {video_path}")
+                        # Pre-log a translate history entry before queuing the async
+                        # translation job. Why: translate_subtitles_file (no job_id)
+                        # defers to the jobs queue and returns immediately; without a
+                        # marker the next wanted-scan cycle re-queues the same
+                        # translation before the worker runs.
+                        translate_msg = (f"BAZARR auto-translate (wanted-scan) queued "
+                                         f"{translate_cfg['from']} -> {lang_code}")
+                        pre_result = create_process_result(
+                            message=translate_msg,
+                            video_path=video_path,
+                            orig_to_lang=lang_code,
+                            forced=language.endswith(':forced') or translate_cfg['forced'],
+                            hi=language.endswith(':hi') or translate_cfg['hi'],
+                            dest_srt_file=source_srt,
+                            media_type='movies',
+                        )
+                        history_log_movie(6, movie.radarrId, pre_result)
                         translate_subtitles_file(
                             video_path=video_path,
                             source_srt_file=source_srt,

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -52,7 +52,11 @@ def _wanted_movie(movie, providers_list, job_id=None):
 
         translate_cfg = translate_from_map.get(lang_code)
         if translate_cfg:
-            source_srt = _find_existing_subtitle_path(movie.subtitles, translate_cfg['from'])
+            source_srt = _find_existing_subtitle_path(
+                movie.subtitles,
+                translate_cfg['from'],
+                path_replace_fn=path_mappings.path_replace_movie,
+            )
             if source_srt:
                 min_score = settings.translator.min_source_score
                 history = database.execute(
@@ -73,15 +77,16 @@ def _wanted_movie(movie, providers_list, job_id=None):
                     source_score_pct = min_score
                 if source_score_pct < min_score:
                     logging.debug(
-                        f"BAZARR auto-translate (wanted-scan) skipped for {video_path}: "
-                        f"source score {source_score_pct}% < threshold {min_score}% "
-                        f"(falling back to provider search)"
+                        "BAZARR auto-translate (wanted-scan) skipped for %s: "
+                        "source score %s%% < threshold %s%% "
+                        "(falling back to provider search)",
+                        video_path, source_score_pct, min_score,
                     )
                 else:
                     # Guard: skip if we already have a translate history entry
-                    # for this target language. Why: the previous translate
-                    # history_log write is what blocks re-queuing after a
-                    # restart while the queued job hasn't run yet. Without this
+                    # for this target language. Why: the translate service
+                    # writes action=6 on successful completion, which blocks
+                    # re-queuing after a successful translation. Without this
                     # check, the wanted-scan would re-queue every cycle.
                     already_translated = database.execute(
                         select(TableHistoryMovie.id)
@@ -94,26 +99,10 @@ def _wanted_movie(movie, providers_list, job_id=None):
                         continue
                     try:
                         from subtitles.tools.translate.main import translate_subtitles_file
-                        from subtitles.tools.translate.core.translator_utils import create_process_result
-                        logging.info(f"BAZARR auto-translate (wanted-scan) queuing "
-                                     f"{translate_cfg['from']} -> {lang_code} for {video_path}")
-                        # Pre-log a translate history entry before queuing the async
-                        # translation job. Why: translate_subtitles_file (no job_id)
-                        # defers to the jobs queue and returns immediately; without a
-                        # marker the next wanted-scan cycle re-queues the same
-                        # translation before the worker runs.
-                        translate_msg = (f"BAZARR auto-translate (wanted-scan) queued "
-                                         f"{translate_cfg['from']} -> {lang_code}")
-                        pre_result = create_process_result(
-                            message=translate_msg,
-                            video_path=video_path,
-                            orig_to_lang=lang_code,
-                            forced=language.endswith(':forced') or translate_cfg['forced'],
-                            hi=language.endswith(':hi') or translate_cfg['hi'],
-                            dest_srt_file=source_srt,
-                            media_type='movies',
+                        logging.info(
+                            "BAZARR auto-translate (wanted-scan) queuing %s -> %s for %s",
+                            translate_cfg['from'], lang_code, video_path,
                         )
-                        history_log_movie(6, movie.radarrId, pre_result)
                         translate_subtitles_file(
                             video_path=video_path,
                             source_srt_file=source_srt,
@@ -128,9 +117,11 @@ def _wanted_movie(movie, providers_list, job_id=None):
                             metadata=None,
                         )
                         continue
-                    except Exception:
-                        logging.exception(f"BAZARR failed to queue auto-translate for {video_path} "
-                                          f"language {lang_code}; falling back to provider search")
+                    except Exception as e:
+                        logging.exception(
+                            "BAZARR failed to queue auto-translate for %s: %s",
+                            video_path, str(e),
+                        )
 
         if is_search_active(desired_language=language, attempt_string=movie.failedAttempts):
             hi_ = "True" if language.endswith(':hi') else "False"

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -4,6 +4,7 @@
 import ast
 import logging
 import operator
+import os
 
 from functools import reduce
 
@@ -12,13 +13,44 @@ from subtitles.indexer.movies import store_subtitles_movie, list_missing_subtitl
 from radarr.history import history_log_movie
 from app.notifier import send_notifications_movie
 from app.get_providers import get_providers
-from app.database import get_exclusion_clause, get_audio_profile_languages, TableMovies, database, update, select
+from app.config import settings
+from app.database import (get_exclusion_clause, get_audio_profile_languages, get_profiles_list, TableMovies,
+                          TableHistoryMovie, database, update, select)
 from app.event_handler import event_stream
 from app.jobs_queue import jobs_queue
-from app.config import settings
+from subliminal_patch.score import MAX_SCORES
 
 from ..adaptive_searching import is_search_active, updateFailedAttempts
 from ..download import generate_subtitles
+
+
+def _find_existing_subtitle_path(subtitles_field, source_lang):
+    """Return on-disk path of an existing external subtitle for source_lang
+    (ignoring :hi / :forced variants), or None. subtitles_field is the raw
+    DB value (a python-literal list of [code, path, length] tuples)."""
+    if not subtitles_field:
+        return None
+    try:
+        entries = ast.literal_eval(subtitles_field)
+    except (ValueError, SyntaxError):
+        return None
+    # First pass: prefer plain (non-HI, non-forced) source language
+    for entry in entries:
+        if not entry or len(entry) < 2:
+            continue
+        code = (entry[0] or '')
+        path = entry[1]
+        if code == source_lang and path and os.path.exists(path):
+            return path
+    # Fallback: accept any source-language variant
+    for entry in entries:
+        if not entry or len(entry) < 2:
+            continue
+        code = (entry[0] or '').split(':')[0]
+        path = entry[1]
+        if code == source_lang and path and os.path.exists(path):
+            return path
+    return None
 
 
 def _wanted_movie(movie, providers_list, job_id=None):
@@ -28,10 +60,71 @@ def _wanted_movie(movie, providers_list, job_id=None):
     else:
         audio_language = 'None'
 
+    profile = get_profiles_list(profile_id=movie.profileId) if movie.profileId else None
+    translate_from_map = {}
+    if profile:
+        for prof_item in profile.get('items', []):
+            src = prof_item.get('translate_from')
+            if src:
+                translate_from_map[prof_item.get('language')] = {
+                    'from': src,
+                    'hi': prof_item.get('hi') == 'True',
+                    'forced': prof_item.get('forced') == 'True',
+                }
+
     languages = []
     languages_to_stamp = []
+    video_path = path_mappings.path_replace_movie(movie.path)
 
     for language in ast.literal_eval(movie.missing_subtitles):
+        lang_code = language.split(':')[0]
+
+        translate_cfg = translate_from_map.get(lang_code)
+        if translate_cfg:
+            source_srt = _find_existing_subtitle_path(movie.subtitles, translate_cfg['from'])
+            if source_srt:
+                min_score = settings.translator.min_source_score
+                history = database.execute(
+                    select(TableHistoryMovie.score)
+                    .where(TableHistoryMovie.radarrId == movie.radarrId)
+                    .where(TableHistoryMovie.language == translate_cfg['from'])
+                    .where(TableHistoryMovie.score.is_not(None))
+                    .order_by(TableHistoryMovie.timestamp.desc())
+                    .limit(1)
+                ).first()
+                source_score_pct = (
+                    round((history.score / MAX_SCORES['movie']) * 100, 1)
+                    if history and history.score else 0
+                )
+                if source_score_pct < min_score:
+                    logging.debug(
+                        f"BAZARR auto-translate (wanted-scan) skipped for {video_path}: "
+                        f"source score {source_score_pct}% < threshold {min_score}% "
+                        f"(falling back to provider search)"
+                    )
+                else:
+                    try:
+                        from subtitles.tools.translate.main import translate_subtitles_file
+                        logging.info(f"BAZARR auto-translate (wanted-scan) queuing "
+                                     f"{translate_cfg['from']} -> {lang_code} for {video_path}")
+                        translate_subtitles_file(
+                            video_path=video_path,
+                            source_srt_file=source_srt,
+                            from_lang=translate_cfg['from'],
+                            to_lang=lang_code,
+                            forced=language.endswith(':forced') or translate_cfg['forced'],
+                            hi=language.endswith(':hi') or translate_cfg['hi'],
+                            media_type='movies',
+                            sonarr_series_id=None,
+                            sonarr_episode_id=None,
+                            radarr_id=movie.radarrId,
+                            metadata=None,
+                        )
+                        continue
+                    except Exception:
+                        logging.exception(f"BAZARR failed to queue auto-translate for {video_path} "
+                                          f"language {lang_code}; falling back to provider search")
+
         if is_search_active(desired_language=language, attempt_string=movie.failedAttempts):
             hi_ = "True" if language.endswith(':hi') else "False"
             forced_ = "True" if language.endswith(':forced') else "False"
@@ -43,7 +136,7 @@ def _wanted_movie(movie, providers_list, job_id=None):
                          f"language: {language}")
 
     found_any = False
-    for result in generate_subtitles(path_mappings.path_replace_movie(movie.path),
+    for result in generate_subtitles(video_path,
                                      languages,
                                      audio_language,
                                      str(movie.sceneName),

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -58,7 +58,7 @@ def _wanted_movie(movie, providers_list, job_id=None):
                 history = database.execute(
                     select(TableHistoryMovie.score)
                     .where(TableHistoryMovie.radarrId == movie.radarrId)
-                    .where(TableHistoryMovie.language == translate_cfg['from'])
+                    .where(TableHistoryMovie.language.like(f"{translate_cfg['from']}%"))
                     .where(TableHistoryMovie.score.is_not(None))
                     .order_by(TableHistoryMovie.timestamp.desc())
                     .limit(1)

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -86,7 +86,7 @@ def _wanted_movie(movie, providers_list, job_id=None):
                     already_translated = database.execute(
                         select(TableHistoryMovie.id)
                         .where(TableHistoryMovie.radarrId == movie.radarrId)
-                        .where(TableHistoryMovie.language == lang_code)
+                        .where(TableHistoryMovie.language.like(f"{lang_code}%"))
                         .where(TableHistoryMovie.action == 6)
                         .limit(1)
                     ).first()

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -100,11 +100,7 @@ def _wanted_episode(episode, providers_list, job_id=None):
                         continue
                     try:
                         from subtitles.tools.translate.main import translate_subtitles_file
-                        logging.info(
-                            "BAZARR auto-translate (wanted-scan) queuing %s -> %s for %s",
-                            translate_cfg['from'], lang_code, video_path,
-                        )
-                        translate_subtitles_file(
+                        translate_kwargs = dict(
                             video_path=video_path,
                             source_srt_file=source_srt,
                             from_lang=translate_cfg['from'],
@@ -117,12 +113,30 @@ def _wanted_episode(episode, providers_list, job_id=None):
                             radarr_id=None,
                             metadata=None,
                         )
-                        continue
-                    except Exception as e:
-                        logging.exception(
-                            "BAZARR failed to queue auto-translate for %s: %s",
-                            video_path, str(e),
+                        # Guard: skip if an identical translate job is already
+                        # pending or running. Why: history guard (action=6) only
+                        # blocks re-queue after successful completion; without
+                        # this check, every wanted-scan tick during a pending
+                        # translation would enqueue a duplicate job.
+                        if jobs_queue._is_an_existing_job(
+                            module='subtitles.tools.translate.main',
+                            func='translate_subtitles_file',
+                            args=[],
+                            kwargs=translate_kwargs,
+                        ):
+                            continue
+                        logging.info(
+                            "BAZARR auto-translate (wanted-scan) queuing %s -> %s for %s",
+                            translate_cfg['from'], lang_code, video_path,
                         )
+                        translate_subtitles_file(**translate_kwargs)
+                        continue
+                    except Exception:
+                        logging.exception(
+                            "BAZARR failed to queue auto-translate for %s",
+                            video_path,
+                        )
+                        # Fall through to normal provider search on queuing failure
 
         if is_search_active(desired_language=language, attempt_string=episode.failedAttempts):
             hi_ = "True" if language.endswith(':hi') else "False"

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -10,7 +10,6 @@ from functools import reduce
 
 from utilities.path_mappings import path_mappings
 from subtitles.indexer.series import store_subtitles, list_missing_subtitles
-from subtitles.indexer.series import store_subtitles  # noqa: F811
 from sonarr.history import history_log
 from app.notifier import send_notifications
 from app.get_providers import get_providers
@@ -80,6 +79,20 @@ def _wanted_episode(episode, providers_list, job_id=None):
                         f"(falling back to provider search)"
                     )
                 else:
+                    # Guard: skip if we already have a translate history entry
+                    # for this target language. Why: the previous translate
+                    # history_log write is what blocks re-queuing after a
+                    # restart while the queued job hasn't run yet. Without this
+                    # check, the wanted-scan would re-queue every cycle.
+                    already_translated = database.execute(
+                        select(TableHistory.id)
+                        .where(TableHistory.sonarrEpisodeId == episode.sonarrEpisodeId)
+                        .where(TableHistory.language == lang_code)
+                        .where(TableHistory.action == 6)
+                        .limit(1)
+                    ).first()
+                    if already_translated:
+                        continue
                     try:
                         from subtitles.tools.translate.main import translate_subtitles_file
                         from subtitles.tools.translate.core.translator_utils import create_process_result

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -4,7 +4,6 @@
 import ast
 import logging
 import operator
-import os
 import gc
 
 from functools import reduce
@@ -24,35 +23,7 @@ from subliminal_patch.score import MAX_SCORES
 
 from ..adaptive_searching import is_search_active, updateFailedAttempts
 from ..download import generate_subtitles
-
-
-def _find_existing_subtitle_path(subtitles_field, source_lang):
-    """Return on-disk path of an existing external subtitle for source_lang
-    (ignoring :hi / :forced variants), or None. subtitles_field is the raw
-    DB value (a python-literal list of [code, path, length] tuples)."""
-    if not subtitles_field:
-        return None
-    try:
-        entries = ast.literal_eval(subtitles_field)
-    except (ValueError, SyntaxError):
-        return None
-    # First pass: prefer plain (non-HI, non-forced) source language
-    for entry in entries:
-        if not entry or len(entry) < 2:
-            continue
-        code = (entry[0] or '')
-        path = entry[1]
-        if code == source_lang and path and os.path.exists(path):
-            return path
-    # Fallback: accept any source-language variant
-    for entry in entries:
-        if not entry or len(entry) < 2:
-            continue
-        code = (entry[0] or '').split(':')[0]
-        path = entry[1]
-        if code == source_lang and path and os.path.exists(path):
-            return path
-    return None
+from .utils import _find_existing_subtitle_path
 
 
 def _wanted_episode(episode, providers_list, job_id=None):
@@ -111,8 +82,26 @@ def _wanted_episode(episode, providers_list, job_id=None):
                 else:
                     try:
                         from subtitles.tools.translate.main import translate_subtitles_file
+                        from subtitles.tools.translate.core.translator_utils import create_process_result
                         logging.info(f"BAZARR auto-translate (wanted-scan) queuing "
                                      f"{translate_cfg['from']} -> {lang_code} for {video_path}")
+                        # Pre-log a translate history entry before queuing the async
+                        # translation job. Why: translate_subtitles_file (no job_id)
+                        # defers to the jobs queue and returns immediately; without a
+                        # marker the next wanted-scan cycle re-queues the same
+                        # translation before the worker runs.
+                        translate_msg = (f"BAZARR auto-translate (wanted-scan) queued "
+                                         f"{translate_cfg['from']} -> {lang_code}")
+                        pre_result = create_process_result(
+                            message=translate_msg,
+                            video_path=video_path,
+                            orig_to_lang=lang_code,
+                            forced=language.endswith(':forced') or translate_cfg['forced'],
+                            hi=language.endswith(':hi') or translate_cfg['hi'],
+                            dest_srt_file=source_srt,
+                            media_type='episode',
+                        )
+                        history_log(6, episode.sonarrSeriesId, episode.sonarrEpisodeId, pre_result)
                         translate_subtitles_file(
                             video_path=video_path,
                             source_srt_file=source_srt,

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -94,10 +94,14 @@ def _wanted_episode(episode, providers_list, job_id=None):
                     .order_by(TableHistory.timestamp.desc())
                     .limit(1)
                 ).first()
-                source_score_pct = (
-                    round((history.score / MAX_SCORES['episode']) * 100, 1)
-                    if history and history.score else 0
-                )
+                if history and history.score:
+                    source_score_pct = round((history.score / MAX_SCORES['episode']) * 100, 1)
+                else:
+                    # No history record — subtitle may have been manually placed or
+                    # predates history tracking. Treat as exactly at threshold so
+                    # we proceed with translation instead of silently falling
+                    # back to provider search.
+                    source_score_pct = min_score
                 if source_score_pct < min_score:
                     logging.debug(
                         f"BAZARR auto-translate (wanted-scan) skipped for {video_path}: "

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -59,7 +59,7 @@ def _wanted_episode(episode, providers_list, job_id=None):
                 history = database.execute(
                     select(TableHistory.score)
                     .where(TableHistory.sonarrEpisodeId == episode.sonarrEpisodeId)
-                    .where(TableHistory.language == translate_cfg['from'])
+                    .where(TableHistory.language.like(f"{translate_cfg['from']}%"))
                     .where(TableHistory.score.is_not(None))
                     .order_by(TableHistory.timestamp.desc())
                     .limit(1)

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -4,6 +4,7 @@
 import ast
 import logging
 import operator
+import os
 import gc
 
 from functools import reduce
@@ -14,14 +15,44 @@ from subtitles.indexer.series import store_subtitles  # noqa: F811
 from sonarr.history import history_log
 from app.notifier import send_notifications
 from app.get_providers import get_providers
-from app.database import get_exclusion_clause, get_audio_profile_languages, TableShows, TableEpisodes, database, \
-    update, select
+from app.database import (get_exclusion_clause, get_audio_profile_languages, get_profiles_list, TableShows,
+                          TableEpisodes, TableHistory, database, update, select)
 from app.event_handler import event_stream
 from app.jobs_queue import jobs_queue
 from app.config import settings
+from subliminal_patch.score import MAX_SCORES
 
 from ..adaptive_searching import is_search_active, updateFailedAttempts
 from ..download import generate_subtitles
+
+
+def _find_existing_subtitle_path(subtitles_field, source_lang):
+    """Return on-disk path of an existing external subtitle for source_lang
+    (ignoring :hi / :forced variants), or None. subtitles_field is the raw
+    DB value (a python-literal list of [code, path, length] tuples)."""
+    if not subtitles_field:
+        return None
+    try:
+        entries = ast.literal_eval(subtitles_field)
+    except (ValueError, SyntaxError):
+        return None
+    # First pass: prefer plain (non-HI, non-forced) source language
+    for entry in entries:
+        if not entry or len(entry) < 2:
+            continue
+        code = (entry[0] or '')
+        path = entry[1]
+        if code == source_lang and path and os.path.exists(path):
+            return path
+    # Fallback: accept any source-language variant
+    for entry in entries:
+        if not entry or len(entry) < 2:
+            continue
+        code = (entry[0] or '').split(':')[0]
+        path = entry[1]
+        if code == source_lang and path and os.path.exists(path):
+            return path
+    return None
 
 
 def _wanted_episode(episode, providers_list, job_id=None):
@@ -31,9 +62,71 @@ def _wanted_episode(episode, providers_list, job_id=None):
     else:
         audio_language = 'None'
 
+    profile = get_profiles_list(profile_id=episode.profileId) if episode.profileId else None
+    translate_from_map = {}
+    if profile:
+        for prof_item in profile.get('items', []):
+            src = prof_item.get('translate_from')
+            if src:
+                translate_from_map[prof_item.get('language')] = {
+                    'from': src,
+                    'hi': prof_item.get('hi') == 'True',
+                    'forced': prof_item.get('forced') == 'True',
+                }
+
     languages = []
     languages_to_stamp = []
+    video_path = path_mappings.path_replace(episode.path)
+
     for language in ast.literal_eval(episode.missing_subtitles):
+        lang_code = language.split(':')[0]
+
+        translate_cfg = translate_from_map.get(lang_code)
+        if translate_cfg:
+            source_srt = _find_existing_subtitle_path(episode.subtitles, translate_cfg['from'])
+            if source_srt:
+                min_score = settings.translator.min_source_score
+                history = database.execute(
+                    select(TableHistory.score)
+                    .where(TableHistory.sonarrEpisodeId == episode.sonarrEpisodeId)
+                    .where(TableHistory.language == translate_cfg['from'])
+                    .where(TableHistory.score.is_not(None))
+                    .order_by(TableHistory.timestamp.desc())
+                    .limit(1)
+                ).first()
+                source_score_pct = (
+                    round((history.score / MAX_SCORES['episode']) * 100, 1)
+                    if history and history.score else 0
+                )
+                if source_score_pct < min_score:
+                    logging.debug(
+                        f"BAZARR auto-translate (wanted-scan) skipped for {video_path}: "
+                        f"source score {source_score_pct}% < threshold {min_score}% "
+                        f"(falling back to provider search)"
+                    )
+                else:
+                    try:
+                        from subtitles.tools.translate.main import translate_subtitles_file
+                        logging.info(f"BAZARR auto-translate (wanted-scan) queuing "
+                                     f"{translate_cfg['from']} -> {lang_code} for {video_path}")
+                        translate_subtitles_file(
+                            video_path=video_path,
+                            source_srt_file=source_srt,
+                            from_lang=translate_cfg['from'],
+                            to_lang=lang_code,
+                            forced=language.endswith(':forced') or translate_cfg['forced'],
+                            hi=language.endswith(':hi') or translate_cfg['hi'],
+                            media_type='series',
+                            sonarr_series_id=episode.sonarrSeriesId,
+                            sonarr_episode_id=episode.sonarrEpisodeId,
+                            radarr_id=None,
+                            metadata=None,
+                        )
+                        continue
+                    except Exception:
+                        logging.exception(f"BAZARR failed to queue auto-translate for {video_path} "
+                                          f"language {lang_code}; falling back to provider search")
+
         if is_search_active(desired_language=language, attempt_string=episode.failedAttempts):
             hi_ = "True" if language.endswith(':hi') else "False"
             forced_ = "True" if language.endswith(':forced') else "False"
@@ -46,7 +139,7 @@ def _wanted_episode(episode, providers_list, job_id=None):
                 f"language: {language}")
 
     found_any = False
-    for result in generate_subtitles(path_mappings.path_replace(episode.path),
+    for result in generate_subtitles(video_path,
                                      languages,
                                      audio_language,
                                      str(episode.sceneName),

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -53,7 +53,11 @@ def _wanted_episode(episode, providers_list, job_id=None):
 
         translate_cfg = translate_from_map.get(lang_code)
         if translate_cfg:
-            source_srt = _find_existing_subtitle_path(episode.subtitles, translate_cfg['from'])
+            source_srt = _find_existing_subtitle_path(
+                episode.subtitles,
+                translate_cfg['from'],
+                path_replace_fn=path_mappings.path_replace,
+            )
             if source_srt:
                 min_score = settings.translator.min_source_score
                 history = database.execute(
@@ -74,15 +78,16 @@ def _wanted_episode(episode, providers_list, job_id=None):
                     source_score_pct = min_score
                 if source_score_pct < min_score:
                     logging.debug(
-                        f"BAZARR auto-translate (wanted-scan) skipped for {video_path}: "
-                        f"source score {source_score_pct}% < threshold {min_score}% "
-                        f"(falling back to provider search)"
+                        "BAZARR auto-translate (wanted-scan) skipped for %s: "
+                        "source score %s%% < threshold %s%% "
+                        "(falling back to provider search)",
+                        video_path, source_score_pct, min_score,
                     )
                 else:
                     # Guard: skip if we already have a translate history entry
-                    # for this target language. Why: the previous translate
-                    # history_log write is what blocks re-queuing after a
-                    # restart while the queued job hasn't run yet. Without this
+                    # for this target language. Why: the translate service
+                    # writes action=6 on successful completion, which blocks
+                    # re-queuing after a successful translation. Without this
                     # check, the wanted-scan would re-queue every cycle.
                     already_translated = database.execute(
                         select(TableHistory.id)
@@ -95,26 +100,10 @@ def _wanted_episode(episode, providers_list, job_id=None):
                         continue
                     try:
                         from subtitles.tools.translate.main import translate_subtitles_file
-                        from subtitles.tools.translate.core.translator_utils import create_process_result
-                        logging.info(f"BAZARR auto-translate (wanted-scan) queuing "
-                                     f"{translate_cfg['from']} -> {lang_code} for {video_path}")
-                        # Pre-log a translate history entry before queuing the async
-                        # translation job. Why: translate_subtitles_file (no job_id)
-                        # defers to the jobs queue and returns immediately; without a
-                        # marker the next wanted-scan cycle re-queues the same
-                        # translation before the worker runs.
-                        translate_msg = (f"BAZARR auto-translate (wanted-scan) queued "
-                                         f"{translate_cfg['from']} -> {lang_code}")
-                        pre_result = create_process_result(
-                            message=translate_msg,
-                            video_path=video_path,
-                            orig_to_lang=lang_code,
-                            forced=language.endswith(':forced') or translate_cfg['forced'],
-                            hi=language.endswith(':hi') or translate_cfg['hi'],
-                            dest_srt_file=source_srt,
-                            media_type='episode',
+                        logging.info(
+                            "BAZARR auto-translate (wanted-scan) queuing %s -> %s for %s",
+                            translate_cfg['from'], lang_code, video_path,
                         )
-                        history_log(6, episode.sonarrSeriesId, episode.sonarrEpisodeId, pre_result)
                         translate_subtitles_file(
                             video_path=video_path,
                             source_srt_file=source_srt,
@@ -129,9 +118,11 @@ def _wanted_episode(episode, providers_list, job_id=None):
                             metadata=None,
                         )
                         continue
-                    except Exception:
-                        logging.exception(f"BAZARR failed to queue auto-translate for {video_path} "
-                                          f"language {lang_code}; falling back to provider search")
+                    except Exception as e:
+                        logging.exception(
+                            "BAZARR failed to queue auto-translate for %s: %s",
+                            video_path, str(e),
+                        )
 
         if is_search_active(desired_language=language, attempt_string=episode.failedAttempts):
             hi_ = "True" if language.endswith(':hi') else "False"

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -87,7 +87,7 @@ def _wanted_episode(episode, providers_list, job_id=None):
                     already_translated = database.execute(
                         select(TableHistory.id)
                         .where(TableHistory.sonarrEpisodeId == episode.sonarrEpisodeId)
-                        .where(TableHistory.language == lang_code)
+                        .where(TableHistory.language.like(f"{lang_code}%"))
                         .where(TableHistory.action == 6)
                         .limit(1)
                     ).first()

--- a/bazarr/subtitles/wanted/utils.py
+++ b/bazarr/subtitles/wanted/utils.py
@@ -1,0 +1,46 @@
+# coding=utf-8
+# fmt: off
+
+import ast
+import os
+
+
+def _find_existing_subtitle_path(subtitles_field, source_lang):
+    """Return on-disk path of an existing external subtitle for source_lang
+    (ignoring :hi / :forced variants), or None. subtitles_field is the raw
+    DB value (a python-literal list of [code, path, length] tuples).
+
+    Why: The wanted-scan auto-translate path in both series and movies needs
+    to locate an existing same-language external subtitle on disk before
+    deciding whether to queue a translation. Sharing this lookup avoids the
+    copy-paste divergence the previous duplicate implementations risked.
+    What: Parses the stored subtitles list and returns the first path whose
+    language matches source_lang and exists on disk (preferring plain over
+    :hi / :forced variants).
+    Test: Pass a literal list like "[['en','/tmp/x.srt',null]]" with an
+    existing file and source_lang='en' — assert it returns '/tmp/x.srt';
+    pass with a missing file or wrong code — assert None.
+    """
+    if not subtitles_field:
+        return None
+    try:
+        entries = ast.literal_eval(subtitles_field)
+    except (ValueError, SyntaxError):
+        return None
+    # First pass: prefer plain (non-HI, non-forced) source language
+    for entry in entries:
+        if not entry or len(entry) < 2:
+            continue
+        code = (entry[0] or '')
+        path = entry[1]
+        if code == source_lang and path and os.path.exists(path):
+            return path
+    # Fallback: accept any source-language variant
+    for entry in entries:
+        if not entry or len(entry) < 2:
+            continue
+        code = (entry[0] or '').split(':')[0]
+        path = entry[1]
+        if code == source_lang and path and os.path.exists(path):
+            return path
+    return None

--- a/bazarr/subtitles/wanted/utils.py
+++ b/bazarr/subtitles/wanted/utils.py
@@ -5,7 +5,7 @@ import ast
 import os
 
 
-def _find_existing_subtitle_path(subtitles_field, source_lang):
+def _find_existing_subtitle_path(subtitles_field, source_lang, path_replace_fn=None):
     """Return on-disk path of an existing external subtitle for source_lang
     (ignoring :hi / :forced variants), or None. subtitles_field is the raw
     DB value (a python-literal list of [code, path, length] tuples).
@@ -16,10 +16,16 @@ def _find_existing_subtitle_path(subtitles_field, source_lang):
     copy-paste divergence the previous duplicate implementations risked.
     What: Parses the stored subtitles list and returns the first path whose
     language matches source_lang and exists on disk (preferring plain over
-    :hi / :forced variants).
+    :hi / :forced variants). When path_replace_fn is provided (e.g.
+    path_mappings.path_replace / path_replace_movie), each candidate path
+    is mapped through it before the existence check and the mapped path is
+    returned, so Docker / remote setups with path mappings see the correct
+    on-disk location.
     Test: Pass a literal list like "[['en','/tmp/x.srt',null]]" with an
     existing file and source_lang='en' — assert it returns '/tmp/x.srt';
-    pass with a missing file or wrong code — assert None.
+    pass with a missing file or wrong code — assert None; pass a
+    path_replace_fn that rewrites '/remote/x.srt' to a real local path and
+    assert the mapped path is returned.
     """
     if not subtitles_field:
         return None
@@ -33,14 +39,16 @@ def _find_existing_subtitle_path(subtitles_field, source_lang):
             continue
         code = (entry[0] or '')
         path = entry[1]
-        if code == source_lang and path and os.path.exists(path):
-            return path
+        mapped = path_replace_fn(path) if (path_replace_fn and path) else path
+        if code == source_lang and mapped and os.path.exists(mapped):
+            return mapped
     # Fallback: accept any source-language variant
     for entry in entries:
         if not entry or len(entry) < 2:
             continue
         code = (entry[0] or '').split(':')[0]
         path = entry[1]
-        if code == source_lang and path and os.path.exists(path):
-            return path
+        mapped = path_replace_fn(path) if (path_replace_fn and path) else path
+        if code == source_lang and mapped and os.path.exists(mapped):
+            return mapped
     return None

--- a/frontend/src/components/forms/ProfileEditForm.tsx
+++ b/frontend/src/components/forms/ProfileEditForm.tsx
@@ -35,6 +35,8 @@ const defaultCutoffOptions: SelectorOption<Language.ProfileItem>[] = [
       forced: "False",
       hi: "False",
       language: "any",
+      // eslint-disable-next-line camelcase
+      translate_from: null,
     },
   },
 ];
@@ -165,6 +167,8 @@ const ProfileEditForm: FunctionComponent<Props> = ({
         audio_only_include: "False",
         hi: "False",
         forced: "False",
+        // eslint-disable-next-line camelcase
+        translate_from: null,
       };
 
       const list = [...form.values.items, item];
@@ -260,6 +264,48 @@ const ProfileEditForm: FunctionComponent<Props> = ({
     },
   );
 
+  const TranslateFromCell = React.memo(
+    ({ item, index }: { item: Language.ProfileItem; index: number }) => {
+      // Exclude the item's own language from the source list (can't translate
+      // a language to itself). Treat undefined translate_from as null for
+      // backward compatibility with profile rows persisted before this field.
+      const translateFromValue = item.translate_from ?? null;
+
+      const filteredOptions = useMemo(
+        () =>
+          languageOptions.options.filter(
+            (l) => l.value.code2 !== item.language,
+          ),
+        [item.language],
+      );
+
+      const selected = useMemo(
+        () =>
+          filteredOptions.find((l) => l.value.code2 === translateFromValue)
+            ?.value ?? null,
+        [filteredOptions, translateFromValue],
+      );
+
+      return (
+        <Selector
+          {...languageOptions}
+          options={filteredOptions}
+          className="table-select"
+          clearable
+          placeholder="None"
+          value={selected}
+          onChange={(value) => {
+            action.mutate(index, {
+              ...item,
+              // eslint-disable-next-line camelcase
+              translate_from: value?.code2 ?? null,
+            });
+          }}
+        ></Selector>
+      );
+    },
+  );
+
   const columns = useMemo<ColumnDef<Language.ProfileItem>[]>(
     () => [
       {
@@ -288,6 +334,13 @@ const ProfileEditForm: FunctionComponent<Props> = ({
         },
       },
       {
+        header: "Translate From",
+        accessorKey: "translate_from",
+        cell: ({ row: { original: item, index } }) => {
+          return <TranslateFromCell item={item} index={index} />;
+        },
+      },
+      {
         id: "action",
         cell: ({ row }) => {
           return (
@@ -301,7 +354,7 @@ const ProfileEditForm: FunctionComponent<Props> = ({
         },
       },
     ],
-    [action, LanguageCell, SubtitleTypeCell, InclusionCell],
+    [action, LanguageCell, SubtitleTypeCell, InclusionCell, TranslateFromCell],
   );
 
   return (

--- a/frontend/src/pages/Movies/Details/index.tsx
+++ b/frontend/src/pages/Movies/Details/index.tsx
@@ -33,6 +33,7 @@ import {
 import {
   useMovieAction,
   useMovieById,
+  useMovieHistory,
   useMovieModification,
 } from "@/apis/hooks/movies";
 import { useInstanceName } from "@/apis/hooks/site";
@@ -54,6 +55,7 @@ const MovieDetailView: FunctionComponent = () => {
   const id = Number.parseInt(param.id ?? "");
   const movieQuery = useMovieById(id);
   const { data: movie, isFetched } = movieQuery;
+  const { data: movieHistory } = useMovieHistory(movie?.radarrId);
 
   const profile = useLanguageProfileBy(movie?.profileId);
 
@@ -272,6 +274,7 @@ const MovieDetailView: FunctionComponent = () => {
             movie={movie ?? null}
             profile={profile}
             disabled={hasTask}
+            history={movieHistory}
           ></Table>
         </Stack>
       </QueryOverlay>

--- a/frontend/src/pages/Movies/Details/table.tsx
+++ b/frontend/src/pages/Movies/Details/table.tsx
@@ -1,12 +1,13 @@
 import React, { FunctionComponent, useMemo } from "react";
 import { useNavigate } from "react-router";
-import { Badge, Text, TextProps } from "@mantine/core";
+import { Badge, Group, Text, TextProps } from "@mantine/core";
 import { faEllipsis } from "@fortawesome/free-solid-svg-icons";
 import { ColumnDef } from "@tanstack/react-table";
 import { isString } from "lodash";
 import { useMovieSubtitleModification } from "@/apis/hooks";
 import { useShowOnlyDesired } from "@/apis/hooks/site";
 import { Action } from "@/components";
+import { HistoryIcon } from "@/components/bazarr";
 import Language from "@/components/bazarr/Language";
 import SubtitleToolsMenu from "@/components/SubtitleToolsMenu";
 import SimpleTable from "@/components/tables/SimpleTable";
@@ -19,7 +20,27 @@ interface Props {
   movie: Item.Movie | null;
   disabled?: boolean;
   profile?: Language.Profile;
+  history?: History.Movie[];
 }
+
+const ScoreBadge: React.FC<{ score?: string | number | null }> = ({
+  score,
+}) => {
+  if (score === undefined || score === null || score === "") {
+    return (
+      <Text c="dimmed" size="xs">
+        —
+      </Text>
+    );
+  }
+  const pct = typeof score === "string" ? parseFloat(score) : score;
+  const color = pct >= 90 ? "green" : pct >= 70 ? "yellow" : "red";
+  return (
+    <Badge color={color} size="sm" variant="light">
+      {typeof score === "number" ? `${score}%` : score}
+    </Badge>
+  );
+};
 
 function isSubtitleTrack(path: string | undefined | null) {
   return !isString(path) || path.length === 0;
@@ -36,7 +57,7 @@ function buildLanguageKey(sub: Subtitle): string {
   return key;
 }
 
-const Table: FunctionComponent<Props> = ({ movie, profile }) => {
+const Table: FunctionComponent<Props> = ({ movie, profile, history }) => {
   const onlyDesired = useShowOnlyDesired();
 
   const profileItems = useProfileItemsToLanguages(profile);
@@ -51,6 +72,29 @@ const Table: FunctionComponent<Props> = ({ movie, profile }) => {
       ),
     [movie?.subtitles],
   );
+
+  const historyMap = useMemo(() => {
+    const map = new Map<string, History.Movie>();
+    history?.forEach((h) => {
+      if (!h.subtitles_path) return;
+      if ([1, 2, 3].includes(h.action)) {
+        if (!map.has(h.subtitles_path)) map.set(h.subtitles_path, h);
+      }
+    });
+    return map;
+  }, [history]);
+
+  const statusMap = useMemo(() => {
+    const map = new Map<string, Set<number>>();
+    history?.forEach((h) => {
+      if (!h.subtitles_path) return;
+      if ([5, 6].includes(h.action)) {
+        if (!map.has(h.subtitles_path)) map.set(h.subtitles_path, new Set());
+        map.get(h.subtitles_path)!.add(h.action);
+      }
+    });
+    return map;
+  }, [history]);
 
   const navigate = useNavigate();
 
@@ -193,13 +237,55 @@ const Table: FunctionComponent<Props> = ({ movie, profile }) => {
         },
       },
       {
+        id: "score",
+        header: "Score",
+        cell: ({ row: { original } }) => {
+          const record = historyMap.get(original.path ?? "");
+          return <ScoreBadge score={record?.score} />;
+        },
+      },
+      {
+        id: "provider",
+        header: "Provider",
+        cell: ({ row: { original } }) => {
+          const record = historyMap.get(original.path ?? "");
+          if (!record?.provider)
+            return (
+              <Text c="dimmed" size="xs">
+                —
+              </Text>
+            );
+          return <Text size="xs">{record.provider}</Text>;
+        },
+      },
+      {
+        id: "status",
+        header: "Status",
+        cell: ({ row: { original } }) => {
+          const actions = statusMap.get(original.path ?? "");
+          if (!actions?.size)
+            return (
+              <Text c="dimmed" size="xs">
+                —
+              </Text>
+            );
+          return (
+            <Group gap={4}>
+              {Array.from(actions).map((action) => (
+                <HistoryIcon key={action} action={action} />
+              ))}
+            </Group>
+          );
+        },
+      },
+      {
         id: "code2",
         cell: ({ row: { original } }) => {
           return <CodeCell item={original} />;
         },
       },
     ],
-    [CodeCell],
+    [CodeCell, historyMap, statusMap],
   );
 
   const data: Subtitle[] = useMemo(() => {

--- a/frontend/src/pages/Settings/Translator/index.tsx
+++ b/frontend/src/pages/Settings/Translator/index.tsx
@@ -292,6 +292,34 @@ const SettingsTranslatorView: FunctionComponent = () => {
             </Tooltip>
           </Group>
           <Group gap="xs" align="center">
+            <MantineText size="sm" c="var(--bz-text-tertiary)">
+              Min Source Score
+            </MantineText>
+            <Number
+              settingKey="settings-translator-min_source_score"
+              min={0}
+              max={100}
+              step={1}
+              w={70}
+              size="xs"
+            />
+            <Tooltip
+              label="Minimum quality score (0-100) a source subtitle must reach before auto-translation triggers via a language profile's 'Translate From' setting. Lower-scoring sources are likely badly synced or poorly matched."
+              multiline
+              w={280}
+              withArrow
+            >
+              <MantineText
+                size="xs"
+                c="var(--bz-text-tertiary)"
+                style={{ cursor: "help" }}
+                component="span"
+              >
+                <FontAwesomeIcon icon={faCircleInfo} />
+              </MantineText>
+            </Tooltip>
+          </Group>
+          <Group gap="xs" align="center">
             <Check
               label="Translation credit"
               settingKey="settings-translator-translator_info"

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -31,6 +31,7 @@ declare namespace Language {
     forced: PythonBoolean;
     hi: PythonBoolean;
     language: CodeType;
+    translate_from: CodeType | null;
   }
 
   interface Profile {


### PR DESCRIPTION
## Summary

Adds a **"Translate From"** field to language profile items. When a subtitle is downloaded in a source language (e.g. English), Bazarr automatically translates it to the target language (e.g. Latvian) — no manual intervention needed.

Solves the problem for users whose native languages have near-zero subtitle provider coverage but good English subtitle availability.

## Features

### Backend (auto-translate trigger)
- New `translator.min_source_score` config setting (default 90%) — only auto-translate from high-quality source subtitles
- `translate_from` field added to language profile items with DB migration backfill
- `_trigger_auto_translation()` hook fires in `process_subtitle()` after every subtitle download
- Wanted-scan integration: if a source subtitle already exists on disk and meets the quality threshold, queues translation instead of provider search

### Frontend
- **"Translate From" dropdown** in the language profile item editor (Settings → Languages → edit profile)
- **Minimum Source Score** field in Translator settings
- **Score badge** (color-coded: green ≥90%, yellow ≥70%, red <70%) on movie detail subtitle table
- **Provider** column on movie detail subtitle table
- **Status** column with sync/translate icons on movie detail subtitle table

## How it works

1. User sets "Translate From: English" on the Latvian language profile item
2. When an English subtitle is downloaded (score ≥ min_source_score), translation to Latvian is automatically queued via the configured translator (Lingarr, OpenRouter, Gemini, etc.)
3. The Latvian subtitle appears in the movie/episode detail page once translation completes

## Notes

- Compatible with all of Bazarr+'s existing translator backends (Lingarr, OpenRouter, Gemini)
- `translate_from` defaults to `null` for all existing profile items (no behavior change unless configured)
- Translation is skipped for forced subtitles and when source score is below threshold