### PR TITLE
fix(provider hub): per-provider apply state and Apply all button

### DIFF
--- a/frontend/src/pages/Settings/Providers/hub/UpdatesPanel.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/UpdatesPanel.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useMemo } from "react";
+import { FunctionComponent, useCallback, useMemo, useState } from "react";
 import { Button, Group, Stack, Text } from "@mantine/core";
 import { faCircleCheck, faRotate } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -34,8 +34,58 @@ export const UpdatesPanel: FunctionComponent<UpdatesPanelProps> = ({
   const applyUpdate = useProviderHubApplyUpdate();
   const checkUpdates = useProviderHubCheckUpdates();
 
+  const [applyingIds, setApplyingIds] = useState<Set<string>>(new Set());
+  const [applyingAll, setApplyingAll] = useState(false);
+
   const stagedRows = summary.pendingRestart;
   const availableRows = summary.available;
+
+  const applyOne = useCallback(
+    async (id: string) => {
+      setApplyingIds((prev) => {
+        if (prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.add(id);
+        return next;
+      });
+      try {
+        await applyUpdate.mutateAsync(id);
+      } catch {
+        // swallow: cleanup runs in finally
+      } finally {
+        setApplyingIds((prev) => {
+          if (!prev.has(id)) return prev;
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+      }
+    },
+    [applyUpdate],
+  );
+
+  const applyAll = useCallback(async () => {
+    const ids = availableRows
+      .map((p) => p.provider_id)
+      .filter((id) => !applyingIds.has(id));
+    if (ids.length === 0) return;
+    setApplyingAll(true);
+    setApplyingIds((prev) => {
+      const next = new Set(prev);
+      ids.forEach((id) => next.add(id));
+      return next;
+    });
+    try {
+      await Promise.allSettled(ids.map((id) => applyUpdate.mutateAsync(id)));
+    } finally {
+      setApplyingIds((prev) => {
+        const next = new Set(prev);
+        ids.forEach((id) => next.delete(id));
+        return next;
+      });
+      setApplyingAll(false);
+    }
+  }, [applyUpdate, applyingIds, availableRows]);
 
   const empty = stagedRows.length === 0 && availableRows.length === 0;
   const changeCount = availableRows.length + stagedRows.length;
@@ -99,9 +149,16 @@ export const UpdatesPanel: FunctionComponent<UpdatesPanelProps> = ({
                 <Text size="sm" fw={600}>
                   Available now
                 </Text>
-                <Text size="xs" c="dimmed">
-                  Apply individually
-                </Text>
+                <Button
+                  size="xs"
+                  variant="light"
+                  loading={applyingAll}
+                  disabled={availableRows.length === 0}
+                  onClick={applyAll}
+                  leftSection={<FontAwesomeIcon icon={faRotate} />}
+                >
+                  Apply all
+                </Button>
               </Group>
               <div className={styles.cardGrid}>
                 {availableRows.map((p) => {
@@ -112,8 +169,8 @@ export const UpdatesPanel: FunctionComponent<UpdatesPanelProps> = ({
                       key={p.provider_id}
                       provider={p}
                       latest={latest}
-                      onApply={(id) => applyUpdate.mutate(id)}
-                      isApplying={applyUpdate.isPending}
+                      onApply={(id) => void applyOne(id)}
+                      isApplying={applyingIds.has(p.provider_id)}
                     />
                   );
                 })}


### PR DESCRIPTION
## Summary
- Clicking *Apply update* on one card used to flip every card's spinner. The whole grid shared a single `useMutation` `isPending` boolean. Track applying provider ids in local state so each card spins independently and the others stay clickable.
- Replace the static "Apply individually" hint in the *Available now* header with an **Apply all** button. It fans out `mutateAsync` per provider, runs in parallel via `Promise.allSettled`, and clears the in-flight set when every apply has settled. The button has its own loading state.

## Files
- `frontend/src/pages/Settings/Providers/hub/UpdatesPanel.tsx`

## Test plan
- [x] `npm run check:ts`
- [x] `npm run check` (0 errors; 10 pre-existing camelcase warnings outside this file)
- [x] `npm run check:fmt`
- [x] `npm test` (488 passed / 3 skipped)
- [x] `npm run build:ci`
- [x] Manual: deployed image to home server, container healthy
- [x] Reviewer: open *Settings → Providers → Hub → Updates*, apply one update (only that card spins), then click *Apply all* (every card spins independently, button shows its own loading state)