### PR TITLE
Fix auto-translate media type and variant matching

### DIFF
--- a/bazarr/subtitles/language_profiles.py
+++ b/bazarr/subtitles/language_profiles.py
@@ -1,0 +1,30 @@
+# coding=utf-8
+
+
+def profile_item_language_code(item):
+    language = item.get('language')
+    if not language:
+        return None
+    if item.get('forced') == 'True':
+        return f'{language}:forced'
+    if item.get('hi') == 'True':
+        return f'{language}:hi'
+    return language
+
+
+def build_translate_from_map(profile):
+    translate_from_map = {}
+    if not profile:
+        return translate_from_map
+
+    for item in profile.get('items', []):
+        source = item.get('translate_from')
+        target = profile_item_language_code(item)
+        if source and target:
+            translate_from_map[target] = {
+                'from': source,
+                'hi': item.get('hi') == 'True',
+                'forced': item.get('forced') == 'True',
+            }
+
+    return translate_from_map

--- a/bazarr/subtitles/processing.py
+++ b/bazarr/subtitles/processing.py
@@ -18,6 +18,7 @@ from app.event_handler import event_stream
 from .utils import _get_download_code3
 from .post_processing import postprocessing
 from .utils import _get_scores
+from .language_profiles import profile_item_language_code
 
 
 class ProcessSubtitlesResult:
@@ -118,11 +119,11 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
             if target_lang == downloaded_lang:
                 continue
 
-            target_codes = {target_lang, f'{target_lang}:hi', f'{target_lang}:forced'}
-            if not (missing_codes & target_codes):
+            target_code = profile_item_language_code(item)
+            if target_code not in missing_codes:
                 logging.debug(
                     'BAZARR auto-translate skipped: %s already satisfied for %s',
-                    target_lang, video_path,
+                    target_code, video_path,
                 )
                 continue
 
@@ -130,7 +131,7 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
                 'BAZARR auto-translate queuing %s -> %s for %s',
                 downloaded_lang, target_lang, video_path,
             )
-            translate_media_type = 'series' if media_type == 'series' else 'movies'
+            translate_media_type = 'episode' if media_type == 'series' else 'movies'
             translate_subtitles_file(
                 video_path=video_path,
                 source_srt_file=subtitle_path,

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -21,6 +21,7 @@ from subliminal_patch.score import MAX_SCORES
 
 from ..adaptive_searching import is_search_active, updateFailedAttempts
 from ..download import generate_subtitles
+from ..language_profiles import build_translate_from_map
 from .utils import _find_existing_subtitle_path
 
 
@@ -32,16 +33,7 @@ def _wanted_movie(movie, providers_list, job_id=None):
         audio_language = 'None'
 
     profile = get_profiles_list(profile_id=movie.profileId) if movie.profileId else None
-    translate_from_map = {}
-    if profile:
-        for prof_item in profile.get('items', []):
-            src = prof_item.get('translate_from')
-            if src:
-                translate_from_map[prof_item.get('language')] = {
-                    'from': src,
-                    'hi': prof_item.get('hi') == 'True',
-                    'forced': prof_item.get('forced') == 'True',
-                }
+    translate_from_map = build_translate_from_map(profile)
 
     languages = []
     languages_to_stamp = []
@@ -50,7 +42,7 @@ def _wanted_movie(movie, providers_list, job_id=None):
     for language in ast.literal_eval(movie.missing_subtitles):
         lang_code = language.split(':')[0]
 
-        translate_cfg = translate_from_map.get(lang_code)
+        translate_cfg = translate_from_map.get(language)
         if translate_cfg:
             source_srt = _find_existing_subtitle_path(
                 movie.subtitles,
@@ -91,7 +83,7 @@ def _wanted_movie(movie, providers_list, job_id=None):
                     already_translated = database.execute(
                         select(TableHistoryMovie.id)
                         .where(TableHistoryMovie.radarrId == movie.radarrId)
-                        .where(TableHistoryMovie.language.like(f"{lang_code}%"))
+                        .where(TableHistoryMovie.language == language)
                         .where(TableHistoryMovie.action == 6)
                         .limit(1)
                     ).first()
@@ -104,8 +96,8 @@ def _wanted_movie(movie, providers_list, job_id=None):
                             source_srt_file=source_srt,
                             from_lang=translate_cfg['from'],
                             to_lang=lang_code,
-                            forced=language.endswith(':forced') or translate_cfg['forced'],
-                            hi=language.endswith(':hi') or translate_cfg['hi'],
+                            forced=translate_cfg['forced'],
+                            hi=translate_cfg['hi'],
                             media_type='movies',
                             sonarr_series_id=None,
                             sonarr_episode_id=None,

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -22,6 +22,7 @@ from subliminal_patch.score import MAX_SCORES
 
 from ..adaptive_searching import is_search_active, updateFailedAttempts
 from ..download import generate_subtitles
+from ..language_profiles import build_translate_from_map
 from .utils import _find_existing_subtitle_path
 
 
@@ -33,16 +34,7 @@ def _wanted_episode(episode, providers_list, job_id=None):
         audio_language = 'None'
 
     profile = get_profiles_list(profile_id=episode.profileId) if episode.profileId else None
-    translate_from_map = {}
-    if profile:
-        for prof_item in profile.get('items', []):
-            src = prof_item.get('translate_from')
-            if src:
-                translate_from_map[prof_item.get('language')] = {
-                    'from': src,
-                    'hi': prof_item.get('hi') == 'True',
-                    'forced': prof_item.get('forced') == 'True',
-                }
+    translate_from_map = build_translate_from_map(profile)
 
     languages = []
     languages_to_stamp = []
@@ -51,7 +43,7 @@ def _wanted_episode(episode, providers_list, job_id=None):
     for language in ast.literal_eval(episode.missing_subtitles):
         lang_code = language.split(':')[0]
 
-        translate_cfg = translate_from_map.get(lang_code)
+        translate_cfg = translate_from_map.get(language)
         if translate_cfg:
             source_srt = _find_existing_subtitle_path(
                 episode.subtitles,
@@ -92,7 +84,7 @@ def _wanted_episode(episode, providers_list, job_id=None):
                     already_translated = database.execute(
                         select(TableHistory.id)
                         .where(TableHistory.sonarrEpisodeId == episode.sonarrEpisodeId)
-                        .where(TableHistory.language.like(f"{lang_code}%"))
+                        .where(TableHistory.language == language)
                         .where(TableHistory.action == 6)
                         .limit(1)
                     ).first()
@@ -105,9 +97,9 @@ def _wanted_episode(episode, providers_list, job_id=None):
                             source_srt_file=source_srt,
                             from_lang=translate_cfg['from'],
                             to_lang=lang_code,
-                            forced=language.endswith(':forced') or translate_cfg['forced'],
-                            hi=language.endswith(':hi') or translate_cfg['hi'],
-                            media_type='series',
+                            forced=translate_cfg['forced'],
+                            hi=translate_cfg['hi'],
+                            media_type='episode',
                             sonarr_series_id=episode.sonarrSeriesId,
                             sonarr_episode_id=episode.sonarrEpisodeId,
                             radarr_id=None,

--- a/tests/bazarr/test_auto_translation_profile.py
+++ b/tests/bazarr/test_auto_translation_profile.py
@@ -1,0 +1,146 @@
+# coding=utf-8
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _missing_language(alpha3, hi=False, forced=False):
+    return SimpleNamespace(alpha3=alpha3, hi=hi, forced=forced)
+
+
+def test_downloaded_series_subtitle_queues_episode_translation():
+    from subtitles.processing import _trigger_auto_translation
+
+    with (
+        patch('subtitles.processing.settings') as mock_settings,
+        patch('app.database.get_profile_id', return_value=1),
+        patch('app.database.get_profiles_list') as mock_profiles,
+        patch('subtitles.download.check_missing_languages') as mock_missing,
+        patch('subtitles.processing.alpha2_from_alpha3', return_value='hu'),
+        patch('subtitles.tools.translate.main.translate_subtitles_file') as mock_translate,
+    ):
+        mock_settings.translator.min_source_score = 0
+        mock_profiles.return_value = {
+            'items': [
+                {
+                    'language': 'hu',
+                    'translate_from': 'en',
+                    'forced': 'False',
+                    'hi': 'False',
+                }
+            ]
+        }
+        mock_missing.return_value = [_missing_language('hun')]
+
+        _trigger_auto_translation(
+            downloaded_lang='en',
+            subtitle_path='/subs/source.en.srt',
+            video_path='/video/episode.mkv',
+            media_type='series',
+            series_id=10,
+            episode_id=20,
+            source_score_percent=100,
+        )
+
+    mock_translate.assert_called_once()
+    assert mock_translate.call_args.kwargs['media_type'] == 'episode'
+
+
+def test_downloaded_subtitle_does_not_translate_for_mismatched_target_variant():
+    from subtitles.processing import _trigger_auto_translation
+
+    with (
+        patch('subtitles.processing.settings') as mock_settings,
+        patch('app.database.get_profile_id', return_value=1),
+        patch('app.database.get_profiles_list') as mock_profiles,
+        patch('subtitles.download.check_missing_languages') as mock_missing,
+        patch('subtitles.processing.alpha2_from_alpha3', return_value='hu'),
+        patch('subtitles.tools.translate.main.translate_subtitles_file') as mock_translate,
+    ):
+        mock_settings.translator.min_source_score = 0
+        mock_profiles.return_value = {
+            'items': [
+                {
+                    'language': 'hu',
+                    'translate_from': 'en',
+                    'forced': 'True',
+                    'hi': 'False',
+                }
+            ]
+        }
+        mock_missing.return_value = [_missing_language('hun')]
+
+        _trigger_auto_translation(
+            downloaded_lang='en',
+            subtitle_path='/subs/source.en.srt',
+            video_path='/video/movie.mkv',
+            media_type='movie',
+            radarr_id=30,
+            source_score_percent=100,
+        )
+
+    mock_translate.assert_not_called()
+
+
+def test_wanted_series_translation_uses_exact_profile_variant():
+    from subtitles.wanted.series import _wanted_episode
+
+    episode = SimpleNamespace(
+        audio_language='English',
+        failedAttempts='[]',
+        missing_subtitles="['hu:forced']",
+        path='/series/episode.mkv',
+        profileId=1,
+        sceneName='Scene.Name',
+        sonarrEpisodeId=20,
+        sonarrSeriesId=10,
+        subtitles="[['en', '/subs/source.en.srt', 100], ['fr', '/subs/source.fr.srt', 100]]",
+        title='Episode title',
+    )
+
+    def source_path(_subtitles, source_lang, path_replace_fn=None):
+        return f'/subs/source.{source_lang}.srt'
+
+    with (
+        patch('subtitles.wanted.series.get_audio_profile_languages',
+              return_value=[{'name': 'English'}]),
+        patch('subtitles.wanted.series.get_profiles_list') as mock_profiles,
+        patch('subtitles.wanted.series._find_existing_subtitle_path',
+              side_effect=source_path),
+        patch('subtitles.wanted.series.path_mappings') as mock_path_mappings,
+        patch('subtitles.wanted.series.settings') as mock_settings,
+        patch('subtitles.wanted.series.database') as mock_database,
+        patch('subtitles.wanted.series.jobs_queue') as mock_jobs_queue,
+        patch('subtitles.tools.translate.main.translate_subtitles_file') as mock_translate,
+        patch('subtitles.wanted.series.generate_subtitles', return_value=[]),
+    ):
+        mock_profiles.return_value = {
+            'items': [
+                {
+                    'language': 'hu',
+                    'translate_from': 'fr',
+                    'forced': 'True',
+                    'hi': 'False',
+                },
+                {
+                    'language': 'hu',
+                    'translate_from': 'en',
+                    'forced': 'False',
+                    'hi': 'False',
+                },
+            ]
+        }
+        mock_path_mappings.path_replace.side_effect = lambda value: value
+        mock_settings.translator.min_source_score = 0
+        mock_database.execute.return_value.first.side_effect = [None, None]
+        mock_jobs_queue._is_an_existing_job.return_value = False
+
+        _wanted_episode(episode, providers_list=[])
+
+    mock_translate.assert_called_once()
+    translate_kwargs = mock_translate.call_args.kwargs
+    assert translate_kwargs['from_lang'] == 'fr'
+    assert translate_kwargs['to_lang'] == 'hu'
+    assert translate_kwargs['forced'] is True
+    assert translate_kwargs['hi'] is False
+    assert translate_kwargs['media_type'] == 'episode'


### PR DESCRIPTION
## Summary
- Follow-up fix for #137.
- Queues series auto-translations with `media_type=episode`, matching what the translator pipeline expects.
- Matches Translate From profile targets by exact language variant, so base, forced, and hearing-impaired entries do not bleed into each other.

## Validation
- `pytest tests/bazarr/test_auto_translation_profile.py`
- `ruff check bazarr/subtitles/processing.py bazarr/subtitles/wanted/movies.py bazarr/subtitles/wanted/series.py bazarr/subtitles/language_profiles.py tests/bazarr/test_auto_translation_profile.py`
- `git diff --check origin/development...HEAD`
- `npm run build`
- Docker build: `ui-test-pr153-fixonly`
- Test server: `bazarr-ui-test` running healthy, version `ui-test-pr153-fixonly`, supervisor `Ready`
- GitHub checks: Frontend, Python 3.12 backend, Python 3.13 backend, Python 3.14 backend, submit-pypi