### PR TITLE
chore: drop opensubtitles-scraper from the releases page

### DIFF
--- a/bazarr/app/check_update.py
+++ b/bazarr/app/check_update.py
@@ -20,9 +20,11 @@ from app.config import settings
 # To use upstream releases, set BAZARR_RELEASES_REPO to the upstream repo
 RELEASES_REPO = os.environ.get('BAZARR_RELEASES_REPO', 'LavX/bazarr')
 
-# Microservice repositories to include in releases page
+# Microservice repositories to include in releases page.
+# opensubtitles-scraper is intentionally absent: it is no longer bundled with Bazarr+
+# (OpenSubtitles.org ships as a native Provider Hub plugin), so its releases should not
+# appear in the Bazarr+ release notes. It lives on standalone at LavX/opensubtitles-scraper.
 MICROSERVICE_REPOS = [
-    ('LavX/opensubtitles-scraper', 'OpenSubtitles Scraper'),
     ('LavX/ai-subtitle-translator', 'AI Subtitle Translator'),
 ]
 


### PR DESCRIPTION
OpenSubtitles.org now ships as a native Provider Hub plugin and the scraper submodule was removed, so the standalone scraper is no longer bundled with Bazarr+. This removes it from `MICROSERVICE_REPOS` (bazarr/app/check_update.py) so its GitHub releases no longer appear in the Bazarr+ release notes.

The scraper remains available standalone at [LavX/opensubtitles-scraper](https://github.com/LavX/opensubtitles-scraper). The built-in scraper-based provider and the AI Subtitle Translator listing are untouched.

Verified locally: syntax OK, ruff clean.