### PR TITLE
chore: remove the opensubtitles-scraper submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "opensubtitles-scraper"]
-	path = opensubtitles-scraper
-	url = https://github.com/LavX/opensubtitles-scraper.git
 [submodule "ai-subtitle-translator"]
 	path = ai-subtitle-translator
 	url = https://github.com/LavX/ai-subtitle-translator.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,13 +94,14 @@ refactor(scraper): simplify response parsing
 
 ## Submodules
 
-Bazarr+ includes two submodules:
-- `opensubtitles-scraper` - OpenSubtitles.org web scraper service
-- `ai-subtitle-translator` - AI-powered subtitle translator
+Bazarr+ includes the `ai-subtitle-translator` submodule (AI-powered subtitle translator).
 
-Changes to these should be submitted to their respective repositories:
-- [LavX/opensubtitles-scraper](https://github.com/LavX/opensubtitles-scraper)
+Changes to it should be submitted to its repository:
 - [LavX/ai-subtitle-translator](https://github.com/LavX/ai-subtitle-translator)
+
+OpenSubtitles.org support is now a native Provider Hub plugin installed from the in-app
+catalog, so the `opensubtitles-scraper` sidecar is no longer bundled here. That project
+lives on standalone at [LavX/opensubtitles-scraper](https://github.com/LavX/opensubtitles-scraper).
 
 ## Running locally
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -12,7 +12,6 @@ extend-exclude = [
     "custom_libs",
     "ai-subtitle-translator",
     "bazarr/ai-subtitle-translator",
-    "opensubtitles-scraper",
     "bazarr-provider-catalog",
     "frontend",
     "bazarr-binaries",


### PR DESCRIPTION
OpenSubtitles.org is now a native Provider Hub plugin installed from the in-app catalog (v2.4), so the scraper sidecar is no longer bundled with Bazarr+.

This removes:
- the `opensubtitles-scraper` submodule gitlink and its `.gitmodules` entry
- its `ruff.toml` `extend-exclude` entry
- the `CONTRIBUTING.md` submodule listing (rewritten to note the native-plugin move)

The scraper remains open-source and maintained standalone at [LavX/opensubtitles-scraper](https://github.com/LavX/opensubtitles-scraper) (its README now documents the v2.4 native-plugin path); it is **not** decommissioned.

**Deliberately out of scope** (scraper *integration* code, not the submodule, flagged for a separate decision since they affect runtime/UI and need a frontend rebuild):
- `bazarr/app/check_update.py` MICROSERVICE_REPOS entry (releases-page listing)
- `bazarr/app/config.py` `scraper_service_url` setting handler
- `frontend/src/pages/Settings/Providers/list.ts` opensubtitles description