### PR TITLE
Fix embedded subtitle history upgrade handling

### DIFF
--- a/bazarr/api/subtitles/batch.py
+++ b/bazarr/api/subtitles/batch.py
@@ -136,11 +136,13 @@ def get_upgradable_media_ids():
     from subtitles.upgrade import get_queries_condition_parameters
     minimum_timestamp, query_actions = get_queries_condition_parameters()
 
-    # Movies: only consider the latest history row per (video_path, language)
+    # Movies: only consider the latest eligible history row per (video_path, language)
     max_movie_ts = select(
         TableHistoryMovie.video_path,
         TableHistoryMovie.language,
         func.max(TableHistoryMovie.timestamp).label('timestamp')
+    ).where(
+        TableHistoryMovie.action.in_(query_actions)
     ).group_by(
         TableHistoryMovie.video_path, TableHistoryMovie.language
     ).distinct().subquery()
@@ -165,11 +167,13 @@ def get_upgradable_media_ids():
     ).all()
     movie_ids = [r.radarrId for r in movie_results]
 
-    # Series: only consider the latest history row per (video_path, language)
+    # Series: only consider the latest eligible history row per (video_path, language)
     max_episode_ts = select(
         TableHistory.video_path,
         TableHistory.language,
         func.max(TableHistory.timestamp).label('timestamp')
+    ).where(
+        TableHistory.action.in_(query_actions)
     ).group_by(
         TableHistory.video_path, TableHistory.language
     ).distinct().subquery()

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -9,15 +9,19 @@ import time  # noqa: F401
 from subliminal_patch import core, search_external_subtitles
 
 from languages.custom_lang import CustomLanguage
-from app.database import get_profiles_list, get_profile_cutoff, TableMovies, get_audio_profile_languages, database, \
-    update, select
+from app.database import get_profiles_list, get_profile_cutoff, TableMovies, TableHistoryMovie, \
+    get_audio_profile_languages, database, update, select
 from languages.get_languages import alpha2_from_alpha3, get_language_set
 from app.config import settings
 from utilities.helper import get_subtitle_destination_folder
 from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import embedded_subs_reader
 from app.event_handler import event_stream
-from subtitles.indexer.utils import guess_external_subtitles, get_external_subtitles_path
+from subtitles.indexer.utils import guess_external_subtitles, get_external_subtitles_path, \
+    normalize_subtitle_language_variant
+from subtitles.processing import ProcessSubtitlesResult
+from subtitles.utils import _get_scores
+from radarr.history import history_log_movie
 from app.jobs_queue import jobs_queue
 from subtitles.adaptive_searching import is_search_given_up
 
@@ -27,6 +31,9 @@ gc.enable()
 def store_subtitles_movie(original_path, reversed_path, use_cache=True):
     logging.debug(f'BAZARR started subtitles indexing for this file: {reversed_path}')  # noqa: G004
     actual_subtitles = []
+    # Languages of embedded subtitle tracks detected on this pass. Used after
+    # indexing to record a source-quality history entry (action=7) per language.
+    embedded_languages = []
     if os.path.exists(reversed_path):
         if settings.general.use_embedded_subs:
             logging.debug("BAZARR is trying to index embedded subtitles.")
@@ -53,13 +60,13 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
                                 continue
 
                             if alpha2_from_alpha3(subtitle_language) is not None:
-                                lang = str(alpha2_from_alpha3(subtitle_language))
-                                if subtitle_forced:
-                                    lang = f'{lang}:forced'
-                                if subtitle_hi:
-                                    lang = f'{lang}:hi'
+                                lang = normalize_subtitle_language_variant(
+                                    alpha2_from_alpha3(subtitle_language),
+                                    forced=subtitle_forced,
+                                    hi=subtitle_hi)
                                 logging.debug(f"BAZARR embedded subtitles detected: {lang}")  # noqa: G004
                                 actual_subtitles.append([lang, None, None])
+                                embedded_languages.append(lang)
                         except Exception as error:
                             logging.debug(f"BAZARR unable to index this unrecognized language: {subtitle_language} "  # noqa: G004
                                           f"({error})")
@@ -151,6 +158,8 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
             if movie:
                 logging.debug(f"BAZARR storing those languages to DB: {actual_subtitles}")  # noqa: G004
                 list_missing_subtitles_movies(no=movie.radarrId)
+                if embedded_languages:
+                    _log_embedded_history_movie(movie.radarrId, embedded_languages, reversed_path)
             else:
                 logging.debug(f"BAZARR haven't been able to update existing subtitles to DB: {actual_subtitles}")  # noqa: G004
     else:
@@ -159,6 +168,52 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
     logging.debug(f'BAZARR ended subtitles indexing for this file: {reversed_path}')  # noqa: G004
 
     return actual_subtitles
+
+
+def _log_embedded_history_movie(radarr_id, embedded_languages, reversed_path):
+    """Record source-quality history entries for newly detected embedded subtitles.
+
+    Why: Embedded subtitle tracks come from disc/streaming rips and are source
+    quality, but previously had no score in history so they appeared as unknown
+    quality and could be wrongly targeted for upgrade.
+    What: For each embedded language not already recorded, writes a
+    TableHistoryMovie entry with action=7 (EmbeddedSource) and score=score_out_of
+    (100%). A history lookup deduplicates so re-indexing the same movie does not
+    duplicate entries.
+    Test: Index a movie with an embedded track twice; assert exactly one action=7
+    row exists for that movie+language with score == score_out_of.
+    """
+    try:
+        _, score_out_of, _ = _get_scores('movie')
+
+        for lang in embedded_languages:
+            lang = normalize_subtitle_language_variant(lang)
+            # Dedup: skip if we already logged action=7 for this movie+language.
+            # Not atomic under AUTOCOMMIT. Concurrent indexing of the same movie
+            # could produce duplicates, but this is rare in practice and consistent
+            # with how other parts of Bazarr dedup history entries.
+            existing = database.execute(
+                select(TableHistoryMovie.id)
+                .where(TableHistoryMovie.radarrId == radarr_id)
+                .where(TableHistoryMovie.language == lang)
+                .where(TableHistoryMovie.action == 7)).first()
+            if existing:
+                continue
+
+            result = ProcessSubtitlesResult(
+                message=f"{lang} embedded subtitles detected.",
+                reversed_path=reversed_path,
+                downloaded_language_code2=lang.split(':')[0],
+                downloaded_provider="embedded",
+                score=score_out_of,
+                forced=lang.endswith(':forced'),
+                subtitle_id=None,
+                reversed_subtitles_path=None,
+                hearing_impaired=lang.endswith(':hi'))
+            history_log_movie(action=7, radarr_id=radarr_id, result=result,
+                              fake_provider="embedded", fake_score=score_out_of)
+    except Exception:
+        logging.exception("BAZARR error writing embedded subtitle history for movie %s", radarr_id)
 
 
 def list_missing_subtitles_movies(no=None):

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -8,7 +8,7 @@ import ast
 from subliminal_patch import core, search_external_subtitles
 
 from languages.custom_lang import CustomLanguage
-from app.database import get_profiles_list, get_profile_cutoff, TableEpisodes, TableShows, \
+from app.database import get_profiles_list, get_profile_cutoff, TableEpisodes, TableShows, TableHistory, \
     get_audio_profile_languages, database, update, select
 from languages.get_languages import alpha2_from_alpha3, get_language_set
 from app.config import settings
@@ -16,7 +16,11 @@ from utilities.helper import get_subtitle_destination_folder
 from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import embedded_subs_reader
 from app.event_handler import event_stream
-from subtitles.indexer.utils import guess_external_subtitles, get_external_subtitles_path
+from subtitles.indexer.utils import guess_external_subtitles, get_external_subtitles_path, \
+    normalize_subtitle_language_variant
+from subtitles.processing import ProcessSubtitlesResult
+from subtitles.utils import _get_scores
+from sonarr.history import history_log
 from app.jobs_queue import jobs_queue
 from subtitles.adaptive_searching import is_search_given_up
 
@@ -26,6 +30,9 @@ gc.enable()
 def store_subtitles(original_path, reversed_path, use_cache=True):
     logging.debug(f'BAZARR started subtitles indexing for this file: {reversed_path}')  # noqa: G004
     actual_subtitles = []
+    # Languages of embedded subtitle tracks detected on this pass. Used after
+    # indexing to record a source-quality history entry (action=7) per language.
+    embedded_languages = []
     if os.path.exists(reversed_path):
         if settings.general.use_embedded_subs:
             logging.debug("BAZARR is trying to index embedded subtitles.")
@@ -52,13 +59,13 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
                                 continue
 
                             if alpha2_from_alpha3(subtitle_language) is not None:
-                                lang = str(alpha2_from_alpha3(subtitle_language))
-                                if subtitle_forced:
-                                    lang = f"{lang}:forced"
-                                if subtitle_hi:
-                                    lang = f"{lang}:hi"
+                                lang = normalize_subtitle_language_variant(
+                                    alpha2_from_alpha3(subtitle_language),
+                                    forced=subtitle_forced,
+                                    hi=subtitle_hi)
                                 logging.debug(f"BAZARR embedded subtitles detected: {lang}")  # noqa: G004
                                 actual_subtitles.append([lang, None, None])
+                                embedded_languages.append(lang)
                         except Exception as error:
                             logging.debug("BAZARR unable to index this unrecognized language: %s (%s)", subtitle_language, error)
                 except Exception:
@@ -140,7 +147,7 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
             .values(subtitles=str(actual_subtitles))
             .where(TableEpisodes.path == original_path))
         matching_episodes = database.execute(
-            select(TableEpisodes.sonarrEpisodeId)
+            select(TableEpisodes.sonarrEpisodeId, TableEpisodes.sonarrSeriesId)
             .where(TableEpisodes.path == original_path))\
             .all()
 
@@ -148,6 +155,9 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
             if episode:
                 logging.debug(f"BAZARR storing those languages to DB: {actual_subtitles}")  # noqa: G004
                 list_missing_subtitles(epno=episode.sonarrEpisodeId)
+                if embedded_languages:
+                    _log_embedded_history(episode.sonarrSeriesId, episode.sonarrEpisodeId,
+                                          embedded_languages, reversed_path)
             else:
                 logging.debug(f"BAZARR haven't been able to update existing subtitles to DB: {actual_subtitles}")  # noqa: G004
     else:
@@ -156,6 +166,51 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
     logging.debug(f'BAZARR ended subtitles indexing for this file: {reversed_path}')  # noqa: G004
 
     return actual_subtitles
+
+
+def _log_embedded_history(series_id, episode_id, embedded_languages, reversed_path):
+    """Record source-quality history entries for newly detected embedded subtitles.
+
+    Why: Embedded subtitle tracks come from disc/streaming rips and are source
+    quality, but previously had no score in history so they appeared as unknown
+    quality and could be wrongly targeted for upgrade.
+    What: For each embedded language not already recorded, writes a TableHistory
+    entry with action=7 (EmbeddedSource) and score=score_out_of (100%). A history
+    lookup deduplicates so re-indexing the same episode does not duplicate entries.
+    Test: Index an episode with an embedded track twice; assert exactly one
+    action=7 row exists for that episode+language with score == score_out_of.
+    """
+    try:
+        _, score_out_of, _ = _get_scores('series')
+
+        for lang in embedded_languages:
+            lang = normalize_subtitle_language_variant(lang)
+            # Dedup: skip if we already logged action=7 for this episode+language.
+            # Not atomic under AUTOCOMMIT. Concurrent indexing of the same episode
+            # could produce duplicates, but this is rare in practice and consistent
+            # with how other parts of Bazarr dedup history entries.
+            existing = database.execute(
+                select(TableHistory.id)
+                .where(TableHistory.sonarrEpisodeId == episode_id)
+                .where(TableHistory.language == lang)
+                .where(TableHistory.action == 7)).first()
+            if existing:
+                continue
+
+            result = ProcessSubtitlesResult(
+                message=f"{lang} embedded subtitles detected.",
+                reversed_path=reversed_path,
+                downloaded_language_code2=lang.split(':')[0],
+                downloaded_provider="embedded",
+                score=score_out_of,
+                forced=lang.endswith(':forced'),
+                subtitle_id=None,
+                reversed_subtitles_path=None,
+                hearing_impaired=lang.endswith(':hi'))
+            history_log(action=7, sonarr_series_id=series_id, sonarr_episode_id=episode_id,
+                        result=result, fake_provider="embedded", fake_score=score_out_of)
+    except Exception:
+        logging.exception("BAZARR error writing embedded subtitle history for episode %s", episode_id)
 
 
 def list_missing_subtitles(no=None, epno=None):

--- a/bazarr/subtitles/indexer/utils.py
+++ b/bazarr/subtitles/indexer/utils.py
@@ -41,6 +41,20 @@ def get_external_subtitles_path(file, subtitle):
     return path
 
 
+def normalize_subtitle_language_variant(language, forced=False, hi=False):
+    language_text = str(language)
+    parts = language_text.split(':')
+    base = parts[0]
+    variants = {part.lower() for part in parts[1:]}
+
+    # Keep the same priority as ProcessSubtitlesResult.language_code.
+    if hi or "hi" in variants:
+        return f"{base}:hi"
+    if forced or "forced" in variants:
+        return f"{base}:forced"
+    return base
+
+
 def guess_external_subtitles(dest_folder, subtitles, media_type, previously_indexed_subtitles_to_exclude=None):
     for subtitle, language in subtitles.items():
         subtitle_path = os.path.join(dest_folder, subtitle)

--- a/bazarr/subtitles/upgrade.py
+++ b/bazarr/subtitles/upgrade.py
@@ -300,6 +300,8 @@ def get_queries_condition_parameters():
     days_to_upgrade_subs = settings.general.days_to_upgrade_subs
     minimum_timestamp = (datetime.now() - timedelta(days=int(days_to_upgrade_subs)))
 
+    # action=7 (EmbeddedSource) intentionally excluded, embedded subs are source
+    # quality and should not be upgraded
     if settings.general.upgrade_manual:
         query_actions = [1, 2, 3, 4, 6]
     else:
@@ -359,14 +361,15 @@ def get_upgradable_episode_subtitles(history_id_list=None):
         return {}
 
     logging.debug("Determining upgradable episode subtitles")
+    minimum_timestamp, query_actions = get_queries_condition_parameters()
     max_id_timestamp = select(TableHistory.video_path,
                               TableHistory.language,
                               func.max(TableHistory.timestamp).label('timestamp')) \
+        .where(TableHistory.action.in_(query_actions)) \
         .group_by(TableHistory.video_path, TableHistory.language) \
         .distinct() \
         .subquery()
 
-    minimum_timestamp, query_actions = get_queries_condition_parameters()
     logging.debug(f"Minimum timestamp used for subtitles upgrade: {minimum_timestamp}")  # noqa: G004
     logging.debug(f"These actions are considered for subtitles upgrade: {query_actions}")  # noqa: G004
 
@@ -426,14 +429,15 @@ def get_upgradable_movies_subtitles(history_id_list=None):
         return {}
 
     logging.debug("Determining upgradable movie subtitles")
+    minimum_timestamp, query_actions = get_queries_condition_parameters()
     max_id_timestamp = select(TableHistoryMovie.video_path,
                               TableHistoryMovie.language,
                               func.max(TableHistoryMovie.timestamp).label('timestamp')) \
+        .where(TableHistoryMovie.action.in_(query_actions)) \
         .group_by(TableHistoryMovie.video_path, TableHistoryMovie.language) \
         .distinct() \
         .subquery()
 
-    minimum_timestamp, query_actions = get_queries_condition_parameters()
     logging.debug(f"Minimum timestamp used for subtitles upgrade: {minimum_timestamp}")  # noqa: G004
     logging.debug(f"These actions are considered for subtitles upgrade: {query_actions}")  # noqa: G004
 

--- a/frontend/src/components/bazarr/HistoryIcon.tsx
+++ b/frontend/src/components/bazarr/HistoryIcon.tsx
@@ -5,6 +5,7 @@ import {
   faClosedCaptioning,
   faCloudUploadAlt,
   faDownload,
+  faFilm,
   faLanguage,
   faMagnifyingGlass,
   faRecycle,
@@ -14,12 +15,13 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 enum HistoryAction {
   Delete = 0,
-  Download,
-  Manual,
-  Upgrade,
-  Upload,
-  Sync,
-  Translated,
+  Download = 1,
+  Manual = 2,
+  Upgrade = 3,
+  Upload = 4,
+  Sync = 5,
+  Translated = 6,
+  EmbeddedSource = 7,
 }
 
 const HistoryIcon: FunctionComponent<{
@@ -56,6 +58,10 @@ const HistoryIcon: FunctionComponent<{
     case HistoryAction.Translated:
       icon = faLanguage;
       label = "Translated";
+      break;
+    case HistoryAction.EmbeddedSource:
+      icon = faFilm;
+      label = "Embedded Source";
       break;
     default:
       icon = faClosedCaptioning;

--- a/tests/bazarr/test_embedded_history_indexer.py
+++ b/tests/bazarr/test_embedded_history_indexer.py
@@ -1,0 +1,112 @@
+# coding=utf-8
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import create_engine, insert, select
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from app.database import Base, TableEpisodes, TableHistory, TableHistoryMovie, TableMovies, TableShows
+
+
+@pytest.fixture
+def history_db(monkeypatch):
+    from subtitles.indexer import movies, series
+    import radarr.history as radarr_history
+    import sonarr.history as sonarr_history
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = scoped_session(sessionmaker(bind=engine))
+
+    monkeypatch.setattr(series, "database", session)
+    monkeypatch.setattr(movies, "database", session)
+    monkeypatch.setattr(sonarr_history, "database", session)
+    monkeypatch.setattr(radarr_history, "database", session)
+    monkeypatch.setattr(sonarr_history, "event_stream", lambda **_: None)
+    monkeypatch.setattr(radarr_history, "event_stream", lambda **_: None)
+
+    try:
+        yield session
+    finally:
+        session.remove()
+        engine.dispose()
+
+
+def test_series_embedded_history_dedup_normalizes_combined_forced_hi(history_db):
+    from subtitles.indexer.series import _log_embedded_history
+
+    _insert_episode(history_db)
+    history_db.execute(insert(TableHistory).values(
+        action=7,
+        description="en:hi embedded subtitles detected.",
+        language="en:hi",
+        provider="embedded",
+        score=100,
+        score_out_of=100,
+        sonarrEpisodeId=20,
+        sonarrSeriesId=10,
+        timestamp=datetime.now(),
+        video_path="/series/show/s01e01.mkv",
+    ))
+
+    _log_embedded_history(10, 20, ["en:forced:hi"], "/series/show/s01e01.mkv")
+
+    rows = history_db.execute(
+        select(TableHistory.language)
+        .where(TableHistory.sonarrEpisodeId == 20)
+        .where(TableHistory.action == 7)
+    ).all()
+    assert [row.language for row in rows] == ["en:hi"]
+
+
+def test_movie_embedded_history_dedup_normalizes_combined_forced_hi(history_db):
+    from subtitles.indexer.movies import _log_embedded_history_movie
+
+    _insert_movie(history_db)
+    history_db.execute(insert(TableHistoryMovie).values(
+        action=7,
+        description="en:hi embedded subtitles detected.",
+        language="en:hi",
+        provider="embedded",
+        score=100,
+        score_out_of=100,
+        radarrId=30,
+        timestamp=datetime.now(),
+        video_path="/movies/movie.mkv",
+    ))
+
+    _log_embedded_history_movie(30, ["en:forced:hi"], "/movies/movie.mkv")
+
+    rows = history_db.execute(
+        select(TableHistoryMovie.language)
+        .where(TableHistoryMovie.radarrId == 30)
+        .where(TableHistoryMovie.action == 7)
+    ).all()
+    assert [row.language for row in rows] == ["en:hi"]
+
+
+def _insert_episode(db):
+    db.execute(insert(TableShows).values(
+        sonarrSeriesId=10,
+        path="/series/show",
+        title="Show",
+    ))
+    db.execute(insert(TableEpisodes).values(
+        episode=1,
+        monitored="True",
+        path="/series/show/s01e01.mkv",
+        season=1,
+        sonarrEpisodeId=20,
+        sonarrSeriesId=10,
+        title="Pilot",
+    ))
+
+
+def _insert_movie(db):
+    db.execute(insert(TableMovies).values(
+        path="/movies/movie.mkv",
+        radarrId=30,
+        title="Movie",
+        tmdbId="100",
+    ))

--- a/tests/bazarr/test_upgrade_embedded_history.py
+++ b/tests/bazarr/test_upgrade_embedded_history.py
@@ -1,0 +1,202 @@
+# coding=utf-8
+
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine, insert
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from app.database import Base, TableEpisodes, TableHistory, TableHistoryMovie, TableMovies, TableShows
+
+
+@pytest.fixture
+def upgrade_db(monkeypatch):
+    from api.subtitles import batch
+    import app.database as database_module
+    from subtitles import upgrade
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = scoped_session(sessionmaker(bind=engine))
+
+    settings = SimpleNamespace(
+        general=SimpleNamespace(
+            days_to_upgrade_subs=365,
+            upgrade_manual=False,
+            upgrade_subs=True,
+        )
+    )
+    monkeypatch.setattr(upgrade, "database", session)
+    monkeypatch.setattr(batch, "database", session)
+    monkeypatch.setattr(upgrade, "settings", settings)
+    monkeypatch.setattr(batch, "settings", settings)
+    monkeypatch.setattr(
+        database_module,
+        "settings",
+        SimpleNamespace(
+            radarr=SimpleNamespace(excluded_tags=[], only_monitored=False),
+            sonarr=SimpleNamespace(
+                excluded_series_types=[],
+                excluded_tags=[],
+                exclude_season_zero=False,
+                only_monitored=False,
+            ),
+        ),
+    )
+
+    try:
+        yield session
+    finally:
+        session.remove()
+        engine.dispose()
+
+
+def test_episode_upgrade_keeps_download_candidate_when_embedded_history_is_newer(upgrade_db):
+    from subtitles.upgrade import get_upgradable_episode_subtitles
+
+    now = datetime.now()
+    _insert_episode(upgrade_db)
+    upgrade_db.execute(insert(TableHistory).values(
+        id=101,
+        action=1,
+        description="English subtitles downloaded.",
+        language="en",
+        provider="opensubtitlescom",
+        score=90,
+        score_out_of=100,
+        sonarrEpisodeId=20,
+        sonarrSeriesId=10,
+        timestamp=now - timedelta(minutes=5),
+        video_path="/series/show/s01e01.mkv",
+    ))
+    upgrade_db.execute(insert(TableHistory).values(
+        id=102,
+        action=7,
+        description="en embedded subtitles detected.",
+        language="en",
+        provider="embedded",
+        score=100,
+        score_out_of=100,
+        sonarrEpisodeId=20,
+        sonarrSeriesId=10,
+        timestamp=now,
+        video_path="/series/show/s01e01.mkv",
+    ))
+
+    assert get_upgradable_episode_subtitles() == {101: None}
+
+
+def test_movie_upgrade_keeps_download_candidate_when_embedded_history_is_newer(upgrade_db):
+    from subtitles.upgrade import get_upgradable_movies_subtitles
+
+    now = datetime.now()
+    _insert_movie(upgrade_db)
+    upgrade_db.execute(insert(TableHistoryMovie).values(
+        id=201,
+        action=1,
+        description="English subtitles downloaded.",
+        language="en",
+        provider="opensubtitlescom",
+        score=90,
+        score_out_of=100,
+        radarrId=30,
+        timestamp=now - timedelta(minutes=5),
+        video_path="/movies/movie.mkv",
+    ))
+    upgrade_db.execute(insert(TableHistoryMovie).values(
+        id=202,
+        action=7,
+        description="en embedded subtitles detected.",
+        language="en",
+        provider="embedded",
+        score=100,
+        score_out_of=100,
+        radarrId=30,
+        timestamp=now,
+        video_path="/movies/movie.mkv",
+    ))
+
+    assert get_upgradable_movies_subtitles() == {201: None}
+
+
+def test_batch_upgrade_ids_ignore_newer_embedded_history(upgrade_db):
+    from api.subtitles.batch import get_upgradable_media_ids
+
+    now = datetime.now()
+    _insert_episode(upgrade_db)
+    _insert_movie(upgrade_db)
+    upgrade_db.execute(insert(TableHistory).values(
+        action=1,
+        description="English subtitles downloaded.",
+        language="en",
+        provider="opensubtitlescom",
+        score=90,
+        score_out_of=100,
+        sonarrEpisodeId=20,
+        sonarrSeriesId=10,
+        timestamp=now - timedelta(minutes=5),
+        video_path="/series/show/s01e01.mkv",
+    ))
+    upgrade_db.execute(insert(TableHistory).values(
+        action=7,
+        description="en embedded subtitles detected.",
+        language="en",
+        provider="embedded",
+        score=100,
+        score_out_of=100,
+        sonarrEpisodeId=20,
+        sonarrSeriesId=10,
+        timestamp=now,
+        video_path="/series/show/s01e01.mkv",
+    ))
+    upgrade_db.execute(insert(TableHistoryMovie).values(
+        action=1,
+        description="English subtitles downloaded.",
+        language="en",
+        provider="opensubtitlescom",
+        score=90,
+        score_out_of=100,
+        radarrId=30,
+        timestamp=now - timedelta(minutes=5),
+        video_path="/movies/movie.mkv",
+    ))
+    upgrade_db.execute(insert(TableHistoryMovie).values(
+        action=7,
+        description="en embedded subtitles detected.",
+        language="en",
+        provider="embedded",
+        score=100,
+        score_out_of=100,
+        radarrId=30,
+        timestamp=now,
+        video_path="/movies/movie.mkv",
+    ))
+
+    assert get_upgradable_media_ids() == {"movies": [30], "series": [10]}
+
+
+def _insert_episode(db):
+    db.execute(insert(TableShows).values(
+        sonarrSeriesId=10,
+        path="/series/show",
+        title="Show",
+    ))
+    db.execute(insert(TableEpisodes).values(
+        episode=1,
+        monitored="True",
+        path="/series/show/s01e01.mkv",
+        season=1,
+        sonarrEpisodeId=20,
+        sonarrSeriesId=10,
+        title="Pilot",
+    ))
+
+
+def _insert_movie(db):
+    db.execute(insert(TableMovies).values(
+        path="/movies/movie.mkv",
+        radarrId=30,
+        title="Movie",
+        tmdbId="100",
+    ))


### PR DESCRIPTION
## Summary

Based on #152 by @davidgut1982. Thanks to David for the original embedded subtitle history implementation.

- Record embedded subtitles as source-quality history entries with `action=7` and full score.
- Add a frontend history icon label for embedded source entries.
- Keep upgrade selection focused on the latest eligible history row so embedded `action=7` rows do not hide older external subtitle candidates.

## Notes

This branch is based on `development` and is intended as the merge path for the #152 contribution. The commit author is preserved as David. Commit trailer attribution is intentionally not used because this repository keeps attribution in Git author metadata and PR text.

## Validation

- `ruff check bazarr/api/subtitles/batch.py bazarr/subtitles/indexer/movies.py bazarr/subtitles/indexer/series.py bazarr/subtitles/upgrade.py tests/bazarr/test_upgrade_embedded_history.py`
- `pytest tests/bazarr/test_upgrade_embedded_history.py tests/bazarr/test_utilities_video_analyzer.py`
- `npm run build`
- Deployed `ghcr.io/lavx/bazarr:ui-test` to `bazarr-ui-test` before pushing. The container reported `healthy`; `/api/system/status` returned `401`, confirming the app is serving behind auth.
