### PR TITLE
feat: Provider Hub local package installs + origin tracking

### DIFF
--- a/bazarr/api/provider_hub/provider_hub.py
+++ b/bazarr/api/provider_hub/provider_hub.py
@@ -148,6 +148,23 @@ class ProviderHubInstallations(Resource):
             return str(error), 400
 
 
+@api_ns_provider_hub.route('provider-hub/installations/local')
+class ProviderHubLocalInstallations(Resource):
+    @authenticate
+    @api_ns_provider_hub.response(200, 'Success')
+    @api_ns_provider_hub.response(400, 'Invalid package')
+    @api_ns_provider_hub.response(401, 'Not Authenticated')
+    def post(self):
+        upload = request.files.get("file") or request.files.get("package")
+        if upload is None:
+            return 'a .zip package file is required', 400
+        archive_bytes = upload.read()
+        try:
+            return service.stage_install_local(archive_bytes)
+        except (ManifestValidationError, ProviderHubInstallError) as error:
+            return str(error), 400
+
+
 @api_ns_provider_hub.route('provider-hub/installations/<string:provider_id>')
 class ProviderHubInstallation(Resource):
     @authenticate

--- a/bazarr/provider_hub/service.py
+++ b/bazarr/provider_hub/service.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 import contextlib
+import io
 import json
 import re
 import shutil
 import tempfile
 import time
 import uuid
+import zipfile
 
 import requests
 
@@ -694,7 +696,10 @@ def runtime_provider_configs() -> dict[str, dict[str, Any]]:
 
 def list_providers(redact: bool = True) -> list[dict[str, Any]]:
     state = load_state()
-    providers = list((state.get("installations") or {}).values())
+    providers = [
+        _with_origin(provider, state) if isinstance(provider, dict) else provider
+        for provider in (state.get("installations") or {}).values()
+    ]
     if not redact:
         return providers
     return [
@@ -708,6 +713,7 @@ def get_provider(provider_id: str, redact: bool = True) -> dict[str, Any] | None
     provider = (state.get("installations") or {}).get(provider_id)
     if not isinstance(provider, dict):
         return None
+    provider = _with_origin(provider, state)
     return _redact_installation(provider) if redact else provider
 
 
@@ -899,6 +905,71 @@ def _fetch_bundle(manifest) -> Path:
     return target
 
 
+def _safe_extract_zip(archive_bytes: bytes, dest: Path) -> None:
+    """Extract a zip into ``dest`` with zip-slip protection."""
+    dest_root = dest.resolve()
+    try:
+        archive = zipfile.ZipFile(io.BytesIO(archive_bytes))
+    except zipfile.BadZipFile as error:
+        raise ProviderHubInstallError("uploaded package is not a valid .zip archive") from error
+    with archive:
+        for member in archive.infolist():
+            name = member.filename
+            if not name or name.endswith("/"):
+                continue
+            target = (dest / name).resolve()
+            if target != dest_root and dest_root not in target.parents:
+                raise ProviderHubInstallError(f"unsafe path in package: {name}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(member) as source, open(target, "wb") as out:
+                shutil.copyfileobj(source, out)
+
+
+def _find_local_manifest(extracted: Path) -> tuple[dict[str, Any], Path]:
+    """Locate the manifest inside an extracted local package and its bundle root."""
+    candidates = sorted(
+        list(extracted.rglob("provider.json")) + list(extracted.rglob("manifest.json")),
+        key=lambda path: len(path.parts),
+    )
+    if not candidates:
+        raise ProviderHubInstallError("package must contain a provider.json manifest")
+    manifest_file = candidates[0]
+    try:
+        manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        raise ProviderHubInstallError(f"invalid manifest in package: {error}") from error
+    if not isinstance(manifest, dict):
+        raise ProviderHubInstallError("package manifest must be a JSON object")
+    return manifest, manifest_file.parent
+
+
+def _stage_local_bundle(validated, source_dir: Path) -> Path:
+    """Stage a bundle from already-extracted local files (no network fetch)."""
+    target = _bundle_path_for(validated)
+    if target.exists():
+        _remove_bundle_runtime_artifacts(target)
+        verify_bundle_tree(validated, target)
+        return target
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=".stage-", dir=str(target.parent)) as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        for relative_path in validated.files:
+            source_file = source_dir / relative_path
+            if not source_file.is_file():
+                raise ProviderHubInstallError(f"package is missing declared file: {relative_path}")
+            destination = tmp_path / relative_path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(source_file.read_bytes())
+
+        _write_manifest_file(validated, tmp_path)
+        verify_bundle_tree(validated, tmp_path)
+        shutil.move(str(tmp_path), str(target))
+
+    verify_bundle_tree(validated, target)
+    return target
+
+
 def _trust_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
     normalized = dict(manifest)
     if isinstance(normalized.get("source"), dict):
@@ -927,6 +998,43 @@ def _catalog_manifest_trusted(manifest: dict[str, Any], state: dict[str, Any]) -
     return False
 
 
+def _install_origin(manifest: dict[str, Any], state: dict[str, Any]) -> tuple[str, str | None]:
+    """Resolve where an install came from, for display/grouping only.
+
+    Returns ("catalog", source_id) when the manifest's catalog_url matches a
+    configured catalog source, otherwise ("local", None). This is independent of
+    the trust decision (_catalog_manifest_trusted), which stays the security gate;
+    a local upload is always recorded as origin="local" regardless of this result.
+    """
+    if not isinstance(manifest, dict):
+        return ("local", None)
+    source = manifest.get("source")
+    catalog_url = source.get("catalog_url") if isinstance(source, dict) else None
+    if catalog_url:
+        for source_id, configured in (state.get("catalog_sources") or {}).items():
+            if isinstance(configured, dict) and configured.get("url") == catalog_url:
+                return ("catalog", source_id)
+    return ("local", None)
+
+
+def _with_origin(provider: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
+    """Ensure a serialized installation carries origin/source_id.
+
+    A stored origin of "local" is authoritative (a local upload can never be
+    relabelled as a catalog provider). Otherwise the origin is resolved from the
+    manifest's catalog_url against the current sources, so pre-existing installs
+    and later source-config changes are reflected on read.
+    """
+    result = dict(provider)
+    if result.get("origin") == "local":
+        result.setdefault("source_id", result.get("source_id"))
+        return result
+    origin, source_id = _install_origin(result.get("manifest") or {}, state)
+    result["origin"] = origin
+    result["source_id"] = source_id
+    return result
+
+
 def _smoke_validate_worker(manifest, bundle_path: Path, python_path: Path) -> None:
     _remove_bundle_runtime_artifacts(bundle_path)
     runner = Path(__file__).with_name("worker_runner.py")
@@ -945,7 +1053,15 @@ def _smoke_validate_worker(manifest, bundle_path: Path, python_path: Path) -> No
         _remove_bundle_runtime_artifacts(bundle_path)
 
 
-def _staged_installation(validated, existing, bundle_path: Path, staged_python_path: Path, source_trusted: bool):
+def _staged_installation(
+    validated,
+    existing,
+    bundle_path: Path,
+    staged_python_path: Path,
+    source_trusted: bool,
+    origin: str = "catalog",
+    source_id: str | None = None,
+):
     existing = existing if isinstance(existing, dict) else {}
     return {
         "provider_id": validated.provider_id,
@@ -963,13 +1079,22 @@ def _staged_installation(validated, existing, bundle_path: Path, staged_python_p
         "activated_at": existing.get("activated_at"),
         "last_error": None,
         "trusted": bool(source_trusted),
+        "origin": origin,
+        "source_id": source_id,
         "manifest": existing.get("manifest") if existing.get("active_version") else validated.raw,
         "enabled": existing.get("enabled", True),
         "config": existing.get("config", {}),
     }
 
 
-def _failed_installation(validated, existing, error: Exception, source_trusted: bool):
+def _failed_installation(
+    validated,
+    existing,
+    error: Exception,
+    source_trusted: bool,
+    origin: str = "catalog",
+    source_id: str | None = None,
+):
     existing = existing if isinstance(existing, dict) else {}
     message = str(error)
     if existing.get("active_version"):
@@ -998,28 +1123,32 @@ def _failed_installation(validated, existing, error: Exception, source_trusted: 
         "activated_at": None,
         "last_error": message,
         "trusted": bool(source_trusted),
+        "origin": origin,
+        "source_id": source_id,
         "manifest": validated.raw,
         "enabled": existing.get("enabled", True),
         "config": existing.get("config", {}),
     }
 
 
-def stage_install(manifest: dict[str, Any]) -> dict[str, Any]:
+def _stage_validated(
+    validated,
+    source_trusted: bool,
+    origin: str,
+    source_id: str | None,
+    bundle_stager,
+    catalog_url: str | None = None,
+) -> dict[str, Any]:
+    """Shared install core: stage the bundle, build the venv, smoke-test, record.
+
+    ``bundle_stager(validated) -> Path`` decides where the bundle comes from
+    (catalog fetch vs already-extracted local files).
+    """
     state = load_state()
-    source_trusted = _catalog_manifest_trusted(manifest, state) if isinstance(manifest, dict) else False
-    validated = validate_manifest(
-        manifest,
-        built_in_provider_ids=_validation_built_in_provider_ids(
-            manifest,
-            source_trusted,
-        ),
-    )
     existing = (state.get("installations") or {}).get(validated.provider_id)
     existing_version = (
         existing.get("active_version") if isinstance(existing, dict) else None
     )
-    manifest_source = validated.raw.get("source") if isinstance(validated.raw, dict) else None
-    catalog_url = manifest_source.get("catalog_url") if isinstance(manifest_source, dict) else None
     is_update = bool(existing_version)
     action = "stage_update" if is_update else "install"
 
@@ -1030,10 +1159,10 @@ def stage_install(manifest: dict[str, Any]) -> dict[str, Any]:
         target_name=validated.raw.get("name") or validated.provider_id,
         from_version=existing_version,
         to_version=validated.version,
-        details={"catalog_url": catalog_url, "trusted": source_trusted},
+        details={"catalog_url": catalog_url, "trusted": source_trusted, "origin": origin},
     ) as job:
         try:
-            bundle_path = _fetch_bundle(validated)
+            bundle_path = bundle_stager(validated)
             env_path = PluginEnvironment(provider_hub_dir()).install(validated)
             staged_python_path = python_executable(env_path)
             _smoke_validate_worker(validated, bundle_path, staged_python_path)
@@ -1043,7 +1172,9 @@ def stage_install(manifest: dict[str, Any]) -> dict[str, Any]:
             def record_failed_install(state: dict[str, Any]) -> dict[str, Any]:
                 installations = state.setdefault("installations", {})
                 current = installations.get(validated.provider_id, existing)
-                installation = _failed_installation(validated, current, install_error, source_trusted)
+                installation = _failed_installation(
+                    validated, current, install_error, source_trusted, origin, source_id
+                )
                 installations[validated.provider_id] = installation
                 return dict(installation)
 
@@ -1059,6 +1190,8 @@ def stage_install(manifest: dict[str, Any]) -> dict[str, Any]:
                 bundle_path,
                 staged_python_path,
                 source_trusted,
+                origin,
+                source_id,
             )
             installations[validated.provider_id] = installation
             return dict(installation)
@@ -1077,6 +1210,61 @@ def stage_install(manifest: dict[str, Any]) -> dict[str, Any]:
             message = f"Staged install of v{validated.version} (restart Bazarr+ to activate)"
         job.update(message=message)
         return _redact_installation(installation)
+
+
+def stage_install(manifest: dict[str, Any]) -> dict[str, Any]:
+    state = load_state()
+    source_trusted = _catalog_manifest_trusted(manifest, state) if isinstance(manifest, dict) else False
+    origin, source_id = _install_origin(manifest, state) if isinstance(manifest, dict) else ("local", None)
+    validated = validate_manifest(
+        manifest,
+        built_in_provider_ids=_validation_built_in_provider_ids(
+            manifest,
+            source_trusted,
+        ),
+    )
+    manifest_source = validated.raw.get("source") if isinstance(validated.raw, dict) else None
+    catalog_url = manifest_source.get("catalog_url") if isinstance(manifest_source, dict) else None
+    return _stage_validated(
+        validated,
+        source_trusted,
+        origin,
+        source_id,
+        _fetch_bundle,
+        catalog_url=catalog_url,
+    )
+
+
+def stage_install_local(archive_bytes: bytes) -> dict[str, Any]:
+    """Install a Provider Hub provider from an uploaded .zip package.
+
+    A local package has no catalog vouching for it, so it is always recorded as
+    origin="local" and forced untrusted: it can never shadow a built-in provider.
+    Its files are still hash-verified against the manifest and smoke-tested before
+    activation, exactly like a catalog install.
+    """
+    if not isinstance(archive_bytes, (bytes, bytearray)) or not archive_bytes:
+        raise ProviderHubInstallError("uploaded package is empty")
+
+    work_dir = Path(tempfile.mkdtemp(prefix="phub-local-", dir=str(provider_hub_dir())))
+    try:
+        _safe_extract_zip(bytes(archive_bytes), work_dir)
+        manifest, bundle_root = _find_local_manifest(work_dir)
+        # Untrusted (full built-in set, no replacements): a local package can
+        # never shadow a built-in provider.
+        validated = validate_manifest(
+            manifest,
+            built_in_provider_ids=_built_in_provider_ids(),
+        )
+        return _stage_validated(
+            validated,
+            source_trusted=False,
+            origin="local",
+            source_id=None,
+            bundle_stager=lambda candidate: _stage_local_bundle(candidate, bundle_root),
+        )
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)
 
 
 def activate_staged_installations() -> list[str]:

--- a/bazarr/provider_hub/service.py
+++ b/bazarr/provider_hub/service.py
@@ -1246,7 +1246,11 @@ def stage_install_local(archive_bytes: bytes) -> dict[str, Any]:
     if not isinstance(archive_bytes, (bytes, bytearray)) or not archive_bytes:
         raise ProviderHubInstallError("uploaded package is empty")
 
-    work_dir = Path(tempfile.mkdtemp(prefix="phub-local-", dir=str(provider_hub_dir())))
+    # A local upload can be the very first Provider Hub write, before any catalog
+    # refresh/job has created the directory, so make sure it exists.
+    hub_dir = provider_hub_dir()
+    hub_dir.mkdir(parents=True, exist_ok=True)
+    work_dir = Path(tempfile.mkdtemp(prefix="phub-local-", dir=str(hub_dir)))
     try:
         _safe_extract_zip(bytes(archive_bytes), work_dir)
         manifest, bundle_root = _find_local_manifest(work_dir)

--- a/bazarr/provider_hub/state.py
+++ b/bazarr/provider_hub/state.py
@@ -33,6 +33,8 @@ class ProviderHubInstallation:
     staged_python_path: str | None = None
     last_error: str | None = None
     trusted: bool = False
+    origin: str = "catalog"
+    source_id: str | None = None
 
 
 def official_catalog_source() -> dict[str, Any]:
@@ -209,6 +211,8 @@ def active_installations(path: str | os.PathLike[str] | None = None) -> list[Pro
                 staged_python_path=item.get("staged_python_path"),
                 last_error=item.get("last_error"),
                 trusted=bool(item.get("trusted", False)),
+                origin=str(item.get("origin") or "catalog"),
+                source_id=item.get("source_id"),
             )
         )
     return installations

--- a/frontend/src/apis/hooks/providerHub.ts
+++ b/frontend/src/apis/hooks/providerHub.ts
@@ -88,6 +88,17 @@ export function useProviderHubInstall() {
   });
 }
 
+export function useProviderHubInstallLocal() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationKey: [...providerHubKey, QueryKeys.Actions, "install-local"],
+    mutationFn: (file: File) => api.providerHub.installLocal(file),
+    onSettled: () => {
+      client.invalidateQueries({ queryKey: providerHubKey });
+    },
+  });
+}
+
 export function useProviderHubUninstall() {
   const client = useQueryClient();
   return useMutation({

--- a/frontend/src/apis/raw/base.ts
+++ b/frontend/src/apis/raw/base.ts
@@ -51,8 +51,9 @@ class BaseApi {
     path: string,
     data?: unknown,
     params?: LooseObject,
+    headers?: LooseObject,
   ): Promise<AxiosResponse<T>> {
-    return client.axios.post(this.prefix + path, data, { params });
+    return client.axios.post(this.prefix + path, data, { params, headers });
   }
 
   protected patch<T = void>(

--- a/frontend/src/apis/raw/providerHub.ts
+++ b/frontend/src/apis/raw/providerHub.ts
@@ -137,9 +137,13 @@ class ProviderHubApi extends BaseApi {
   async installLocal(file: File) {
     const form = new FormData();
     form.append("file", file);
+    // Override the client's default application/json Content-Type so Axios sends
+    // real multipart/form-data (with boundary) and Flask populates request.files.
     const response = await this.postRaw<ProviderHubInstallation>(
       "/installations/local",
       form,
+      undefined,
+      { "Content-Type": "multipart/form-data" },
     );
     return response.data;
   }

--- a/frontend/src/apis/raw/providerHub.ts
+++ b/frontend/src/apis/raw/providerHub.ts
@@ -48,6 +48,10 @@ export interface ProviderHubInstallation {
   installed_at?: string | null;
   activated_at?: string | null;
   manifest?: ProviderHubManifest;
+  /** "catalog" for marketplace installs, "local" for uploaded packages. */
+  origin?: string;
+  /** Catalog source id this install came from, or null for local packages. */
+  source_id?: string | null;
 }
 
 export interface ProviderHubInstallRequest {
@@ -126,6 +130,16 @@ class ProviderHubApi extends BaseApi {
     const response = await this.postRaw<ProviderHubInstallation>(
       "/installations",
       { manifest },
+    );
+    return response.data;
+  }
+
+  async installLocal(file: File) {
+    const form = new FormData();
+    form.append("file", file);
+    const response = await this.postRaw<ProviderHubInstallation>(
+      "/installations/local",
+      form,
     );
     return response.data;
   }

--- a/frontend/src/pages/Settings/Providers/hub/MarketplacePanel.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/MarketplacePanel.tsx
@@ -1,9 +1,21 @@
 import { FunctionComponent, useCallback, useMemo, useState } from "react";
-import { Button, Chip, Group, SegmentedControl, Stack } from "@mantine/core";
-import { faSliders, faStore } from "@fortawesome/free-solid-svg-icons";
+import {
+  Button,
+  Chip,
+  FileButton,
+  Group,
+  SegmentedControl,
+  Stack,
+} from "@mantine/core";
+import {
+  faSliders,
+  faStore,
+  faUpload,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   useProviderHubInstall,
+  useProviderHubInstallLocal,
   useProviderHubTest,
   useProviderHubUninstall,
 } from "@/apis/hooks";
@@ -63,6 +75,7 @@ export const MarketplacePanel: FunctionComponent<MarketplacePanelProps> = ({
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   const install = useProviderHubInstall();
+  const installLocal = useProviderHubInstallLocal();
   const testProvider = useProviderHubTest();
   const uninstall = useProviderHubUninstall();
 
@@ -146,8 +159,46 @@ export const MarketplacePanel: FunctionComponent<MarketplacePanelProps> = ({
     [install],
   );
 
+  const isLocalInstall = useCallback(
+    (entry: ProviderHubCatalogEntry) =>
+      installedById.get(entry.provider_id)?.origin === "local",
+    [installedById],
+  );
+
+  const marketplaceCards = useMemo(
+    () => filtered.filter((entry) => !isLocalInstall(entry)),
+    [filtered, isLocalInstall],
+  );
+  const localCards = useMemo(
+    () => filtered.filter((entry) => isLocalInstall(entry)),
+    [filtered, isLocalInstall],
+  );
+
+  const renderCard = useCallback(
+    (entry: ProviderHubCatalogEntry, isLocal: boolean) => (
+      <CatalogCard
+        key={`${entry.provider_id}-${entry.version}`}
+        entry={entry}
+        installed={installedById.get(entry.provider_id) ?? null}
+        onInstall={handleInstall}
+        isInstalling={
+          install.isPending &&
+          install.variables?.manifest?.provider_id === entry.provider_id
+        }
+        onTest={(providerId) => testProvider.mutate(providerId)}
+        onUninstall={(providerId) => uninstall.mutate(providerId)}
+        isTesting={
+          testProvider.isPending && testProvider.variables === entry.provider_id
+        }
+        isLocal={isLocal}
+      />
+    ),
+    [installedById, handleInstall, install, testProvider, uninstall],
+  );
+
   const noSources = sources.length === 0 && marketplaceEntries.length === 0;
-  const noResults = !noSources && filtered.length === 0;
+  const noResults =
+    !noSources && marketplaceCards.length === 0 && localCards.length === 0;
 
   return (
     <Stack gap="md">
@@ -160,13 +211,32 @@ export const MarketplacePanel: FunctionComponent<MarketplacePanelProps> = ({
             sources. Installed plugins can be tested or removed here.
           </p>
         </div>
-        <Button
-          variant="default"
-          leftSection={<FontAwesomeIcon icon={faSliders} />}
-          onClick={() => setDrawerOpen(true)}
-        >
-          Manage sources ({sources.length})
-        </Button>
+        <Group gap="xs">
+          <FileButton
+            accept=".zip,application/zip"
+            onChange={(file) => {
+              if (file) installLocal.mutate(file);
+            }}
+          >
+            {(props) => (
+              <Button
+                {...props}
+                variant="default"
+                leftSection={<FontAwesomeIcon icon={faUpload} />}
+                loading={installLocal.isPending}
+              >
+                Install local package
+              </Button>
+            )}
+          </FileButton>
+          <Button
+            variant="default"
+            leftSection={<FontAwesomeIcon icon={faSliders} />}
+            onClick={() => setDrawerOpen(true)}
+          >
+            Manage sources ({sources.length})
+          </Button>
+        </Group>
       </div>
 
       <Group className={styles.toolbar}>
@@ -221,26 +291,31 @@ export const MarketplacePanel: FunctionComponent<MarketplacePanelProps> = ({
           body="Try a different search term or clear the active filters."
         />
       ) : (
-        <div className={styles.cardGrid}>
-          {filtered.map((entry) => (
-            <CatalogCard
-              key={`${entry.provider_id}-${entry.version}`}
-              entry={entry}
-              installed={installedById.get(entry.provider_id) ?? null}
-              onInstall={handleInstall}
-              isInstalling={
-                install.isPending &&
-                install.variables?.manifest?.provider_id === entry.provider_id
-              }
-              onTest={(providerId) => testProvider.mutate(providerId)}
-              onUninstall={(providerId) => uninstall.mutate(providerId)}
-              isTesting={
-                testProvider.isPending &&
-                testProvider.variables === entry.provider_id
-              }
-            />
-          ))}
-        </div>
+        <>
+          {marketplaceCards.length > 0 && (
+            <div className={styles.cardGrid}>
+              {marketplaceCards.map((entry) => renderCard(entry, false))}
+            </div>
+          )}
+          {localCards.length > 0 && (
+            <Stack gap="md">
+              <div>
+                <div className={styles.eyebrow}>Local</div>
+                <h3 className={styles.panelTitle} style={{ fontSize: 18 }}>
+                  Local / manually installed
+                </h3>
+                <p className={styles.panelDescription}>
+                  Providers installed from an uploaded package rather than a
+                  catalog source. They are never trusted and can never replace a
+                  built-in provider.
+                </p>
+              </div>
+              <div className={styles.cardGrid}>
+                {localCards.map((entry) => renderCard(entry, true))}
+              </div>
+            </Stack>
+          )}
+        </>
       )}
 
       <SourcesDrawer

--- a/frontend/src/pages/Settings/Providers/hub/MarketplacePanel.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/MarketplacePanel.tsx
@@ -116,26 +116,54 @@ export const MarketplacePanel: FunctionComponent<MarketplacePanelProps> = ({
     return Array.from(seen.values());
   }, [catalog?.entries]);
 
+  // Providers installed from an uploaded package. They own their card (built from
+  // the installation, not a catalog entry) and are excluded from the marketplace
+  // list so a local override is never shown as a catalog card.
+  const localProviderIds = useMemo(
+    () =>
+      new Set(
+        (providers ?? [])
+          .filter((provider) => provider.origin === "local")
+          .map((provider) => provider.provider_id),
+      ),
+    [providers],
+  );
+
+  const localEntries = useMemo(
+    () =>
+      (providers ?? [])
+        .filter((provider) => provider.origin === "local")
+        .map(catalogEntryFromInstallation),
+    [providers],
+  );
+
   const marketplaceEntries = useMemo(() => {
     const catalogProviderIds = new Set(
       latestPerProvider.map((entry) => entry.provider_id),
     );
     const installedOnlyEntries = (providers ?? [])
-      .filter((provider) => !catalogProviderIds.has(provider.provider_id))
+      .filter(
+        (provider) =>
+          !catalogProviderIds.has(provider.provider_id) &&
+          provider.origin !== "local",
+      )
       .map(catalogEntryFromInstallation);
 
-    return [...latestPerProvider, ...installedOnlyEntries];
-  }, [latestPerProvider, providers]);
+    const catalogEntries = latestPerProvider.filter(
+      (entry) => !localProviderIds.has(entry.provider_id),
+    );
+    return [...catalogEntries, ...installedOnlyEntries];
+  }, [latestPerProvider, providers, localProviderIds]);
 
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return marketplaceEntries.filter((entry) => {
+  const matchesFilters = useCallback(
+    (entry: ProviderHubCatalogEntry) => {
       if (trustFilter === "trusted" && !entry.trusted) return false;
       if (trustFilter === "community" && entry.trusted) return false;
       if (activeSources.length > 0) {
         const sn = entry.source ?? entry.source_name ?? "";
         if (!activeSources.includes(sn)) return false;
       }
+      const q = query.trim().toLowerCase();
       if (!q) return true;
       const haystack = [
         entry.name,
@@ -148,8 +176,9 @@ export const MarketplacePanel: FunctionComponent<MarketplacePanelProps> = ({
         .join(" ")
         .toLowerCase();
       return haystack.includes(q);
-    });
-  }, [marketplaceEntries, query, trustFilter, activeSources]);
+    },
+    [query, trustFilter, activeSources],
+  );
 
   const handleInstall = useCallback(
     (entry: ProviderHubCatalogEntry) => {
@@ -159,19 +188,13 @@ export const MarketplacePanel: FunctionComponent<MarketplacePanelProps> = ({
     [install],
   );
 
-  const isLocalInstall = useCallback(
-    (entry: ProviderHubCatalogEntry) =>
-      installedById.get(entry.provider_id)?.origin === "local",
-    [installedById],
-  );
-
   const marketplaceCards = useMemo(
-    () => filtered.filter((entry) => !isLocalInstall(entry)),
-    [filtered, isLocalInstall],
+    () => marketplaceEntries.filter(matchesFilters),
+    [marketplaceEntries, matchesFilters],
   );
   const localCards = useMemo(
-    () => filtered.filter((entry) => isLocalInstall(entry)),
-    [filtered, isLocalInstall],
+    () => localEntries.filter(matchesFilters),
+    [localEntries, matchesFilters],
   );
 
   const renderCard = useCallback(

--- a/frontend/src/pages/Settings/Providers/hub/components/CatalogCard.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/components/CatalogCard.tsx
@@ -37,6 +37,8 @@ interface CatalogCardProps {
   onTest?: (id: string) => void;
   onUninstall?: (id: string) => void;
   isTesting?: boolean;
+  /** True for providers installed from an uploaded local package, not a catalog. */
+  isLocal?: boolean;
 }
 
 type CtaState = "install" | "installed" | "update" | "restart" | "broken";
@@ -83,6 +85,7 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
   onTest,
   onUninstall,
   isTesting,
+  isLocal = false,
 }) => {
   const manifest = useMemo(() => parseManifest(entry), [entry]);
   const cta = deriveCta(entry, installed, manifest !== null);
@@ -163,7 +166,9 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
     }
   })();
 
-  const sourceLabel = entry.source ?? entry.source_name ?? "Unknown source";
+  const sourceLabel = isLocal
+    ? "local package"
+    : (entry.source ?? entry.source_name ?? "Unknown source");
   const description =
     (manifest?.description as string | undefined) ??
     (manifest?.summary as string | undefined) ??
@@ -272,7 +277,15 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
               activeVersion={installed.active_version}
             />
           )}
-          <TrustBadge trusted={entry.trusted} />
+          {isLocal ? (
+            <Tooltip label="Installed from an uploaded local package, not a catalog source. Never trusted; cannot replace a built-in provider.">
+              <Badge size="xs" variant="light" color="grape">
+                Local
+              </Badge>
+            </Tooltip>
+          ) : (
+            <TrustBadge trusted={entry.trusted} />
+          )}
         </Group>
         <div className={styles.hubCardAction}>{ctaButton}</div>
       </div>

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -3052,3 +3052,31 @@ def test_stage_install_local_rejects_zip_slip(tmp_path, monkeypatch):
 
     with pytest.raises(ProviderHubInstallError, match="unsafe path"):
         stage_install_local(buffer.getvalue())
+
+
+def test_stage_install_local_creates_hub_dir_when_missing(tmp_path, monkeypatch):
+    # A local upload can be the first Provider Hub write, before the hub dir exists;
+    # it must create the directory instead of failing with FileNotFoundError.
+    from provider_hub.service import stage_install_local
+
+    provider_content = b"class LocalProvider: pass\n"
+    file_payloads = {"provider.py": provider_content}
+    manifest = _manifest(
+        provider_id="firstlocal",
+        name="First Local",
+        provider_content=provider_content,
+        dependencies={"requirements": []},
+    )
+    package = _provider_zip(manifest, file_payloads)
+
+    # Point the state at a provider_hub dir that does not exist yet.
+    state_file = tmp_path / "provider_hub" / "state.json"
+    assert not state_file.parent.exists()
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+    _patch_local_install_env(monkeypatch, tmp_path)
+
+    installation = stage_install_local(package)
+
+    assert installation["provider_id"] == "firstlocal"
+    assert installation["origin"] == "local"
+    assert state_file.parent.exists()

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -1,9 +1,11 @@
 # coding=utf-8
 import base64
+import io
 import json
 import os
 import subprocess
 import threading
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -74,6 +76,29 @@ def _manifest(**overrides):
     }
     manifest.update(overrides)
     return manifest
+
+
+def _provider_zip(manifest, file_payloads, *, manifest_name="provider.json", prefix=""):
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr(f"{prefix}{manifest_name}", json.dumps(manifest))
+        for path, content in file_payloads.items():
+            archive.writestr(f"{prefix}{path}", content)
+    return buffer.getvalue()
+
+
+def _patch_local_install_env(monkeypatch, tmp_path):
+    class FakeEnvironment:
+        def __init__(self, root):
+            self.root = Path(root)
+
+        def install(self, validated):
+            return self.root / "envs" / validated.provider_id / validated.version / "test"
+
+    monkeypatch.setattr("provider_hub.service.PluginEnvironment", FakeEnvironment)
+    monkeypatch.setattr("provider_hub.service.python_executable", lambda env_path: tmp_path / "python")
+    monkeypatch.setattr("provider_hub.service._smoke_validate_worker", lambda manifest, bundle_path, python_path: None)
+    monkeypatch.setattr("provider_hub.service._set_bazarr_provider_enabled", lambda provider_id, enabled: True)
 
 
 class _FakeResponse:
@@ -2911,3 +2936,119 @@ def test_remove_catalog_source_purges_catalog_entries(tmp_path, monkeypatch):
     remaining = load_state()["catalog_entries"]
     assert "community:foo:1.0.0" not in remaining
     assert "official:bar:1.0.0" in remaining
+
+
+def test_install_origin_resolves_catalog_and_local():
+    from provider_hub.service import _install_origin
+
+    state = {
+        "catalog_sources": {
+            "official": {
+                "id": "official",
+                "url": "https://github.com/owner/repo/blob/main/catalog.json",
+            }
+        }
+    }
+    catalog_manifest = _manifest()  # source.catalog_url matches the official source
+    assert _install_origin(catalog_manifest, state) == ("catalog", "official")
+
+    local_manifest = _manifest(
+        source={
+            "type": "github",
+            "repo": "someone/elsewhere",
+            "ref": "main",
+            "commit": "a" * 40,
+            "catalog_url": "https://github.com/someone/elsewhere/blob/main/catalog.json",
+            "trusted": False,
+        }
+    )
+    assert _install_origin(local_manifest, state) == ("local", None)
+
+
+def test_stage_install_local_records_origin_local_and_untrusted(tmp_path, monkeypatch):
+    from provider_hub.service import stage_install_local
+    from provider_hub.state import load_state
+
+    provider_content = b"class LocalProvider: pass\n"
+    file_payloads = {"provider.py": provider_content}
+    manifest = _manifest(
+        provider_id="locallyinstalled",
+        name="Locally Installed",
+        provider_content=provider_content,
+        dependencies={"requirements": []},
+        # Even with a catalog_url, an uploaded package is always local + untrusted.
+        source={
+            "type": "github",
+            "repo": "owner/repo",
+            "ref": "main",
+            "commit": "b" * 40,
+            "catalog_url": "https://github.com/owner/repo/blob/main/catalog.json",
+            "trusted": True,
+        },
+    )
+    package = _provider_zip(manifest, file_payloads, prefix="locallyinstalled/")
+
+    state_file = tmp_path / "provider_hub" / "state.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(json.dumps({"installations": {}, "jobs": []}), encoding="utf-8")
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+    _patch_local_install_env(monkeypatch, tmp_path)
+
+    installation = stage_install_local(package)
+
+    assert installation["provider_id"] == "locallyinstalled"
+    assert installation["origin"] == "local"
+    assert installation["source_id"] is None
+    assert installation["trusted"] is False
+    assert installation["state"] == "staged"
+
+    stored = load_state()["installations"]["locallyinstalled"]
+    assert stored["origin"] == "local"
+    assert stored["trusted"] is False
+    # A local install is authoritative: even a catalog_url that matches a source
+    # must not relabel it as a catalog provider on read.
+    from provider_hub.service import list_providers
+    listed = {p["provider_id"]: p for p in list_providers()}
+    assert listed["locallyinstalled"]["origin"] == "local"
+
+
+def test_stage_install_local_rejects_built_in_shadow(tmp_path, monkeypatch):
+    from provider_hub.manifest import ManifestValidationError
+    from provider_hub.service import stage_install_local
+
+    provider_content = b"class GestdownProvider: pass\n"
+    file_payloads = {"provider.py": provider_content}
+    manifest = _manifest(
+        provider_id="gestdown",
+        name="Gestdown",
+        provider_content=provider_content,
+        dependencies={"requirements": []},
+    )
+    package = _provider_zip(manifest, file_payloads)
+
+    state_file = tmp_path / "provider_hub" / "state.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(json.dumps({"installations": {}, "jobs": []}), encoding="utf-8")
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+    monkeypatch.setattr("provider_hub.service._built_in_provider_ids", lambda: {"gestdown"})
+    _patch_local_install_env(monkeypatch, tmp_path)
+
+    # Untrusted local packages can never shadow a built-in, even an allowlisted one.
+    with pytest.raises(ManifestValidationError, match="built-in"):
+        stage_install_local(package)
+
+
+def test_stage_install_local_rejects_zip_slip(tmp_path, monkeypatch):
+    from provider_hub.service import ProviderHubInstallError, stage_install_local
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("../escaped.py", b"print('pwned')\n")
+
+    state_file = tmp_path / "provider_hub" / "state.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(json.dumps({"installations": {}, "jobs": []}), encoding="utf-8")
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+
+    with pytest.raises(ProviderHubInstallError, match="unsafe path"):
+        stage_install_local(buffer.getvalue())


### PR DESCRIPTION
## Summary

Distinguishes **locally-installed** Provider Hub providers from **marketplace** (catalog) ones, and adds a way to install a provider from an uploaded **.zip package**. This resolves the confusing "two of the same provider" cards (one labelled by its GitHub repo slug, one by the catalog source) and gives manually-installed providers a clear home.

## Backend
- **Origin tracking:** each installation records `origin` (`"catalog"` | `"local"`) and the resolved `source_id`. Origin is resolved from the manifest's `catalog_url` against configured sources; a stored `"local"` is authoritative and is never relabelled on read. This also fixes catalog installs previously mislabelled by their repo slug instead of their source.
- **Local install:** `stage_install_local(zip)` extracts the package (with **zip-slip protection**), validates the manifest, **hash-verifies** the bundle from the uploaded files, builds the venv and smoke-tests, then records the install. A local package is **always `origin="local"` and forced untrusted**, so it can never shadow a built-in provider. The catalog and local paths share one `_stage_validated` core.
- New endpoint: `POST /provider-hub/installations/local` (multipart upload).

## Frontend
- `providerHub` API/types gain `origin`/`source_id` + an `installLocal(file)` call and a `useProviderHubInstallLocal` hook.
- Marketplace gains an **"Install local package"** upload button and renders local installs in a separate **"Local / manually installed"** section with a **Local** badge instead of a misleading source chip.

## Security
Local packages are untrusted by construction: no catalog vouches for them, they're hash-verified against their own manifest, smoke-tested, and the validator (full built-in set, no replacements) prevents them from shadowing any built-in provider. Zip extraction is path-guarded.

## Verification (local)
- `pytest tests/bazarr tests/compat` → 969 passed, 2 failed (both pre-existing on `development`, unrelated: a provider-hub order-dependent test and a `test_ui` auth test). New tests: origin resolution, local-origin + untrusted, local-cannot-shadow-built-in, zip-slip rejected.
- Frontend: `tsc` clean, `eslint` 0 errors, `prettier` clean, hub vitest 47 passed.