### PR TITLE
fix(provider-hub): collapse same-id catalog plugins onto the built-in card

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "bazarr-binaries"]
 	path = bazarr-binaries
 	url = https://github.com/LavX/bazarr-binaries.git
+[submodule "bazarr-provider-catalog"]
+	path = bazarr-provider-catalog
+	url = https://github.com/LavX/bazarr-provider-catalog.git

--- a/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
@@ -410,6 +410,67 @@ describe("Settings > Providers (Provider Hub)", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps the plugin card while a same-id update is staged for restart", async () => {
+    const subdlPluginManifest = {
+      ...manifest,
+      provider_id: "subdl",
+      name: "SubDL",
+      description: "SubDL plugin.",
+      version: "0.1.0",
+      config_schema: {
+        type: "object",
+        properties: {
+          api_key: { type: "string", title: "API key", secret: true },
+        },
+      },
+      secret_fields: ["api_key"],
+    };
+    server.use(
+      http.get("/api/provider-hub/providers", () => {
+        return HttpResponse.json({
+          data: [
+            {
+              // An update is staged: the backend keeps active_version serving and
+              // marks pending_restart, so the plugin must still own the card.
+              provider_id: "subdl",
+              name: "SubDL",
+              active_version: "0.1.0",
+              staged_version: "0.2.0",
+              state: "staged",
+              pending_restart: true,
+              trusted: true,
+              last_error: null,
+              manifest: subdlPluginManifest,
+            },
+          ],
+        });
+      }),
+    );
+
+    customRender(<SettingsProvidersView />);
+
+    const panel = await screen.findByRole("tabpanel", {
+      name: /My Providers/i,
+    });
+    await userEvent.click(
+      await within(panel).findByRole("button", {
+        name: /Add search provider/i,
+      }),
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: /Provider settings/i,
+    });
+
+    // Exactly one SubDL option (the plugin), not the shipped built-in card.
+    const subdlOptions = await within(dialog).findAllByText("SubDL");
+    expect(subdlOptions).toHaveLength(1);
+    await userEvent.click(subdlOptions[0]);
+    expect(screen.getByLabelText("API key")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Provider Hub plugin is installed but not enabled/i),
+    ).toBeInTheDocument();
+  });
+
   it("stages per-provider excluded language configuration from the provider drawer", async () => {
     const updateRequest = vi.fn();
     server.use(

--- a/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
@@ -341,6 +341,75 @@ describe("Settings > Providers (Provider Hub)", () => {
     ).toBeInTheDocument();
   });
 
+  it("replaces the shipped built-in card with its same-id replacement plugin", async () => {
+    const embeddedPluginManifest = {
+      ...manifest,
+      provider_id: "embeddedsubtitles",
+      name: "Embedded Subtitles",
+      description: "Embedded subtitles plugin.",
+      version: "0.1.2",
+      config_schema: {
+        type: "object",
+        properties: {
+          ffmpeg_path: {
+            type: "string",
+            title: "ffmpeg path",
+          },
+        },
+      },
+    };
+    server.use(
+      http.get("/api/provider-hub/providers", () => {
+        return HttpResponse.json({
+          data: [
+            {
+              // Catalog plugin reuses the built-in id it replaces.
+              provider_id: "embeddedsubtitles",
+              name: "Embedded Subtitles",
+              active_version: "0.1.2",
+              staged_version: null,
+              state: "active",
+              pending_restart: false,
+              trusted: true,
+              last_error: null,
+              manifest: embeddedPluginManifest,
+            },
+          ],
+        });
+      }),
+    );
+
+    customRender(<SettingsProvidersView />);
+
+    const panel = await screen.findByRole("tabpanel", {
+      name: /My Providers/i,
+    });
+
+    await userEvent.click(
+      await within(panel).findByRole("button", {
+        name: /Add search provider/i,
+      }),
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: /Provider settings/i,
+    });
+
+    // Exactly one "Embedded Subtitles" option: the plugin replaces the shipped
+    // built-in card instead of appearing as a second, duplicate provider.
+    const embeddedOptions =
+      await within(dialog).findAllByText("Embedded Subtitles");
+    expect(embeddedOptions).toHaveLength(1);
+
+    await userEvent.click(embeddedOptions[0]);
+
+    // The single card is plugin-backed: it renders the plugin's config schema
+    // and the Provider Hub notice (not the shipped built-in inputs).
+    expect(screen.getByLabelText("ffmpeg path")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Provider Hub plugin is installed but not enabled/i),
+    ).toBeInTheDocument();
+  });
+
   it("stages per-provider excluded language configuration from the provider drawer", async () => {
     const updateRequest = vi.fn();
     server.use(

--- a/frontend/src/pages/Settings/Providers/index.tsx
+++ b/frontend/src/pages/Settings/Providers/index.tsx
@@ -134,17 +134,24 @@ function useProviderOptions(
   providers: ProviderHubInstallation[] | undefined,
 ): Readonly<ProviderInfo[]> {
   return useMemo(() => {
-    const seen = new Set(ProviderList.map((provider) => provider.key));
-    const hubOptions = (providers ?? [])
-      .filter(
-        (provider) => provider.state === "active" && !provider.pending_restart,
-      )
+    const active = (providers ?? []).filter(
+      (provider) => provider.state === "active" && !provider.pending_restart,
+    );
+    // A catalog plugin reuses the built-in's id when it replaces it (e.g. subdl,
+    // embeddedsubtitles). Drop the shipped card for any id an active plugin owns
+    // so the plugin replaces it instead of appearing as a second duplicate, and
+    // so a same-id plugin can actually be added (the shipped key no longer masks
+    // it). Plugins with a brand-new id are simply appended.
+    const replaced = new Set(active.map((provider) => provider.provider_id));
+    const base = ProviderList.filter((provider) => !replaced.has(provider.key));
+    const seen = new Set(base.map((provider) => provider.key));
+    const hubOptions = active
       .filter((provider) => !seen.has(provider.provider_id))
       .map((provider) => {
         seen.add(provider.provider_id);
         return providerHubOption(provider);
       });
-    return [...ProviderList, ...hubOptions];
+    return [...base, ...hubOptions];
   }, [providers]);
 }
 

--- a/frontend/src/pages/Settings/Providers/index.tsx
+++ b/frontend/src/pages/Settings/Providers/index.tsx
@@ -134,18 +134,26 @@ function useProviderOptions(
   providers: ProviderHubInstallation[] | undefined,
 ): Readonly<ProviderInfo[]> {
   return useMemo(() => {
-    const active = (providers ?? []).filter(
-      (provider) => provider.state === "active" && !provider.pending_restart,
+    // A plugin "owns" its id (and shadows the built-in) for as long as it has an
+    // active version serving searches. Gate on active_version rather than
+    // state/pending_restart: while an update is staged for restart the backend
+    // keeps active_version set with pending_restart=true and
+    // runtime_provider_configs still routes through the plugin, so the card must
+    // stay put instead of briefly falling back to the shipped card (which would
+    // expose the wrong config schema in the drawer). A first-install staged row
+    // has no active_version yet, so the built-in keeps serving until activation.
+    const live = (providers ?? []).filter((provider) =>
+      Boolean(provider.active_version),
     );
     // A catalog plugin reuses the built-in's id when it replaces it (e.g. subdl,
-    // embeddedsubtitles). Drop the shipped card for any id an active plugin owns
+    // embeddedsubtitles). Drop the shipped card for any id a live plugin owns
     // so the plugin replaces it instead of appearing as a second duplicate, and
     // so a same-id plugin can actually be added (the shipped key no longer masks
     // it). Plugins with a brand-new id are simply appended.
-    const replaced = new Set(active.map((provider) => provider.provider_id));
+    const replaced = new Set(live.map((provider) => provider.provider_id));
     const base = ProviderList.filter((provider) => !replaced.has(provider.key));
     const seen = new Set(base.map((provider) => provider.key));
-    const hubOptions = active
+    const hubOptions = live
       .filter((provider) => !seen.has(provider.provider_id))
       .map((provider) => {
         seen.add(provider.provider_id);

--- a/ruff.toml
+++ b/ruff.toml
@@ -13,6 +13,7 @@ extend-exclude = [
     "ai-subtitle-translator",
     "bazarr/ai-subtitle-translator",
     "opensubtitles-scraper",
+    "bazarr-provider-catalog",
     "frontend",
     "bazarr-binaries",
     ".worktrees",


### PR DESCRIPTION
## Problem

Two duplicate/availability bugs in the Provider Hub "My Providers" add-list:

- **SubDL** (and any catalog plugin that reuses a built-in id) was **filtered out** of the add menu and could not be added; the stale shipped card was shown instead of the plugin.
- **Embedded Subtitles** showed up **twice** (shipped card + plugin card) because the catalog plugin used a different id (`embedded_subtitles`) that the dedup did not match.

Root cause: `useProviderOptions` deduped active hub plugins against the shipped `ProviderList` by exact `provider_id`. Same-id plugins got dropped; different-id plugins duplicated.

## Fix

Replace the dedup with a **replacement model** in `Settings/Providers/index.tsx`:

1. Compute the set of `provider_id`s that active plugins own.
2. Drop those keys from the shipped `ProviderList` (the plugin replaces the shipped card).
3. Append one option per active plugin.

Same-id plugins now replace the shipped card (addable, using the plugin's config schema); brand-new ids are appended. Covered by a hub test asserting a same-id plugin yields a single, plugin-backed card.

## Companion catalog change

This pairs with the official catalog renaming the two providers that used a separate id + `legacy_provider_id` bridge back to their built-in ids (`embedded_subtitles` -> `embeddedsubtitles`, `opensubtitles_org` -> `opensubtitles`), so the same-id registry overwrite shadows the built-in cleanly: https://github.com/LavX/bazarr-provider-catalog/pull/79

## Submodule registration

`bazarr-provider-catalog` was present in the worktree but only half-wired (gitdir + `.git/config`, no `.gitmodules`/gitlink), so it always showed as untracked. Registered it as a proper submodule (added to `.gitmodules`, gitlink, and ruff `extend-exclude` like the other vendored submodules). Pinned to the catalog rename commit; bump to `main` after the catalog PR merges.

## Tests / CI (run locally on final branch state)

- Frontend: `check:ts`, eslint, prettier, **530 unit tests**, `build:ci` — all green.
- `ruff check .` — passes.