### PR TITLE
ci: run the provider_hub test suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,13 +122,14 @@ jobs:
           pip install pytest pyjwt
           pytest tests/compat/ -v --tb=short
 
-      - name: pytest dependency and Subliminal rebase guards
+      - name: pytest dependency, Provider Hub, and Subliminal rebase guards
         run: |
           pytest \
             tests/bazarr/test_pretty_date.py \
             tests/bazarr/test_dependency_loading.py \
             tests/bazarr/test_signalrcore_compat.py \
             tests/bazarr/test_app_get_providers.py \
+            tests/bazarr/test_provider_hub.py \
             tests/subliminal_patch/test_subliminal_rebase.py \
             tests/subliminal_patch/test_embeddedsubtitles.py \
             tests/subliminal_patch/test_subsunacs.py \

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -540,6 +540,7 @@ def test_venv_installer_uses_isolated_hash_checked_pip(monkeypatch, tmp_path):
 
 
 def test_active_provider_hub_installation_registers_proxy(tmp_path, monkeypatch):
+    import provider_hub.registry as hub_registry
     from provider_hub.registry import register_active_provider_classes
     from subliminal_patch.extensions import provider_registry
 
@@ -569,10 +570,17 @@ def test_active_provider_hub_installation_registers_proxy(tmp_path, monkeypatch)
 
     register_active_provider_classes()
 
-    assert provider_id in provider_registry.names()
-    provider_cls = provider_registry[provider_id]
-    assert provider_cls.provider_name == provider_id
-    assert provider_cls.languages
+    try:
+        assert provider_id in provider_registry.names()
+        provider_cls = provider_registry[provider_id]
+        assert provider_cls.provider_name == provider_id
+        assert provider_cls.languages
+    finally:
+        # Do not leak this registration into the shared provider_registry, or the
+        # subliminal rebase guard (run in the same pytest process in CI) fails.
+        hub_registry._REGISTERED_PROVIDER_HUB_IDS.discard(provider_id)
+        if provider_id in provider_registry:
+            del provider_registry[provider_id]
 
 
 def test_active_trusted_migrated_provider_replaces_built_in(tmp_path, monkeypatch):
@@ -915,6 +923,7 @@ def test_active_trusted_provider_replaces_non_gestdown_built_in():
 
 
 def test_get_providers_registers_active_provider_hub_installation(tmp_path, monkeypatch):
+    import provider_hub.registry as hub_registry
     from app import get_providers
     from subliminal_patch.extensions import provider_registry
 
@@ -943,7 +952,14 @@ def test_get_providers_registers_active_provider_hub_installation(tmp_path, monk
     monkeypatch.setenv("BAZARR_PROVIDER_HUB_STATE", str(state_file))
     monkeypatch.setattr(get_providers.settings.general, "enabled_providers", [provider_id], raising=False)
 
-    assert get_providers.get_providers() == [provider_id]
+    try:
+        assert get_providers.get_providers() == [provider_id]
+    finally:
+        # Avoid leaking this registration into the shared provider_registry (see the
+        # subliminal rebase guard, which runs in the same pytest process in CI).
+        hub_registry._REGISTERED_PROVIDER_HUB_IDS.discard(provider_id)
+        if provider_id in provider_registry:
+            del provider_registry[provider_id]
 
 
 def test_get_providers_retries_provider_hub_registration_after_failure(monkeypatch):


### PR DESCRIPTION
The provider_hub test module (132 tests covering the protocol, manifest/registry, host-side archive extraction, and release-based scoring) was not in the curated pytest list, so it only ran locally. This adds `tests/bazarr/test_provider_hub.py` to the backend guard step.

Verified locally on the current development tip: 132 passed, ruff clean, ci.yml validates as YAML.