### PR TITLE
Use SQLAlchemy 2 declarative base import

### DIFF
--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -13,8 +13,7 @@ from datetime import datetime
 from sqlalchemy import create_engine, inspect, DateTime, ForeignKey, Index, Integer, LargeBinary, Text, func, text, BigInteger
 # importing here to be indirectly imported in other modules later
 from sqlalchemy import update, delete, select, func  # noqa: F401, F811
-from sqlalchemy.orm import scoped_session, sessionmaker, mapped_column, close_all_sessions
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker, mapped_column, close_all_sessions, declarative_base
 from sqlalchemy.pool import NullPool
 
 from flask_sqlalchemy import SQLAlchemy


### PR DESCRIPTION
## Summary

- Import `declarative_base` from `sqlalchemy.orm`.
- Remove the SQLAlchemy 2.0 `MovedIn20Warning` emitted when `app.database` is imported.

## Root Cause

`app.database` still imported `declarative_base` from `sqlalchemy.ext.declarative`. SQLAlchemy keeps that path working, but emits a deprecation warning because the function moved to `sqlalchemy.orm`.

## Validation

- `PYTHONPATH=bazarr:custom_libs python -c "import warnings; from sqlalchemy.exc import MovedIn20Warning; warnings.simplefilter('error', MovedIn20Warning); import app.database"`
- `pytest tests/bazarr/test_database_sqlite_maintenance.py tests/bazarr/test_config.py tests/compat/unit/test_provider_languages.py`
- `git diff --check`

## Notes

The warning still printed by pytest comes from the `pep8` pytest plugin regex, not SQLAlchemy.
