### PR TITLE
Allow trusted Provider Hub migrations

### DIFF
--- a/bazarr/provider_hub/migration.py
+++ b/bazarr/provider_hub/migration.py
@@ -1,0 +1,21 @@
+# coding=utf-8
+from __future__ import annotations
+
+MIGRATED_BUILT_IN_PROVIDER_IDS = frozenset({
+    "gestdown",
+})
+
+
+def can_shadow_built_in_provider(provider_id: str, trusted: bool) -> bool:
+    return bool(trusted) and str(provider_id or "") in MIGRATED_BUILT_IN_PROVIDER_IDS
+
+
+def validation_built_in_provider_ids(
+    provider_id: str,
+    built_in_provider_ids: set[str] | None,
+    trusted: bool,
+) -> set[str]:
+    provider_ids = set(built_in_provider_ids or set())
+    if can_shadow_built_in_provider(provider_id, trusted):
+        provider_ids.discard(str(provider_id or ""))
+    return provider_ids

--- a/bazarr/provider_hub/registry.py
+++ b/bazarr/provider_hub/registry.py
@@ -13,6 +13,7 @@ from subliminal_patch.providers import Provider
 
 from .manifest import ManifestValidationError, validate_manifest
 from .migration import (
+    MIGRATED_BUILT_IN_PROVIDER_IDS,
     can_shadow_built_in_provider,
     validation_built_in_provider_ids,
 )
@@ -126,7 +127,15 @@ def _make_provider_class(manifest, worker_client=None, installation=None):
 
 def register_active_provider_classes(installations=None) -> list[str]:
     registered = []
-    built_in_provider_ids = set(provider_registry.names()) - _REGISTERED_PROVIDER_HUB_IDS
+    # Always treat migrated built-in ids as built-in for the shadow gate, even once a
+    # hub provider has registered one: otherwise, after the trusted migration registers
+    # (adding the id to _REGISTERED_PROVIDER_HUB_IDS and dropping it from the dynamic
+    # set), a later UNTRUSTED install of the same id would no longer count as shadowing
+    # a built-in and could silently replace the migrated provider.
+    built_in_provider_ids = (
+        (set(provider_registry.names()) - _REGISTERED_PROVIDER_HUB_IDS)
+        | MIGRATED_BUILT_IN_PROVIDER_IDS
+    )
     installations = installations if installations is not None else active_installations()
 
     for installation in installations:

--- a/bazarr/provider_hub/registry.py
+++ b/bazarr/provider_hub/registry.py
@@ -149,9 +149,16 @@ def register_active_provider_classes(installations=None) -> list[str]:
             logger.exception("Skipping invalid Provider Hub manifest for %s", provider_id)
             continue
 
-        if shadows_builtin and manifest.provider_id in provider_registry:
-            del provider_registry[manifest.provider_id]
-        provider_registry.register(manifest.provider_id, _make_provider_class(manifest, installation=installation))
+        try:
+            provider_cls = _make_provider_class(manifest, installation=installation)
+        except Exception:
+            # Build the proxy class before touching the registry. If this fails for a
+            # provider that shadows a built-in, the built-in must stay in place rather
+            # than be left deleted (provider_registry.register overwrites in place, so
+            # no explicit delete is needed on the success path).
+            logger.exception("Skipping Provider Hub provider %s because its proxy class could not be built", provider_id)
+            continue
+        provider_registry.register(manifest.provider_id, provider_cls)
         _REGISTERED_PROVIDER_HUB_IDS.add(manifest.provider_id)
         registered.append(manifest.provider_id)
 

--- a/bazarr/provider_hub/registry.py
+++ b/bazarr/provider_hub/registry.py
@@ -12,6 +12,10 @@ from subliminal_patch.extensions import provider_registry
 from subliminal_patch.providers import Provider
 
 from .manifest import ManifestValidationError, validate_manifest
+from .migration import (
+    can_shadow_built_in_provider,
+    validation_built_in_provider_ids,
+)
 from .protocol import candidate_from_worker, language_to_payload, video_to_payload, worker_download_to_content
 from .state import active_installations
 from .worker import ProviderWorkerClient, WorkerError, worker_command
@@ -127,18 +131,26 @@ def register_active_provider_classes(installations=None) -> list[str]:
 
     for installation in installations:
         provider_id = installation.provider_id
-        if provider_id in built_in_provider_ids:
+        trusted = bool(getattr(installation, "trusted", False))
+        shadows_builtin = provider_id in built_in_provider_ids
+        if shadows_builtin and not can_shadow_built_in_provider(provider_id, trusted):
             logger.warning("Skipping Provider Hub provider %s because it shadows a built-in provider", provider_id)
             continue
         try:
             manifest = validate_manifest(
                 installation.manifest,
-                built_in_provider_ids=built_in_provider_ids,
+                built_in_provider_ids=validation_built_in_provider_ids(
+                    provider_id,
+                    built_in_provider_ids,
+                    trusted,
+                ),
             )
         except ManifestValidationError:
             logger.exception("Skipping invalid Provider Hub manifest for %s", provider_id)
             continue
 
+        if shadows_builtin and manifest.provider_id in provider_registry:
+            del provider_registry[manifest.provider_id]
         provider_registry.register(manifest.provider_id, _make_provider_class(manifest, installation=installation))
         _REGISTERED_PROVIDER_HUB_IDS.add(manifest.provider_id)
         registered.append(manifest.provider_id)

--- a/bazarr/provider_hub/service.py
+++ b/bazarr/provider_hub/service.py
@@ -20,6 +20,7 @@ from subliminal_patch.extensions import provider_registry
 
 from .manifest import validate_manifest
 from .bundle import verify_bundle_tree
+from .migration import validation_built_in_provider_ids
 from .state import (
     OFFICIAL_CATALOG_SOURCE_ID,
     OFFICIAL_CATALOG_URL,
@@ -762,7 +763,14 @@ def test_provider_connection(provider_id: str) -> dict[str, Any] | None:
             if not python_path:
                 raise ProviderHubInstallError("provider Python path is missing")
 
-            manifest = validate_manifest(manifest_data, built_in_provider_ids=_built_in_provider_ids())
+            trusted = bool(provider.get("trusted", False))
+            manifest = validate_manifest(
+                manifest_data,
+                built_in_provider_ids=_validation_built_in_provider_ids(
+                    manifest_data,
+                    trusted,
+                ),
+            )
             bundle_path = Path(active_path)
             _remove_bundle_runtime_artifacts(bundle_path)
             verify_bundle_tree(manifest, bundle_path)
@@ -818,6 +826,20 @@ def _built_in_provider_ids() -> set[str]:
         return provider_ids - _REGISTERED_PROVIDER_HUB_IDS
     except Exception:
         return provider_ids
+
+
+def _manifest_provider_id(manifest: dict[str, Any]) -> str:
+    if not isinstance(manifest, dict):
+        return ""
+    return str(manifest.get("provider_id") or "")
+
+
+def _validation_built_in_provider_ids(manifest: dict[str, Any], trusted: bool) -> set[str]:
+    return validation_built_in_provider_ids(
+        _manifest_provider_id(manifest),
+        _built_in_provider_ids(),
+        trusted,
+    )
 
 
 def _bundle_path_for(manifest) -> Path:
@@ -980,9 +1002,15 @@ def _failed_installation(validated, existing, error: Exception, source_trusted: 
 
 
 def stage_install(manifest: dict[str, Any]) -> dict[str, Any]:
-    validated = validate_manifest(manifest, built_in_provider_ids=_built_in_provider_ids())
     state = load_state()
-    source_trusted = _catalog_manifest_trusted(validated.raw, state)
+    source_trusted = _catalog_manifest_trusted(manifest, state) if isinstance(manifest, dict) else False
+    validated = validate_manifest(
+        manifest,
+        built_in_provider_ids=_validation_built_in_provider_ids(
+            manifest,
+            source_trusted,
+        ),
+    )
     existing = (state.get("installations") or {}).get(validated.provider_id)
     existing_version = (
         existing.get("active_version") if isinstance(existing, dict) else None
@@ -1085,11 +1113,23 @@ def activate_staged_installations() -> list[str]:
             to_version=target_version,
         ) as job:
             try:
-                manifest = validate_manifest(installation.get("manifest") or {}, built_in_provider_ids=_built_in_provider_ids())
+                trusted = bool(installation.get("trusted", False))
+                manifest_data = installation.get("manifest") or {}
+                manifest = validate_manifest(
+                    manifest_data,
+                    built_in_provider_ids=_validation_built_in_provider_ids(
+                        manifest_data,
+                        trusted,
+                    ),
+                )
                 if isinstance(installation.get("staged_manifest"), dict):
+                    staged_manifest = installation.get("staged_manifest")
                     manifest = validate_manifest(
-                        installation.get("staged_manifest"),
-                        built_in_provider_ids=_built_in_provider_ids(),
+                        staged_manifest,
+                        built_in_provider_ids=_validation_built_in_provider_ids(
+                            staged_manifest,
+                            trusted,
+                        ),
                     )
                 staged_path = installation.get("staged_path")
                 staged_python_path = installation.get("staged_python_path")

--- a/bazarr/provider_hub/service.py
+++ b/bazarr/provider_hub/service.py
@@ -20,7 +20,7 @@ from subliminal_patch.extensions import provider_registry
 
 from .manifest import validate_manifest
 from .bundle import verify_bundle_tree
-from .migration import validation_built_in_provider_ids
+from .migration import MIGRATED_BUILT_IN_PROVIDER_IDS, validation_built_in_provider_ids
 from .state import (
     OFFICIAL_CATALOG_SOURCE_ID,
     OFFICIAL_CATALOG_URL,
@@ -823,9 +823,12 @@ def _built_in_provider_ids() -> set[str]:
     provider_ids = set(provider_registry.names())
     try:
         from .registry import _REGISTERED_PROVIDER_HUB_IDS
-        return provider_ids - _REGISTERED_PROVIDER_HUB_IDS
+        provider_ids = provider_ids - _REGISTERED_PROVIDER_HUB_IDS
     except Exception:
-        return provider_ids
+        pass
+    # Keep migrated built-in ids in the denylist even after a hub provider has
+    # registered one, so an untrusted install of the same id can never shadow it.
+    return provider_ids | MIGRATED_BUILT_IN_PROVIDER_IDS
 
 
 def _manifest_provider_id(manifest: dict[str, Any]) -> str:

--- a/bazarr/provider_hub/state.py
+++ b/bazarr/provider_hub/state.py
@@ -32,6 +32,7 @@ class ProviderHubInstallation:
     staged_path: str | None = None
     staged_python_path: str | None = None
     last_error: str | None = None
+    trusted: bool = False
 
 
 def official_catalog_source() -> dict[str, Any]:
@@ -207,6 +208,7 @@ def active_installations(path: str | os.PathLike[str] | None = None) -> list[Pro
                 staged_path=item.get("staged_path"),
                 staged_python_path=item.get("staged_python_path"),
                 last_error=item.get("last_error"),
+                trusted=bool(item.get("trusted", False)),
             )
         )
     return installations

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -341,6 +341,65 @@ def test_active_provider_hub_installation_registers_proxy(tmp_path, monkeypatch)
     assert provider_cls.languages
 
 
+def test_active_trusted_migrated_provider_replaces_built_in(tmp_path, monkeypatch):
+    import provider_hub.registry as hub_registry
+    from provider_hub.registry import HubProxyProvider, register_active_provider_classes
+    from subliminal_patch.extensions import provider_registry
+    from subliminal_patch.providers import Provider
+
+    provider_id = "gestdown"
+    had_existing = provider_id in provider_registry
+    original_cls = provider_registry[provider_id] if had_existing else None
+
+    class BuiltInGestdownProvider(Provider):
+        provider_name = provider_id
+        languages = {Language("eng")}
+        video_types = (Movie,)
+
+    if not had_existing:
+        provider_registry.register(provider_id, BuiltInGestdownProvider)
+        original_cls = BuiltInGestdownProvider
+
+    state_file = tmp_path / "state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "installations": {
+                    provider_id: {
+                        "provider_id": provider_id,
+                        "name": "Gestdown",
+                        "active_version": "1.0.0",
+                        "state": "active",
+                        "pending_restart": False,
+                        "trusted": True,
+                        "manifest": _manifest(
+                            provider_id=provider_id,
+                            name="Gestdown",
+                            dependencies={"requirements": []},
+                        ),
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+
+    try:
+        registered = register_active_provider_classes()
+
+        assert registered == [provider_id]
+        assert provider_registry[provider_id] is not original_cls
+        assert issubclass(provider_registry[provider_id], HubProxyProvider)
+        assert provider_registry[provider_id].provider_name == provider_id
+    finally:
+        hub_registry._REGISTERED_PROVIDER_HUB_IDS.discard(provider_id)
+        if provider_id in provider_registry:
+            del provider_registry[provider_id]
+        if had_existing and original_cls is not None:
+            provider_registry.register(provider_id, original_cls)
+
+
 def test_get_providers_registers_active_provider_hub_installation(tmp_path, monkeypatch):
     from app import get_providers
     from subliminal_patch.extensions import provider_registry
@@ -1527,6 +1586,94 @@ def test_stage_install_trust_comes_from_catalog_entry_only(tmp_path, monkeypatch
     installation = stage_install(tampered_manifest)
 
     assert installation["trusted"] is False
+
+
+def test_stage_install_rejects_untrusted_built_in_shadow(tmp_path, monkeypatch):
+    from provider_hub.manifest import ManifestValidationError
+    from provider_hub.service import stage_install
+
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(tmp_path / "provider_hub" / "state.json"))
+    monkeypatch.setattr("provider_hub.service._built_in_provider_ids", lambda: {"gestdown"})
+
+    with pytest.raises(ManifestValidationError, match="built-in"):
+        stage_install(
+            _manifest(
+                provider_id="gestdown",
+                name="Gestdown",
+                dependencies={"requirements": []},
+            )
+        )
+
+
+def test_stage_install_accepts_trusted_migrated_built_in_shadow(tmp_path, monkeypatch):
+    from provider_hub.service import stage_install
+    from provider_hub.state import load_state, official_catalog_source
+
+    provider_content = b"class GestdownProvider: pass\n"
+    catalog_manifest = _manifest(
+        provider_id="gestdown",
+        name="Gestdown",
+        file_payloads={"provider.py": provider_content},
+        dependencies={"requirements": []},
+        source={
+            "type": "github",
+            "repo": "owner/repo",
+            "ref": "main",
+            "commit": "e" * 40,
+            "catalog_url": "https://github.com/owner/repo/blob/main/catalog.json",
+            "trusted": True,
+        },
+    )
+    install_manifest = json.loads(json.dumps(catalog_manifest))
+    install_manifest["source"].pop("trusted")
+
+    state_file = tmp_path / "provider_hub" / "state.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        json.dumps(
+            {
+                "catalog_sources": {"official": official_catalog_source()},
+                "catalog_entries": {
+                    "official:gestdown:1.0.0": {
+                        "source": "official",
+                        "provider_id": "gestdown",
+                        "version": "1.0.0",
+                        "trusted": True,
+                        "manifest": catalog_manifest,
+                    }
+                },
+                "installations": {},
+                "jobs": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+    monkeypatch.setattr("provider_hub.service._built_in_provider_ids", lambda: {"gestdown"})
+    monkeypatch.setattr("provider_hub.service._fetch_bundle", lambda manifest: tmp_path / "bundle")
+
+    class FakeEnvironment:
+        def __init__(self, root):
+            self.root = Path(root)
+
+        def install(self, validated):
+            return self.root / "envs" / validated.provider_id / validated.version / "test"
+
+    monkeypatch.setattr("provider_hub.service.PluginEnvironment", FakeEnvironment)
+    monkeypatch.setattr("provider_hub.service.python_executable", lambda env_path: tmp_path / "python")
+    monkeypatch.setattr("provider_hub.service._smoke_validate_worker", lambda manifest, bundle_path, python_path: None)
+    monkeypatch.setattr("provider_hub.service._set_bazarr_provider_enabled", lambda provider_id, enabled: True)
+
+    installation = stage_install(install_manifest)
+
+    assert installation["provider_id"] == "gestdown"
+    assert installation["trusted"] is True
+    assert installation["state"] == "staged"
+    assert installation["pending_restart"] is True
+    assert installation["staged_version"] == "1.0.0"
+    stored = load_state()["installations"]["gestdown"]
+    assert stored["trusted"] is True
+    assert stored["staged_manifest"] == install_manifest
 
 
 def test_stage_install_smoke_failure_records_failed_install(tmp_path, monkeypatch):

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -554,6 +554,75 @@ def test_failed_proxy_build_preserves_shadowed_built_in(monkeypatch):
             del provider_registry[provider_id]
 
 
+def test_built_in_denylist_keeps_migrated_id_after_registration():
+    # Once the trusted migration registers gestdown as a hub provider, gestdown is in
+    # _REGISTERED_PROVIDER_HUB_IDS and is no longer a plain built-in class. It must still
+    # be reported as a built-in id so a later untrusted install cannot shadow it.
+    import provider_hub.registry as hub_registry
+    from provider_hub.service import _built_in_provider_ids
+    from subliminal_patch.extensions import provider_registry
+
+    provider_id = "gestdown"
+    had_existing = provider_id in provider_registry
+    original_cls = provider_registry[provider_id] if had_existing else None
+
+    # Simulate post-migration state: registered as a hub id, absent as a built-in class.
+    if had_existing:
+        del provider_registry[provider_id]
+    hub_registry._REGISTERED_PROVIDER_HUB_IDS.add(provider_id)
+
+    try:
+        assert provider_id in _built_in_provider_ids()
+    finally:
+        hub_registry._REGISTERED_PROVIDER_HUB_IDS.discard(provider_id)
+        if had_existing and original_cls is not None:
+            provider_registry.register(provider_id, original_cls)
+
+
+def test_untrusted_install_cannot_replace_registered_migrated_provider():
+    # gestdown is already registered as a (trusted) hub provider. An untrusted gestdown
+    # installation must still be skipped, leaving the registered provider untouched, even
+    # though gestdown is no longer in the dynamic built-in set.
+    import provider_hub.registry as hub_registry
+    from provider_hub.registry import register_active_provider_classes
+    from subliminal_patch.extensions import provider_registry
+    from subliminal_patch.providers import Provider
+
+    provider_id = "gestdown"
+    had_existing = provider_id in provider_registry
+    original_cls = provider_registry[provider_id] if had_existing else None
+
+    class RegisteredHubGestdown(Provider):
+        provider_name = provider_id
+        languages = {Language("eng")}
+        video_types = (Movie,)
+
+    provider_registry.register(provider_id, RegisteredHubGestdown)
+    hub_registry._REGISTERED_PROVIDER_HUB_IDS.add(provider_id)
+
+    installation = _install(
+        provider_id,
+        trusted=False,
+        manifest=_manifest(
+            provider_id=provider_id,
+            name="Gestdown",
+            dependencies={"requirements": []},
+        ),
+    )
+
+    try:
+        registered = register_active_provider_classes(installations=[installation])
+
+        assert provider_id not in registered
+        assert provider_registry[provider_id] is RegisteredHubGestdown
+    finally:
+        hub_registry._REGISTERED_PROVIDER_HUB_IDS.discard(provider_id)
+        if provider_id in provider_registry:
+            del provider_registry[provider_id]
+        if had_existing and original_cls is not None:
+            provider_registry.register(provider_id, original_cls)
+
+
 def test_get_providers_registers_active_provider_hub_installation(tmp_path, monkeypatch):
     from app import get_providers
     from subliminal_patch.extensions import provider_registry

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -400,6 +400,160 @@ def test_active_trusted_migrated_provider_replaces_built_in(tmp_path, monkeypatc
             provider_registry.register(provider_id, original_cls)
 
 
+def _install(provider_id, *, trusted, manifest):
+    from provider_hub.state import ProviderHubInstallation
+
+    return ProviderHubInstallation(
+        provider_id=provider_id,
+        name=provider_id.title(),
+        active_version="1.0.0",
+        state="active",
+        pending_restart=False,
+        manifest=manifest,
+        trusted=trusted,
+    )
+
+
+def test_active_trusted_non_allowlisted_provider_cannot_shadow_built_in():
+    # The shadow gate is "trusted AND on the migration allowlist". Trust alone must
+    # not be enough: a trusted provider whose id is NOT in MIGRATED_BUILT_IN_PROVIDER_IDS
+    # must still be refused and the built-in left untouched. A regression that dropped
+    # the allowlist check (e.g. `return bool(trusted)`) would silently fail this test.
+    import provider_hub.registry as hub_registry
+    from provider_hub.migration import MIGRATED_BUILT_IN_PROVIDER_IDS
+    from provider_hub.registry import register_active_provider_classes
+    from subliminal_patch.extensions import provider_registry
+    from subliminal_patch.providers import Provider
+
+    provider_id = "examplebuiltin"
+    assert provider_id not in MIGRATED_BUILT_IN_PROVIDER_IDS
+    had_existing = provider_id in provider_registry
+    original_cls = provider_registry[provider_id] if had_existing else None
+
+    class BuiltInExampleProvider(Provider):
+        provider_name = provider_id
+        languages = {Language("eng")}
+        video_types = (Movie,)
+
+    if not had_existing:
+        provider_registry.register(provider_id, BuiltInExampleProvider)
+        original_cls = BuiltInExampleProvider
+
+    installation = _install(
+        provider_id,
+        trusted=True,
+        manifest=_manifest(
+            provider_id=provider_id,
+            name="Example Built-in",
+            dependencies={"requirements": []},
+        ),
+    )
+
+    try:
+        registered = register_active_provider_classes(installations=[installation])
+
+        assert provider_id not in registered
+        assert provider_registry[provider_id] is original_cls
+    finally:
+        hub_registry._REGISTERED_PROVIDER_HUB_IDS.discard(provider_id)
+        if not had_existing and provider_id in provider_registry:
+            del provider_registry[provider_id]
+
+
+def test_active_untrusted_migrated_provider_cannot_shadow_built_in():
+    # The provider id IS on the migration allowlist, but the install is untrusted, so
+    # register must skip it and leave the built-in class in place (last line of defense
+    # against an untrusted state row that shadows a built-in).
+    import provider_hub.registry as hub_registry
+    from provider_hub.migration import MIGRATED_BUILT_IN_PROVIDER_IDS
+    from provider_hub.registry import register_active_provider_classes
+    from subliminal_patch.extensions import provider_registry
+    from subliminal_patch.providers import Provider
+
+    provider_id = "gestdown"
+    assert provider_id in MIGRATED_BUILT_IN_PROVIDER_IDS
+    had_existing = provider_id in provider_registry
+    original_cls = provider_registry[provider_id] if had_existing else None
+
+    class BuiltInGestdownProvider(Provider):
+        provider_name = provider_id
+        languages = {Language("eng")}
+        video_types = (Movie,)
+
+    if not had_existing:
+        provider_registry.register(provider_id, BuiltInGestdownProvider)
+        original_cls = BuiltInGestdownProvider
+
+    installation = _install(
+        provider_id,
+        trusted=False,
+        manifest=_manifest(
+            provider_id=provider_id,
+            name="Gestdown",
+            dependencies={"requirements": []},
+        ),
+    )
+
+    try:
+        registered = register_active_provider_classes(installations=[installation])
+
+        assert provider_id not in registered
+        assert provider_registry[provider_id] is original_cls
+    finally:
+        hub_registry._REGISTERED_PROVIDER_HUB_IDS.discard(provider_id)
+        if not had_existing and provider_id in provider_registry:
+            del provider_registry[provider_id]
+
+
+def test_failed_proxy_build_preserves_shadowed_built_in(monkeypatch):
+    # A trusted, allowlisted manifest that passes validation but blows up while the
+    # proxy class is being built must not destroy the built-in it shadows: the build
+    # happens before the registry is mutated, so on failure the built-in stays intact
+    # and the exception does not propagate out of the loop.
+    import provider_hub.registry as hub_registry
+    from provider_hub.registry import register_active_provider_classes
+    from subliminal_patch.extensions import provider_registry
+    from subliminal_patch.providers import Provider
+
+    provider_id = "gestdown"
+    had_existing = provider_id in provider_registry
+    original_cls = provider_registry[provider_id] if had_existing else None
+
+    class BuiltInGestdownProvider(Provider):
+        provider_name = provider_id
+        languages = {Language("eng")}
+        video_types = (Movie,)
+
+    if not had_existing:
+        provider_registry.register(provider_id, BuiltInGestdownProvider)
+        original_cls = BuiltInGestdownProvider
+
+    def _boom(manifest, installation=None):
+        raise RuntimeError("proxy class construction failed")
+
+    monkeypatch.setattr(hub_registry, "_make_provider_class", _boom)
+
+    installation = _install(
+        provider_id,
+        trusted=True,
+        manifest=_manifest(
+            provider_id=provider_id,
+            name="Gestdown",
+            dependencies={"requirements": []},
+        ),
+    )
+
+    try:
+        registered = register_active_provider_classes(installations=[installation])
+
+        assert provider_id not in registered
+        assert provider_registry[provider_id] is original_cls
+    finally:
+        hub_registry._REGISTERED_PROVIDER_HUB_IDS.discard(provider_id)
+        if not had_existing and provider_id in provider_registry:
+            del provider_registry[provider_id]
+
+
 def test_get_providers_registers_active_provider_hub_installation(tmp_path, monkeypatch):
     from app import get_providers
     from subliminal_patch.extensions import provider_registry


### PR DESCRIPTION
## Summary
- allow trusted Provider Hub catalog entries to replace explicitly migrated built-in provider ids
- keep untrusted built-in shadowing blocked
- register trusted migrated Provider Hub providers instead of silently skipping them

## Verification
- pytest tests/bazarr/test_provider_hub.py -q
- ruff check bazarr/provider_hub/migration.py bazarr/provider_hub/registry.py bazarr/provider_hub/service.py bazarr/provider_hub/state.py tests/bazarr/test_provider_hub.py
- python -m compileall bazarr/provider_hub/manifest.py bazarr/provider_hub/migration.py bazarr/provider_hub/registry.py bazarr/provider_hub/service.py bazarr/provider_hub/state.py tests/bazarr/test_provider_hub.py
- git diff --check