### PR TITLE
feat(provider-hub): auto-install & shadow built-ins from the official catalog on startup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "bazarr-binaries"]
 	path = bazarr-binaries
 	url = https://github.com/LavX/bazarr-binaries.git
+[submodule "bazarr-provider-catalog"]
+	path = bazarr-provider-catalog
+	url = https://github.com/LavX/bazarr-provider-catalog.git

--- a/bazarr/init.py
+++ b/bazarr/init.py
@@ -139,6 +139,18 @@ write_config()
 # installations() later, but that's already past this filter.
 from subliminal_patch.extensions import provider_registry  # noqa: E402
 provider_hub_registration_ok = True
+# Auto-install official-catalog versions of enabled built-in providers so the
+# catalog becomes the canonical provider source. Staged here so the
+# activate_staged_installations() + register_active_provider_classes() calls
+# below bring them live and shadow the built-in in this same boot. Best-effort:
+# failures must never prevent startup.
+try:
+    from provider_hub.service import autoinstall_enabled_builtins
+    auto_staged = autoinstall_enabled_builtins()
+    if auto_staged:
+        logging.info("Provider Hub auto-installed from official catalog: %s", auto_staged)
+except Exception:  # pragma: no cover - hub failures must not prevent startup
+    logging.exception("Unable to auto-install Provider Hub providers on startup")
 try:
     from provider_hub.service import activate_staged_installations
     activated = activate_staged_installations()

--- a/bazarr/provider_hub/service.py
+++ b/bazarr/provider_hub/service.py
@@ -519,9 +519,13 @@ def autoinstall_enabled_builtins() -> list[str]:
     except Exception:
         logger.exception("Provider Hub startup auto-install: catalog refresh failed; using cached catalog")
 
-    state = load_state()
-    existing = set((state.get("installations") or {}).keys())
-    enabled = _bazarr_enabled_providers()
+    try:
+        state = load_state()
+        existing = set((state.get("installations") or {}).keys())
+        enabled = _bazarr_enabled_providers()
+    except Exception:
+        logger.exception("Provider Hub startup auto-install: could not load state; skipping")
+        return []
 
     budget_seconds = 180.0
     started = time.monotonic()

--- a/bazarr/provider_hub/service.py
+++ b/bazarr/provider_hub/service.py
@@ -968,8 +968,25 @@ def _github_raw_url(manifest, relative_path: str) -> str:
     return f"https://raw.githubusercontent.com/{manifest.source_repo}/{manifest.source_commit}/{raw_path}"
 
 
-def _fetch_github_bundle_file(manifest, relative_path: str) -> bytes:
-    response = requests.get(_github_raw_url(manifest, relative_path), timeout=30)
+def _deadline_request_timeout(deadline: float | None, default: float = 30.0) -> float:
+    """Per-request timeout bounded by an optional wall-clock deadline (monotonic).
+
+    Raises ``ProviderHubInstallError`` when the deadline has already passed so a
+    slow bundle fetch can't run the startup auto-install past its time budget.
+    """
+    if deadline is None:
+        return default
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise ProviderHubInstallError("bundle fetch exceeded the install time budget")
+    return max(1.0, min(default, remaining))
+
+
+def _fetch_github_bundle_file(manifest, relative_path: str, deadline: float | None = None) -> bytes:
+    response = requests.get(
+        _github_raw_url(manifest, relative_path),
+        timeout=_deadline_request_timeout(deadline),
+    )
     response.raise_for_status()
     content = response.content
     if not isinstance(content, bytes):
@@ -984,7 +1001,7 @@ def _write_manifest_file(manifest, root: Path) -> None:
     )
 
 
-def _fetch_bundle(manifest) -> Path:
+def _fetch_bundle(manifest, deadline: float | None = None) -> Path:
     target = _bundle_path_for(manifest)
     if target.exists():
         _remove_bundle_runtime_artifacts(target)
@@ -997,7 +1014,7 @@ def _fetch_bundle(manifest) -> Path:
         for relative_path in manifest.files:
             destination = tmp_path / relative_path
             destination.parent.mkdir(parents=True, exist_ok=True)
-            destination.write_bytes(_fetch_github_bundle_file(manifest, relative_path))
+            destination.write_bytes(_fetch_github_bundle_file(manifest, relative_path, deadline=deadline))
 
         _write_manifest_file(manifest, tmp_path)
         verify_bundle_tree(manifest, tmp_path)
@@ -1271,8 +1288,11 @@ def _stage_validated(
 ) -> dict[str, Any]:
     """Shared install core: stage the bundle, build the venv, smoke-test, record.
 
-    ``bundle_stager(validated) -> Path`` decides where the bundle comes from
-    (catalog fetch vs already-extracted local files).
+    ``bundle_stager(validated, deadline) -> Path`` decides where the bundle comes
+    from (catalog fetch vs already-extracted local files). ``install_timeout``, when
+    set, is a single wall-clock budget for the whole stage (bundle fetch + venv
+    build) shared via ``deadline``, so the startup auto-install can't run past it;
+    ``None`` (manual installs) leaves it unbounded.
     """
     state = load_state()
     existing = (state.get("installations") or {}).get(validated.provider_id)
@@ -1292,8 +1312,10 @@ def _stage_validated(
         details={"catalog_url": catalog_url, "trusted": source_trusted, "origin": origin},
     ) as job:
         try:
-            bundle_path = bundle_stager(validated)
-            env_path = PluginEnvironment(provider_hub_dir()).install(validated, timeout=install_timeout)
+            deadline = None if install_timeout is None else time.monotonic() + max(0.0, install_timeout)
+            bundle_path = bundle_stager(validated, deadline)
+            install_remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+            env_path = PluginEnvironment(provider_hub_dir()).install(validated, timeout=install_remaining)
             staged_python_path = python_executable(env_path)
             _smoke_validate_worker(validated, bundle_path, staged_python_path)
         except Exception as error:
@@ -1396,7 +1418,7 @@ def stage_install_local(archive_bytes: bytes) -> dict[str, Any]:
             source_trusted=False,
             origin="local",
             source_id=None,
-            bundle_stager=lambda candidate: _stage_local_bundle(candidate, bundle_root),
+            bundle_stager=lambda candidate, deadline=None: _stage_local_bundle(candidate, bundle_root),
         )
     finally:
         shutil.rmtree(work_dir, ignore_errors=True)

--- a/bazarr/provider_hub/service.py
+++ b/bazarr/provider_hub/service.py
@@ -553,14 +553,18 @@ def autoinstall_enabled_builtins() -> list[str]:
         manifest = _latest_official_catalog_manifest(state, provider_id)
         if manifest is None:
             continue
-        if time.monotonic() - started > budget_seconds:
+        remaining = budget_seconds - (time.monotonic() - started)
+        if remaining <= 0:
             logger.warning(
                 "Provider Hub startup auto-install: time budget exceeded at %s; deferring remaining to next start",
                 provider_id,
             )
             break
         try:
-            stage_install(manifest)
+            # Bound the install itself by the remaining budget so one stuck pip/venv
+            # step can't block boot indefinitely; failures are swallowed and the
+            # built-in keeps serving until the next start.
+            stage_install(manifest, install_timeout=remaining)
             staged.append(provider_id)
             logger.info("Provider Hub startup auto-install: staged %s from the official catalog", provider_id)
         except Exception:
@@ -1263,6 +1267,7 @@ def _stage_validated(
     source_id: str | None,
     bundle_stager,
     catalog_url: str | None = None,
+    install_timeout: float | None = None,
 ) -> dict[str, Any]:
     """Shared install core: stage the bundle, build the venv, smoke-test, record.
 
@@ -1288,7 +1293,7 @@ def _stage_validated(
     ) as job:
         try:
             bundle_path = bundle_stager(validated)
-            env_path = PluginEnvironment(provider_hub_dir()).install(validated)
+            env_path = PluginEnvironment(provider_hub_dir()).install(validated, timeout=install_timeout)
             staged_python_path = python_executable(env_path)
             _smoke_validate_worker(validated, bundle_path, staged_python_path)
         except Exception as error:
@@ -1337,7 +1342,7 @@ def _stage_validated(
         return _redact_installation(installation)
 
 
-def stage_install(manifest: dict[str, Any]) -> dict[str, Any]:
+def stage_install(manifest: dict[str, Any], install_timeout: float | None = None) -> dict[str, Any]:
     state = load_state()
     source_trusted = _catalog_manifest_trusted(manifest, state) if isinstance(manifest, dict) else False
     origin, source_id = _install_origin(manifest, state) if isinstance(manifest, dict) else ("local", None)
@@ -1357,6 +1362,7 @@ def stage_install(manifest: dict[str, Any]) -> dict[str, Any]:
         source_id,
         _fetch_bundle,
         catalog_url=catalog_url,
+        install_timeout=install_timeout,
     )
 
 

--- a/bazarr/provider_hub/service.py
+++ b/bazarr/provider_hub/service.py
@@ -515,24 +515,41 @@ def autoinstall_enabled_builtins() -> list[str]:
     logger.info("Provider Hub startup auto-install: reconciling enabled providers against the official catalog")
 
     try:
-        refresh_catalog()
-    except Exception:
-        logger.exception("Provider Hub startup auto-install: catalog refresh failed; using cached catalog")
-
-    try:
         state = load_state()
-        existing = set((state.get("installations") or {}).keys())
+        # Skip rows that are live or mid-lifecycle, but NOT "failed": a transient
+        # bundle/venv error should be retried on a later boot rather than blocking
+        # the migration forever.
+        existing = {
+            provider_id
+            for provider_id, row in (state.get("installations") or {}).items()
+            if isinstance(row, dict) and row.get("state") != "failed"
+        }
         enabled = _bazarr_enabled_providers()
     except Exception:
         logger.exception("Provider Hub startup auto-install: could not load state; skipping")
         return []
 
+    candidates = [provider_id for provider_id in enabled if provider_id not in existing]
+    if not candidates:
+        # Everything enabled is already installed: no migration work, so don't touch
+        # the network at all. Keeps the common boot fast and independent of catalog
+        # source health.
+        return []
+
+    # There is potential work, so force a fresh OFFICIAL catalog (only) to pick up a
+    # newly-merged provider id. Best-effort: refresh_catalog isolates per-source
+    # failures and the call is guarded, so a slow/broken catalog can never block or
+    # crash boot, and unrelated third-party sources are not fetched on the boot path.
+    try:
+        refresh_catalog(source_ids={OFFICIAL_CATALOG_SOURCE_ID})
+        state = load_state()
+    except Exception:
+        logger.exception("Provider Hub startup auto-install: catalog refresh failed; using cached catalog")
+
     budget_seconds = 180.0
     started = time.monotonic()
     staged: list[str] = []
-    for provider_id in enabled:
-        if provider_id in existing:
-            continue
+    for provider_id in candidates:
         manifest = _latest_official_catalog_manifest(state, provider_id)
         if manifest is None:
             continue
@@ -562,7 +579,10 @@ def _normalize_catalog_manifest(manifest: dict[str, Any], source: dict[str, Any]
     return normalized
 
 
-def refresh_catalog() -> dict[str, Any]:
+def refresh_catalog(source_ids: set[str] | None = None) -> dict[str, Any]:
+    """Refresh catalog sources. When ``source_ids`` is given, only those source ids
+    are fetched (e.g. the startup migration refreshes only the official source so an
+    unrelated slow/broken third-party source can't delay boot); otherwise all are."""
     with record_job("refresh_catalog", target_kind="system") as job:
         def refresh(state: dict[str, Any]) -> dict[str, Any]:
             now = utcnow_iso()
@@ -574,6 +594,8 @@ def refresh_catalog() -> dict[str, Any]:
             failed_sources: list[str] = []
             for source in (state.get("catalog_sources") or {}).values():
                 if not isinstance(source, dict):
+                    continue
+                if source_ids is not None and source.get("id") not in source_ids:
                     continue
                 sources_count += 1
                 source["last_checked_at"] = now

--- a/bazarr/provider_hub/service.py
+++ b/bazarr/provider_hub/service.py
@@ -515,7 +515,7 @@ def autoinstall_enabled_builtins() -> list[str]:
     logger.info("Provider Hub startup auto-install: reconciling enabled providers against the official catalog")
 
     try:
-        list_catalog(auto_refresh=True)
+        refresh_catalog()
     except Exception:
         logger.exception("Provider Hub startup auto-install: catalog refresh failed; using cached catalog")
 

--- a/bazarr/provider_hub/service.py
+++ b/bazarr/provider_hub/service.py
@@ -475,6 +475,78 @@ def list_catalog(auto_refresh: bool = False) -> dict[str, Any]:
     }
 
 
+def _latest_official_catalog_manifest(state: dict[str, Any], provider_id: str) -> dict[str, Any] | None:
+    """Latest manifest for ``provider_id`` from the OFFICIAL (trusted) catalog source."""
+    candidates: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+    for entry in (state.get("catalog_entries") or {}).values():
+        if not isinstance(entry, dict) or entry.get("provider_id") != provider_id:
+            continue
+        if entry.get("source") != OFFICIAL_CATALOG_SOURCE_ID or not entry.get("trusted", False):
+            continue
+        manifest = entry.get("manifest")
+        if not isinstance(manifest, dict):
+            continue
+        version_key = _version_key(manifest.get("version") or entry.get("version"))
+        if version_key is None:
+            continue
+        candidates.append((version_key, manifest))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[0])[1]
+
+
+def autoinstall_enabled_builtins() -> list[str]:
+    """Stage-install official-catalog versions of enabled providers not yet installed.
+
+    For each provider in Bazarr's ``enabled_providers`` that (a) has no Provider Hub
+    installation row yet and (b) has a matching entry in the OFFICIAL catalog, stage
+    the latest official manifest. The caller's ``activate_staged_installations()`` +
+    ``register_active_provider_classes()`` then activate and shadow the built-in in the
+    same boot (catalog plugins reuse the built-in id). Idempotent and best-effort:
+    never raises, never enables/disables/uninstalls anything.
+    """
+    import logging
+    import os
+
+    logger = logging.getLogger(__name__)
+    if os.environ.get("BAZARR_DISABLE_PROVIDER_AUTOINSTALL"):
+        return []
+
+    logger.info("Provider Hub startup auto-install: reconciling enabled providers against the official catalog")
+
+    try:
+        list_catalog(auto_refresh=True)
+    except Exception:
+        logger.exception("Provider Hub startup auto-install: catalog refresh failed; using cached catalog")
+
+    state = load_state()
+    existing = set((state.get("installations") or {}).keys())
+    enabled = _bazarr_enabled_providers()
+
+    budget_seconds = 180.0
+    started = time.monotonic()
+    staged: list[str] = []
+    for provider_id in enabled:
+        if provider_id in existing:
+            continue
+        manifest = _latest_official_catalog_manifest(state, provider_id)
+        if manifest is None:
+            continue
+        if time.monotonic() - started > budget_seconds:
+            logger.warning(
+                "Provider Hub startup auto-install: time budget exceeded at %s; deferring remaining to next start",
+                provider_id,
+            )
+            break
+        try:
+            stage_install(manifest)
+            staged.append(provider_id)
+            logger.info("Provider Hub startup auto-install: staged %s from the official catalog", provider_id)
+        except Exception:
+            logger.exception("Provider Hub startup auto-install: failed to stage %s; keeping built-in", provider_id)
+    return staged
+
+
 def _normalize_catalog_manifest(manifest: dict[str, Any], source: dict[str, Any], commit: str) -> dict[str, Any]:
     normalized = dict(manifest)
     manifest_source = dict(normalized.get("source") or {})

--- a/bazarr/provider_hub/venv.py
+++ b/bazarr/provider_hub/venv.py
@@ -5,6 +5,7 @@ import hashlib
 import os
 import subprocess
 import sys
+import time
 
 from pathlib import Path
 
@@ -39,46 +40,70 @@ class PluginEnvironment:
     def path_for(self, manifest: ValidatedManifest) -> Path:
         return self.root / "envs" / manifest.provider_id / manifest.version / self._fingerprint(manifest)
 
-    def install(self, manifest: ValidatedManifest) -> Path:
+    def install(self, manifest: ValidatedManifest, timeout: float | None = None) -> Path:
+        """Build the provider venv. When ``timeout`` is set it is a hard wall-clock
+        budget for the whole install (shared across the venv/pip subprocesses): the
+        startup auto-install passes its remaining budget so one stuck pip/venv step
+        can't block boot indefinitely. ``None`` (manual installs) leaves it unbounded.
+        """
+        deadline = None if timeout is None else time.monotonic() + max(0.0, timeout)
+
+        def _remaining() -> float | None:
+            if deadline is None:
+                return None
+            left = deadline - time.monotonic()
+            if left <= 0:
+                raise PluginEnvironmentError(
+                    f"Provider Hub install for {manifest.provider_id} exceeded its time budget"
+                )
+            return left
+
         env_path = self.path_for(manifest)
         env_path.mkdir(parents=True, exist_ok=True)
 
         python_exe = python_executable(env_path)
-        if not python_exe.exists():
+        try:
+            if not python_exe.exists():
+                subprocess.run(
+                    [sys.executable, "-m", "venv", str(env_path)],
+                    check=True,
+                    timeout=_remaining(),
+                )
+
+            if manifest.dependency_requirements:
+                requirements_path = env_path / "requirements.txt"
+                requirements_path.write_text(
+                    "\n".join(requirement.pip_line for requirement in manifest.dependency_requirements) + "\n",
+                    encoding="utf-8",
+                )
+                cmd = [
+                    str(python_exe),
+                    "-m",
+                    "pip",
+                    "install",
+                    "--disable-pip-version-check",
+                    "--no-warn-script-location",
+                    "--require-hashes",
+                    "--prefer-binary",
+                    "-r",
+                    str(requirements_path),
+                ]
+
+                env = {
+                    "PATH": os.environ.get("PATH", ""),
+                    "PYTHONNOUSERSITE": "1",
+                }
+                subprocess.run(cmd, check=True, env=env, cwd=str(env_path), timeout=_remaining())
+
             subprocess.run(
-                [sys.executable, "-m", "venv", str(env_path)],
+                [str(python_exe), "-m", "pip", "check"],
                 check=True,
+                env={"PATH": os.environ.get("PATH", ""), "PYTHONNOUSERSITE": "1"},
+                cwd=str(env_path),
+                timeout=_remaining(),
             )
-
-        if manifest.dependency_requirements:
-            requirements_path = env_path / "requirements.txt"
-            requirements_path.write_text(
-                "\n".join(requirement.pip_line for requirement in manifest.dependency_requirements) + "\n",
-                encoding="utf-8",
-            )
-            cmd = [
-                str(python_exe),
-                "-m",
-                "pip",
-                "install",
-                "--disable-pip-version-check",
-                "--no-warn-script-location",
-                "--require-hashes",
-                "--prefer-binary",
-                "-r",
-                str(requirements_path),
-            ]
-
-            env = {
-                "PATH": os.environ.get("PATH", ""),
-                "PYTHONNOUSERSITE": "1",
-            }
-            subprocess.run(cmd, check=True, env=env, cwd=str(env_path))
-
-        subprocess.run(
-            [str(python_exe), "-m", "pip", "check"],
-            check=True,
-            env={"PATH": os.environ.get("PATH", ""), "PYTHONNOUSERSITE": "1"},
-            cwd=str(env_path),
-        )
+        except subprocess.TimeoutExpired as error:
+            raise PluginEnvironmentError(
+                f"Provider Hub install for {manifest.provider_id} timed out"
+            ) from error
         return env_path

--- a/docker/supervisor.py
+++ b/docker/supervisor.py
@@ -63,6 +63,7 @@ class BackendManager:
     # Ordered startup stages (must match actual stdout from bazarr subprocess)
     STAGES = [
         "Launching process",
+        "Installing providers",
         "Checking for updates",
         "Starting scheduler",
         "Starting jobs queue",
@@ -74,11 +75,12 @@ class BackendManager:
     # Map log fragments to stage index (only markers that ACTUALLY appear in stdout)
     _STAGE_MARKERS = [
         ("starting child process", 0),                  # Launching process
-        ("check_update", 1),                            # Checking for updates
-        ("Scheduler will use this timezone", 2),        # Starting scheduler
-        ("jobs queue started", 3),                      # Starting jobs queue
-        ("waiting for requests on", 4),                 # Starting HTTP server
-        ("SignalR client for", 5),                      # Connecting to Sonarr/Radarr
+        ("Provider Hub startup auto-install", 1),       # Installing providers
+        ("check_update", 2),                            # Checking for updates
+        ("Scheduler will use this timezone", 3),        # Starting scheduler
+        ("jobs queue started", 4),                      # Starting jobs queue
+        ("waiting for requests on", 5),                 # Starting HTTP server
+        ("SignalR client for", 6),                      # Connecting to Sonarr/Radarr
     ]
 
     def __init__(self, bazarr_args: list[str]):

--- a/docker/supervisor.py
+++ b/docker/supervisor.py
@@ -147,11 +147,20 @@ class BackendManager:
             pass
 
     async def _wait_for_ready(self):
-        """Poll the backend until it responds, then set state to RUNNING."""
+        """Poll the backend until it responds, then set state to RUNNING.
+
+        Poll for as long as the backend process is alive and still starting,
+        rather than giving up after a fixed number of attempts. A long first-boot
+        migration (e.g. auto-installing providers that build dependency venvs) can
+        delay the backend binding past a fixed window; abandoning the poll would
+        leave the startup screen stuck even though the process is healthy and
+        about to bind. Process exit is handled by run() (which flips state to
+        CRASHED); the dead-process guard below also ends this loop.
+        """
         url = f"http://{BACKEND_HOST}:{BACKEND_PORT}/api/system/status"
         timeout = ClientTimeout(total=2, connect=1)
-        for _ in range(120):  # up to ~2 minutes
-            if self.state != self.STATE_STARTING:
+        while self.state == self.STATE_STARTING:
+            if self.process is None or self.process.returncode is not None:
                 return
             try:
                 async with ClientSession(timeout=timeout) as session:

--- a/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
@@ -410,6 +410,67 @@ describe("Settings > Providers (Provider Hub)", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps the plugin card while a same-id update is staged for restart", async () => {
+    const subdlPluginManifest = {
+      ...manifest,
+      provider_id: "subdl",
+      name: "SubDL",
+      description: "SubDL plugin.",
+      version: "0.1.0",
+      config_schema: {
+        type: "object",
+        properties: {
+          api_key: { type: "string", title: "API key", secret: true },
+        },
+      },
+      secret_fields: ["api_key"],
+    };
+    server.use(
+      http.get("/api/provider-hub/providers", () => {
+        return HttpResponse.json({
+          data: [
+            {
+              // An update is staged: the backend keeps active_version serving and
+              // marks pending_restart, so the plugin must still own the card.
+              provider_id: "subdl",
+              name: "SubDL",
+              active_version: "0.1.0",
+              staged_version: "0.2.0",
+              state: "staged",
+              pending_restart: true,
+              trusted: true,
+              last_error: null,
+              manifest: subdlPluginManifest,
+            },
+          ],
+        });
+      }),
+    );
+
+    customRender(<SettingsProvidersView />);
+
+    const panel = await screen.findByRole("tabpanel", {
+      name: /My Providers/i,
+    });
+    await userEvent.click(
+      await within(panel).findByRole("button", {
+        name: /Add search provider/i,
+      }),
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: /Provider settings/i,
+    });
+
+    // Exactly one SubDL option (the plugin), not the shipped built-in card.
+    const subdlOptions = await within(dialog).findAllByText("SubDL");
+    expect(subdlOptions).toHaveLength(1);
+    await userEvent.click(subdlOptions[0]);
+    expect(screen.getByLabelText("API key")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Provider Hub plugin is installed but not enabled/i),
+    ).toBeInTheDocument();
+  });
+
   it("stages per-provider excluded language configuration from the provider drawer", async () => {
     const updateRequest = vi.fn();
     server.use(

--- a/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
@@ -558,6 +558,12 @@ describe("Settings > Providers (Provider Hub)", () => {
       await within(panel).findByText(/no providers enabled/i),
     ).toBeInTheDocument();
 
+    // The add-provider control stays available in the empty state so a shipped
+    // provider can still be added directly (not only via the Marketplace).
+    expect(
+      within(panel).getByRole("button", { name: /Add search provider/i }),
+    ).toBeInTheDocument();
+
     await userEvent.click(
       within(panel).getByRole("button", { name: /browse the marketplace/i }),
     );

--- a/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
@@ -341,6 +341,75 @@ describe("Settings > Providers (Provider Hub)", () => {
     ).toBeInTheDocument();
   });
 
+  it("replaces the shipped built-in card with its same-id replacement plugin", async () => {
+    const embeddedPluginManifest = {
+      ...manifest,
+      provider_id: "embeddedsubtitles",
+      name: "Embedded Subtitles",
+      description: "Embedded subtitles plugin.",
+      version: "0.1.2",
+      config_schema: {
+        type: "object",
+        properties: {
+          ffmpeg_path: {
+            type: "string",
+            title: "ffmpeg path",
+          },
+        },
+      },
+    };
+    server.use(
+      http.get("/api/provider-hub/providers", () => {
+        return HttpResponse.json({
+          data: [
+            {
+              // Catalog plugin reuses the built-in id it replaces.
+              provider_id: "embeddedsubtitles",
+              name: "Embedded Subtitles",
+              active_version: "0.1.2",
+              staged_version: null,
+              state: "active",
+              pending_restart: false,
+              trusted: true,
+              last_error: null,
+              manifest: embeddedPluginManifest,
+            },
+          ],
+        });
+      }),
+    );
+
+    customRender(<SettingsProvidersView />);
+
+    const panel = await screen.findByRole("tabpanel", {
+      name: /My Providers/i,
+    });
+
+    await userEvent.click(
+      await within(panel).findByRole("button", {
+        name: /Add search provider/i,
+      }),
+    );
+    const dialog = await screen.findByRole("dialog", {
+      name: /Provider settings/i,
+    });
+
+    // Exactly one "Embedded Subtitles" option: the plugin replaces the shipped
+    // built-in card instead of appearing as a second, duplicate provider.
+    const embeddedOptions =
+      await within(dialog).findAllByText("Embedded Subtitles");
+    expect(embeddedOptions).toHaveLength(1);
+
+    await userEvent.click(embeddedOptions[0]);
+
+    // The single card is plugin-backed: it renders the plugin's config schema
+    // and the Provider Hub notice (not the shipped built-in inputs).
+    expect(screen.getByLabelText("ffmpeg path")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Provider Hub plugin is installed but not enabled/i),
+    ).toBeInTheDocument();
+  });
+
   it("stages per-provider excluded language configuration from the provider drawer", async () => {
     const updateRequest = vi.fn();
     server.use(

--- a/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/__tests__/hub.test.tsx
@@ -471,6 +471,40 @@ describe("Settings > Providers (Provider Hub)", () => {
     );
   });
 
+  it("nudges to the Marketplace when no providers are enabled", async () => {
+    server.use(
+      http.get("/api/system/settings", () => {
+        return HttpResponse.json({
+          general: {
+            enabled_providers: [],
+            provider_priorities: {},
+            provider_languages: {},
+            use_provider_priority: true,
+          },
+        });
+      }),
+      http.get("/api/provider-hub/providers", () => {
+        return HttpResponse.json({ data: [] });
+      }),
+    );
+
+    customRender(<SettingsProvidersView />);
+
+    const panel = await screen.findByRole("tabpanel", {
+      name: /My Providers/i,
+    });
+    expect(
+      await within(panel).findByText(/no providers enabled/i),
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      within(panel).getByRole("button", { name: /browse the marketplace/i }),
+    );
+    expect(
+      await screen.findByRole("tabpanel", { name: /Marketplace/i }),
+    ).toBeInTheDocument();
+  });
+
   it("preserves the trusted-source attribution when installing from catalog", async () => {
     const installRequest = vi.fn();
     server.use(

--- a/frontend/src/pages/Settings/Providers/index.tsx
+++ b/frontend/src/pages/Settings/Providers/index.tsx
@@ -134,17 +134,24 @@ function useProviderOptions(
   providers: ProviderHubInstallation[] | undefined,
 ): Readonly<ProviderInfo[]> {
   return useMemo(() => {
-    const seen = new Set(ProviderList.map((provider) => provider.key));
-    const hubOptions = (providers ?? [])
-      .filter(
-        (provider) => provider.state === "active" && !provider.pending_restart,
-      )
+    const active = (providers ?? []).filter(
+      (provider) => provider.state === "active" && !provider.pending_restart,
+    );
+    // A catalog plugin reuses the built-in's id when it replaces it (e.g. subdl,
+    // embeddedsubtitles). Drop the shipped card for any id an active plugin owns
+    // so the plugin replaces it instead of appearing as a second duplicate, and
+    // so a same-id plugin can actually be added (the shipped key no longer masks
+    // it). Plugins with a brand-new id are simply appended.
+    const replaced = new Set(active.map((provider) => provider.provider_id));
+    const base = ProviderList.filter((provider) => !replaced.has(provider.key));
+    const seen = new Set(base.map((provider) => provider.key));
+    const hubOptions = active
       .filter((provider) => !seen.has(provider.provider_id))
       .map((provider) => {
         seen.add(provider.provider_id);
         return providerHubOption(provider);
       });
-    return [...ProviderList, ...hubOptions];
+    return [...base, ...hubOptions];
   }, [providers]);
 }
 

--- a/frontend/src/pages/Settings/Providers/index.tsx
+++ b/frontend/src/pages/Settings/Providers/index.tsx
@@ -189,23 +189,23 @@ const EnabledProvidersSection: FunctionComponent<{
         minimum score is found. When disabled, all providers are queried
         simultaneously and the best result is selected.
       </Message>
-      {isEmpty ? (
-        <Stack gap="xs" align="flex-start" py="md">
+      {isEmpty && (
+        <Stack gap="xs" align="flex-start" py="xs">
           <MantineText fw={600}>No providers enabled</MantineText>
           <Message>
-            Install subtitle providers from the Marketplace, then add them here.
+            New here? Install subtitle providers from the Marketplace, then add
+            them below. You can also add a shipped provider with the + button.
           </Message>
           <Button variant="light" onClick={onBrowseMarketplace}>
             Browse the Marketplace
           </Button>
         </Stack>
-      ) : (
-        <ProviderView
-          addLabel="Add search provider"
-          availableOptions={providerOptions}
-          settingsKey="settings-general-enabled_providers"
-        />
       )}
+      <ProviderView
+        addLabel="Add search provider"
+        availableOptions={providerOptions}
+        settingsKey="settings-general-enabled_providers"
+      />
     </Stack>
   );
 };

--- a/frontend/src/pages/Settings/Providers/index.tsx
+++ b/frontend/src/pages/Settings/Providers/index.tsx
@@ -1,5 +1,11 @@
 import { FunctionComponent, useMemo, useState } from "react";
-import { Anchor, Stack, Tabs } from "@mantine/core";
+import {
+  Anchor,
+  Button,
+  Stack,
+  Tabs,
+  Text as MantineText,
+} from "@mantine/core";
 import {
   faGears,
   faListCheck,
@@ -27,6 +33,7 @@ import {
 } from "@/pages/Settings/Providers/hub";
 import { summarizeUpdates } from "@/pages/Settings/Providers/hub/utils";
 import { antiCaptchaOption } from "@/pages/Settings/Providers/options";
+import { useSettingValue } from "@/pages/Settings/utilities/hooks";
 import { ProviderView } from "./components";
 import {
   AvailableInput,
@@ -157,24 +164,43 @@ function useProviderOptions(
 
 const EnabledProvidersSection: FunctionComponent<{
   providerOptions: Readonly<ProviderInfo[]>;
-}> = ({ providerOptions }) => (
-  <Stack gap="xs">
-    <Check
-      label="Provider Priority"
-      settingKey="settings-general-use_provider_priority"
-    />
-    <Message>
-      Query providers in priority order and stop when a subtitle meeting the
-      minimum score is found. When disabled, all providers are queried
-      simultaneously and the best result is selected.
-    </Message>
-    <ProviderView
-      addLabel="Add search provider"
-      availableOptions={providerOptions}
-      settingsKey="settings-general-enabled_providers"
-    />
-  </Stack>
-);
+  onBrowseMarketplace: () => void;
+}> = ({ providerOptions, onBrowseMarketplace }) => {
+  const enabled = useSettingValue<string[]>(
+    "settings-general-enabled_providers",
+  );
+  const isEmpty = Array.isArray(enabled) && enabled.length === 0;
+  return (
+    <Stack gap="xs">
+      <Check
+        label="Provider Priority"
+        settingKey="settings-general-use_provider_priority"
+      />
+      <Message>
+        Query providers in priority order and stop when a subtitle meeting the
+        minimum score is found. When disabled, all providers are queried
+        simultaneously and the best result is selected.
+      </Message>
+      {isEmpty ? (
+        <Stack gap="xs" align="flex-start" py="md">
+          <MantineText fw={600}>No providers enabled</MantineText>
+          <Message>
+            Install subtitle providers from the Marketplace, then add them here.
+          </Message>
+          <Button variant="light" onClick={onBrowseMarketplace}>
+            Browse the Marketplace
+          </Button>
+        </Stack>
+      ) : (
+        <ProviderView
+          addLabel="Add search provider"
+          availableOptions={providerOptions}
+          settingsKey="settings-general-enabled_providers"
+        />
+      )}
+    </Stack>
+  );
+};
 
 const AntiCaptchaSection: FunctionComponent = () => (
   <Stack gap="xs">
@@ -296,7 +322,10 @@ const SettingsProvidersView: FunctionComponent = () => {
         <Tabs.Panel value="my-providers" pt="md">
           <MyProvidersPanel
             enabledProviders={
-              <EnabledProvidersSection providerOptions={providerOptions} />
+              <EnabledProvidersSection
+                providerOptions={providerOptions}
+                onBrowseMarketplace={() => setTab("marketplace")}
+              />
             }
             antiCaptcha={<AntiCaptchaSection />}
             integrations={<IntegrationsSection />}

--- a/frontend/src/pages/Settings/Providers/index.tsx
+++ b/frontend/src/pages/Settings/Providers/index.tsx
@@ -134,18 +134,26 @@ function useProviderOptions(
   providers: ProviderHubInstallation[] | undefined,
 ): Readonly<ProviderInfo[]> {
   return useMemo(() => {
-    const active = (providers ?? []).filter(
-      (provider) => provider.state === "active" && !provider.pending_restart,
+    // A plugin "owns" its id (and shadows the built-in) for as long as it has an
+    // active version serving searches. Gate on active_version rather than
+    // state/pending_restart: while an update is staged for restart the backend
+    // keeps active_version set with pending_restart=true and
+    // runtime_provider_configs still routes through the plugin, so the card must
+    // stay put instead of briefly falling back to the shipped card (which would
+    // expose the wrong config schema in the drawer). A first-install staged row
+    // has no active_version yet, so the built-in keeps serving until activation.
+    const live = (providers ?? []).filter((provider) =>
+      Boolean(provider.active_version),
     );
     // A catalog plugin reuses the built-in's id when it replaces it (e.g. subdl,
-    // embeddedsubtitles). Drop the shipped card for any id an active plugin owns
+    // embeddedsubtitles). Drop the shipped card for any id a live plugin owns
     // so the plugin replaces it instead of appearing as a second duplicate, and
     // so a same-id plugin can actually be added (the shipped key no longer masks
     // it). Plugins with a brand-new id are simply appended.
-    const replaced = new Set(active.map((provider) => provider.provider_id));
+    const replaced = new Set(live.map((provider) => provider.provider_id));
     const base = ProviderList.filter((provider) => !replaced.has(provider.key));
     const seen = new Set(base.map((provider) => provider.key));
-    const hubOptions = active
+    const hubOptions = live
       .filter((provider) => !seen.has(provider.provider_id))
       .map((provider) => {
         seen.add(provider.provider_id);

--- a/ruff.toml
+++ b/ruff.toml
@@ -13,6 +13,7 @@ extend-exclude = [
     "ai-subtitle-translator",
     "bazarr/ai-subtitle-translator",
     "opensubtitles-scraper",
+    "bazarr-provider-catalog",
     "frontend",
     "bazarr-binaries",
     ".worktrees",

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -3288,7 +3288,7 @@ def test_autoinstall_stages_enabled_official_providers_not_yet_installed(tmp_pat
         },
     )
     monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
-    monkeypatch.setattr(service, "refresh_catalog", lambda: None)
+    monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: None)
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl", "opensubtitlescom"])
     staged = []
     monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
@@ -3312,7 +3312,7 @@ def test_autoinstall_is_idempotent_skips_existing_installs(tmp_path, monkeypatch
         entries={"official:subdl:1.0.0": _official_entry("subdl")},
     )
     monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
-    monkeypatch.setattr(service, "refresh_catalog", lambda: None)
+    monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: None)
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
     staged = []
     monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
@@ -3329,7 +3329,7 @@ def test_autoinstall_ignores_non_official_catalog_entries(tmp_path, monkeypatch)
     third_party["trusted"] = False
     state_file = _catalog_state(tmp_path, entries={"thirdparty:subdl:1.0.0": third_party})
     monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
-    monkeypatch.setattr(service, "refresh_catalog", lambda: None)
+    monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: None)
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
     staged = []
     monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
@@ -3346,7 +3346,7 @@ def test_autoinstall_swallows_stage_failures(tmp_path, monkeypatch):
         "official:gestdown:1.0.0": _official_entry("gestdown"),
     })
     monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
-    monkeypatch.setattr(service, "refresh_catalog", lambda: None)
+    monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: None)
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl", "gestdown"])
 
     calls = []
@@ -3372,7 +3372,7 @@ def test_autoinstall_kill_switch_returns_empty(monkeypatch):
 
 def test_autoinstall_returns_empty_when_state_load_fails(monkeypatch):
     from provider_hub import service
-    monkeypatch.setattr(service, "refresh_catalog", lambda: None)
+    monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: None)
     def boom(*a, **k):
         raise RuntimeError("corrupt state")
     monkeypatch.setattr(service, "load_state", boom)
@@ -3386,7 +3386,7 @@ def test_autoinstall_proceeds_when_catalog_refresh_fails(tmp_path, monkeypatch):
     state_file = _catalog_state(tmp_path, entries={"official:subdl:1.0.0": _official_entry("subdl")})
     monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
 
-    def boom():
+    def boom(source_ids=None):
         raise RuntimeError("github unreachable")
 
     monkeypatch.setattr(service, "refresh_catalog", boom)
@@ -3397,3 +3397,59 @@ def test_autoinstall_proceeds_when_catalog_refresh_fails(tmp_path, monkeypatch):
     # Refresh failure is swallowed; auto-install still stages from the cached catalog.
     assert service.autoinstall_enabled_builtins() == ["subdl"]
     assert staged == ["subdl"]
+
+
+def test_autoinstall_retries_failed_install_rows(tmp_path, monkeypatch):
+    from provider_hub import service
+
+    # A previous attempt left a "failed" row; it must not be treated as installed.
+    state_file = _catalog_state(
+        tmp_path,
+        installations={"subdl": {"provider_id": "subdl", "state": "failed",
+                                 "active_version": None, "manifest": _manifest(provider_id="subdl")}},
+        entries={"official:subdl:1.0.0": _official_entry("subdl")},
+    )
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+    monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: None)
+    monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
+    staged = []
+    monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
+
+    assert service.autoinstall_enabled_builtins() == ["subdl"]
+    assert staged == ["subdl"]
+
+
+def test_autoinstall_skips_refresh_when_nothing_to_install(tmp_path, monkeypatch):
+    from provider_hub import service
+
+    # Every enabled provider already has an install row -> no migration work, so the
+    # network is never touched (no refresh_catalog call).
+    state_file = _catalog_state(
+        tmp_path,
+        installations={"subdl": {"provider_id": "subdl", "state": "active",
+                                 "active_version": "1.0.0", "manifest": _manifest(provider_id="subdl")}},
+        entries={"official:subdl:1.0.0": _official_entry("subdl")},
+    )
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+    refresh_calls = []
+    monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: refresh_calls.append(source_ids))
+    monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
+    monkeypatch.setattr(service, "stage_install", lambda manifest: (_ for _ in ()).throw(AssertionError("should not install")))
+
+    assert service.autoinstall_enabled_builtins() == []
+    assert refresh_calls == []  # no candidates -> no catalog fetch
+
+
+def test_autoinstall_refreshes_only_the_official_source(tmp_path, monkeypatch):
+    from provider_hub import service
+    from provider_hub.state import OFFICIAL_CATALOG_SOURCE_ID
+
+    state_file = _catalog_state(tmp_path, entries={"official:subdl:1.0.0": _official_entry("subdl")})
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+    refresh_calls = []
+    monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: refresh_calls.append(source_ids))
+    monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
+    monkeypatch.setattr(service, "stage_install", lambda manifest: None)
+
+    service.autoinstall_enabled_builtins()
+    assert refresh_calls == [{OFFICIAL_CATALOG_SOURCE_ID}]

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -3247,3 +3247,124 @@ def test_stage_install_local_rejects_oversized_package(tmp_path, monkeypatch):
 
     with pytest.raises(ProviderHubInstallError, match="too large"):
         stage_install_local(package)
+
+
+def _catalog_state(tmp_path, *, installations=None, entries=None):
+    state = {
+        "catalog_sources": {
+            "official": {"id": "official", "name": "Official Bazarr Provider Catalog",
+                         "type": "github", "url": "https://github.com/LavX/bazarr-provider-catalog/blob/main/catalog.json",
+                         "enabled": True, "official": True, "trusted": True},
+        },
+        "catalog_entries": entries or {},
+        "installations": installations or {},
+        "jobs": [],
+    }
+    f = tmp_path / "state.json"
+    f.write_text(json.dumps(state), encoding="utf-8")
+    return f
+
+
+def _official_entry(provider_id, version="1.0.0"):
+    return {
+        "source": "official",
+        "provider_id": provider_id,
+        "version": version,
+        "trusted": True,
+        "manifest": _manifest(provider_id=provider_id, version=version,
+                              dependencies={"requirements": []}),
+    }
+
+
+def test_autoinstall_stages_enabled_official_providers_not_yet_installed(tmp_path, monkeypatch):
+    from provider_hub import service
+
+    state_file = _catalog_state(
+        tmp_path,
+        installations={},  # nothing installed yet
+        entries={
+            "official:subdl:1.0.0": _official_entry("subdl"),
+            "official:gestdown:1.0.0": _official_entry("gestdown"),
+        },
+    )
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+    monkeypatch.setattr(service, "list_catalog", lambda auto_refresh=False: None)
+    monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl", "opensubtitlescom"])
+    staged = []
+    monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
+
+    result = service.autoinstall_enabled_builtins()
+
+    # only "subdl" is enabled AND in the official catalog AND not installed.
+    # "opensubtitlescom" is enabled but not in the catalog -> skipped.
+    # "gestdown" is in the catalog but not enabled -> skipped.
+    assert result == ["subdl"]
+    assert staged == ["subdl"]
+
+
+def test_autoinstall_is_idempotent_skips_existing_installs(tmp_path, monkeypatch):
+    from provider_hub import service
+
+    state_file = _catalog_state(
+        tmp_path,
+        installations={"subdl": {"provider_id": "subdl", "state": "active",
+                                 "active_version": "1.0.0", "manifest": _manifest(provider_id="subdl")}},
+        entries={"official:subdl:1.0.0": _official_entry("subdl")},
+    )
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+    monkeypatch.setattr(service, "list_catalog", lambda auto_refresh=False: None)
+    monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
+    staged = []
+    monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
+
+    assert service.autoinstall_enabled_builtins() == []
+    assert staged == []
+
+
+def test_autoinstall_ignores_non_official_catalog_entries(tmp_path, monkeypatch):
+    from provider_hub import service
+
+    third_party = _official_entry("subdl")
+    third_party["source"] = "thirdparty"
+    third_party["trusted"] = False
+    state_file = _catalog_state(tmp_path, entries={"thirdparty:subdl:1.0.0": third_party})
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+    monkeypatch.setattr(service, "list_catalog", lambda auto_refresh=False: None)
+    monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
+    staged = []
+    monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
+
+    assert service.autoinstall_enabled_builtins() == []
+    assert staged == []
+
+
+def test_autoinstall_swallows_stage_failures(tmp_path, monkeypatch):
+    from provider_hub import service
+
+    state_file = _catalog_state(tmp_path, entries={
+        "official:subdl:1.0.0": _official_entry("subdl"),
+        "official:gestdown:1.0.0": _official_entry("gestdown"),
+    })
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+    monkeypatch.setattr(service, "list_catalog", lambda auto_refresh=False: None)
+    monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl", "gestdown"])
+
+    calls = []
+
+    def flaky(manifest):
+        calls.append(manifest["provider_id"])
+        if manifest["provider_id"] == "subdl":
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(service, "stage_install", flaky)
+
+    # subdl fails (swallowed), gestdown still staged; never raises.
+    assert service.autoinstall_enabled_builtins() == ["gestdown"]
+    assert calls == ["subdl", "gestdown"]
+
+
+def test_autoinstall_kill_switch_returns_empty(monkeypatch):
+    from provider_hub import service
+    monkeypatch.setenv("BAZARR_DISABLE_PROVIDER_AUTOINSTALL", "1")
+    monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
+    assert service.autoinstall_enabled_builtins() == []

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -3368,3 +3368,13 @@ def test_autoinstall_kill_switch_returns_empty(monkeypatch):
     monkeypatch.setenv("BAZARR_DISABLE_PROVIDER_AUTOINSTALL", "1")
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
     assert service.autoinstall_enabled_builtins() == []
+
+
+def test_autoinstall_returns_empty_when_state_load_fails(monkeypatch):
+    from provider_hub import service
+    monkeypatch.setattr(service, "list_catalog", lambda auto_refresh=False: None)
+    def boom(*a, **k):
+        raise RuntimeError("corrupt state")
+    monkeypatch.setattr(service, "load_state", boom)
+    # Must not raise; returns [].
+    assert service.autoinstall_enabled_builtins() == []

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -3288,7 +3288,7 @@ def test_autoinstall_stages_enabled_official_providers_not_yet_installed(tmp_pat
         },
     )
     monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
-    monkeypatch.setattr(service, "list_catalog", lambda auto_refresh=False: None)
+    monkeypatch.setattr(service, "refresh_catalog", lambda: None)
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl", "opensubtitlescom"])
     staged = []
     monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
@@ -3312,7 +3312,7 @@ def test_autoinstall_is_idempotent_skips_existing_installs(tmp_path, monkeypatch
         entries={"official:subdl:1.0.0": _official_entry("subdl")},
     )
     monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
-    monkeypatch.setattr(service, "list_catalog", lambda auto_refresh=False: None)
+    monkeypatch.setattr(service, "refresh_catalog", lambda: None)
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
     staged = []
     monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
@@ -3329,7 +3329,7 @@ def test_autoinstall_ignores_non_official_catalog_entries(tmp_path, monkeypatch)
     third_party["trusted"] = False
     state_file = _catalog_state(tmp_path, entries={"thirdparty:subdl:1.0.0": third_party})
     monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
-    monkeypatch.setattr(service, "list_catalog", lambda auto_refresh=False: None)
+    monkeypatch.setattr(service, "refresh_catalog", lambda: None)
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
     staged = []
     monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
@@ -3346,7 +3346,7 @@ def test_autoinstall_swallows_stage_failures(tmp_path, monkeypatch):
         "official:gestdown:1.0.0": _official_entry("gestdown"),
     })
     monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
-    monkeypatch.setattr(service, "list_catalog", lambda auto_refresh=False: None)
+    monkeypatch.setattr(service, "refresh_catalog", lambda: None)
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl", "gestdown"])
 
     calls = []
@@ -3372,9 +3372,28 @@ def test_autoinstall_kill_switch_returns_empty(monkeypatch):
 
 def test_autoinstall_returns_empty_when_state_load_fails(monkeypatch):
     from provider_hub import service
-    monkeypatch.setattr(service, "list_catalog", lambda auto_refresh=False: None)
+    monkeypatch.setattr(service, "refresh_catalog", lambda: None)
     def boom(*a, **k):
         raise RuntimeError("corrupt state")
     monkeypatch.setattr(service, "load_state", boom)
     # Must not raise; returns [].
     assert service.autoinstall_enabled_builtins() == []
+
+
+def test_autoinstall_proceeds_when_catalog_refresh_fails(tmp_path, monkeypatch):
+    from provider_hub import service
+
+    state_file = _catalog_state(tmp_path, entries={"official:subdl:1.0.0": _official_entry("subdl")})
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+
+    def boom():
+        raise RuntimeError("github unreachable")
+
+    monkeypatch.setattr(service, "refresh_catalog", boom)
+    monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
+    staged = []
+    monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
+
+    # Refresh failure is swallowed; auto-install still stages from the cached catalog.
+    assert service.autoinstall_enabled_builtins() == ["subdl"]
+    assert staged == ["subdl"]

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -93,7 +93,7 @@ def _patch_local_install_env(monkeypatch, tmp_path):
         def __init__(self, root):
             self.root = Path(root)
 
-        def install(self, validated):
+        def install(self, validated, timeout=None):
             return self.root / "envs" / validated.provider_id / validated.version / "test"
 
     monkeypatch.setattr("provider_hub.service.PluginEnvironment", FakeEnvironment)
@@ -932,7 +932,7 @@ def test_apply_update_uses_latest_catalog_manifest(tmp_path, monkeypatch):
         def __init__(self, root):
             self.root = root
 
-        def install(self, validated):
+        def install(self, validated, timeout=None):
             return tmp_path / "env"
 
     monkeypatch.setattr("provider_hub.service.PluginEnvironment", FakeEnvironment)
@@ -1745,7 +1745,7 @@ def test_stage_install_fetches_bundle_builds_env_and_records_staged_paths(tmp_pa
         def __init__(self, root):
             self.root = Path(root)
 
-        def install(self, validated):
+        def install(self, validated, timeout=None):
             env_calls.append((self.root, validated.provider_id, validated.version))
             env_path = self.root / "envs" / validated.provider_id / validated.version / "test"
             python_path = env_path / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
@@ -1812,7 +1812,7 @@ def test_stage_install_fetches_bundle_from_manifest_source_path(tmp_path, monkey
         def __init__(self, root):
             self.root = Path(root)
 
-        def install(self, validated):
+        def install(self, validated, timeout=None):
             env_path = self.root / "envs" / validated.provider_id / validated.version / "test"
             python_path = env_path / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
             python_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1883,7 +1883,7 @@ def test_stage_install_trust_comes_from_catalog_entry_only(tmp_path, monkeypatch
         def __init__(self, root):
             self.root = Path(root)
 
-        def install(self, validated):
+        def install(self, validated, timeout=None):
             env_path = self.root / "envs" / validated.provider_id / validated.version / "test"
             python_path = env_path / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
             python_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1974,7 +1974,7 @@ def test_stage_install_accepts_trusted_migrated_built_in_shadow(tmp_path, monkey
         def __init__(self, root):
             self.root = Path(root)
 
-        def install(self, validated):
+        def install(self, validated, timeout=None):
             return self.root / "envs" / validated.provider_id / validated.version / "test"
 
     monkeypatch.setattr("provider_hub.service.PluginEnvironment", FakeEnvironment)
@@ -2012,7 +2012,7 @@ def test_stage_install_smoke_failure_records_failed_install(tmp_path, monkeypatc
         def __init__(self, root):
             self.root = Path(root)
 
-        def install(self, validated):
+        def install(self, validated, timeout=None):
             env_path = self.root / "envs" / validated.provider_id / validated.version / "test"
             python_path = env_path / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
             python_path.parent.mkdir(parents=True, exist_ok=True)
@@ -2772,7 +2772,7 @@ def test_stage_install_records_install_job_on_success(tmp_path, monkeypatch):
         def __init__(self, root):
             self.root = Path(root)
 
-        def install(self, validated):
+        def install(self, validated, timeout=None):
             env_path = self.root / "envs" / validated.provider_id / validated.version / "test"
             python_path = env_path / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
             python_path.parent.mkdir(parents=True, exist_ok=True)
@@ -2814,7 +2814,7 @@ def test_stage_install_records_failed_job_on_smoke_error(tmp_path, monkeypatch):
         def __init__(self, root):
             self.root = Path(root)
 
-        def install(self, validated):
+        def install(self, validated, timeout=None):
             env_path = self.root / "envs" / validated.provider_id / validated.version / "test"
             python_path = env_path / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
             python_path.parent.mkdir(parents=True, exist_ok=True)
@@ -3291,7 +3291,7 @@ def test_autoinstall_stages_enabled_official_providers_not_yet_installed(tmp_pat
     monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: None)
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl", "opensubtitlescom"])
     staged = []
-    monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
+    monkeypatch.setattr(service, "stage_install", lambda manifest, install_timeout=None: staged.append(manifest["provider_id"]))
 
     result = service.autoinstall_enabled_builtins()
 
@@ -3315,7 +3315,7 @@ def test_autoinstall_is_idempotent_skips_existing_installs(tmp_path, monkeypatch
     monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: None)
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
     staged = []
-    monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
+    monkeypatch.setattr(service, "stage_install", lambda manifest, install_timeout=None: staged.append(manifest["provider_id"]))
 
     assert service.autoinstall_enabled_builtins() == []
     assert staged == []
@@ -3332,7 +3332,7 @@ def test_autoinstall_ignores_non_official_catalog_entries(tmp_path, monkeypatch)
     monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: None)
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
     staged = []
-    monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
+    monkeypatch.setattr(service, "stage_install", lambda manifest, install_timeout=None: staged.append(manifest["provider_id"]))
 
     assert service.autoinstall_enabled_builtins() == []
     assert staged == []
@@ -3351,7 +3351,7 @@ def test_autoinstall_swallows_stage_failures(tmp_path, monkeypatch):
 
     calls = []
 
-    def flaky(manifest):
+    def flaky(manifest, install_timeout=None):
         calls.append(manifest["provider_id"])
         if manifest["provider_id"] == "subdl":
             raise RuntimeError("boom")
@@ -3392,7 +3392,7 @@ def test_autoinstall_proceeds_when_catalog_refresh_fails(tmp_path, monkeypatch):
     monkeypatch.setattr(service, "refresh_catalog", boom)
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
     staged = []
-    monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
+    monkeypatch.setattr(service, "stage_install", lambda manifest, install_timeout=None: staged.append(manifest["provider_id"]))
 
     # Refresh failure is swallowed; auto-install still stages from the cached catalog.
     assert service.autoinstall_enabled_builtins() == ["subdl"]
@@ -3413,7 +3413,7 @@ def test_autoinstall_retries_failed_install_rows(tmp_path, monkeypatch):
     monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: None)
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
     staged = []
-    monkeypatch.setattr(service, "stage_install", lambda manifest: staged.append(manifest["provider_id"]))
+    monkeypatch.setattr(service, "stage_install", lambda manifest, install_timeout=None: staged.append(manifest["provider_id"]))
 
     assert service.autoinstall_enabled_builtins() == ["subdl"]
     assert staged == ["subdl"]
@@ -3434,7 +3434,7 @@ def test_autoinstall_skips_refresh_when_nothing_to_install(tmp_path, monkeypatch
     refresh_calls = []
     monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: refresh_calls.append(source_ids))
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
-    monkeypatch.setattr(service, "stage_install", lambda manifest: (_ for _ in ()).throw(AssertionError("should not install")))
+    monkeypatch.setattr(service, "stage_install", lambda manifest, install_timeout=None: (_ for _ in ()).throw(AssertionError("should not install")))
 
     assert service.autoinstall_enabled_builtins() == []
     assert refresh_calls == []  # no candidates -> no catalog fetch
@@ -3449,7 +3449,48 @@ def test_autoinstall_refreshes_only_the_official_source(tmp_path, monkeypatch):
     refresh_calls = []
     monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: refresh_calls.append(source_ids))
     monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
-    monkeypatch.setattr(service, "stage_install", lambda manifest: None)
+    monkeypatch.setattr(service, "stage_install", lambda manifest, install_timeout=None: None)
 
     service.autoinstall_enabled_builtins()
     assert refresh_calls == [{OFFICIAL_CATALOG_SOURCE_ID}]
+
+
+def test_autoinstall_bounds_each_install_with_remaining_budget(tmp_path, monkeypatch):
+    from provider_hub import service
+
+    state_file = _catalog_state(tmp_path, entries={"official:subdl:1.0.0": _official_entry("subdl")})
+    monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
+    monkeypatch.setattr(service, "refresh_catalog", lambda source_ids=None: None)
+    monkeypatch.setattr(service, "_bazarr_enabled_providers", lambda: ["subdl"])
+    captured = {}
+
+    def capture(manifest, install_timeout=None):
+        captured["install_timeout"] = install_timeout
+
+    monkeypatch.setattr(service, "stage_install", capture)
+
+    service.autoinstall_enabled_builtins()
+    # The install is bounded by the remaining startup budget, not left unbounded.
+    assert captured["install_timeout"] is not None
+    assert 0 < captured["install_timeout"] <= 180.0
+
+
+def test_plugin_environment_install_times_out(tmp_path, monkeypatch):
+    import subprocess
+
+    from provider_hub.manifest import validate_manifest
+    from provider_hub.venv import PluginEnvironment, PluginEnvironmentError
+
+    validated = validate_manifest(
+        _manifest(dependencies={"requirements": []}), built_in_provider_ids=set()
+    )
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    # A stuck venv/pip step is surfaced as a clean PluginEnvironmentError rather than
+    # hanging the install (and therefore boot) indefinitely.
+    with pytest.raises(PluginEnvironmentError):
+        PluginEnvironment(tmp_path).install(validated, timeout=30)

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -927,7 +927,7 @@ def test_apply_update_uses_latest_catalog_manifest(tmp_path, monkeypatch):
         encoding="utf-8",
     )
     monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
-    monkeypatch.setattr("provider_hub.service._fetch_bundle", lambda manifest: tmp_path / "bundle")
+    monkeypatch.setattr("provider_hub.service._fetch_bundle", lambda manifest, deadline=None: tmp_path / "bundle")
     class FakeEnvironment:
         def __init__(self, root):
             self.root = root
@@ -1968,7 +1968,7 @@ def test_stage_install_accepts_trusted_migrated_built_in_shadow(tmp_path, monkey
     )
     monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
     monkeypatch.setattr("provider_hub.service._built_in_provider_ids", lambda: {"gestdown"})
-    monkeypatch.setattr("provider_hub.service._fetch_bundle", lambda manifest: tmp_path / "bundle")
+    monkeypatch.setattr("provider_hub.service._fetch_bundle", lambda manifest, deadline=None: tmp_path / "bundle")
 
     class FakeEnvironment:
         def __init__(self, root):
@@ -3494,3 +3494,20 @@ def test_plugin_environment_install_times_out(tmp_path, monkeypatch):
     # hanging the install (and therefore boot) indefinitely.
     with pytest.raises(PluginEnvironmentError):
         PluginEnvironment(tmp_path).install(validated, timeout=30)
+
+
+def test_deadline_request_timeout_bounds_and_rejects():
+    import time
+
+    from provider_hub.service import ProviderHubInstallError, _deadline_request_timeout
+
+    # No deadline -> the full per-request default.
+    assert _deadline_request_timeout(None) == 30.0
+    # Plenty of budget left -> still capped at the default.
+    assert _deadline_request_timeout(time.monotonic() + 1000) == 30.0
+    # Little budget left -> shrunk to the remaining time.
+    shrunk = _deadline_request_timeout(time.monotonic() + 5)
+    assert 1.0 <= shrunk <= 5.0
+    # Budget exhausted -> the bundle fetch is rejected instead of running long.
+    with pytest.raises(ProviderHubInstallError):
+        _deadline_request_timeout(time.monotonic() - 1)

--- a/tests/bazarr/test_supervisor_stages.py
+++ b/tests/bazarr/test_supervisor_stages.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib.util
 from pathlib import Path
 
@@ -30,3 +31,18 @@ def test_installing_providers_stage_present_and_ordered():
     # The auto-install marker maps to the new stage.
     assert any(marker == "Provider Hub startup auto-install" and idx == install_idx
                for marker, idx in markers)
+
+
+def test_wait_for_ready_returns_when_process_not_alive():
+    # The readiness poll waits as long as the backend process is alive (so a long
+    # first-boot migration can't leave the startup screen stuck), but must end
+    # promptly when there is no live process rather than looping forever.
+    sup = _load_supervisor()
+    mgr = sup.BackendManager([])
+    mgr.state = mgr.STATE_STARTING
+    mgr.process = None  # no live backend process
+
+    asyncio.run(asyncio.wait_for(mgr._wait_for_ready(), timeout=5))
+
+    # It never falsely marks RUNNING without a responding backend.
+    assert mgr.state == mgr.STATE_STARTING

--- a/tests/bazarr/test_supervisor_stages.py
+++ b/tests/bazarr/test_supervisor_stages.py
@@ -1,0 +1,32 @@
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_supervisor():
+    spec = importlib.util.spec_from_file_location(
+        "bazarr_supervisor", ROOT / "docker" / "supervisor.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_installing_providers_stage_present_and_ordered():
+    sup = _load_supervisor()
+    stages = sup.BackendManager.STAGES
+    markers = sup.BackendManager._STAGE_MARKERS
+
+    assert "Installing providers" in stages
+    install_idx = stages.index("Installing providers")
+    # It runs after launch, before checking for updates.
+    assert stages.index("Launching process") < install_idx < stages.index("Checking for updates")
+
+    # Marker indices stay within range and increase in declaration order (forward-only).
+    idxs = [idx for _, idx in markers]
+    assert idxs == sorted(idxs)
+    assert all(0 <= idx < len(stages) for _, idx in markers)
+    # The auto-install marker maps to the new stage.
+    assert any(marker == "Provider Hub startup auto-install" and idx == install_idx
+               for marker, idx in markers)


### PR DESCRIPTION
> Stacked on #183 (the same-id collapse fix). Merge #183 first; until then this PR's diff also shows #183's commits. Real-world effect also needs the catalog rename (LavX/bazarr-provider-catalog#79) on `main` so the official catalog serves the built-in ids.

## What

On startup, auto-install and shadow the official-catalog version of every **enabled** provider still served by a shipped built-in, surfaced as a visible **"Installing providers"** stage on the existing startup screen. This makes the official catalog the canonical provider source and is the migration bridge toward phasing out the bundled subliminal_patch providers. Also adds an empty-state Marketplace nudge when no providers are enabled.

Catalog plugins reuse the built-in `provider_id`, so the existing same-id registry overwrite is the "shadow" — no runtime-id rename, so throttling/compat/language hooks/config sections keep working.

## How

1. **`provider_hub.service.autoinstall_enabled_builtins()`** — stages the latest **official + trusted** catalog manifest for each enabled provider that has no hub install row yet. Idempotent (skips any existing row), best-effort (never raises — guarded `load_state` + per-provider `try/except`), 180s time budget with `break`, env kill-switch `BAZARR_DISABLE_PROVIDER_AUTOINSTALL`.
2. **`init.py`** — calls it immediately before `activate_staged_installations()`, so plugins activate + register + shadow the built-in **in the same boot**, before the `enabled_providers` strip filter.
3. **`docker/supervisor.py`** — new "Installing providers" startup stage (index 1) keyed off the backend's `Provider Hub startup auto-install` log line; the existing SSE startup screen renders it.
4. **Frontend** — "No providers enabled → Browse the Marketplace" nudge when `enabled_providers` is empty.

## Tests / review

- Backend: 6 autoinstall unit tests + supervisor stage/marker consistency test; full suites green (`ruff` clean, 506 backend tests).
- Frontend: empty-state nudge behavioral test; full suite green (531 tests, `check:ts`/eslint/prettier/build).
- Two-stage review per task + a final whole-feature review: **READY TO MERGE** (marker consistency, same-boot shadow ordering, idempotency, trust gating, failure containment all verified).

## Live verification (test server)

Deployed the built image; confirmed the auto-install runs during boot (`Provider Hub startup auto-install: reconciling ...` logged before `check_update`, matching the supervisor's stage marker), boot completes cleanly, and it is a correct idempotent no-op when providers are already installed (53 installs, all active, no errors). A live install of a missing enabled provider is exercisable via the source `dev_ref` against #79 / after #79 merges to `main`; the install path itself is covered by the unit tests.