### PR TITLE
Fix site GitHub stars badge

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -87,7 +87,7 @@
     <nav class="ctas" aria-label="Primary actions">
       <a href="#quick-start" class="btn btn-primary">Switch to Bazarr+</a>
       <a href="https://github.com/LavX/bazarr" class="btn btn-outline" target="_blank" rel="noopener">
-        <img src="https://img.shields.io/github/stars/LavX/bazarr?style=flat&color=e68a00&labelColor=1a1a2e&logo=github&logoColor=e8e8f0" alt="GitHub stars" height="20" loading="lazy">
+        <img src="https://img.shields.io/github/stars/LavX/bazarr?style=flat&color=%23e68a00&labelColor=%231a1a2e&logo=github&logoColor=%23e8e8f0" alt="GitHub stars" height="20" loading="lazy">
         Star on GitHub
       </a>
     </nav>


### PR DESCRIPTION
## Summary
- Encode the Shields hex color query parameters for the GitHub stars badge.
- Fixes the live badge rendering as stars: invalid on GitHub Pages.

## Validation
- Checked the fixed Shields URL returns the real stars count instead of invalid.
- Ran git diff --check.
