### PR TITLE
provider_hub: host-side archive extraction (zip/rar/7z)

### DIFF
--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -209,6 +209,30 @@ def worker_download_to_content(subtitle: HubWorkerSubtitle, payload: dict[str, A
     return True
 
 
+# Hard caps so a worker, or the untrusted site it fetched the archive from, cannot OOM
+# the host with a decompression bomb or an oversized response. Real subtitle archives
+# are a few KB; these limits are deliberately generous.
+_MAX_ARCHIVE_BYTES = 32 * 1024 * 1024
+_MAX_MEMBER_BYTES = 16 * 1024 * 1024
+_MAX_ARCHIVE_TOTAL_BYTES = 64 * 1024 * 1024
+
+
+def _guard_archive_members(archive) -> None:
+    """Reject decompression bombs by checking declared uncompressed sizes up front."""
+    try:
+        infos = archive.infolist()
+    except Exception:  # pragma: no cover - exotic archive objects
+        return
+    total = 0
+    for info in infos:
+        size = int(getattr(info, "file_size", 0) or 0)
+        if size > _MAX_MEMBER_BYTES:
+            raise WorkerProtocolError("download.archive_b64 member exceeds the size limit")
+        total += size
+        if total > _MAX_ARCHIVE_TOTAL_BYTES:
+            raise WorkerProtocolError("download.archive_b64 decompresses past the size limit")
+
+
 def _worker_archive_to_content(
     subtitle: HubWorkerSubtitle, payload: dict[str, Any], archive_b64: str
 ) -> bool:
@@ -225,7 +249,11 @@ def _worker_archive_to_content(
         get_subtitle_from_archive,
     )
 
+    if len(archive_b64) > _MAX_ARCHIVE_BYTES * 4 // 3 + 16:
+        raise WorkerProtocolError("download.archive_b64 exceeds the maximum archive size")
     raw = base64.b64decode(archive_b64.encode("ascii"), validate=True)
+    if len(raw) > _MAX_ARCHIVE_BYTES:
+        raise WorkerProtocolError("download.archive_b64 exceeds the maximum archive size")
     expected_hash = payload.get("archive_sha256")
     if expected_hash:
         if hashlib.sha256(raw).hexdigest() != str(expected_hash).lower():
@@ -234,6 +262,7 @@ def _worker_archive_to_content(
     archive = get_archive_from_bytes(raw)
     if archive is None:
         raise WorkerProtocolError("download.archive_b64 is not a zip or rar archive")
+    _guard_archive_members(archive)
 
     member = payload.get("member")
     if member:
@@ -243,10 +272,13 @@ def _worker_archive_to_content(
         chosen = member
     else:
         forced = bool(getattr(getattr(subtitle, "language", None), "forced", False))
+        episode = payload.get("episode")
+        if isinstance(episode, (list, tuple)):
+            episode = episode[0] if episode else None
         content = get_subtitle_from_archive(
             archive,
             forced=forced,
-            episode=payload.get("episode"),
+            episode=episode,
             get_first_subtitle=bool(payload.get("first_subtitle")),
         )
         if content is None:

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -215,6 +215,10 @@ def worker_download_to_content(subtitle: HubWorkerSubtitle, payload: dict[str, A
 _MAX_ARCHIVE_BYTES = 32 * 1024 * 1024
 _MAX_MEMBER_BYTES = 16 * 1024 * 1024
 _MAX_ARCHIVE_TOTAL_BYTES = 64 * 1024 * 1024
+# Real subtitle archives hold a handful of files; cap the member count so a 32 MB zip
+# packed with hundreds of thousands of zero-byte entries cannot DoS the host (the byte
+# caps above never trip on empty members). Mirrors service.py's _LOCAL_PACKAGE_MAX_MEMBERS.
+_MAX_ARCHIVE_MEMBERS = 5000
 
 
 def _guard_archive_members(archive) -> None:
@@ -223,6 +227,10 @@ def _guard_archive_members(archive) -> None:
         infos = archive.infolist()
     except Exception:  # pragma: no cover - exotic archive objects
         return
+    # Cap the entry count before the O(N) scan below (and the later namelist()/extract):
+    # an archive can stay under the byte caps while carrying a pathological member count.
+    if len(infos) > _MAX_ARCHIVE_MEMBERS:
+        raise WorkerProtocolError("download.archive_b64 contains too many members")
     total = 0
     for info in infos:
         # zip/rar expose file_size; py7zr exposes uncompressed.
@@ -344,7 +352,9 @@ def _worker_archive_to_content(
             archive,
             forced=forced,
             episode=episode,
+            episode_title=payload.get("episode_title"),
             get_first_subtitle=bool(payload.get("first_subtitle")),
+            extensions=(".srt", ".sub", ".ssa", ".ass", ".vtt"),
         )
         if content is None:
             raise WorkerProtocolError("download.archive_b64 has no usable subtitle member")
@@ -352,6 +362,9 @@ def _worker_archive_to_content(
 
     subtitle.content = content
     subtitle.format = payload.get("format") or _format_from_member(chosen) or getattr(subtitle, "format", "srt")
-    # Leave subtitle.encoding unset so Subtitle.normalize()/chardet detects it, the
-    # same as native subliminal providers; do not let the worker pin a guess.
+    # Clear any encoding carried over from search (e.g. via the display attribute splat)
+    # so Subtitle.normalize()/chardet detects it from the extracted bytes, the same as
+    # native subliminal providers; do not let a stale or worker-supplied guess pin it.
+    subtitle.encoding = None
+    subtitle._guessed_encoding = None
     return True

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -267,9 +267,21 @@ class _SevenZipArchive:
         with tempfile.TemporaryDirectory() as tmp:
             with self._open() as archive:
                 archive.extract(path=tmp, targets=[name])
-            for root, _dirs, files in os.walk(tmp):
+            # py7zr preserves the archived file's mode, which can drop the owner read
+            # bit; make directories traversable and files readable before reading.
+            for root, dirs, files in os.walk(tmp):
+                for directory in dirs:
+                    try:
+                        os.chmod(os.path.join(root, directory), 0o700)
+                    except OSError:  # pragma: no cover
+                        pass
                 for filename in files:
-                    with open(os.path.join(root, filename), "rb") as handle:
+                    path = os.path.join(root, filename)
+                    try:
+                        os.chmod(path, 0o600)
+                    except OSError:  # pragma: no cover
+                        pass
+                    with open(path, "rb") as handle:
                         return handle.read()
         raise WorkerProtocolError(f"download.archive_b64 7z member could not be read: {name}")
 

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -174,14 +174,27 @@ def candidate_from_worker(provider_name: str, payload: dict[str, Any]) -> HubWor
     return subtitle
 
 
+_SUBTITLE_FORMATS = {"srt": "srt", "ass": "ass", "ssa": "ass", "vtt": "vtt", "sub": "sub"}
+
+
+def _format_from_member(name: str | None) -> str | None:
+    if not name or "." not in name:
+        return None
+    return _SUBTITLE_FORMATS.get(name.rsplit(".", 1)[-1].lower())
+
+
 def worker_download_to_content(subtitle: HubWorkerSubtitle, payload: dict[str, Any]) -> bool:
     if payload.get("empty"):
         subtitle.content = b""
         return True
 
+    archive_b64 = payload.get("archive_b64")
+    if isinstance(archive_b64, str):
+        return _worker_archive_to_content(subtitle, payload, archive_b64)
+
     content_b64 = payload.get("content_b64")
     if not isinstance(content_b64, str):
-        raise WorkerProtocolError("download.content_b64 is required")
+        raise WorkerProtocolError("download.content_b64 or download.archive_b64 is required")
 
     content = base64.b64decode(content_b64.encode("ascii"), validate=True)
     expected_hash = payload.get("content_sha256")
@@ -193,4 +206,55 @@ def worker_download_to_content(subtitle: HubWorkerSubtitle, payload: dict[str, A
     subtitle.content = content
     subtitle.format = payload.get("format") or getattr(subtitle, "format", "srt")
     subtitle.encoding = payload.get("encoding") or getattr(subtitle, "encoding", None)
+    return True
+
+
+def _worker_archive_to_content(
+    subtitle: HubWorkerSubtitle, payload: dict[str, Any], archive_b64: str
+) -> bool:
+    """Extract a subtitle from an archive the worker handed back.
+
+    The worker returns the raw zip/rar bytes and, when it chose one during search,
+    the member name. Bazarr extracts with its own rarfile/zipfile stack, so provider
+    bundles never carry an archive binary (no py7zz), and the encoding is left to
+    Subtitle.normalize() rather than being guessed inside the worker.
+    """
+    from subliminal.subtitle import fix_line_ending
+    from subliminal_patch.providers.utils import (
+        get_archive_from_bytes,
+        get_subtitle_from_archive,
+    )
+
+    raw = base64.b64decode(archive_b64.encode("ascii"), validate=True)
+    expected_hash = payload.get("archive_sha256")
+    if expected_hash:
+        if hashlib.sha256(raw).hexdigest() != str(expected_hash).lower():
+            raise WorkerProtocolError("download.archive_sha256 mismatch")
+
+    archive = get_archive_from_bytes(raw)
+    if archive is None:
+        raise WorkerProtocolError("download.archive_b64 is not a zip or rar archive")
+
+    member = payload.get("member")
+    if member:
+        if member not in set(archive.namelist()):
+            raise WorkerProtocolError(f"download.member is not in the archive: {member}")
+        content = fix_line_ending(archive.read(member))
+        chosen = member
+    else:
+        forced = bool(getattr(getattr(subtitle, "language", None), "forced", False))
+        content = get_subtitle_from_archive(
+            archive,
+            forced=forced,
+            episode=payload.get("episode"),
+            get_first_subtitle=bool(payload.get("first_subtitle")),
+        )
+        if content is None:
+            raise WorkerProtocolError("download.archive_b64 has no usable subtitle member")
+        chosen = payload.get("filename") or ""
+
+    subtitle.content = content
+    subtitle.format = payload.get("format") or _format_from_member(chosen) or getattr(subtitle, "format", "srt")
+    # Leave subtitle.encoding unset so Subtitle.normalize()/chardet detects it, the
+    # same as native subliminal providers; do not let the worker pin a guess.
     return True

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -225,12 +225,63 @@ def _guard_archive_members(archive) -> None:
         return
     total = 0
     for info in infos:
-        size = int(getattr(info, "file_size", 0) or 0)
+        # zip/rar expose file_size; py7zr exposes uncompressed.
+        size = int(getattr(info, "file_size", 0) or getattr(info, "uncompressed", 0) or 0)
         if size > _MAX_MEMBER_BYTES:
             raise WorkerProtocolError("download.archive_b64 member exceeds the size limit")
         total += size
         if total > _MAX_ARCHIVE_TOTAL_BYTES:
             raise WorkerProtocolError("download.archive_b64 decompresses past the size limit")
+
+
+_SEVEN_ZIP_MAGIC = b"7z\xbc\xaf\x27\x1c"
+
+
+class _SevenZipArchive:
+    """A minimal zip/rar-like view over py7zr so get_subtitle_from_archive and the bomb
+    guard work on 7z archives unchanged. py7zr (a bazarr host dependency) extracts to
+    disk, so read() extracts one member into a temp dir and returns its bytes."""
+
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def _open(self):
+        import io as _io
+
+        import py7zr
+
+        return py7zr.SevenZipFile(_io.BytesIO(self._data))
+
+    def namelist(self):
+        with self._open() as archive:
+            return archive.getnames()
+
+    def infolist(self):
+        with self._open() as archive:
+            return archive.list()
+
+    def read(self, name: str) -> bytes:
+        import os
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with self._open() as archive:
+                archive.extract(path=tmp, targets=[name])
+            for root, _dirs, files in os.walk(tmp):
+                for filename in files:
+                    with open(os.path.join(root, filename), "rb") as handle:
+                        return handle.read()
+        raise WorkerProtocolError(f"download.archive_b64 7z member could not be read: {name}")
+
+
+def _seven_zip_archive(raw: bytes):
+    if not raw.startswith(_SEVEN_ZIP_MAGIC):
+        return None
+    try:
+        import py7zr  # noqa: F401
+    except Exception:  # pragma: no cover - py7zr is a declared host dependency
+        return None
+    return _SevenZipArchive(raw)
 
 
 def _worker_archive_to_content(
@@ -261,7 +312,9 @@ def _worker_archive_to_content(
 
     archive = get_archive_from_bytes(raw)
     if archive is None:
-        raise WorkerProtocolError("download.archive_b64 is not a zip or rar archive")
+        archive = _seven_zip_archive(raw)
+    if archive is None:
+        raise WorkerProtocolError("download.archive_b64 is not a zip, rar, or 7z archive")
     _guard_archive_members(archive)
 
     member = payload.get("member")

--- a/bazarr/provider_hub/worker.py
+++ b/bazarr/provider_hub/worker.py
@@ -19,6 +19,19 @@ from . import WORKER_ABI_VERSION
 
 logger = logging.getLogger(__name__)
 
+# Cap a single worker->host NDJSON response line. ``readline()`` buffers a whole
+# line before ``json.loads`` runs, and the protocol-level archive cap only fires
+# after the line is already in memory, so a runaway or malicious worker could OOM
+# the host with one giant line. Sized comfortably above the 32 MB archive cap
+# (base64 is ~43 MB, plus the JSON envelope) so legitimate responses still pass.
+_MAX_RESPONSE_LINE_BYTES = 48 * 1024 * 1024
+# Read granularity for the bounded readline loop, so the cap is enforced before a
+# whole oversized line accumulates.
+_READ_CHUNK_CHARS = 1024 * 1024
+# Queued by the reader thread when a response line exceeds the cap, so the
+# consumer kills the worker at the transport layer instead of assembling it.
+_OVERSIZE_RESPONSE = object()
+
 
 def _json_default(obj):
     """Coerce values not natively JSON-serializable into safe representations.
@@ -60,7 +73,7 @@ class ProviderWorkerClient:
         self.env = env
         self.process: subprocess.Popen | None = None
         self._lock = threading.Lock()
-        self._stdout_queue: queue.Queue[str | None] | None = None
+        self._stdout_queue: queue.Queue[Any] | None = None
         self._stdout_thread: threading.Thread | None = None
 
     def start(self) -> None:
@@ -94,17 +107,28 @@ class ProviderWorkerClient:
         self._stdout_thread.start()
 
     @staticmethod
-    def _enqueue_stdout(process: subprocess.Popen, stdout_queue: queue.Queue[str | None]) -> None:
+    def _enqueue_stdout(process: subprocess.Popen, stdout_queue: queue.Queue[Any]) -> None:
         stdout = process.stdout
         if stdout is None:
             stdout_queue.put(None)
             return
         try:
+            # Read in bounded chunks (readline(size) stops at a newline or after
+            # ``size`` chars) and track the current line's length, so an oversized
+            # response is rejected here instead of buffering in full before
+            # json.loads. A normal multi-chunk line is reassembled downstream.
+            line_len = 0
             while True:
-                line = stdout.readline()
-                if not line:
+                chunk = stdout.readline(_READ_CHUNK_CHARS)
+                if not chunk:
                     break
-                stdout_queue.put(line)
+                line_len += len(chunk)
+                if line_len > _MAX_RESPONSE_LINE_BYTES:
+                    stdout_queue.put(_OVERSIZE_RESPONSE)
+                    break
+                stdout_queue.put(chunk)
+                if chunk.endswith("\n"):
+                    line_len = 0
         finally:
             stdout_queue.put(None)
 
@@ -149,6 +173,11 @@ class ProviderWorkerClient:
                 continue
             if chunk is None:
                 return "".join(chunks)
+            if chunk is _OVERSIZE_RESPONSE:
+                self._kill_worker()
+                raise WorkerError(
+                    f"worker response exceeded {_MAX_RESPONSE_LINE_BYTES} bytes"
+                )
             chunks.append(chunk)
             if chunk.endswith("\n"):
                 return "".join(chunks)

--- a/custom_libs/subliminal_patch/providers/utils.py
+++ b/custom_libs/subliminal_patch/providers/utils.py
@@ -110,13 +110,18 @@ def _analize_sub_name(sub_name: str, title_: str):
 
 
 def get_subtitle_from_archive(
-    archive, forced=False, episode=None, get_first_subtitle=False, **kwargs
+    archive,
+    forced=False,
+    episode=None,
+    get_first_subtitle=False,
+    extensions=(".srt", ".sub", ".ssa", ".ass"),
+    **kwargs,
 ):
     "Get subtitle from Rarfile/Zipfile object. Return None if nothing is found."
     subs_in_archive = [
         name
         for name in archive.namelist()
-        if name.endswith((".srt", ".sub", ".ssa", ".ass"))
+        if name.endswith(tuple(extensions))
     ]
 
     if not subs_in_archive:

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -422,6 +422,66 @@ def test_worker_download_rejects_oversized_archive(monkeypatch):
         worker_download_to_content(candidate, {"archive_b64": payload_b64})
 
 
+def test_worker_reader_caps_oversized_response_line(monkeypatch):
+    # The reader thread must reject an oversized response at the transport layer
+    # (a giant readline() line buffers in full before json.loads otherwise).
+    import queue
+    from types import SimpleNamespace
+    from provider_hub import worker as worker_mod
+
+    monkeypatch.setattr(worker_mod, "_MAX_RESPONSE_LINE_BYTES", 8)
+    monkeypatch.setattr(worker_mod, "_READ_CHUNK_CHARS", 4)
+
+    class FakeStdout:
+        def __init__(self, data):
+            self.data = data
+            self.pos = 0
+
+        def readline(self, size=-1):
+            if self.pos >= len(self.data):
+                return ""
+            window = len(self.data) if size is None or size < 0 else size
+            end = min(self.pos + window, len(self.data))
+            newline = self.data.find("\n", self.pos, end)
+            if newline != -1:
+                end = newline + 1
+            chunk = self.data[self.pos:end]
+            self.pos = end
+            return chunk
+
+    stdout_queue: queue.Queue = queue.Queue()
+    # A long line with no newline until the very end exceeds the 8-byte cap.
+    worker_mod.ProviderWorkerClient._enqueue_stdout(
+        SimpleNamespace(stdout=FakeStdout("X" * 100 + "\n")), stdout_queue
+    )
+    items = []
+    while True:
+        item = stdout_queue.get_nowait()
+        items.append(item)
+        if item is None:
+            break
+    assert worker_mod._OVERSIZE_RESPONSE in items
+    # The reader stopped early instead of buffering the whole 100-char line.
+    buffered = sum(len(i) for i in items if isinstance(i, str))
+    assert buffered <= worker_mod._MAX_RESPONSE_LINE_BYTES + worker_mod._READ_CHUNK_CHARS
+
+
+def test_worker_consumer_kills_on_oversized_sentinel():
+    import queue
+    from types import SimpleNamespace
+    from provider_hub import worker as worker_mod
+    from provider_hub.worker import ProviderWorkerClient, WorkerError
+
+    client = ProviderWorkerClient.__new__(ProviderWorkerClient)
+    client.process = SimpleNamespace(
+        stdout=object(), kill=lambda: None, wait=lambda timeout=None: None
+    )
+    client._stdout_queue = queue.Queue()
+    client._stdout_queue.put(worker_mod._OVERSIZE_RESPONSE)
+    with pytest.raises(WorkerError, match="exceeded"):
+        client._read_line_with_deadline(5.0)
+
+
 def test_venv_installer_uses_isolated_hash_checked_pip(monkeypatch, tmp_path):
     from provider_hub.venv import PluginEnvironment
     from provider_hub.manifest import validate_manifest

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -307,6 +307,91 @@ def test_worker_protocol_round_trips_language_video_and_download_payload():
     assert candidate.content == content
 
 
+def _hub_candidate(worker_id="sub-arch"):
+    from provider_hub.protocol import candidate_from_worker, language_to_payload
+
+    return candidate_from_worker(
+        provider_name="examplehub",
+        payload={
+            "provider": "upstream",
+            "id": worker_id,
+            "language": language_to_payload(Language("ces")),
+            "provider_payload": {"provider": "upstream", "schema": 1},
+        },
+    )
+
+
+def test_worker_download_extracts_named_archive_member_host_side():
+    from provider_hub.protocol import worker_download_to_content
+
+    candidate = _hub_candidate()
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("Show.S01E01.ces.srt", b"1\r\n00:00:01,000 --> 00:00:02,000\r\nAhoj\r\n")
+        archive.writestr("readme.txt", b"ignore me")
+    archive_bytes = buffer.getvalue()
+
+    worker_download_to_content(
+        candidate,
+        {
+            "archive_b64": base64.b64encode(archive_bytes).decode("ascii"),
+            "archive_sha256": _sha256(archive_bytes),
+            "member": "Show.S01E01.ces.srt",
+            "encoding": "latin-1",  # a wrong worker guess that must be ignored
+        },
+    )
+
+    assert b"Ahoj" in candidate.content
+    assert b"\r\n" not in candidate.content  # host applied fix_line_ending
+    assert candidate.format == "srt"
+    # Archive mode ignores any worker-supplied encoding and keeps the detect-friendly
+    # default (utf-8 first, then chardet via Subtitle.normalize()), so a wrong latin-1
+    # guess cannot lock in mojibake the way it did in per-provider download payloads.
+    assert candidate.encoding != "latin-1"
+
+
+def test_worker_download_auto_selects_single_archive_member():
+    from provider_hub.protocol import worker_download_to_content
+
+    candidate = _hub_candidate("sub-single")
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("only.srt", b"1\n00:00:01,000 --> 00:00:02,000\nHi\n")
+    archive_bytes = buffer.getvalue()
+
+    worker_download_to_content(
+        candidate,
+        {"archive_b64": base64.b64encode(archive_bytes).decode("ascii")},
+    )
+
+    assert b"Hi" in candidate.content
+
+
+def test_worker_download_rejects_missing_member_and_bad_archive():
+    from provider_hub.protocol import WorkerProtocolError, worker_download_to_content
+
+    candidate = _hub_candidate("sub-bad")
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("Show.S01E01.srt", b"1\n00:00:01,000 --> 00:00:02,000\nHi\n")
+    archive_bytes = buffer.getvalue()
+
+    with pytest.raises(WorkerProtocolError):
+        worker_download_to_content(
+            candidate,
+            {
+                "archive_b64": base64.b64encode(archive_bytes).decode("ascii"),
+                "member": "does-not-exist.srt",
+            },
+        )
+
+    with pytest.raises(WorkerProtocolError):
+        worker_download_to_content(
+            candidate,
+            {"archive_b64": base64.b64encode(b"not an archive").decode("ascii")},
+        )
+
+
 def test_venv_installer_uses_isolated_hash_checked_pip(monkeypatch, tmp_path):
     from provider_hub.venv import PluginEnvironment
     from provider_hub.manifest import validate_manifest

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -392,6 +392,36 @@ def test_worker_download_rejects_missing_member_and_bad_archive():
         )
 
 
+def test_worker_download_rejects_decompression_bomb(monkeypatch):
+    from provider_hub import protocol
+    from provider_hub.protocol import WorkerProtocolError, worker_download_to_content
+
+    candidate = _hub_candidate("sub-bomb")
+    # 2 MiB member that compresses to almost nothing: a classic zip bomb shape.
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("Show.S01E01.srt", b"\0" * (2 * 1024 * 1024))
+    archive_bytes = buffer.getvalue()
+    assert len(archive_bytes) < 50 * 1024  # tiny on disk, huge decompressed
+
+    monkeypatch.setattr(protocol, "_MAX_MEMBER_BYTES", 64 * 1024)
+    with pytest.raises(WorkerProtocolError):
+        worker_download_to_content(
+            candidate, {"archive_b64": base64.b64encode(archive_bytes).decode("ascii")}
+        )
+
+
+def test_worker_download_rejects_oversized_archive(monkeypatch):
+    from provider_hub import protocol
+    from provider_hub.protocol import WorkerProtocolError, worker_download_to_content
+
+    candidate = _hub_candidate("sub-big")
+    monkeypatch.setattr(protocol, "_MAX_ARCHIVE_BYTES", 1024)
+    payload_b64 = base64.b64encode(b"x" * 4096).decode("ascii")
+    with pytest.raises(WorkerProtocolError):
+        worker_download_to_content(candidate, {"archive_b64": payload_b64})
+
+
 def test_venv_installer_uses_isolated_hash_checked_pip(monkeypatch, tmp_path):
     from provider_hub.venv import PluginEnvironment
     from provider_hub.manifest import validate_manifest

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -3707,3 +3707,104 @@ def test_deadline_request_timeout_bounds_and_rejects():
     # Budget exhausted -> the bundle fetch is rejected instead of running long.
     with pytest.raises(ProviderHubInstallError):
         _deadline_request_timeout(time.monotonic() - 1)
+
+
+def test_worker_download_rejects_excessive_archive_member_count(monkeypatch):
+    # The byte caps never trip on an archive full of tiny members, so an entry-count
+    # bomb (hundreds of thousands of zero-byte members) would still be scanned/extracted.
+    # The guard must also cap the member count, like service.py's _LOCAL_PACKAGE_MAX_MEMBERS.
+    from provider_hub import protocol
+    from provider_hub.protocol import WorkerProtocolError, worker_download_to_content
+
+    candidate = _hub_candidate("sub-manymembers")
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        # Without a count cap this archive extracts fine (one usable .srt); the only
+        # thing that should reject it is the member-count guard.
+        archive.writestr("only.srt", b"1\n00:00:01,000 --> 00:00:02,000\nHi\n")
+        for i in range(20):
+            archive.writestr(f"junk{i}.txt", b"x")
+    archive_bytes = buffer.getvalue()
+
+    monkeypatch.setattr(protocol, "_MAX_ARCHIVE_MEMBERS", 5, raising=False)
+    with pytest.raises(WorkerProtocolError):
+        worker_download_to_content(
+            candidate, {"archive_b64": base64.b64encode(archive_bytes).decode("ascii")}
+        )
+
+
+def test_worker_download_archive_clears_stale_encoding():
+    # An encoding can be carried onto the subtitle at search time (e.g. via the display
+    # attribute splat in candidate_from_worker). The archive path must clear it so
+    # Subtitle.normalize()/chardet detects encoding from the extracted bytes instead of
+    # pinning a stale legacy guess (which silently decodes UTF-8 as mojibake).
+    from provider_hub.protocol import worker_download_to_content
+
+    candidate = _hub_candidate("sub-staleenc")
+    candidate.encoding = "latin-1"
+    candidate._guessed_encoding = "latin-1"
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("only.srt", b"1\n00:00:01,000 --> 00:00:02,000\nHi\n")
+    archive_bytes = buffer.getvalue()
+
+    worker_download_to_content(
+        candidate, {"archive_b64": base64.b64encode(archive_bytes).decode("ascii")}
+    )
+
+    assert candidate.encoding is None
+    assert candidate._guessed_encoding is None
+
+
+def test_worker_download_auto_selects_single_vtt_member():
+    # The explicit-member path already supports VTT; the auto-select path must too, so a
+    # worker archive containing a lone WebVTT file is not rejected as "no usable member".
+    from provider_hub.protocol import worker_download_to_content
+
+    candidate = _hub_candidate("sub-vtt")
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("only.vtt", b"WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHi\n")
+    archive_bytes = buffer.getvalue()
+
+    worker_download_to_content(
+        candidate, {"archive_b64": base64.b64encode(archive_bytes).decode("ascii")}
+    )
+
+    assert b"WEBVTT" in candidate.content
+
+
+def test_worker_download_forwards_episode_title_to_archive_selection(monkeypatch):
+    # Episode packs are disambiguated by episode_title when filenames carry the title
+    # rather than the number (as subdl/subf2m do). The host must forward episode_title
+    # into the shared selector, not just the episode number.
+    import subliminal_patch.providers.utils as utils
+
+    from provider_hub.protocol import worker_download_to_content
+
+    captured = {}
+
+    def fake_select(archive, **kwargs):
+        captured.update(kwargs)
+        return b"1\n00:00:01,000 --> 00:00:02,000\nHi\n"
+
+    monkeypatch.setattr(utils, "get_subtitle_from_archive", fake_select)
+
+    candidate = _hub_candidate("sub-eptitle")
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("a.srt", b"x")
+        archive.writestr("b.srt", b"y")
+    archive_bytes = buffer.getvalue()
+
+    worker_download_to_content(
+        candidate,
+        {
+            "archive_b64": base64.b64encode(archive_bytes).decode("ascii"),
+            "episode": 1,
+            "episode_title": "The One With The Test",
+        },
+    )
+
+    assert captured.get("episode_title") == "The One With The Test"

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -422,6 +422,27 @@ def test_worker_download_rejects_oversized_archive(monkeypatch):
         worker_download_to_content(candidate, {"archive_b64": payload_b64})
 
 
+def test_worker_download_extracts_seven_zip_member_host_side():
+    py7zr = pytest.importorskip("py7zr")
+    from provider_hub.protocol import worker_download_to_content
+
+    candidate = _hub_candidate("sub-7z")
+    buffer = io.BytesIO()
+    with py7zr.SevenZipFile(buffer, "w") as archive:
+        archive.writestr(b"1\r\n00:00:01,000 --> 00:00:02,000\r\nAhoj\r\n", "Show.S01E01.ces.srt")
+    archive_bytes = buffer.getvalue()
+    assert archive_bytes[:6] == b"7z\xbc\xaf\x27\x1c"
+
+    worker_download_to_content(
+        candidate,
+        {"archive_b64": base64.b64encode(archive_bytes).decode("ascii"), "member": "Show.S01E01.ces.srt"},
+    )
+
+    assert b"Ahoj" in candidate.content
+    assert b"\r\n" not in candidate.content  # host applied fix_line_ending
+    assert candidate.format == "srt"
+
+
 def test_worker_reader_caps_oversized_response_line(monkeypatch):
     # The reader thread must reject an oversized response at the transport layer
     # (a giant readline() line buffers in full before json.loads otherwise).


### PR DESCRIPTION
Moves zip/rar/7z subtitle extraction from provider worker bundles into the host. A worker can now hand back the raw archive bytes plus the member it chose (or none, to let the host pick), and Bazarr extracts with its own `rarfile`/`zipfile` stack, the same code native subliminal providers use, leaving the encoding to `Subtitle.normalize()`/chardet.

**Beta only.** This pairs with the catalog providers' archive-mode migration; the two ship together as 2.4.0-beta and must not land in 2.3.1. The change is additive: the existing `content_b64` download mode is unchanged, so nothing breaks until catalog providers start returning `archive_b64`.

## What this fixes
- The aarch64 / macOS / Windows install failures from providers bundling an archive binary (py7zz). Extraction now happens host-side with the binary already in the image, so provider bundles carry zero archive dependencies (several collapse to no deps at all).
- The per-provider "wrong codepage to mojibake" class: encoding is detected once on the host instead of guessed inside each worker.
- The 22-50x duplication of extraction / member-selection / encoding logic across providers.

## What's in the branch
- **Host archive contract** (`protocol.py`): `worker_download_to_content` accepts `archive_b64` (+ optional `member`, `episode`, `archive_sha256`), extracts via `get_archive_from_bytes` / `get_subtitle_from_archive`, applies `fix_line_ending`, and resolves the format from the member name.
- **Bomb / oversized hardening**: declared-uncompressed-size check via `infolist()`, plus `_MAX_ARCHIVE_BYTES` (32 MB), `_MAX_MEMBER_BYTES` (16 MB), and `_MAX_ARCHIVE_TOTAL_BYTES` (64 MB) caps, with the base64 size rejected before decode.
- **Transport-layer pipe cap** (`worker.py`): the worker stdout reader now reads in bounded chunks and rejects a response line past 48 MB at the transport layer, so a giant line can no longer buffer in full before `json.loads` and the protocol cap could reject it (an OOM hole). The consumer kills the worker on the oversize sentinel.
- **Host 7z support** via `py7zr` (a declared host dependency), with a minimal zip/rar-like view so the bomb guard and member selection work unchanged on 7z archives.

## Tests & verification
- 128 `provider_hub` tests pass, exercising real zip/rar/7z archives (not mocks): member selection, the host pick path, CRLF normalization, bad-archive rejection, bomb/oversized rejection, and the transport-cap reader/consumer.
- Built and deployed to the test server; verified at runtime that `py7zr 1.1.0` and `7z` (7-Zip 25.01, Rar + Rar5 codecs) load, and that a real ZIP round-trips through `worker_download_to_content` host-side with line-ending normalization.

## Notes for the runtime image
- RAR/7z extraction uses the image's `p7zip-full` (7-Zip) plus `py7zr`; `unrar`/`unar` are intentionally absent. The binary is apt-installed fresh (not pinned) so it stays security-patched, and members are read in memory (`archive.read`), not extracted to disk, which neuters archive path traversal.

The catalog-side wheel-gate exemption removal and the full real-provider live-verify are tracked separately.