### PR TITLE
fix: query all providers during manual search (#134)

### DIFF
--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -480,12 +480,17 @@ class SZProviderPool(ProviderPool):
 
         return subtitles
 
-    def list_subtitles_prioritized(self, video, languages, min_score=0, provider_order=None, compute_score=None):
+    def list_subtitles_prioritized(self, video, languages, min_score=0, provider_order=None, compute_score=None,
+                                   exhaustive=False):
         """List subtitles with priority-based provider search.
 
         Search providers in priority order. Stop only when every requested
         language has at least one subtitle meeting min_score, or all providers
         have been exhausted.
+
+        When ``exhaustive=True`` (manual search), the early-exit on satisfied
+        languages is disabled so every provider is queried and the user sees
+        the full set of candidates regardless of score.
         """
         from .score import compute_score as default_compute_score
         compute_score = compute_score or default_compute_score
@@ -537,7 +542,7 @@ class SZProviderPool(ProviderPool):
 
             all_subtitles.extend(valid_subtitles)
 
-            if required_languages and satisfied_languages >= required_languages:
+            if not exhaustive and required_languages and satisfied_languages >= required_languages:
                 logger.info('All requested languages satisfied after provider %s, stopping search', name)
                 return all_subtitles
 

--- a/custom_libs/subliminal_patch/core_persistent.py
+++ b/custom_libs/subliminal_patch/core_persistent.py
@@ -28,7 +28,8 @@ def list_all_subtitles(videos, languages, pool_instance, min_score=0):
     for video in videos:
         logger.info("Listing subtitles for %r", video)
         subtitles = pool_instance.list_subtitles_prioritized(
-            video, languages - video.subtitle_languages, min_score=min_score
+            video, languages - video.subtitle_languages, min_score=min_score,
+            exhaustive=True,
         )
         listed_subtitles[video].extend(subtitles)
         logger.info("Found %d subtitle(s)", len(subtitles))
@@ -80,7 +81,14 @@ def download_best_subtitles(
     for video in checked_videos:
         logger.info("Downloading best subtitles for %r", video)
         if use_provider_priority:
-            listed = pool_instance.list_subtitles_prioritized(video, languages - video.subtitle_languages, min_score=min_score)
+            # exhaustive=False is the default, but spelling it out here keeps
+            # the auto/scheduled download intent obvious and prevents a silent
+            # behavior change if the default ever flips. The exhaustive path
+            # is reserved for manual searches (see list_all_subtitles).
+            listed = pool_instance.list_subtitles_prioritized(
+                video, languages - video.subtitle_languages,
+                min_score=min_score, exhaustive=False,
+            )
         else:
             listed = pool_instance.list_subtitles(video, languages - video.subtitle_languages)
         subtitles = pool_instance.download_best_subtitles(

--- a/tests/subliminal_patch/test_core.py
+++ b/tests/subliminal_patch/test_core.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -166,3 +167,104 @@ def test_language_equals_pool_intance_list_subtitles_return_nothing(movies):
     assert not language_equals_pool_intance.download_best_subtitles(
         subs, movies["dune"], {core.Language("spa")}
     )
+
+
+# ---- list_subtitles_prioritized: exhaustive flag behavior ----
+
+def _make_fake_subtitle(language):
+    """Why: list_subtitles_prioritized requires real-looking subtitle objects
+    (filters out anything lacking get_matches) and reads ``subtitle.language.alpha3``.
+    What: Build a MagicMock that satisfies both requirements.
+    Test: Used by the exhaustive-flag tests below.
+    """
+    sub = MagicMock()
+    sub.language = language
+    sub.get_matches = MagicMock(return_value=set())
+    return sub
+
+
+def _fixed_score(value):
+    """Why: Decouple the exhaustive-flag test from the real scoring formula so
+    we can deterministically place subtitles above or below min_score.
+    What: Returns a (score, _) tuple matching the compute_score contract.
+    Test: Pass as compute_score= to list_subtitles_prioritized.
+    """
+    return lambda matches, subtitle, video, hearing_impaired: (value, None)
+
+
+@pytest.fixture
+def two_provider_pool():
+    """SZProviderPool with two providers in a deterministic order so we can
+    assert which providers were queried after the early-exit decision."""
+    yield core.SZProviderPool(["provider_a", "provider_b"], {})
+
+
+def test_list_subtitles_prioritized_early_exit_when_not_exhaustive(
+    two_provider_pool, monkeypatch
+):
+    """Why: Auto-download must stop after the first provider that satisfies all
+    requested languages above min_score - otherwise we waste provider quota.
+    What: With exhaustive=False (default), provider_b must NOT be queried when
+    provider_a already returns a high-scoring subtitle for the only language.
+    Test: Patch list_subtitles_provider, count invocations per provider.
+    """
+    lang = core.Language("eng")
+    sub_a = _make_fake_subtitle(lang)
+
+    call_log = []
+
+    def fake_list(self, provider, video, languages):
+        call_log.append(provider)
+        if provider == "provider_a":
+            return [sub_a]
+        return []  # provider_b would return something too, but we should never get here
+
+    monkeypatch.setattr(
+        core.SZProviderPool, "list_subtitles_provider", fake_list
+    )
+
+    video = MagicMock()
+    result = two_provider_pool.list_subtitles_prioritized(
+        video, {lang}, min_score=80,
+        compute_score=_fixed_score(100),  # above min_score -> satisfied
+    )
+
+    assert call_log == ["provider_a"]
+    assert result == [sub_a]
+
+
+def test_list_subtitles_prioritized_no_early_exit_when_exhaustive(
+    two_provider_pool, monkeypatch
+):
+    """Why: Manual search must show every provider's candidates even when the
+    first one already satisfies min_score - users want the full picture.
+    What: With exhaustive=True, both providers are queried even though
+    provider_a alone satisfies all requested languages above min_score.
+    Test: Patch list_subtitles_provider, assert both providers appear in
+    call_log and both subtitles appear in the result.
+    """
+    lang = core.Language("eng")
+    sub_a = _make_fake_subtitle(lang)
+    sub_b = _make_fake_subtitle(lang)
+
+    call_log = []
+
+    def fake_list(self, provider, video, languages):
+        call_log.append(provider)
+        if provider == "provider_a":
+            return [sub_a]
+        return [sub_b]
+
+    monkeypatch.setattr(
+        core.SZProviderPool, "list_subtitles_provider", fake_list
+    )
+
+    video = MagicMock()
+    result = two_provider_pool.list_subtitles_prioritized(
+        video, {lang}, min_score=80,
+        compute_score=_fixed_score(100),
+        exhaustive=True,
+    )
+
+    assert call_log == ["provider_a", "provider_b"]
+    assert sub_a in result and sub_b in result

--- a/tests/subliminal_patch/test_core_persistent.py
+++ b/tests/subliminal_patch/test_core_persistent.py
@@ -3,7 +3,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from subliminal_patch.core_persistent import download_best_subtitles
+from subliminal_patch.core_persistent import (
+    download_best_subtitles,
+    list_all_subtitles,
+)
 
 
 @pytest.fixture
@@ -64,3 +67,44 @@ def test_uses_regular_listing_when_disabled(mock_pool, mock_video):
 
     mock_pool.list_subtitles.assert_called_once()
     mock_pool.list_subtitles_prioritized.assert_not_called()
+
+
+def test_list_all_subtitles_requests_exhaustive(mock_pool, mock_video):
+    """Why: Manual search must query every provider; the exhaustive flag is the
+    only thing that disables the early-exit in list_subtitles_prioritized.
+    What: list_all_subtitles calls list_subtitles_prioritized with exhaustive=True.
+    Test: Inspect the call kwargs and assert exhaustive=True.
+    """
+    languages = {MagicMock()}
+
+    list_all_subtitles(
+        videos={mock_video},
+        languages=languages,
+        pool_instance=mock_pool,
+        min_score=80,
+    )
+
+    mock_pool.list_subtitles_prioritized.assert_called_once()
+    _, kwargs = mock_pool.list_subtitles_prioritized.call_args
+    assert kwargs.get("exhaustive") is True
+    assert kwargs.get("min_score") == 80
+
+
+def test_download_best_subtitles_does_not_request_exhaustive(mock_pool, mock_video):
+    """Why: Auto/scheduled downloads must keep the early-exit so we stop after
+    the first provider that satisfies all languages above min_score.
+    What: download_best_subtitles never passes exhaustive=True.
+    Test: Inspect call_args and assert exhaustive is False (and definitely not True).
+    """
+    languages = {MagicMock()}
+
+    with patch("subliminal_patch.core_persistent.check_video", return_value=True):
+        download_best_subtitles(
+            videos={mock_video},
+            languages=languages,
+            pool_instance=mock_pool,
+        )
+
+    mock_pool.list_subtitles_prioritized.assert_called_once()
+    _, kwargs = mock_pool.list_subtitles_prioritized.call_args
+    assert kwargs.get("exhaustive", False) is False


### PR DESCRIPTION
## Summary

This fix addresses issue #134 where manual subtitle search was not querying all providers due to an unconditional early-exit in the search logic.

## Root Cause

The `list_subtitles_prioritized` function had logic that would stop querying providers as soon as it found a subtitle meeting the minimum score for all requested languages. While this optimization is appropriate for auto-download (to avoid unnecessary provider calls), it's incorrect for manual search where users expect comprehensive results from all available providers.

## Changes

Added an `exhaustive` parameter (default `False`) to `list_subtitles_prioritized`:
- When `exhaustive=True`: Skips the early-exit optimization and queries all providers
- When `exhaustive=False`: Maintains the current optimization for auto-download efficiency

**Modified files:**
- `custom_libs/subliminal_patch/core.py` — Added `exhaustive=False` parameter and gated early-exit logic
- `custom_libs/subliminal_patch/core_persistent.py` — Updated callers:
  - `list_all_subtitles` (manual search path) passes `exhaustive=True`
  - `download_best_subtitles` (auto-download path) explicitly passes `exhaustive=False`
- `tests/subliminal_patch/test_core.py` — 2 new unit tests for the exhaustive flag
- `tests/subliminal_patch/test_core_persistent.py` — 2 new integration tests for both callers

## Test Plan

All 4 new tests pass:
- Unit tests verify the `exhaustive` parameter behavior in isolation
- Integration tests verify both `list_all_subtitles` and `download_best_subtitles` behave correctly with the new parameter

Existing tests continue to pass, ensuring backward compatibility.

Closes #134