### PR TITLE
feat: Add per-provider language exclusions

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -149,6 +149,7 @@ validators = [
               is_in=['', '1m', '3m', '6m', '1y', '2y']),
     Validator('general.enabled_providers', must_exist=True, default=[], is_type_of=list),
     Validator('general.provider_priorities', must_exist=True, default={}, is_type_of=dict),
+    Validator('general.provider_languages', must_exist=True, default={}, is_type_of=dict),
     Validator('general.use_provider_priority', must_exist=True, default=True, is_type_of=bool),
     Validator('general.enabled_integrations', must_exist=True, default=[], is_type_of=list),
     Validator('general.multithreading', must_exist=True, default=True, is_type_of=bool),
@@ -886,7 +887,7 @@ def save_settings(settings_items):
             value = False
 
         # Handle JSON strings for dict settings
-        if settings_keys[-1] == 'provider_priorities' and isinstance(value, str):
+        if settings_keys[-1] in ['provider_priorities', 'provider_languages'] and isinstance(value, str):
             try:
                 value = json.loads(value)
             except ValueError:

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -201,6 +201,49 @@ def get_language_equals(settings_=None):
     return items
 
 
+def get_provider_language_allowlist(settings_=None):
+    settings_ = settings_ or settings
+
+    configured = getattr(settings_.general, "provider_languages", {}) or {}
+    if isinstance(configured, str):
+        try:
+            configured = json.loads(configured)
+        except ValueError:
+            logging.info("Invalid provider language configuration: %r", configured)
+            return {}
+
+    if not isinstance(configured, dict):
+        return {}
+
+    allowlist = {}
+    for provider, language_codes in configured.items():
+        if not provider or not isinstance(language_codes, (list, tuple, set)):
+            continue
+
+        languages = set()
+        for language_code in language_codes:
+            if not isinstance(language_code, str) or not language_code.strip():
+                continue
+            try:
+                languages.add(_lang_from_str(language_code.strip()))
+            except Exception as error:
+                logging.info("Invalid provider language value for %s: '%s' [%s]", provider, language_code, error)
+
+        if languages:
+            allowlist[str(provider)] = languages
+
+    return allowlist
+
+
+def get_provider_language_hook(settings_=None):
+    settings_ = settings_ or settings
+
+    def provider_language_hook(provider):
+        return get_provider_language_allowlist(settings_).get(provider)
+
+    return provider_language_hook
+
+
 def get_providers():
     _ensure_provider_hub_registered()
     providers_list = []

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -201,7 +201,7 @@ def get_language_equals(settings_=None):
     return items
 
 
-def get_provider_language_allowlist(settings_=None):
+def get_provider_language_exclusions(settings_=None):
     settings_ = settings_ or settings
 
     configured = getattr(settings_.general, "provider_languages", {}) or {}
@@ -215,7 +215,7 @@ def get_provider_language_allowlist(settings_=None):
     if not isinstance(configured, dict):
         return {}
 
-    allowlist = {}
+    exclusions = {}
     for provider, language_codes in configured.items():
         if not provider or not isinstance(language_codes, (list, tuple, set)):
             continue
@@ -230,16 +230,16 @@ def get_provider_language_allowlist(settings_=None):
                 logging.info("Invalid provider language value for %s: '%s' [%s]", provider, language_code, error)
 
         if languages:
-            allowlist[str(provider)] = languages
+            exclusions[str(provider)] = languages
 
-    return allowlist
+    return exclusions
 
 
 def get_provider_language_hook(settings_=None):
     settings_ = settings_ or settings
 
     def provider_language_hook(provider):
-        return get_provider_language_allowlist(settings_).get(provider)
+        return get_provider_language_exclusions(settings_).get(provider)
 
     return provider_language_hook
 

--- a/bazarr/compat/service.py
+++ b/bazarr/compat/service.py
@@ -9,7 +9,7 @@ from subliminal.video import Episode, Movie, Video
 from subliminal_patch.core_persistent import list_all_subtitles_parallel
 
 from app.config import settings
-from app.get_providers import get_providers_sorted, get_providers_auth
+from app.get_providers import get_provider_language_hook, get_providers_sorted, get_providers_auth
 from . import auth, cache as C, response_mapper as M
 from .local_subs import search_local
 from utilities.url_guard import assert_safe_outbound, resolve_safe_url, UnsafeURLError  # noqa: F401
@@ -31,7 +31,7 @@ def _get_compat_pool():
                 provider_configs=get_providers_auth(),
                 blacklist=None,
                 ban_list=None,
-                language_hook=None,
+                language_hook=get_provider_language_hook(),
                 language_equals=[],
             )
         return _compat_pool

--- a/bazarr/subtitles/pool.py
+++ b/bazarr/subtitles/pool.py
@@ -9,7 +9,7 @@ from inspect import getfullargspec
 from radarr.blacklist import get_blacklist_movie
 from sonarr.blacklist import get_blacklist
 from app.get_providers import get_providers, get_providers_auth, provider_throttle, provider_pool, get_language_equals, \
-    get_providers_sorted  # noqa: F401
+    get_provider_language_hook, get_providers_sorted  # noqa: F401
 
 from .utils import get_ban_list
 
@@ -23,7 +23,7 @@ def _init_pool(media_type, profile_id=None, providers=None):
         blacklist=get_blacklist() if media_type == "series" else get_blacklist_movie(),
         throttle_callback=provider_throttle,
         ban_list=get_ban_list(profile_id),
-        language_hook=None,
+        language_hook=get_provider_language_hook(),
         language_equals=get_language_equals(),
     )
 

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -354,9 +354,8 @@ class SZProviderPool(ProviderPool):
         """
         logger.debug("Languages requested: %r", languages)
 
-        if self.language_hook:
-            languages_search_base = self.language_hook(provider)
-        else:
+        languages_search_base = self.language_hook(provider) if self.language_hook else None
+        if languages_search_base is None:
             languages_search_base = languages
 
         # check video validity

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -354,9 +354,9 @@ class SZProviderPool(ProviderPool):
         """
         logger.debug("Languages requested: %r", languages)
 
-        languages_search_base = self.language_hook(provider) if self.language_hook else None
-        if languages_search_base is None:
-            languages_search_base = languages
+        excluded_languages = self.language_hook(provider) if self.language_hook else None
+        if excluded_languages is None:
+            excluded_languages = set()
 
         # check video validity
         if not provider_registry[provider].check(video):
@@ -364,10 +364,10 @@ class SZProviderPool(ProviderPool):
             return []
 
         # check whether we want to search this provider for the languages
-        use_languages = languages_search_base & languages
+        use_languages = languages - excluded_languages
         if not use_languages:
-            logger.info('Skipping provider %r: no language to search for (advanced: %r, requested: %r)', provider,
-                        languages_search_base, languages)
+            logger.info('Skipping provider %r: no language to search for (excluded: %r, requested: %r)', provider,
+                        excluded_languages, languages)
             return []
 
         # check supported languages

--- a/frontend/src/pages/Settings/Providers/components.tsx
+++ b/frontend/src/pages/Settings/Providers/components.tsx
@@ -116,6 +116,43 @@ const parseProviderPriorities = (
   return null;
 };
 
+const parseProviderLanguages = (
+  value: unknown,
+): Record<string, string[]> | null => {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parseProviderLanguages(parsed);
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  if (typeof value === "object" && !Array.isArray(value)) {
+    const out: Record<string, string[]> = {};
+    for (const [provider, languages] of Object.entries(value)) {
+      if (!Array.isArray(languages)) {
+        continue;
+      }
+      const valid = languages.filter(
+        (language): language is string => typeof language === "string",
+      );
+      if (valid.length > 0) {
+        out[provider] = valid;
+      }
+    }
+    return out;
+  }
+
+  return null;
+};
+
 const resolveProviderPriorities = (
   staged: LooseObject | undefined,
   settings: Settings | null,
@@ -129,6 +166,27 @@ const resolveProviderPriorities = (
 
   const fromSettings = parseProviderPriorities(
     settings?.general?.provider_priorities,
+  );
+  if (fromSettings) {
+    return { ...fromSettings };
+  }
+
+  return {};
+};
+
+const resolveProviderLanguages = (
+  staged: LooseObject | undefined,
+  settings: Settings | null,
+): Record<string, string[]> => {
+  const fromStaged = parseProviderLanguages(
+    staged?.["settings-general-provider_languages"],
+  );
+  if (fromStaged) {
+    return { ...fromStaged };
+  }
+
+  const fromSettings = parseProviderLanguages(
+    settings?.general?.provider_languages,
   );
   if (fromSettings) {
     return { ...fromSettings };
@@ -691,6 +749,7 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
 
   const [info, setInfo] = useState<Nullable<ProviderInfo>>(payload);
   const seededPriorities = resolveProviderPriorities(staged, settings);
+  const seededProviderLanguages = resolveProviderLanguages(staged, settings);
 
   const form = useForm<FormValues>({
     initialValues: {
@@ -698,6 +757,8 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
         ...staged,
         [`settings-general-provider_priorities-${info?.key}`]:
           seededPriorities[info?.key ?? ""] ?? 100,
+        [`settings-general-provider_languages-${info?.key}`]:
+          seededProviderLanguages[info?.key ?? ""] ?? [],
       },
       hooks: {},
     },
@@ -712,6 +773,11 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
       const priorityValue =
         resolveProviderPriorities(staged, settings)[info.key] ?? 100;
       form.setFieldValue(`settings.${priorityKey}`, priorityValue);
+
+      const languagesKey = `settings-general-provider_languages-${info.key}`;
+      const languageValue =
+        resolveProviderLanguages(staged, settings)[info.key] ?? [];
+      form.setFieldValue(`settings.${languagesKey}`, languageValue);
     }
   }, [info?.key]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -729,6 +795,15 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
         delete nextPriorities[payload.key];
         changes["settings-general-provider_priorities"] =
           JSON.stringify(nextPriorities);
+
+        if (settingsKey === "settings-general-enabled_providers") {
+          const providerLanguages = resolveProviderLanguages(staged, settings);
+          const nextProviderLanguages = { ...providerLanguages };
+          delete nextProviderLanguages[payload.key];
+          changes["settings-general-provider_languages"] = JSON.stringify(
+            nextProviderLanguages,
+          );
+        }
 
         onChangeRef.current(changes);
         onClose();
@@ -768,6 +843,28 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
         changes["settings-general-provider_priorities"] =
           JSON.stringify(priorities);
         delete changes[priorityKey];
+
+        if (settingsKey === "settings-general-enabled_providers") {
+          const languageKey = `settings-general-provider_languages-${info.key}`;
+          const providerLanguages = resolveProviderLanguages(
+            values.settings,
+            settings,
+          );
+          const selectedLanguages = values.settings[languageKey];
+
+          if (
+            Array.isArray(selectedLanguages) &&
+            selectedLanguages.length > 0
+          ) {
+            providerLanguages[info.key] = selectedLanguages;
+          } else {
+            delete providerLanguages[info.key];
+          }
+
+          changes["settings-general-provider_languages"] =
+            JSON.stringify(providerLanguages);
+          delete changes[languageKey];
+        }
 
         // Apply submit hooks
         runHooks(hooks, changes);
@@ -904,6 +1001,29 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
     return <Stack gap="xs">{elements}</Stack>;
   }, [info, form, form.values.settings]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const providerLanguageKey = info?.key
+    ? `settings-general-provider_languages-${info.key}`
+    : null;
+
+  const providerLanguageOptions = useMemo(() => {
+    if (!info || settingsKey !== "settings-general-enabled_providers") {
+      return [];
+    }
+
+    const shipped = getShippedMeta(info.key, info.inputs);
+    const languages = info.languages ?? shipped.languages;
+    const available = new Set(languages);
+    const options =
+      languages.length > 0
+        ? ALL_LANGUAGE_OPTIONS.filter((option) => available.has(option.code))
+        : ALL_LANGUAGE_OPTIONS;
+
+    return options.map((option) => ({
+      value: option.code,
+      label: option.name,
+    }));
+  }, [info, settingsKey]);
+
   const displayName =
     info?.name ?? (info?.key ? capitalize(info.key) : undefined);
 
@@ -996,6 +1116,36 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
                   {inputs}
                 </Stack>
               )}
+
+              {info &&
+                providerLanguageKey &&
+                settingsKey === "settings-general-enabled_providers" && (
+                  <Stack gap="xs">
+                    <MultiSelect
+                      label="Search languages"
+                      data={providerLanguageOptions}
+                      value={
+                        (form.values.settings[
+                          providerLanguageKey
+                        ] as string[]) ?? []
+                      }
+                      onChange={(value) =>
+                        form.setFieldValue(
+                          `settings.${providerLanguageKey}`,
+                          value,
+                        )
+                      }
+                      placeholder="All available languages"
+                      searchable
+                      clearable
+                      hidePickedOptions
+                      nothingFoundMessage="No matching language"
+                      maxDropdownHeight={240}
+                      comboboxProps={{ withinPortal: true }}
+                      leftSection={<FontAwesomeIcon icon={faLanguage} />}
+                    />
+                  </Stack>
+                )}
 
               {info?.message && (
                 <Stack gap="xs">

--- a/frontend/src/pages/Settings/Providers/components.tsx
+++ b/frontend/src/pages/Settings/Providers/components.tsx
@@ -116,7 +116,7 @@ const parseProviderPriorities = (
   return null;
 };
 
-const parseProviderLanguages = (
+const parseProviderLanguageExclusions = (
   value: unknown,
 ): Record<string, string[]> | null => {
   if (!value) {
@@ -127,7 +127,7 @@ const parseProviderLanguages = (
     try {
       const parsed = JSON.parse(value);
       if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        return parseProviderLanguages(parsed);
+        return parseProviderLanguageExclusions(parsed);
       }
     } catch {
       return null;
@@ -174,18 +174,18 @@ const resolveProviderPriorities = (
   return {};
 };
 
-const resolveProviderLanguages = (
+const resolveProviderLanguageExclusions = (
   staged: LooseObject | undefined,
   settings: Settings | null,
 ): Record<string, string[]> => {
-  const fromStaged = parseProviderLanguages(
+  const fromStaged = parseProviderLanguageExclusions(
     staged?.["settings-general-provider_languages"],
   );
   if (fromStaged) {
     return { ...fromStaged };
   }
 
-  const fromSettings = parseProviderLanguages(
+  const fromSettings = parseProviderLanguageExclusions(
     settings?.general?.provider_languages,
   );
   if (fromSettings) {
@@ -749,7 +749,10 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
 
   const [info, setInfo] = useState<Nullable<ProviderInfo>>(payload);
   const seededPriorities = resolveProviderPriorities(staged, settings);
-  const seededProviderLanguages = resolveProviderLanguages(staged, settings);
+  const seededProviderLanguageExclusions = resolveProviderLanguageExclusions(
+    staged,
+    settings,
+  );
 
   const form = useForm<FormValues>({
     initialValues: {
@@ -758,7 +761,7 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
         [`settings-general-provider_priorities-${info?.key}`]:
           seededPriorities[info?.key ?? ""] ?? 100,
         [`settings-general-provider_languages-${info?.key}`]:
-          seededProviderLanguages[info?.key ?? ""] ?? [],
+          seededProviderLanguageExclusions[info?.key ?? ""] ?? [],
       },
       hooks: {},
     },
@@ -776,7 +779,7 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
 
       const languagesKey = `settings-general-provider_languages-${info.key}`;
       const languageValue =
-        resolveProviderLanguages(staged, settings)[info.key] ?? [];
+        resolveProviderLanguageExclusions(staged, settings)[info.key] ?? [];
       form.setFieldValue(`settings.${languagesKey}`, languageValue);
     }
   }, [info?.key]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -797,11 +800,16 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
           JSON.stringify(nextPriorities);
 
         if (settingsKey === "settings-general-enabled_providers") {
-          const providerLanguages = resolveProviderLanguages(staged, settings);
-          const nextProviderLanguages = { ...providerLanguages };
-          delete nextProviderLanguages[payload.key];
+          const providerLanguageExclusions = resolveProviderLanguageExclusions(
+            staged,
+            settings,
+          );
+          const nextProviderLanguageExclusions = {
+            ...providerLanguageExclusions,
+          };
+          delete nextProviderLanguageExclusions[payload.key];
           changes["settings-general-provider_languages"] = JSON.stringify(
-            nextProviderLanguages,
+            nextProviderLanguageExclusions,
           );
         }
 
@@ -846,23 +854,24 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
 
         if (settingsKey === "settings-general-enabled_providers") {
           const languageKey = `settings-general-provider_languages-${info.key}`;
-          const providerLanguages = resolveProviderLanguages(
+          const providerLanguageExclusions = resolveProviderLanguageExclusions(
             values.settings,
             settings,
           );
-          const selectedLanguages = values.settings[languageKey];
+          const excludedLanguages = values.settings[languageKey];
 
           if (
-            Array.isArray(selectedLanguages) &&
-            selectedLanguages.length > 0
+            Array.isArray(excludedLanguages) &&
+            excludedLanguages.length > 0
           ) {
-            providerLanguages[info.key] = selectedLanguages;
+            providerLanguageExclusions[info.key] = excludedLanguages;
           } else {
-            delete providerLanguages[info.key];
+            delete providerLanguageExclusions[info.key];
           }
 
-          changes["settings-general-provider_languages"] =
-            JSON.stringify(providerLanguages);
+          changes["settings-general-provider_languages"] = JSON.stringify(
+            providerLanguageExclusions,
+          );
           delete changes[languageKey];
         }
 
@@ -1122,7 +1131,7 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
                 settingsKey === "settings-general-enabled_providers" && (
                   <Stack gap="xs">
                     <MultiSelect
-                      label="Search languages"
+                      label="Excluded languages"
                       data={providerLanguageOptions}
                       value={
                         (form.values.settings[
@@ -1135,7 +1144,7 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
                           value,
                         )
                       }
-                      placeholder="All available languages"
+                      placeholder="No languages excluded"
                       searchable
                       clearable
                       hidePickedOptions

--- a/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
@@ -341,6 +341,67 @@ describe("Settings > Providers (Provider Hub)", () => {
     ).toBeInTheDocument();
   });
 
+  it("stages per-provider language configuration from the provider drawer", async () => {
+    const updateRequest = vi.fn();
+    server.use(
+      http.get("/api/system/settings", () => {
+        return HttpResponse.json({
+          general: {
+            enabled_providers: ["opensubtitlescom"],
+            provider_priorities: {
+              opensubtitlescom: 10,
+            },
+            provider_languages: {},
+            use_provider_priority: true,
+          },
+          opensubtitlescom: {
+            username: "",
+            password: "",
+            use_hash: true,
+            include_ai_translated: false,
+            include_machine_translated: false,
+          },
+        });
+      }),
+      http.post("/api/system/settings", async ({ request }) => {
+        const data = await request.formData();
+        updateRequest(data.get("settings-general-provider_languages"));
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    customRender(<SettingsProvidersView />);
+
+    const panel = await screen.findByRole("tabpanel", {
+      name: /My Providers/i,
+    });
+    await userEvent.click(await within(panel).findByText("OpenSubtitles.com"));
+
+    const dialog = await screen.findByRole("dialog", {
+      name: /Provider settings/i,
+    });
+    const languageInput =
+      await within(dialog).findByLabelText("Search languages");
+
+    await userEvent.click(languageInput);
+    await userEvent.type(languageInput, "English");
+    await userEvent.click(await screen.findByText("English"));
+    await userEvent.clear(languageInput);
+    await userEvent.type(languageInput, "Bulgarian");
+    await userEvent.click(await screen.findByText("Bulgarian"));
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Save \d+ pending changes/i }),
+    );
+
+    await waitFor(() =>
+      expect(updateRequest).toHaveBeenCalledWith(
+        JSON.stringify({ opensubtitlescom: ["eng", "bul"] }),
+      ),
+    );
+  });
+
   it("preserves the trusted-source attribution when installing from catalog", async () => {
     const installRequest = vi.fn();
     server.use(

--- a/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
@@ -341,7 +341,7 @@ describe("Settings > Providers (Provider Hub)", () => {
     ).toBeInTheDocument();
   });
 
-  it("stages per-provider language configuration from the provider drawer", async () => {
+  it("stages per-provider excluded language configuration from the provider drawer", async () => {
     const updateRequest = vi.fn();
     server.use(
       http.get("/api/system/settings", () => {
@@ -381,7 +381,7 @@ describe("Settings > Providers (Provider Hub)", () => {
       name: /Provider settings/i,
     });
     const languageInput =
-      await within(dialog).findByLabelText("Search languages");
+      await within(dialog).findByLabelText("Excluded languages");
 
     await userEvent.click(languageInput);
     await userEvent.type(languageInput, "English");

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -81,6 +81,7 @@ declare namespace Settings {
     use_sonarr: boolean;
     utf8_encode: boolean;
     provider_priorities?: string;
+    provider_languages?: Record<string, string[]> | string;
     wanted_search_frequency: number;
     wanted_search_frequency_movie: number;
     use_external_webhook?: boolean;

--- a/tests/bazarr/test_app_get_providers.py
+++ b/tests/bazarr/test_app_get_providers.py
@@ -115,6 +115,80 @@ def test_get_language_equals_injected_settings_hi():
     assert result == [(Language("eng", hi=True), Language("eng"))]
 
 
+def test_get_provider_language_allowlist_parses_configured_languages():
+    config = get_providers.settings
+    original = getattr(config.general, "provider_languages", {})
+    config.set(
+        "general.provider_languages",
+        {
+            "opensubtitlescom": ["eng", "bul"],
+            "subsunacs": [],
+        },
+    )
+
+    try:
+        result = get_providers.get_provider_language_allowlist(config)
+    finally:
+        config.set("general.provider_languages", original)
+
+    assert result == {
+        "opensubtitlescom": {Language("eng"), Language("bul")},
+    }
+
+
+def test_get_provider_language_hook_returns_configured_allowlist():
+    config = get_providers.settings
+    original = getattr(config.general, "provider_languages", {})
+    config.set(
+        "general.provider_languages",
+        {
+            "opensubtitlescom": ["eng"],
+        },
+    )
+
+    try:
+        hook = get_providers.get_provider_language_hook(config)
+        result = hook("opensubtitlescom")
+        unrestricted = hook("subsunacs")
+    finally:
+        config.set("general.provider_languages", original)
+
+    assert result == {Language("eng")}
+    assert unrestricted is None
+
+
+def test_native_subtitle_pool_uses_provider_language_hook(monkeypatch):
+    from subtitles import pool as subtitle_pool
+
+    captured = {}
+
+    class CapturingPool:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(subtitle_pool, "provider_pool", lambda: CapturingPool)
+    monkeypatch.setattr(subtitle_pool, "get_providers_sorted", lambda: ["opensubtitlescom"])
+    monkeypatch.setattr(subtitle_pool, "get_providers_auth", lambda: {})
+    monkeypatch.setattr(subtitle_pool, "get_blacklist", lambda: [])
+    monkeypatch.setattr(subtitle_pool, "get_blacklist_movie", lambda: [])
+    monkeypatch.setattr(
+        subtitle_pool,
+        "get_ban_list",
+        lambda profile_id: {"must_contain": [], "must_not_contain": []},
+    )
+    monkeypatch.setattr(subtitle_pool, "get_language_equals", lambda: [])
+    monkeypatch.setattr(
+        subtitle_pool,
+        "get_provider_language_hook",
+        lambda: lambda provider: {Language("eng")},
+    )
+
+    subtitle_pool._init_pool("movie")
+
+    assert callable(captured["language_hook"])
+    assert captured["language_hook"]("opensubtitlescom") == {Language("eng")}
+
+
 def _get_error():
     try:
         raise ValueError("Some error" * 100)

--- a/tests/bazarr/test_app_get_providers.py
+++ b/tests/bazarr/test_app_get_providers.py
@@ -115,7 +115,7 @@ def test_get_language_equals_injected_settings_hi():
     assert result == [(Language("eng", hi=True), Language("eng"))]
 
 
-def test_get_provider_language_allowlist_parses_configured_languages():
+def test_get_provider_language_exclusions_parses_configured_languages():
     config = get_providers.settings
     original = getattr(config.general, "provider_languages", {})
     config.set(
@@ -127,7 +127,7 @@ def test_get_provider_language_allowlist_parses_configured_languages():
     )
 
     try:
-        result = get_providers.get_provider_language_allowlist(config)
+        result = get_providers.get_provider_language_exclusions(config)
     finally:
         config.set("general.provider_languages", original)
 
@@ -136,7 +136,7 @@ def test_get_provider_language_allowlist_parses_configured_languages():
     }
 
 
-def test_get_provider_language_hook_returns_configured_allowlist():
+def test_get_provider_language_hook_returns_configured_exclusions():
     config = get_providers.settings
     original = getattr(config.general, "provider_languages", {})
     config.set(

--- a/tests/compat/unit/test_provider_languages.py
+++ b/tests/compat/unit/test_provider_languages.py
@@ -1,0 +1,27 @@
+from subzero.language import Language
+
+
+def test_compat_pool_uses_provider_language_hook(monkeypatch):
+    from compat import service
+
+    captured = {}
+
+    class CapturingPool:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(service, "_compat_pool", None)
+    monkeypatch.setattr(service, "get_providers_sorted", lambda: ["opensubtitlescom"])
+    monkeypatch.setattr(service, "get_providers_auth", lambda: {})
+    monkeypatch.setattr(
+        service,
+        "get_provider_language_hook",
+        lambda: lambda provider: {Language("eng")},
+        raising=False,
+    )
+    monkeypatch.setattr("subliminal_patch.core.SZAsyncProviderPool", CapturingPool)
+
+    service._get_compat_pool()
+
+    assert callable(captured["language_hook"])
+    assert captured["language_hook"]("opensubtitlescom") == {Language("eng")}

--- a/tests/subliminal_patch/test_core.py
+++ b/tests/subliminal_patch/test_core.py
@@ -169,6 +169,40 @@ def test_language_equals_pool_intance_list_subtitles_return_nothing(movies):
     )
 
 
+def test_language_hook_none_keeps_requested_languages(monkeypatch, movies):
+    calls = []
+
+    class HookedProvider:
+        languages = {core.Language("eng"), core.Language("spa")}
+
+        @classmethod
+        def check(cls, video):
+            return True
+
+        def initialize(self):
+            pass
+
+        def list_subtitles(self, video, languages):
+            calls.append(languages)
+            return []
+
+    original = core.provider_registry.providers.copy()
+    core.provider_registry.providers.clear()
+    core.provider_registry.register("hooked", HookedProvider)
+
+    try:
+        pool = core.SZProviderPool(["hooked"], language_hook=lambda provider: None)
+        pool.list_subtitles(
+            movies["dune"],
+            {core.Language("eng"), core.Language("spa")},
+        )
+    finally:
+        core.provider_registry.providers.clear()
+        core.provider_registry.providers.update(original)
+
+    assert calls == [{core.Language("eng"), core.Language("spa")}]
+
+
 # ---- list_subtitles_prioritized: exhaustive flag behavior ----
 
 def _make_fake_subtitle(language):

--- a/tests/subliminal_patch/test_core.py
+++ b/tests/subliminal_patch/test_core.py
@@ -203,6 +203,43 @@ def test_language_hook_none_keeps_requested_languages(monkeypatch, movies):
     assert calls == [{core.Language("eng"), core.Language("spa")}]
 
 
+def test_language_hook_excludes_configured_languages(monkeypatch, movies):
+    calls = []
+
+    class HookedProvider:
+        languages = {core.Language("eng"), core.Language("spa")}
+
+        @classmethod
+        def check(cls, video):
+            return True
+
+        def initialize(self):
+            pass
+
+        def list_subtitles(self, video, languages):
+            calls.append(languages)
+            return []
+
+    original = core.provider_registry.providers.copy()
+    core.provider_registry.providers.clear()
+    core.provider_registry.register("hooked", HookedProvider)
+
+    try:
+        pool = core.SZProviderPool(
+            ["hooked"],
+            language_hook=lambda provider: {core.Language("eng")},
+        )
+        pool.list_subtitles(
+            movies["dune"],
+            {core.Language("eng"), core.Language("spa")},
+        )
+    finally:
+        core.provider_registry.providers.clear()
+        core.provider_registry.providers.update(original)
+
+    assert calls == [{core.Language("spa")}]
+
+
 # ---- list_subtitles_prioritized: exhaustive flag behavior ----
 
 def _make_fake_subtitle(language):


### PR DESCRIPTION
https://bazarr.featureupvote.com/suggestions/78910/per-provider-language

## Summary
- add per-provider language exclusion settings in the provider drawer
- apply exclusions to native and compat provider pools before provider queries
- keep `general.provider_languages` as the stored config key, now interpreted as excluded languages

## Validation
- `pytest -q tests/bazarr/test_app_get_providers.py tests/compat/unit/test_provider_languages.py tests/subliminal_patch/test_core.py::test_language_hook_none_keeps_requested_languages tests/subliminal_patch/test_core.py::test_language_hook_excludes_configured_languages`
- `ruff check bazarr/app/get_providers.py custom_libs/subliminal_patch/core.py bazarr/subtitles/pool.py bazarr/compat/service.py tests/bazarr/test_app_get_providers.py tests/compat/unit/test_provider_languages.py tests/subliminal_patch/test_core.py`
- `npm run test -- --run src/pages/Settings/Providers/hub/__tests__/hub.test.tsx`
- `npm run check:ts`
- `npm run build`
- validated on `bazarr-ui-test`: backend hook exclusions, provider pool exclusion behavior, served frontend bundle text, and compat Matrix Hungarian search excluding OpenSubtitles/OpenSubtitles.com/SubtitleCat