### PR TITLE
Reset compat pool for Provider Hub settings

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -827,6 +827,34 @@ def _settings_mapping(parent, key):
     return mapping
 
 
+def _settings_value(parent, keys):
+    value = parent
+    for key in keys:
+        if value is None:
+            return None
+        if hasattr(value, "get"):
+            value = value.get(key)
+        else:
+            value = getattr(value, key, None)
+    return value
+
+
+def _active_provider_hub_provider_ids():
+    try:
+        from provider_hub.state import active_installations
+        return {
+            str(provider_id)
+            for provider_id in (
+                getattr(installation, "provider_id", None)
+                for installation in active_installations()
+            )
+            if provider_id
+        }
+    except Exception:
+        logging.exception("Unable to inspect active Provider Hub providers")
+        return set()
+
+
 def save_settings(settings_items):
     configure_debug = False
     configure_captcha = False
@@ -846,6 +874,7 @@ def save_settings(settings_items):
     reset_providers = False
     reset_fanout_pool = False
     reset_compat_pool = False
+    active_provider_hub_provider_ids = None
 
     # Subzero Mods
     update_subzero = False
@@ -1030,6 +1059,13 @@ def save_settings(settings_items):
             # Defer the reset until AFTER all values in this batch are
             # written, same reasoning as reset_fanout_pool below.
             reset_compat_pool = True
+
+        if settings_keys[0] == 'settings' and len(settings_keys) >= 3:
+            if active_provider_hub_provider_ids is None:
+                active_provider_hub_provider_ids = _active_provider_hub_provider_ids()
+            if settings_keys[1] in active_provider_hub_provider_ids:
+                if value != _settings_value(settings, settings_keys[1:]):
+                    reset_compat_pool = True
 
         if key in ('settings-compat_endpoint-fanout_max_workers',
                    'settings-compat_endpoint-max_concurrent_fanouts'):

--- a/tests/bazarr/test_config_save.py
+++ b/tests/bazarr/test_config_save.py
@@ -40,3 +40,50 @@ def test_save_settings_creates_missing_provider_section_for_hub_config(monkeypat
         assert executed
     finally:
         config.settings.unset(provider_id.upper())
+
+
+def test_save_settings_resets_compat_pool_for_dynamic_provider_hub_config(monkeypatch):
+    from app import config
+
+    provider_id = "sub_scene"
+    executed = []
+    reset_calls = []
+
+    def record_compat_pool_reset():
+        reset_calls.append(config.settings[provider_id]["flaresolverr_url"])
+
+    monkeypatch.setattr(config, "write_config", lambda: None)
+    monkeypatch.setattr(config, "validate_log_regex", lambda: None)
+    monkeypatch.setattr(config.settings.validators, "validate", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "app.database",
+        SimpleNamespace(
+            database=SimpleNamespace(execute=lambda statement: executed.append(statement)),
+            update=lambda _model: _FakeUpdate(),
+            System=object,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "compat.service",
+        SimpleNamespace(reset_compat_pool=record_compat_pool_reset),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "provider_hub.state",
+        SimpleNamespace(active_installations=lambda: [SimpleNamespace(provider_id=provider_id)]),
+    )
+
+    try:
+        config.save_settings(
+            [
+                (f"settings-{provider_id}-flaresolverr_url", ["http://solver:8191"]),
+            ]
+        )
+
+        assert config.settings[provider_id]["flaresolverr_url"] == "http://solver:8191"
+        assert reset_calls == ["http://solver:8191"]
+        assert executed
+    finally:
+        config.settings.unset(provider_id.upper())


### PR DESCRIPTION
## Summary

- Reset the compat provider pool when active Provider Hub provider settings change.
- Add regression coverage for dynamic Provider Hub config fields such as `settings-sub_scene-flaresolverr_url`.

## Root Cause

`save_settings()` only invalidated the compat provider pool for a fixed set of known provider credential keys. Dynamic Provider Hub settings were written to `config.yaml`, but an already-initialized compat pool kept provider configs from before the save.

## Validation

- `pytest tests/bazarr/test_config_save.py`
- `pytest tests/bazarr/test_config.py tests/bazarr/test_config_save.py`
- `pytest tests/bazarr/test_provider_hub.py::test_active_provider_hub_installation_registers_proxy tests/bazarr/test_app_get_providers.py tests/compat/unit/test_provider_languages.py`
- `git diff --check`

## Notes

Live Bazarr test-server validation was not run in this publish turn.
