### PR TITLE
fix: address Codex re-review of Provider Hub local installs

### DIFF
--- a/bazarr/provider_hub/service.py
+++ b/bazarr/provider_hub/service.py
@@ -905,15 +905,26 @@ def _fetch_bundle(manifest) -> Path:
     return target
 
 
+_LOCAL_PACKAGE_MAX_MEMBERS = 5000
+_LOCAL_PACKAGE_MAX_TOTAL_BYTES = 100 * 1024 * 1024  # 100 MB uncompressed
+
+
 def _safe_extract_zip(archive_bytes: bytes, dest: Path) -> None:
-    """Extract a zip into ``dest`` with zip-slip protection."""
+    """Extract a zip into ``dest`` with zip-slip, size and read-error guards."""
     dest_root = dest.resolve()
     try:
         archive = zipfile.ZipFile(io.BytesIO(archive_bytes))
     except zipfile.BadZipFile as error:
         raise ProviderHubInstallError("uploaded package is not a valid .zip archive") from error
     with archive:
-        for member in archive.infolist():
+        infos = archive.infolist()
+        # Bound the work before extracting so an oversized or zip-bomb upload
+        # cannot fill the disk or stall the install.
+        if len(infos) > _LOCAL_PACKAGE_MAX_MEMBERS:
+            raise ProviderHubInstallError("package contains too many files")
+        if sum(max(0, info.file_size) for info in infos) > _LOCAL_PACKAGE_MAX_TOTAL_BYTES:
+            raise ProviderHubInstallError("package is too large")
+        for member in infos:
             name = member.filename
             if not name or name.endswith("/"):
                 continue
@@ -921,8 +932,15 @@ def _safe_extract_zip(archive_bytes: bytes, dest: Path) -> None:
             if target != dest_root and dest_root not in target.parents:
                 raise ProviderHubInstallError(f"unsafe path in package: {name}")
             target.parent.mkdir(parents=True, exist_ok=True)
-            with archive.open(member) as source, open(target, "wb") as out:
-                shutil.copyfileobj(source, out)
+            try:
+                with archive.open(member) as source, open(target, "wb") as out:
+                    shutil.copyfileobj(source, out)
+            except (RuntimeError, zipfile.BadZipFile, OSError) as error:
+                # Encrypted/corrupt members raise here, outside the open() guard
+                # above; surface them as a 400 invalid-package, not a 500.
+                raise ProviderHubInstallError(
+                    f"could not read package entry {name}: {error}"
+                ) from error
 
 
 def _find_local_manifest(extracted: Path) -> tuple[dict[str, Any], Path]:
@@ -998,40 +1016,49 @@ def _catalog_manifest_trusted(manifest: dict[str, Any], state: dict[str, Any]) -
     return False
 
 
-def _install_origin(manifest: dict[str, Any], state: dict[str, Any]) -> tuple[str, str | None]:
-    """Resolve where an install came from, for display/grouping only.
-
-    Returns ("catalog", source_id) when the manifest's catalog_url matches a
-    configured catalog source, otherwise ("local", None). This is independent of
-    the trust decision (_catalog_manifest_trusted), which stays the security gate;
-    a local upload is always recorded as origin="local" regardless of this result.
-    """
+def _catalog_source_id_for_manifest(manifest: dict[str, Any], state: dict[str, Any]) -> str | None:
+    """Return the configured catalog source id whose url matches the manifest's
+    catalog_url, or None when no configured source matches."""
     if not isinstance(manifest, dict):
-        return ("local", None)
+        return None
     source = manifest.get("source")
     catalog_url = source.get("catalog_url") if isinstance(source, dict) else None
-    if catalog_url:
-        for source_id, configured in (state.get("catalog_sources") or {}).items():
-            if isinstance(configured, dict) and configured.get("url") == catalog_url:
-                return ("catalog", source_id)
-    return ("local", None)
+    if not catalog_url:
+        return None
+    for source_id, configured in (state.get("catalog_sources") or {}).items():
+        if isinstance(configured, dict) and configured.get("url") == catalog_url:
+            return source_id
+    return None
+
+
+def _install_origin(manifest: dict[str, Any], state: dict[str, Any]) -> tuple[str, str | None]:
+    """Resolve (origin, source_id) for a catalog install.
+
+    A catalog install is always origin="catalog"; the source_id is the configured
+    source matching the manifest's catalog_url, or None if none is configured (the
+    source may have been removed, or this is an older install). "local" is reserved
+    for uploads, which stage_install_local records explicitly. This is for
+    display/grouping only and is independent of the trust gate.
+    """
+    return ("catalog", _catalog_source_id_for_manifest(manifest, state))
 
 
 def _with_origin(provider: dict[str, Any], state: dict[str, Any]) -> dict[str, Any]:
     """Ensure a serialized installation carries origin/source_id.
 
-    A stored origin of "local" is authoritative (a local upload can never be
-    relabelled as a catalog provider). Otherwise the origin is resolved from the
-    manifest's catalog_url against the current sources, so pre-existing installs
-    and later source-config changes are reflected on read.
+    A stored origin of "local" is authoritative (a local upload is never
+    relabelled as a catalog provider). Otherwise it is a catalog install and the
+    source_id is resolved from the manifest's catalog_url against the current
+    sources, so source-config changes are reflected on read.
     """
     result = dict(provider)
     if result.get("origin") == "local":
         result.setdefault("source_id", result.get("source_id"))
         return result
-    origin, source_id = _install_origin(result.get("manifest") or {}, state)
-    result["origin"] = origin
-    result["source_id"] = source_id
+    result["origin"] = "catalog"
+    result["source_id"] = _catalog_source_id_for_manifest(
+        result.get("manifest") or {}, state
+    )
     return result
 
 
@@ -1440,6 +1467,9 @@ def check_updates() -> dict[str, Any]:
         for provider_id, installation in (state.get("installations") or {}).items():
             if not isinstance(installation, dict):
                 continue
+            if installation.get("origin") == "local":
+                # Local packages are owned by their uploaded file, not the catalog.
+                continue
             active_version = installation.get("active_version")
             if not active_version:
                 continue
@@ -1524,6 +1554,9 @@ def apply_update(provider_id: str) -> dict[str, Any] | None:
     provider = get_provider(provider_id, redact=False)
     if not provider:
         return None
+    if provider.get("origin") == "local":
+        # A local package is never replaced by a catalog update; ignore the request.
+        return _redact_installation(provider)
     state = load_state()
     manifest = provider.get("available_manifest") or _latest_catalog_manifest(
         state,

--- a/frontend/src/pages/Settings/Providers/hub/MarketplacePanel.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/MarketplacePanel.tsx
@@ -219,7 +219,10 @@ export const MarketplacePanel: FunctionComponent<MarketplacePanelProps> = ({
     [installedById, handleInstall, install, testProvider, uninstall],
   );
 
-  const noSources = sources.length === 0 && marketplaceEntries.length === 0;
+  const noSources =
+    sources.length === 0 &&
+    marketplaceEntries.length === 0 &&
+    localEntries.length === 0;
   const noResults =
     !noSources && marketplaceCards.length === 0 && localCards.length === 0;
 

--- a/frontend/src/pages/Settings/Providers/hub/utils.ts
+++ b/frontend/src/pages/Settings/Providers/hub/utils.ts
@@ -205,7 +205,11 @@ export function summarizeUpdates(
 ): UpdateSummary {
   const list = providers ?? [];
   return {
-    available: list.filter((p) => isUpdateAvailable(p, catalog)),
+    // Local packages are owned by their uploaded file, so a catalog update is
+    // never offered for them (the backend also refuses apply_update for local).
+    available: list.filter(
+      (p) => p.origin !== "local" && isUpdateAvailable(p, catalog),
+    ),
     pendingRestart: list.filter((p) => p.pending_restart === true),
   };
 }

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -3008,7 +3008,10 @@ def test_remove_catalog_source_purges_catalog_entries(tmp_path, monkeypatch):
     assert "official:bar:1.0.0" in remaining
 
 
-def test_install_origin_resolves_catalog_and_local():
+def test_install_origin_resolves_catalog_source_id():
+    # A catalog install is always origin="catalog"; the source_id is resolved from
+    # the manifest's catalog_url, or None when no configured source matches.
+    # ("local" is reserved for uploads, recorded explicitly by stage_install_local.)
     from provider_hub.service import _install_origin
 
     state = {
@@ -3022,7 +3025,7 @@ def test_install_origin_resolves_catalog_and_local():
     catalog_manifest = _manifest()  # source.catalog_url matches the official source
     assert _install_origin(catalog_manifest, state) == ("catalog", "official")
 
-    local_manifest = _manifest(
+    unmatched_manifest = _manifest(
         source={
             "type": "github",
             "repo": "someone/elsewhere",
@@ -3032,7 +3035,7 @@ def test_install_origin_resolves_catalog_and_local():
             "trusted": False,
         }
     )
-    assert _install_origin(local_manifest, state) == ("local", None)
+    assert _install_origin(unmatched_manifest, state) == ("catalog", None)
 
 
 def test_stage_install_local_records_origin_local_and_untrusted(tmp_path, monkeypatch):
@@ -3150,3 +3153,97 @@ def test_stage_install_local_creates_hub_dir_when_missing(tmp_path, monkeypatch)
     assert installation["provider_id"] == "firstlocal"
     assert installation["origin"] == "local"
     assert state_file.parent.exists()
+
+
+def _local_install_state_file(tmp_path):
+    state_file = tmp_path / "provider_hub" / "state.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        json.dumps(
+            {
+                "catalog_entries": {
+                    "official:locallyowned:2.0.0": {
+                        "source": "official",
+                        "provider_id": "locallyowned",
+                        "version": "2.0.0",
+                        "trusted": True,
+                        "manifest": _manifest(
+                            provider_id="locallyowned",
+                            version="2.0.0",
+                            dependencies={"requirements": []},
+                        ),
+                    }
+                },
+                "installations": {
+                    "locallyowned": {
+                        "provider_id": "locallyowned",
+                        "name": "Locally Owned",
+                        "active_version": "1.0.0",
+                        "state": "active",
+                        "pending_restart": False,
+                        "origin": "local",
+                        "trusted": False,
+                        "manifest": _manifest(
+                            provider_id="locallyowned",
+                            version="1.0.0",
+                            dependencies={"requirements": []},
+                        ),
+                    }
+                },
+                "jobs": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return state_file
+
+
+def test_check_updates_skips_local_installs(tmp_path, monkeypatch):
+    # A local install with a higher catalog version must NOT be reported as an
+    # available update; the catalog does not own local packages.
+    from provider_hub.service import check_updates
+
+    monkeypatch.setenv(
+        "BAZARR_PROVIDER_HUB_STATE", str(_local_install_state_file(tmp_path))
+    )
+
+    result = check_updates()
+
+    assert (result.get("details") or {}).get("updates_available") == 0
+
+
+def test_apply_update_ignores_local_install(tmp_path, monkeypatch):
+    # apply_update must refuse to replace a local package with a catalog version.
+    from provider_hub.service import apply_update
+    from provider_hub.state import load_state
+
+    monkeypatch.setenv(
+        "BAZARR_PROVIDER_HUB_STATE", str(_local_install_state_file(tmp_path))
+    )
+
+    provider = apply_update("locallyowned")
+
+    assert provider["origin"] == "local"
+    assert provider.get("staged_version") is None
+    stored = load_state()["installations"]["locallyowned"]
+    assert stored["active_version"] == "1.0.0"
+    assert stored.get("staged_version") is None
+
+
+def test_stage_install_local_rejects_oversized_package(tmp_path, monkeypatch):
+    # An upload whose declared uncompressed size exceeds the bound is rejected as a
+    # 400-class error before extraction, not allowed to fill the disk.
+    import provider_hub.service as svc
+    from provider_hub.service import ProviderHubInstallError, stage_install_local
+
+    monkeypatch.setattr(svc, "_LOCAL_PACKAGE_MAX_TOTAL_BYTES", 10)
+    state_file = tmp_path / "provider_hub" / "state.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(json.dumps({"installations": {}, "jobs": []}), encoding="utf-8")
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+
+    manifest = _manifest(provider_id="toobig", dependencies={"requirements": []})
+    package = _provider_zip(manifest, {"provider.py": b"class P: pass\n"})
+
+    with pytest.raises(ProviderHubInstallError, match="too large"):
+        stage_install_local(package)


### PR DESCRIPTION
Follow-up to #177, addressing the 4 findings Codex raised on its re-review (which landed after the fix commit, so they weren't in the merged PR).

- **Local-only installs hidden:** `noSources` ignored local cards, so a first-time local install with no catalog sources showed "No catalog sources yet" instead of the provider. Now local installs count toward that decision.
- **Local installs reachable by catalog updates:** `check_updates` and `apply_update` matched by `provider_id` only, so a local package sharing an id with a catalog provider could be offered/overwritten by a catalog "Apply update". Now `check_updates` skips local installs, `apply_update` refuses them, and the frontend `summarizeUpdates` excludes local-origin installs.
- **Zip extraction hardening:** bound member count + total uncompressed size (zip-bomb guard), and convert per-member read errors (encrypted/corrupt entries) into a 400 invalid-package instead of a 500.
- **Origin model corrected:** `local` now means an explicit upload only; a catalog install whose `catalog_url` matches no configured source is still `origin="catalog"` (`source_id=None`). This also fixes `apply_update` wrongly refusing such installs.

## Verification
- `pytest tests/bazarr/test_provider_hub.py` → 107 passed. New tests: updates skip local, apply_update ignores local, oversized package rejected.
- Frontend: `tsc` clean, `eslint` 0 errors, `prettier` clean, hub vitest 47 passed.