### PR TITLE
Allow Provider Hub source dependency installs

### DIFF
--- a/bazarr/provider_hub/venv.py
+++ b/bazarr/provider_hub/venv.py
@@ -64,7 +64,7 @@ class PluginEnvironment:
                 "--disable-pip-version-check",
                 "--no-warn-script-location",
                 "--require-hashes",
-                "--only-binary=:all:",
+                "--prefer-binary",
                 "-r",
                 str(requirements_path),
             ]

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -325,7 +325,8 @@ def test_venv_installer_uses_isolated_hash_checked_pip(monkeypatch, tmp_path):
     assert pip_calls, calls
     install_cmd = " ".join(pip_calls[-1])
     assert "--require-hashes" in install_cmd
-    assert "--only-binary=:all:" in install_cmd
+    assert "--prefer-binary" in install_cmd
+    assert "--only-binary=:all:" not in install_cmd
     assert "--no-warn-script-location" in install_cmd
     assert "-r" in install_cmd
     assert "/usr/local" not in install_cmd


### PR DESCRIPTION
## Summary
- replace Provider Hub pip --only-binary enforcement with --prefer-binary while keeping --require-hashes
- allow hash-checked source distributions such as pyjsparser required by ai-cloudscraper
- update the installer unit test to assert the new pip flags

## Tests
- python3 -B -m pytest tests/bazarr/test_provider_hub.py -q -k 'venv_installer_uses_isolated_hash_checked_pip'
- python3 -B -m pytest tests/bazarr/test_provider_hub.py -q
- python3 -B -m py_compile bazarr/provider_hub/venv.py
- git diff --check