### PR TITLE
Address v2.3.1 PR review findings (next-release fixes)

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -1026,9 +1026,12 @@ def save_settings(settings_items):
             if value != settings.subsource.apikey:
                 reset_providers = True
 
-        if key == 'settings-general-enabled_providers':
+        if key in ('settings-general-enabled_providers',
+                   'settings-general-provider_languages'):
             # Defer the reset until AFTER all values in this batch are
             # written, same reasoning as reset_fanout_pool below.
+            # provider_languages changes affect per-provider exclusions
+            # which alter compat cache keys and provider pool behavior.
             reset_compat_pool = True
 
         if key in ('settings-compat_endpoint-fanout_max_workers',

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -159,7 +159,12 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
                 logging.debug(f"BAZARR storing those languages to DB: {actual_subtitles}")  # noqa: G004
                 list_missing_subtitles_movies(no=movie.radarrId)
                 if embedded_languages:
-                    _log_embedded_history_movie(movie.radarrId, embedded_languages, reversed_path)
+                    # Pass the DB-side path (original_path), not the local
+                    # filesystem path. history_log_movie stores result.path
+                    # verbatim, and download history rows store DB-side paths
+                    # via path_replace_reverse_movie. Embedded rows must match
+                    # so path comparisons line up in path-mapped installs.
+                    _log_embedded_history_movie(movie.radarrId, embedded_languages, original_path)
             else:
                 logging.debug(f"BAZARR haven't been able to update existing subtitles to DB: {actual_subtitles}")  # noqa: G004
     else:

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -156,8 +156,13 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
                 logging.debug(f"BAZARR storing those languages to DB: {actual_subtitles}")  # noqa: G004
                 list_missing_subtitles(epno=episode.sonarrEpisodeId)
                 if embedded_languages:
+                    # Pass the DB-side path (original_path), not the local
+                    # filesystem path. history_log stores result.path verbatim,
+                    # and download history rows store DB-side paths via
+                    # path_replace_reverse. Embedded rows must match so path
+                    # comparisons line up in path-mapped installs.
                     _log_embedded_history(episode.sonarrSeriesId, episode.sonarrEpisodeId,
-                                          embedded_languages, reversed_path)
+                                          embedded_languages, original_path)
             else:
                 logging.debug(f"BAZARR haven't been able to update existing subtitles to DB: {actual_subtitles}")  # noqa: G004
     else:

--- a/bazarr/subtitles/processing.py
+++ b/bazarr/subtitles/processing.py
@@ -60,6 +60,8 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
         from app.database import get_profile_id, get_profiles_list
         from subtitles.tools.translate.main import translate_subtitles_file
         from subtitles.download import check_missing_languages
+        from app.database import (TableEpisodes, TableShows, TableMovies,
+                                  database, select)
 
         if not subtitle_path or not downloaded_lang:
             return
@@ -89,6 +91,29 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
         profile = get_profiles_list(profile_id=profile_id)
         if not profile:
             return
+
+        # Fetch the episode/movie row that postprocess_subtitles dereferences
+        # for plex/jellyfin refresh (sonarrSeriesId, imdbId, season, episode,
+        # tvdbId for episodes; imdbId, tmdbId for movies). Passing None here
+        # crashed the translation job during post-processing.
+        translation_metadata = None
+        if media_type == 'series' and episode_id:
+            translation_metadata = database.execute(
+                select(TableEpisodes.sonarrSeriesId,
+                       TableEpisodes.season,
+                       TableEpisodes.episode,
+                       TableShows.imdbId,
+                       TableShows.tvdbId)
+                .select_from(TableEpisodes)
+                .join(TableShows)
+                .where(TableEpisodes.sonarrEpisodeId == episode_id)
+            ).first()
+        elif media_type == 'movies' and radarr_id:
+            translation_metadata = database.execute(
+                select(TableMovies.imdbId,
+                       TableMovies.tmdbId)
+                .where(TableMovies.radarrId == radarr_id)
+            ).first()
 
         # Hoisted out of the loop: check_missing_languages is independent of the
         # profile item being considered, so calling it once per profile item
@@ -143,7 +168,7 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
                 sonarr_series_id=series_id,
                 sonarr_episode_id=episode_id,
                 radarr_id=radarr_id,
-                metadata=None,
+                metadata=translation_metadata,
             )
     except Exception:
         logging.exception('BAZARR error in _trigger_auto_translation')

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -4,6 +4,7 @@
 import ast
 import logging
 import operator
+import os
 
 from functools import reduce
 
@@ -76,19 +77,36 @@ def _wanted_movie(movie, providers_list, job_id=None):
                     )
                 else:
                     # Guard: skip if we already have a translate history entry
-                    # for this target language. Why: the translate service
-                    # writes action=6 on successful completion, which blocks
-                    # re-queuing after a successful translation. Without this
-                    # check, the wanted-scan would re-queue every cycle.
+                    # for this target language AND the translated file still
+                    # exists on disk. Why: the translate service writes
+                    # action=6 on successful completion, which blocks
+                    # re-queuing after a successful translation. But if the
+                    # translated subtitle was deleted or moved after that
+                    # success, the file is missing again and we must re-queue;
+                    # checking only the history row would suppress the
+                    # replacement forever.
                     already_translated = database.execute(
-                        select(TableHistoryMovie.id)
+                        select(TableHistoryMovie.subtitles_path)
                         .where(TableHistoryMovie.radarrId == movie.radarrId)
                         .where(TableHistoryMovie.language == language)
                         .where(TableHistoryMovie.action == 6)
+                        .order_by(TableHistoryMovie.timestamp.desc())
                         .limit(1)
                     ).first()
-                    if already_translated:
-                        continue
+                    if already_translated and already_translated.subtitles_path:
+                        local_subs_path = path_mappings.path_replace_movie(
+                            already_translated.subtitles_path
+                        )
+                        if local_subs_path and os.path.exists(local_subs_path):
+                            continue
+                    # Fetch additional columns required by postprocess_subtitles
+                    # (imdbId/tmdbId for plex/jellyfin refresh). movie row
+                    # only carries the subset selected for wanted scans.
+                    metadata = database.execute(
+                        select(TableMovies.imdbId,
+                               TableMovies.tmdbId)
+                        .where(TableMovies.radarrId == movie.radarrId)
+                    ).first()
                     try:
                         from subtitles.tools.translate.main import translate_subtitles_file
                         translate_kwargs = dict(
@@ -102,7 +120,7 @@ def _wanted_movie(movie, providers_list, job_id=None):
                             sonarr_series_id=None,
                             sonarr_episode_id=None,
                             radarr_id=movie.radarrId,
-                            metadata=None,
+                            metadata=metadata,
                         )
                         # Guard: skip if an identical translate job is already
                         # pending or running. Why: history guard (action=6) only

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -4,6 +4,7 @@
 import ast
 import logging
 import operator
+import os
 import gc
 
 from functools import reduce
@@ -77,19 +78,41 @@ def _wanted_episode(episode, providers_list, job_id=None):
                     )
                 else:
                     # Guard: skip if we already have a translate history entry
-                    # for this target language. Why: the translate service
-                    # writes action=6 on successful completion, which blocks
-                    # re-queuing after a successful translation. Without this
-                    # check, the wanted-scan would re-queue every cycle.
+                    # for this target language AND the translated file still
+                    # exists on disk. Why: the translate service writes
+                    # action=6 on successful completion, which blocks
+                    # re-queuing after a successful translation. But if the
+                    # translated subtitle was deleted or moved after that
+                    # success, the file is missing again and we must re-queue;
+                    # checking only the history row would suppress the
+                    # replacement forever.
                     already_translated = database.execute(
-                        select(TableHistory.id)
+                        select(TableHistory.subtitles_path)
                         .where(TableHistory.sonarrEpisodeId == episode.sonarrEpisodeId)
                         .where(TableHistory.language == language)
                         .where(TableHistory.action == 6)
+                        .order_by(TableHistory.timestamp.desc())
                         .limit(1)
                     ).first()
-                    if already_translated:
-                        continue
+                    if already_translated and already_translated.subtitles_path:
+                        local_subs_path = path_mappings.path_replace(
+                            already_translated.subtitles_path
+                        )
+                        if local_subs_path and os.path.exists(local_subs_path):
+                            continue
+                    # Fetch additional columns required by postprocess_subtitles
+                    # (imdbId/tvdbId for plex/jellyfin refresh). episode_details
+                    # only carries the subset selected for wanted scans.
+                    metadata = database.execute(
+                        select(TableEpisodes.sonarrSeriesId,
+                               TableEpisodes.season,
+                               TableEpisodes.episode,
+                               TableShows.imdbId,
+                               TableShows.tvdbId)
+                        .select_from(TableEpisodes)
+                        .join(TableShows)
+                        .where(TableEpisodes.sonarrEpisodeId == episode.sonarrEpisodeId)
+                    ).first()
                     try:
                         from subtitles.tools.translate.main import translate_subtitles_file
                         translate_kwargs = dict(
@@ -103,7 +126,7 @@ def _wanted_episode(episode, providers_list, job_id=None):
                             sonarr_series_id=episode.sonarrSeriesId,
                             sonarr_episode_id=episode.sonarrEpisodeId,
                             radarr_id=None,
-                            metadata=None,
+                            metadata=metadata,
                         )
                         # Guard: skip if an identical translate job is already
                         # pending or running. Why: history guard (action=6) only

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -364,7 +364,18 @@ class SZProviderPool(ProviderPool):
             return []
 
         # check whether we want to search this provider for the languages
-        use_languages = languages - excluded_languages
+        # Compare by alpha3 (and country/script when specified on the
+        # exclusion) so that HI and forced variants like Language('eng',
+        # hi=True) are correctly excluded when the base Language('eng') is
+        # in the exclusion set. Language.__eq__ compares hi/forced flags,
+        # so plain set subtraction misses variants.
+        excluded_bases = set()
+        for el in excluded_languages:
+            excluded_bases.add((el.alpha3, el.country, el.script))
+        use_languages = {
+            lang for lang in languages
+            if (lang.alpha3, lang.country, lang.script) not in excluded_bases
+        }
         if not use_languages:
             logger.info('Skipping provider %r: no language to search for (excluded: %r, requested: %r)', provider,
                         excluded_languages, languages)

--- a/frontend/src/pages/Settings/Providers/components.tsx
+++ b/frontend/src/pages/Settings/Providers/components.tsx
@@ -760,8 +760,12 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
         ...staged,
         [`settings-general-provider_priorities-${info?.key}`]:
           seededPriorities[info?.key ?? ""] ?? 100,
-        [`settings-general-provider_languages-${info?.key}`]:
-          seededProviderLanguageExclusions[info?.key ?? ""] ?? [],
+        ...(info?.key
+          ? {
+              [`settings-general-provider_languages-${info.key}`]:
+                seededProviderLanguageExclusions[info.key] ?? [],
+            }
+          : {}),
       },
       hooks: {},
     },
@@ -872,6 +876,9 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
           changes["settings-general-provider_languages"] = JSON.stringify(
             providerLanguageExclusions,
           );
+          delete changes[languageKey];
+        } else {
+          const languageKey = `settings-general-provider_languages-${info.key}`;
           delete changes[languageKey];
         }
 

--- a/tests/bazarr/test_auto_translation_profile.py
+++ b/tests/bazarr/test_auto_translation_profile.py
@@ -132,7 +132,15 @@ def test_wanted_series_translation_uses_exact_profile_variant():
         }
         mock_path_mappings.path_replace.side_effect = lambda value: value
         mock_settings.translator.min_source_score = 0
-        mock_database.execute.return_value.first.side_effect = [None, None]
+        # 3 queries inside _wanted_episode when auto-translate fires:
+        # source-score lookup, already-translated guard, and the metadata
+        # fetch for postprocess_subtitles.
+        mock_database.execute.return_value.first.side_effect = [
+            None,
+            None,
+            SimpleNamespace(sonarrSeriesId=10, season=1, episode=1,
+                            imdbId='tt1', tvdbId='1'),
+        ]
         mock_jobs_queue._is_an_existing_job.return_value = False
 
         _wanted_episode(episode, providers_list=[])


### PR DESCRIPTION
## Summary

Seven fixes from the review pass on the v2.3.1 PRs (#137 / #151 / #152 / #154 / #157). Held back from the v2.3.1 patch line and targeted at the next release.

### Auto-translation (P1 + P2)
- **`metadata=None` crash**: `_trigger_auto_translation`, `_wanted_episode`, and `_wanted_movie` now fetch the episode/movie row that `postprocess_subtitles` dereferences (`sonarrSeriesId`, `imdbId`, `season`, `episode`, `tvdbId` / `tmdbId`) instead of passing `None`. Without this, every auto-translated subtitle would crash the post-processing step on Plex/Jellyfin refresh paths.
- **Re-queue suppression**: the wanted-scan guard now also checks that the previously translated file still exists on disk via `TableHistory.subtitles_path` + `os.path.exists`. The old `action=6` history check alone left deleted/moved translations permanently unsatisfied.

### Provider language exclusions
- **HI/forced variants**: `SZProviderPool.list_subtitles` now compares exclusions by `(alpha3, country, script)` so excluding base `eng` also excludes `eng:hi` and `eng:forced`. `Language.__eq__` includes the hi/forced flags, so plain set subtraction missed variants.
- **Compat cache invalidation**: `save_settings` now triggers `reset_compat_pool` for `provider_languages` changes too, not just `enabled_providers`. Without this, exclusion edits would not take effect until cache TTL expired.

### Embedded subtitle history
- **Path mapping**: `_log_embedded_history` and `_log_embedded_history_movie` now receive the DB-side path (`original_path`) instead of the local filesystem path. Download history rows store DB-side paths via `path_replace_reverse`; embedded rows now match so path comparisons line up in path-mapped installs.

### Provider settings UI
- **`undefined` key pollution**: `ProviderTool` no longer seeds `settings-general-provider_languages-undefined` when the drawer opens in add-provider mode (`info?.key` undefined).
- **Integrations drawer leak**: the temporary `settings-general-provider_languages-<key>` staging field is now stripped from `changes` for integrations drawers too, not only for provider drawers.

### One reported finding excluded
The reported "embedded dedup language normalization mismatch" turned out to be a false positive — the existing code already calls `normalize_subtitle_language_variant(lang)` before the dedup lookup, and the regression tests in `tests/bazarr/test_embedded_history_indexer.py` confirm `en:forced:hi` correctly normalizes to `en:hi` on both write and lookup.

## Test plan

- [x] `tests/bazarr/test_auto_translation_profile.py` (3 tests, side-effect mock count updated for the new metadata fetch)
- [x] `tests/bazarr/test_embedded_history_indexer.py` (2 tests, unchanged, still pass)
- [x] `tests/bazarr/test_upgrade_embedded_history.py` (3 tests, still pass)
- [x] `frontend/`: `check:ts`, `check`, `check:fmt`, `test` (489 pass), `build`
- [x] Auto-translate a series episode end-to-end on a fresh install and confirm no `metadata=None` traceback in the translate job log
- [x] Delete a previously translated subtitle and run wanted scan; verify translation is re-queued
- [x] Configure provider exclusion for `eng`; confirm provider not queried for `eng`, `eng:hi`, or `eng:forced`
- [x] Change provider language exclusion; verify cached compat responses pick up the change without restart
- [x] In a path-mapped install, index a video with embedded subtitles; confirm the resulting action=7 row's `video_path` matches the DB path stored on `TableEpisodes.path`