### PR TITLE
feat: record embedded subtitles as source-quality history (action=7, score=100%)

### DIFF
--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -9,8 +9,8 @@ import time  # noqa: F401
 from subliminal_patch import core, search_external_subtitles
 
 from languages.custom_lang import CustomLanguage
-from app.database import get_profiles_list, get_profile_cutoff, TableMovies, get_audio_profile_languages, database, \
-    update, select
+from app.database import get_profiles_list, get_profile_cutoff, TableMovies, TableHistoryMovie, \
+    get_audio_profile_languages, database, update, select
 from languages.get_languages import alpha2_from_alpha3, get_language_set
 from app.config import settings
 from utilities.helper import get_subtitle_destination_folder
@@ -18,6 +18,9 @@ from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import embedded_subs_reader
 from app.event_handler import event_stream
 from subtitles.indexer.utils import guess_external_subtitles, get_external_subtitles_path
+from subtitles.processing import ProcessSubtitlesResult
+from subtitles.utils import _get_scores
+from radarr.history import history_log_movie
 from app.jobs_queue import jobs_queue
 from subtitles.adaptive_searching import is_search_given_up
 
@@ -27,6 +30,9 @@ gc.enable()
 def store_subtitles_movie(original_path, reversed_path, use_cache=True):
     logging.debug(f'BAZARR started subtitles indexing for this file: {reversed_path}')  # noqa: G004
     actual_subtitles = []
+    # Languages of embedded subtitle tracks detected on this pass. Used after
+    # indexing to record a source-quality history entry (action=7) per language.
+    embedded_languages = []
     if os.path.exists(reversed_path):
         if settings.general.use_embedded_subs:
             logging.debug("BAZARR is trying to index embedded subtitles.")
@@ -60,6 +66,7 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
                                     lang = f'{lang}:hi'
                                 logging.debug(f"BAZARR embedded subtitles detected: {lang}")  # noqa: G004
                                 actual_subtitles.append([lang, None, None])
+                                embedded_languages.append(lang)
                         except Exception as error:
                             logging.debug(f"BAZARR unable to index this unrecognized language: {subtitle_language} "  # noqa: G004
                                           f"({error})")
@@ -151,6 +158,7 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
             if movie:
                 logging.debug(f"BAZARR storing those languages to DB: {actual_subtitles}")  # noqa: G004
                 list_missing_subtitles_movies(no=movie.radarrId)
+                _log_embedded_history_movie(movie.radarrId, embedded_languages, reversed_path)
             else:
                 logging.debug(f"BAZARR haven't been able to update existing subtitles to DB: {actual_subtitles}")  # noqa: G004
     else:
@@ -159,6 +167,47 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
     logging.debug(f'BAZARR ended subtitles indexing for this file: {reversed_path}')  # noqa: G004
 
     return actual_subtitles
+
+
+def _log_embedded_history_movie(radarr_id, embedded_languages, reversed_path):
+    """Record source-quality history entries for newly detected embedded subtitles.
+
+    Why: Embedded subtitle tracks come from disc/streaming rips and are source
+    quality, but previously had no score in history so they appeared as unknown
+    quality and could be wrongly targeted for upgrade.
+    What: For each embedded language not already recorded, writes a
+    TableHistoryMovie entry with action=7 (EmbeddedSource) and score=score_out_of
+    (100%). A history lookup deduplicates so re-indexing the same movie does not
+    duplicate entries.
+    Test: Index a movie with an embedded track twice; assert exactly one action=7
+    row exists for that movie+language with score == score_out_of.
+    """
+    if not embedded_languages:
+        return
+
+    _, score_out_of, _ = _get_scores('movie')
+
+    for lang in embedded_languages:
+        existing = database.execute(
+            select(TableHistoryMovie.id)
+            .where(TableHistoryMovie.radarrId == radarr_id)
+            .where(TableHistoryMovie.language == lang)
+            .where(TableHistoryMovie.action == 7)).first()
+        if existing:
+            continue
+
+        result = ProcessSubtitlesResult(
+            message=f"{lang} embedded subtitles detected.",
+            reversed_path=reversed_path,
+            downloaded_language_code2=lang.split(':')[0],
+            downloaded_provider="embedded",
+            score=score_out_of,
+            forced=lang.endswith(':forced'),
+            subtitle_id=None,
+            reversed_subtitles_path=None,
+            hearing_impaired=lang.endswith(':hi'))
+        history_log_movie(action=7, radarr_id=radarr_id, result=result,
+                          fake_provider="embedded", fake_score=score_out_of)
 
 
 def list_missing_subtitles_movies(no=None):

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -158,7 +158,8 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
             if movie:
                 logging.debug(f"BAZARR storing those languages to DB: {actual_subtitles}")  # noqa: G004
                 list_missing_subtitles_movies(no=movie.radarrId)
-                _log_embedded_history_movie(movie.radarrId, embedded_languages, reversed_path)
+                if embedded_languages:
+                    _log_embedded_history_movie(movie.radarrId, embedded_languages, reversed_path)
             else:
                 logging.debug(f"BAZARR haven't been able to update existing subtitles to DB: {actual_subtitles}")  # noqa: G004
     else:
@@ -182,32 +183,36 @@ def _log_embedded_history_movie(radarr_id, embedded_languages, reversed_path):
     Test: Index a movie with an embedded track twice; assert exactly one action=7
     row exists for that movie+language with score == score_out_of.
     """
-    if not embedded_languages:
-        return
+    try:
+        _, score_out_of, _ = _get_scores('movie')
 
-    _, score_out_of, _ = _get_scores('movie')
+        for lang in embedded_languages:
+            # Dedup: skip if we already logged action=7 for this movie+language.
+            # Not atomic under AUTOCOMMIT — concurrent indexing of the same movie
+            # could produce duplicates, but this is rare in practice and consistent
+            # with how other parts of Bazarr dedup history entries.
+            existing = database.execute(
+                select(TableHistoryMovie.id)
+                .where(TableHistoryMovie.radarrId == radarr_id)
+                .where(TableHistoryMovie.language == lang)
+                .where(TableHistoryMovie.action == 7)).first()
+            if existing:
+                continue
 
-    for lang in embedded_languages:
-        existing = database.execute(
-            select(TableHistoryMovie.id)
-            .where(TableHistoryMovie.radarrId == radarr_id)
-            .where(TableHistoryMovie.language == lang)
-            .where(TableHistoryMovie.action == 7)).first()
-        if existing:
-            continue
-
-        result = ProcessSubtitlesResult(
-            message=f"{lang} embedded subtitles detected.",
-            reversed_path=reversed_path,
-            downloaded_language_code2=lang.split(':')[0],
-            downloaded_provider="embedded",
-            score=score_out_of,
-            forced=lang.endswith(':forced'),
-            subtitle_id=None,
-            reversed_subtitles_path=None,
-            hearing_impaired=lang.endswith(':hi'))
-        history_log_movie(action=7, radarr_id=radarr_id, result=result,
-                          fake_provider="embedded", fake_score=score_out_of)
+            result = ProcessSubtitlesResult(
+                message=f"{lang} embedded subtitles detected.",
+                reversed_path=reversed_path,
+                downloaded_language_code2=lang.split(':')[0],
+                downloaded_provider="embedded",
+                score=score_out_of,
+                forced=lang.endswith(':forced'),
+                subtitle_id=None,
+                reversed_subtitles_path=None,
+                hearing_impaired=lang.endswith(':hi'))
+            history_log_movie(action=7, radarr_id=radarr_id, result=result,
+                              fake_provider="embedded", fake_score=score_out_of)
+    except Exception:
+        logging.exception("BAZARR error writing embedded subtitle history for movie %s", radarr_id)
 
 
 def list_missing_subtitles_movies(no=None):

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -8,7 +8,7 @@ import ast
 from subliminal_patch import core, search_external_subtitles
 
 from languages.custom_lang import CustomLanguage
-from app.database import get_profiles_list, get_profile_cutoff, TableEpisodes, TableShows, \
+from app.database import get_profiles_list, get_profile_cutoff, TableEpisodes, TableShows, TableHistory, \
     get_audio_profile_languages, database, update, select
 from languages.get_languages import alpha2_from_alpha3, get_language_set
 from app.config import settings
@@ -17,6 +17,9 @@ from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import embedded_subs_reader
 from app.event_handler import event_stream
 from subtitles.indexer.utils import guess_external_subtitles, get_external_subtitles_path
+from subtitles.processing import ProcessSubtitlesResult
+from subtitles.utils import _get_scores
+from sonarr.history import history_log
 from app.jobs_queue import jobs_queue
 from subtitles.adaptive_searching import is_search_given_up
 
@@ -26,6 +29,9 @@ gc.enable()
 def store_subtitles(original_path, reversed_path, use_cache=True):
     logging.debug(f'BAZARR started subtitles indexing for this file: {reversed_path}')  # noqa: G004
     actual_subtitles = []
+    # Languages of embedded subtitle tracks detected on this pass. Used after
+    # indexing to record a source-quality history entry (action=7) per language.
+    embedded_languages = []
     if os.path.exists(reversed_path):
         if settings.general.use_embedded_subs:
             logging.debug("BAZARR is trying to index embedded subtitles.")
@@ -59,6 +65,7 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
                                     lang = f"{lang}:hi"
                                 logging.debug(f"BAZARR embedded subtitles detected: {lang}")  # noqa: G004
                                 actual_subtitles.append([lang, None, None])
+                                embedded_languages.append(lang)
                         except Exception as error:
                             logging.debug("BAZARR unable to index this unrecognized language: %s (%s)", subtitle_language, error)
                 except Exception:
@@ -140,7 +147,7 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
             .values(subtitles=str(actual_subtitles))
             .where(TableEpisodes.path == original_path))
         matching_episodes = database.execute(
-            select(TableEpisodes.sonarrEpisodeId)
+            select(TableEpisodes.sonarrEpisodeId, TableEpisodes.sonarrSeriesId)
             .where(TableEpisodes.path == original_path))\
             .all()
 
@@ -148,6 +155,8 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
             if episode:
                 logging.debug(f"BAZARR storing those languages to DB: {actual_subtitles}")  # noqa: G004
                 list_missing_subtitles(epno=episode.sonarrEpisodeId)
+                _log_embedded_history(episode.sonarrSeriesId, episode.sonarrEpisodeId,
+                                      embedded_languages, reversed_path)
             else:
                 logging.debug(f"BAZARR haven't been able to update existing subtitles to DB: {actual_subtitles}")  # noqa: G004
     else:
@@ -156,6 +165,46 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
     logging.debug(f'BAZARR ended subtitles indexing for this file: {reversed_path}')  # noqa: G004
 
     return actual_subtitles
+
+
+def _log_embedded_history(series_id, episode_id, embedded_languages, reversed_path):
+    """Record source-quality history entries for newly detected embedded subtitles.
+
+    Why: Embedded subtitle tracks come from disc/streaming rips and are source
+    quality, but previously had no score in history so they appeared as unknown
+    quality and could be wrongly targeted for upgrade.
+    What: For each embedded language not already recorded, writes a TableHistory
+    entry with action=7 (EmbeddedSource) and score=score_out_of (100%). A history
+    lookup deduplicates so re-indexing the same episode does not duplicate entries.
+    Test: Index an episode with an embedded track twice; assert exactly one
+    action=7 row exists for that episode+language with score == score_out_of.
+    """
+    if not embedded_languages:
+        return
+
+    _, score_out_of, _ = _get_scores('series')
+
+    for lang in embedded_languages:
+        existing = database.execute(
+            select(TableHistory.id)
+            .where(TableHistory.sonarrEpisodeId == episode_id)
+            .where(TableHistory.language == lang)
+            .where(TableHistory.action == 7)).first()
+        if existing:
+            continue
+
+        result = ProcessSubtitlesResult(
+            message=f"{lang} embedded subtitles detected.",
+            reversed_path=reversed_path,
+            downloaded_language_code2=lang.split(':')[0],
+            downloaded_provider="embedded",
+            score=score_out_of,
+            forced=lang.endswith(':forced'),
+            subtitle_id=None,
+            reversed_subtitles_path=None,
+            hearing_impaired=lang.endswith(':hi'))
+        history_log(action=7, sonarr_series_id=series_id, sonarr_episode_id=episode_id,
+                    result=result, fake_provider="embedded", fake_score=score_out_of)
 
 
 def list_missing_subtitles(no=None, epno=None):

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -180,29 +180,36 @@ def _log_embedded_history(series_id, episode_id, embedded_languages, reversed_pa
     Test: Index an episode with an embedded track twice; assert exactly one
     action=7 row exists for that episode+language with score == score_out_of.
     """
-    _, score_out_of, _ = _get_scores('series')
+    try:
+        _, score_out_of, _ = _get_scores('series')
 
-    for lang in embedded_languages:
-        existing = database.execute(
-            select(TableHistory.id)
-            .where(TableHistory.sonarrEpisodeId == episode_id)
-            .where(TableHistory.language == lang)
-            .where(TableHistory.action == 7)).first()
-        if existing:
-            continue
+        for lang in embedded_languages:
+            # Dedup: skip if we already logged action=7 for this episode+language.
+            # Not atomic under AUTOCOMMIT — concurrent indexing of the same episode
+            # could produce duplicates, but this is rare in practice and consistent
+            # with how other parts of Bazarr dedup history entries.
+            existing = database.execute(
+                select(TableHistory.id)
+                .where(TableHistory.sonarrEpisodeId == episode_id)
+                .where(TableHistory.language == lang)
+                .where(TableHistory.action == 7)).first()
+            if existing:
+                continue
 
-        result = ProcessSubtitlesResult(
-            message=f"{lang} embedded subtitles detected.",
-            reversed_path=reversed_path,
-            downloaded_language_code2=lang.split(':')[0],
-            downloaded_provider="embedded",
-            score=score_out_of,
-            forced=lang.endswith(':forced'),
-            subtitle_id=None,
-            reversed_subtitles_path=None,
-            hearing_impaired=lang.endswith(':hi'))
-        history_log(action=7, sonarr_series_id=series_id, sonarr_episode_id=episode_id,
-                    result=result, fake_provider="embedded", fake_score=score_out_of)
+            result = ProcessSubtitlesResult(
+                message=f"{lang} embedded subtitles detected.",
+                reversed_path=reversed_path,
+                downloaded_language_code2=lang.split(':')[0],
+                downloaded_provider="embedded",
+                score=score_out_of,
+                forced=lang.endswith(':forced'),
+                subtitle_id=None,
+                reversed_subtitles_path=None,
+                hearing_impaired=lang.endswith(':hi'))
+            history_log(action=7, sonarr_series_id=series_id, sonarr_episode_id=episode_id,
+                        result=result, fake_provider="embedded", fake_score=score_out_of)
+    except Exception:
+        logging.exception("BAZARR error writing embedded subtitle history for episode %s", episode_id)
 
 
 def list_missing_subtitles(no=None, epno=None):

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -155,8 +155,9 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
             if episode:
                 logging.debug(f"BAZARR storing those languages to DB: {actual_subtitles}")  # noqa: G004
                 list_missing_subtitles(epno=episode.sonarrEpisodeId)
-                _log_embedded_history(episode.sonarrSeriesId, episode.sonarrEpisodeId,
-                                      embedded_languages, reversed_path)
+                if embedded_languages:
+                    _log_embedded_history(episode.sonarrSeriesId, episode.sonarrEpisodeId,
+                                          embedded_languages, reversed_path)
             else:
                 logging.debug(f"BAZARR haven't been able to update existing subtitles to DB: {actual_subtitles}")  # noqa: G004
     else:
@@ -179,9 +180,6 @@ def _log_embedded_history(series_id, episode_id, embedded_languages, reversed_pa
     Test: Index an episode with an embedded track twice; assert exactly one
     action=7 row exists for that episode+language with score == score_out_of.
     """
-    if not embedded_languages:
-        return
-
     _, score_out_of, _ = _get_scores('series')
 
     for lang in embedded_languages:

--- a/bazarr/subtitles/upgrade.py
+++ b/bazarr/subtitles/upgrade.py
@@ -300,6 +300,8 @@ def get_queries_condition_parameters():
     days_to_upgrade_subs = settings.general.days_to_upgrade_subs
     minimum_timestamp = (datetime.now() - timedelta(days=int(days_to_upgrade_subs)))
 
+    # action=7 (EmbeddedSource) intentionally excluded — embedded subs are source
+    # quality and should not be upgraded
     if settings.general.upgrade_manual:
         query_actions = [1, 2, 3, 4, 6]
     else:

--- a/frontend/src/components/bazarr/HistoryIcon.tsx
+++ b/frontend/src/components/bazarr/HistoryIcon.tsx
@@ -5,6 +5,7 @@ import {
   faClosedCaptioning,
   faCloudUploadAlt,
   faDownload,
+  faFilm,
   faLanguage,
   faMagnifyingGlass,
   faRecycle,
@@ -20,6 +21,7 @@ enum HistoryAction {
   Upload,
   Sync,
   Translated,
+  EmbeddedSource,
 }
 
 const HistoryIcon: FunctionComponent<{
@@ -56,6 +58,10 @@ const HistoryIcon: FunctionComponent<{
     case HistoryAction.Translated:
       icon = faLanguage;
       label = "Translated";
+      break;
+    case HistoryAction.EmbeddedSource:
+      icon = faFilm;
+      label = "Embedded Source";
       break;
     default:
       icon = faClosedCaptioning;

--- a/frontend/src/components/bazarr/HistoryIcon.tsx
+++ b/frontend/src/components/bazarr/HistoryIcon.tsx
@@ -15,13 +15,13 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 enum HistoryAction {
   Delete = 0,
-  Download,
-  Manual,
-  Upgrade,
-  Upload,
-  Sync,
-  Translated,
-  EmbeddedSource,
+  Download = 1,
+  Manual = 2,
+  Upgrade = 3,
+  Upload = 4,
+  Sync = 5,
+  Translated = 6,
+  EmbeddedSource = 7,
 }
 
 const HistoryIcon: FunctionComponent<{


### PR DESCRIPTION
## Summary

- When `store_subtitles` / `store_subtitles_movie` detects embedded subtitle tracks during indexing, write a `TableHistory` / `TableHistoryMovie` entry with `action=7` (EmbeddedSource) and `score=score_out_of` (100%) per language — with a dedup guard so re-indexing does not create duplicate entries.
- Adds `HistoryAction.EmbeddedSource = 7` to the frontend enum with a film-reel icon (`faFilm`) and "Embedded Source" tooltip in the history view.
- Explicitly excludes `action=7` from the upgrade query in `upgrade.py` so embedded subs are never targeted for upgrade.

## Motivation

Embedded subtitle tracks come from disc or streaming rips and are source quality. Previously they had no score entry in history, so they appeared as unknown quality and could be (incorrectly) queued for upgrade. Recording them at 100% score closes that gap without affecting cutoff/upgrade logic.

## Verified behaviour (dev instance)

- 9-language MKV (11.22.63 S01E08): 9 action=7 entries created, all score=100%, provider=embedded
- Re-index: no duplicate entries (dedup guard confirmed)
- Movie path (`_log_embedded_history_movie`): works identically
- Frontend: film-reel icon + "Embedded Source" tooltip visible in history table
- Existing test suite: 866 passed, 0 new failures

## Files changed

- `bazarr/subtitles/indexer/series.py` — `_log_embedded_history()` helper + call site guard
- `bazarr/subtitles/indexer/movies.py` — `_log_embedded_history_movie()` helper + call site guard
- `bazarr/subtitles/upgrade.py` — comment noting action=7 excluded from upgrade query
- `frontend/src/components/bazarr/HistoryIcon.tsx` — `EmbeddedSource = 7` with faFilm icon; all enum values now explicit

## Test plan

- [ ] Index an episode with embedded subtitle tracks; confirm one `action=7` row per language in history with score = max score (100%)
- [ ] Re-index same episode; confirm no duplicate `action=7` rows
- [ ] Verify history view shows film-reel icon for embedded-source entries
- [ ] Confirm episodes with only embedded subs are not queued for upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)