### PR TITLE
Distribution Hub: address allow-list/local-subs review follow-ups

### DIFF
--- a/bazarr/api/distribution_hub/distribution_hub.py
+++ b/bazarr/api/distribution_hub/distribution_hub.py
@@ -206,7 +206,10 @@ class DistributionHubProviders(Resource):
             providers = get_providers_sorted() or []
         except Exception:
             providers = []
-        return {"providers": sorted(providers)}
+        names = sorted(providers)
+        if bool(settings.compat_endpoint.serve_local_subs):
+            names = [*names, "local"]
+        return {"providers": names}
 
 
 # ---------------------------------------------------------------- settings
@@ -265,3 +268,14 @@ class DistributionHubRegenerate(Resource):
         token = regenerate_all_secrets()
         keyring.seed_legacy_key()   # re-point the Default key at the new token
         return {"ok": True, "token": token}
+
+
+@api_ns_distribution_hub.route('distribution-hub/legacy-token')
+class DistributionHubLegacyToken(Resource):
+    @authenticate
+    def get(self):
+        # Reveal the current shared legacy token so an operator can copy it to a
+        # new client without rotating (which would break every client still on
+        # the old value). The Default key maps this token; the keys table only
+        # shows its prefix.
+        return {"token": settings.compat_endpoint.token or ""}

--- a/bazarr/compat/routes.py
+++ b/bazarr/compat/routes.py
@@ -270,27 +270,25 @@ def subtitles():
     exclude_param = args.get("exclude_providers") or ""
     req_exclude = [p.strip() for p in exclude_param.split(",") if p.strip()]
     eff_exclude = req_exclude or (key_rec.get("excluded_providers") or [])
-    # only_providers (req #1, advanced): the inverse allow-list. A per-request
-    # value NARROWS within the key's allowed_providers grant by intersection; it
-    # never expands it, so a key the operator scoped to provider X cannot reach Y
-    # via only_providers=Y. With no per-key grant the request stands alone; with
-    # no request the key's grant applies. allow_list_active tracks whether any
-    # allow-list is in force, so an intersection that resolves to nothing is sent
-    # as an (active) empty list -> data == [], kept distinct from None ("no
-    # allow-list, every provider in play"). eff_exclude is still subtracted
-    # downstream, so an allow-list can never reach a provider the operator
-    # excluded for this key.
-    only_param = args.get("only_providers") or ""
-    req_only = [p.strip() for p in only_param.split(",") if p.strip()]
+    # `only_providers` is tri-state by PRESENCE, not just content: a present-
+    # but-empty param (?only_providers= or only commas/whitespace) is a
+    # deliberate "select nothing" and stays active (-> data: []), distinct from
+    # an absent param (no allow-list, every provider in play). It still NARROWS
+    # within the key's allowed_providers grant by intersection.
+    only_raw = args.get("only_providers")
+    only_present = only_raw is not None
+    req_only = [p.strip() for p in (only_raw or "").split(",") if p.strip()]
     key_allowed = key_rec.get("allowed_providers") or []
-    if req_only and key_allowed:
+    if only_present and key_allowed:
         allowed_set = set(key_allowed)
         eff_only = [p for p in req_only if p in allowed_set]
-    elif req_only:
+    elif only_present:
         eff_only = req_only
-    else:
+    elif key_allowed:
         eff_only = list(key_allowed)
-    allow_list_active = bool(req_only or key_allowed)
+    else:
+        eff_only = []
+    allow_list_active = only_present or bool(key_allowed)
     only_arg = eff_only if allow_list_active else None
     req_timeout = args.get("timeout_seconds", type=int)
     raw_timeout = req_timeout or key_rec.get("timeout_seconds")

--- a/frontend/src/apis/hooks/distributionHub.ts
+++ b/frontend/src/apis/hooks/distributionHub.ts
@@ -155,3 +155,15 @@ export function useDistRegenerate() {
       }),
   });
 }
+
+export function useDistLegacyToken() {
+  return useMutation({
+    mutationKey: [...distKey, QueryKeys.Actions, "legacy-token"],
+    mutationFn: () => api.distributionHub.legacyToken(),
+    onError: () =>
+      showNotification({
+        color: "red",
+        message: "Failed to load the legacy token",
+      }),
+  });
+}

--- a/frontend/src/apis/raw/distributionHub.ts
+++ b/frontend/src/apis/raw/distributionHub.ts
@@ -186,6 +186,10 @@ class DistributionHubApi extends BaseApi {
     );
     return response.data;
   }
+
+  legacyToken() {
+    return this.get<{ token: string }>("/legacy-token");
+  }
 }
 
 export default new DistributionHubApi();

--- a/frontend/src/pages/DistributionHub/KeyEditorModal.tsx
+++ b/frontend/src/pages/DistributionHub/KeyEditorModal.tsx
@@ -145,7 +145,7 @@ const KeyEditorModal: FunctionComponent<Props> = ({
         />
         <MultiSelect
           label="Allowed providers (default for this key)"
-          description="Restrict this key to ONLY these providers. Leave empty to allow all. Exclusions above still apply on top. A per-request only_providers value overrides this."
+          description="Restrict this key to ONLY these providers. Leave empty to allow all. Exclusions above still apply on top. A per-request only_providers value narrows within this; it can never reach a provider outside this list. Include 'local' to allow on-disk subtitles."
           data={providers}
           searchable
           clearable

--- a/frontend/src/pages/DistributionHub/KeysPanel.tsx
+++ b/frontend/src/pages/DistributionHub/KeysPanel.tsx
@@ -1,11 +1,9 @@
 import { FunctionComponent, useState } from "react";
 import {
   ActionIcon,
-  Alert,
   Badge,
   Button,
   Code,
-  CopyButton,
   Group,
   Menu,
   Modal,
@@ -16,8 +14,8 @@ import {
   Tooltip,
 } from "@mantine/core";
 import {
-  faCopy,
   faEllipsisVertical,
+  faEye,
   faKey,
   faPlus,
   faRotate,
@@ -28,6 +26,7 @@ import {
   useDistCreateKey,
   useDistDeleteKey,
   useDistKeys,
+  useDistLegacyToken,
   useDistProviders,
   useDistRegenerate,
   useDistRotateKey,
@@ -38,6 +37,7 @@ import type { DistKey } from "@/apis/raw/distributionHub";
 import { QueryOverlay } from "@/components/async";
 import KeyEditorModal, { KeyDraft } from "./KeyEditorModal";
 import { formatLimit, WINDOW_LABELS, WINDOWS } from "./limits";
+import TokenRevealModal from "./TokenRevealModal";
 
 function draftToBody(draft: KeyDraft) {
   return {
@@ -103,40 +103,6 @@ const UsageCell: FunctionComponent<{ keyData: DistKey }> = ({ keyData }) => {
   );
 };
 
-const TokenRevealModal: FunctionComponent<{
-  token: string | null;
-  onClose: () => void;
-}> = ({ token, onClose }) => (
-  <Modal opened={token != null} onClose={onClose} title="Copy your API key">
-    <Stack gap="sm">
-      <Alert color="yellow">
-        This key is shown only once. Copy it now and store it securely. You can
-        rotate it later, but it cannot be retrieved again.
-      </Alert>
-      <Group gap="xs" wrap="nowrap">
-        <Code style={{ flex: 1, overflowWrap: "anywhere" }}>{token}</Code>
-        <CopyButton value={token ?? ""}>
-          {({ copied, copy }) => (
-            <Button
-              size="xs"
-              color={copied ? "teal" : "blue"}
-              leftSection={<FontAwesomeIcon icon={faCopy} />}
-              onClick={copy}
-            >
-              {copied ? "Copied" : "Copy"}
-            </Button>
-          )}
-        </CopyButton>
-      </Group>
-      <Group justify="flex-end">
-        <Button variant="default" onClick={onClose}>
-          Done
-        </Button>
-      </Group>
-    </Stack>
-  </Modal>
-);
-
 const KeysPanel: FunctionComponent = () => {
   const keys = useDistKeys();
   const tiers = useDistTiers();
@@ -146,12 +112,14 @@ const KeysPanel: FunctionComponent = () => {
   const deleteKey = useDistDeleteKey();
   const rotateKey = useDistRotateKey();
   const regenerate = useDistRegenerate();
+  const revealLegacy = useDistLegacyToken();
 
   const [editorOpen, setEditorOpen] = useState(false);
   const [editing, setEditing] = useState<DistKey | null>(null);
   const [revealToken, setRevealToken] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<DistKey | null>(null);
   const [confirmLegacyRotate, setConfirmLegacyRotate] = useState(false);
+  const [legacyReveal, setLegacyReveal] = useState<string | null>(null);
 
   const openCreate = () => {
     setEditing(null);
@@ -270,15 +238,29 @@ const KeysPanel: FunctionComponent = () => {
                         </Menu.Item>
                         {key.is_legacy === 1 ? (
                           // The legacy Default key maps the shared config token.
-                          // Rotating it calls the regenerate endpoint, which
-                          // rotates signing secrets + shared token atomically
-                          // so the config secret and DB row stay in sync.
-                          <Menu.Item
-                            leftSection={<FontAwesomeIcon icon={faRotate} />}
-                            onClick={() => setConfirmLegacyRotate(true)}
-                          >
-                            Rotate token
-                          </Menu.Item>
+                          // It is re-viewable (unlike named keys) so an operator
+                          // can copy it to a new client without rotating. Rotating
+                          // calls the regenerate endpoint, which rotates signing
+                          // secrets + shared token atomically so the config secret
+                          // and DB row stay in sync.
+                          <>
+                            <Menu.Item
+                              leftSection={<FontAwesomeIcon icon={faEye} />}
+                              onClick={() =>
+                                revealLegacy.mutate(undefined, {
+                                  onSuccess: (d) => setLegacyReveal(d.token),
+                                })
+                              }
+                            >
+                              Reveal token
+                            </Menu.Item>
+                            <Menu.Item
+                              leftSection={<FontAwesomeIcon icon={faRotate} />}
+                              onClick={() => setConfirmLegacyRotate(true)}
+                            >
+                              Rotate token
+                            </Menu.Item>
+                          </>
                         ) : (
                           <>
                             <Menu.Item
@@ -338,6 +320,12 @@ const KeysPanel: FunctionComponent = () => {
       <TokenRevealModal
         token={revealToken}
         onClose={() => setRevealToken(null)}
+      />
+
+      <TokenRevealModal
+        token={legacyReveal}
+        oneTime={false}
+        onClose={() => setLegacyReveal(null)}
       />
 
       <Modal

--- a/frontend/src/pages/DistributionHub/SettingsPanel.tsx
+++ b/frontend/src/pages/DistributionHub/SettingsPanel.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/apis/hooks";
 import type { DistSettings } from "@/apis/raw/distributionHub";
 import { QueryOverlay } from "@/components/async";
+import TokenRevealModal from "./TokenRevealModal";
 
 const SettingsPanel: FunctionComponent = () => {
   const settings = useDistSettings();
@@ -23,6 +24,7 @@ const SettingsPanel: FunctionComponent = () => {
   const regenerate = useDistRegenerate();
 
   const [draft, setDraft] = useState<DistSettings | null>(null);
+  const [revealToken, setRevealToken] = useState<string | null>(null);
 
   useEffect(() => {
     if (settings.data) {
@@ -137,7 +139,11 @@ const SettingsPanel: FunctionComponent = () => {
                   color="orange"
                   variant="light"
                   loading={regenerate.isPending}
-                  onClick={() => regenerate.mutate()}
+                  onClick={() =>
+                    regenerate.mutate(undefined, {
+                      onSuccess: (res) => setRevealToken(res.token),
+                    })
+                  }
                 >
                   Regenerate secrets
                 </Button>
@@ -151,6 +157,11 @@ const SettingsPanel: FunctionComponent = () => {
             </Card>
           </>
         )}
+
+        <TokenRevealModal
+          token={revealToken}
+          onClose={() => setRevealToken(null)}
+        />
       </Stack>
     </QueryOverlay>
   );

--- a/frontend/src/pages/DistributionHub/TokenRevealModal.tsx
+++ b/frontend/src/pages/DistributionHub/TokenRevealModal.tsx
@@ -1,0 +1,63 @@
+import { FunctionComponent } from "react";
+import {
+  Alert,
+  Button,
+  Code,
+  CopyButton,
+  Group,
+  Modal,
+  Stack,
+} from "@mantine/core";
+import { faCopy } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+interface TokenRevealModalProps {
+  token: string | null;
+  onClose: () => void;
+  // Freshly created/rotated keys are one-time secrets and warn they cannot be
+  // retrieved again. The shared legacy token is re-viewable, so it skips that
+  // warning and uses copy that reflects an existing, persistent secret.
+  oneTime?: boolean;
+}
+
+const TokenRevealModal: FunctionComponent<TokenRevealModalProps> = ({
+  token,
+  onClose,
+  oneTime = true,
+}) => (
+  <Modal
+    opened={token != null}
+    onClose={onClose}
+    title={oneTime ? "Copy your API key" : "Legacy Default key token"}
+  >
+    <Stack gap="sm">
+      <Alert color="yellow">
+        {oneTime
+          ? "This key is shown only once. Copy it now and store it securely. You can rotate it later, but it cannot be retrieved again."
+          : "This is the current shared token for the legacy Default key. Keep it secret. Anyone holding it can use the endpoint until you rotate it."}
+      </Alert>
+      <Group gap="xs" wrap="nowrap">
+        <Code style={{ flex: 1, overflowWrap: "anywhere" }}>{token}</Code>
+        <CopyButton value={token ?? ""}>
+          {({ copied, copy }) => (
+            <Button
+              size="xs"
+              color={copied ? "teal" : "blue"}
+              leftSection={<FontAwesomeIcon icon={faCopy} />}
+              onClick={copy}
+            >
+              {copied ? "Copied" : "Copy"}
+            </Button>
+          )}
+        </CopyButton>
+      </Group>
+      <Group justify="flex-end">
+        <Button variant="default" onClick={onClose}>
+          Done
+        </Button>
+      </Group>
+    </Stack>
+  </Modal>
+);
+
+export default TokenRevealModal;

--- a/frontend/src/pages/DistributionHub/__tests__/KeysPanel.test.tsx
+++ b/frontend/src/pages/DistributionHub/__tests__/KeysPanel.test.tsx
@@ -40,6 +40,9 @@ describe("DistributionHub > KeysPanel legacy rotation", () => {
       http.post("/api/distribution-hub/regenerate", () =>
         HttpResponse.json({ ok: true, token: "newtok123" }),
       ),
+      http.get("/api/distribution-hub/legacy-token", () =>
+        HttpResponse.json({ token: "legacytok456" }),
+      ),
     );
   });
 
@@ -57,5 +60,18 @@ describe("DistributionHub > KeysPanel legacy rotation", () => {
     await user.click(await screen.findByRole("button", { name: /^rotate$/i }));
 
     expect(await screen.findByText("newtok123")).toBeInTheDocument();
+  });
+
+  it("reveals the legacy token inline without rotating", async () => {
+    const user = userEvent.setup();
+    customRender(<KeysPanel />);
+
+    expect(await screen.findByText("Default")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /key actions/i }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: /reveal token/i }),
+    );
+    // The stored shared token is shown as-is (re-viewable, not a one-time secret).
+    expect(await screen.findByText("legacytok456")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/DistributionHub/__tests__/SettingsPanel.test.tsx
+++ b/frontend/src/pages/DistributionHub/__tests__/SettingsPanel.test.tsx
@@ -49,4 +49,20 @@ describe("DistributionHub > SettingsPanel consent", () => {
     await waitFor(() => expect(patched).toHaveBeenCalled());
     expect(patched.mock.calls[0][0]).toMatchObject({ consent: true });
   });
+
+  it("reveals the regenerated token so the operator can copy it", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.post("/api/distribution-hub/regenerate", () =>
+        HttpResponse.json({ ok: true, token: "regentok789" }),
+      ),
+    );
+
+    customRender(<SettingsPanel />);
+
+    await user.click(
+      await screen.findByRole("button", { name: /regenerate secrets/i }),
+    );
+    expect(await screen.findByText("regentok789")).toBeInTheDocument();
+  });
 });

--- a/tests/compat/integration/test_dist_search_and_auth.py
+++ b/tests/compat/integration/test_dist_search_and_auth.py
@@ -394,3 +394,25 @@ def test_request_only_providers_intersects_key_grant(compat_db, monkeypatch):
     # no grant, with request: the request stands alone
     c.get(f"{base}&only_providers=p2", headers={"Api-Key": open_key})
     assert captured["only_providers"] == ["p2"]
+
+
+def test_present_but_empty_only_providers_is_active_empty(compat_db, monkeypatch):
+    from app.config import settings
+    monkeypatch.setattr(settings.compat_endpoint, "search_rate_limit_enabled", False)
+    captured = {}
+
+    def _fake_search(*a, **k):
+        captured.clear()
+        captured.update(k)
+        return {"data": []}
+
+    monkeypatch.setattr("compat.routes.service.search", _fake_search)
+    from compat import keyring
+    _, token = keyring.create("open", tier="free")
+    keyring.invalidate_cache()
+    c = _app().test_client()
+    c.get("/api/v1/subtitles?imdb_id=tt1&languages=en&only_providers=",
+          headers={"Api-Key": token})
+    assert captured["only_providers"] == []        # present-but-empty -> active []
+    c.get("/api/v1/subtitles?imdb_id=tt1&languages=en", headers={"Api-Key": token})
+    assert captured["only_providers"] is None        # absent -> None

--- a/tests/compat/integration/test_distribution_hub_api.py
+++ b/tests/compat/integration/test_distribution_hub_api.py
@@ -181,3 +181,18 @@ def test_providers_list(client):
     r = client.get("/distribution-hub/providers", headers=_h())
     assert r.status_code == 200
     assert isinstance(r.get_json()["providers"], list)
+
+
+def test_legacy_token_reveal(client):
+    """GET /distribution-hub/legacy-token returns the current shared secret for
+    operators who need to copy it without rotating; an unknown key is rejected."""
+    from app.config import settings
+    settings["compat_endpoint"]["token"] = "reveal-test-token-xyz"
+    r = client.get("/distribution-hub/legacy-token", headers=_h())
+    assert r.status_code == 200
+    assert r.get_json() == {"token": "reveal-test-token-xyz"}
+
+
+def test_legacy_token_reveal_requires_auth(client):
+    r = client.get("/distribution-hub/legacy-token")
+    assert r.status_code == 401


### PR DESCRIPTION
Follow-up to the merged Distribution Hub consolidation, addressing automated-review (Codex) findings on the per-request allow-list and local-subs gating.

## Fixes

- **Present-but-empty `only_providers`** (`routes.py`) — a present-but-empty param (`?only_providers=`, or only commas/whitespace) is now detected by presence and treated as an active-empty allow-list (yields `data: []`), distinct from an absent param (no allow-list, every provider in play). Previously it silently widened to all providers.
- **Settings "Regenerate secrets" reveals the new token** — the rotated shared token was discarded, leaving operators with broken clients and no token to copy. It now opens a token-reveal modal (shared component extracted from the API Keys panel).
- **Reveal the existing legacy token** — the legacy Default key gets a "Reveal token" action (new authed `GET /distribution-hub/legacy-token`) so an operator can copy the current shared token to a new client without rotating (which would break existing clients). Restores the copy path the retired External page provided.
- **`local` selectable in the key editor** — the management providers list includes the reserved `local` name when `serve_local_subs` is on, so the key editor's allowed/excluded selectors can grant or deny on-disk subtitles per key. Help text updated to say a request `only_providers` narrows within the grant rather than overriding it.

## Not changed
- The "restart-required warning lost after redirect" finding does not apply: `DistributionHubView` already renders the `restart_required` banner, and the `/settings/external` redirect lands there. Explained on the review thread.

## Tests
Backend: present-empty vs absent `only_providers`, legacy-token reveal + auth gating. Frontend: legacy-token reveal flow, Settings regenerate reveal. Full compat suite green locally (376 passed); frontend 526 passed; ruff and typecheck clean.