### PR TITLE
Map compat hashes for Shooter and Napisy24

### DIFF
--- a/bazarr/compat/service.py
+++ b/bazarr/compat/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import logging
 import os
+import re
 from threading import Lock
 from typing import Iterable
 from urllib.parse import quote
@@ -24,9 +25,11 @@ _compat_pool = None  # lazy singleton, dedicated (B2)
 # get_subhash() raise instead of matching.
 _CLIENT_MOVIEHASH_PROVIDERS = (
     "bsplayer",
+    "napisy24",
     "opensubtitles",
     "opensubtitlescom",
 )
+_SHOOTER_HASH_RE = re.compile(r"^[0-9a-fA-F]{32}(?:;[0-9a-fA-F]{32}){3}$")
 
 
 def _get_compat_pool():
@@ -208,9 +211,14 @@ def _parse_video_from_library(path: str, meta: dict, media_type: str,
 def _apply_client_moviehash(video, moviehash: str | None = None):
     if not moviehash:
         return video
+    client_hash = str(moviehash).strip()
     hashes = dict(getattr(video, "hashes", {}) or {})
+    if _SHOOTER_HASH_RE.match(client_hash):
+        hashes["shooter"] = client_hash.lower()
+        video.hashes = hashes
+        return video
     for provider_id in _CLIENT_MOVIEHASH_PROVIDERS:
-        hashes[provider_id] = str(moviehash)
+        hashes[provider_id] = client_hash
     video.hashes = hashes
     return video
 

--- a/tests/compat/unit/test_client_moviehash.py
+++ b/tests/compat/unit/test_client_moviehash.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+
+
+def test_client_opensubtitles_moviehash_populates_os_hash_consumers():
+    from compat import service
+
+    video = SimpleNamespace(hashes={})
+
+    service._apply_client_moviehash(video, "8e245d9679d31e12")
+
+    assert video.hashes["bsplayer"] == "8e245d9679d31e12"
+    assert video.hashes["opensubtitles"] == "8e245d9679d31e12"
+    assert video.hashes["opensubtitlescom"] == "8e245d9679d31e12"
+    assert video.hashes["napisy24"] == "8e245d9679d31e12"
+    assert "shooter" not in video.hashes
+
+
+def test_client_shooter_moviehash_populates_only_shooter_hash():
+    from compat import service
+
+    video = SimpleNamespace(hashes={})
+    shooter_hash = (
+        "fc884e136ada6a0d21cb22df64095850;"
+        "bf11c971a439215af399213fa49fee02;"
+        "3bbc3ecb4646f0e86bc9197eae2aed06;"
+        "d96fe613346c17d345ecc723318e1b1d"
+    )
+
+    service._apply_client_moviehash(video, shooter_hash)
+
+    assert video.hashes == {"shooter": shooter_hash}


### PR DESCRIPTION
## Summary

- Map OpenSubtitles-style compat `moviehash` values into `napisy24` as well as the existing OpenSubtitles consumers.
- Detect Shooter four-part hashes supplied through compat `moviehash` and map them only into `hashes.shooter`.
- Add unit coverage for both hash shapes.

## Root cause

Compat virtual videos only populated OpenSubtitles-style hash keys. Napisy24 needs the same OpenSubtitles-style hash under its own key in Bazarr's built-in path, and Shooter needs its four-part MD5 hash under `hashes.shooter`. Query-only compat requests could not prove Shooter even when the client supplied a valid Shooter hash.

## Verification

- `pytest -q tests/compat/integration/test_search_flow.py tests/compat/unit/test_cache.py tests/compat/unit/test_client_moviehash.py`
- `git diff --check`
- Test server, Napisy24: compat search returned one `napisy24` row with `moviehash_match=True`; download returned a stream link; stream returned 59,591 SRT bytes.
- Test server, Shooter: compat search returned three `shooter` rows with `moviehash_match=True`; download returned a stream link; stream returned 75,314 SRT bytes.
