### PR TITLE
fix(subtitles): fall back to on-disk filename when the scene name can't be parsed

### DIFF
--- a/bazarr/subtitles/utils.py
+++ b/bazarr/subtitles/utils.py
@@ -5,6 +5,8 @@ import logging
 import os
 import json
 
+from urllib.parse import unquote
+
 from subzero.language import Language
 from subzero.video import parse_video
 from guessit.jsonutils import GuessitEncoder
@@ -34,13 +36,15 @@ def get_video(path, title, sceneName, providers=None, media_type="movie"):
         skip_hashing = settings.general.skip_hashing
         video = parse_video(path, hints=hints, skip_hashing=skip_hashing, dry_run=False, providers=providers)
         if sceneName != "None":
-            # refine the video object using the sceneName and update the video object accordingly
-            scenename_with_extension = sceneName + os.path.splitext(path)[1]
-            logging.debug(f'BAZARR guessing video object using scene name: {scenename_with_extension}')  # noqa: G004
-            scenename_video = parse_video(scenename_with_extension, hints=hints, dry_run=True)
-            refine_video_with_scenename(initial_video=video, scenename_video=scenename_video)
-            logging.debug('BAZARR resulting video object once refined using scene name: %s',
-                          json.dumps(vars(video), cls=GuessitEncoder, indent=4, ensure_ascii=False))
+            # Refine the video object using the sceneName. A scene name we can't parse
+            # (e.g. a URL-encoded release title from some indexers) must never discard the
+            # good on-disk parse and abort the search (LavX/bazarr#198): _parse_scenename_video
+            # returns None on failure so we keep the video parsed from the file path.
+            scenename_video = _parse_scenename_video(sceneName, os.path.splitext(path)[1], hints)
+            if scenename_video is not None:
+                refine_video_with_scenename(initial_video=video, scenename_video=scenename_video)
+                logging.debug('BAZARR resulting video object once refined using scene name: %s',
+                              json.dumps(vars(video), cls=GuessitEncoder, indent=4, ensure_ascii=False))
 
         for key, refiner in registered_refiners.items():
             logging.debug("Running refiner: %s", key)
@@ -53,6 +57,35 @@ def get_video(path, title, sceneName, providers=None, media_type="movie"):
 
     except Exception as error:
         logging.exception("BAZARR Error (%s) trying to get video information for this file: %s", error, path)
+
+
+def _parse_scenename_video(scene_name, extension, hints):
+    """Parse a scene name into a Video for refinement, degrading gracefully.
+
+    Some indexers store a URL-encoded release title as the scene name (e.g.
+    ``Rick%20and%20Morty%20S09E02%20...``). guessit can't make sense of that and
+    subliminal raises, which previously bubbled up and made ``get_video`` return None,
+    discarding the good on-disk parse and aborting subtitle search (LavX/bazarr#198).
+    Try the scene name as-is, then URL-decoded; if both fail, return None so the caller
+    keeps the video parsed from the on-disk filename.
+    """
+    candidates = [scene_name]
+    decoded = unquote(scene_name)
+    if decoded != scene_name:
+        candidates.append(decoded)
+
+    last_error = None
+    for candidate in candidates:
+        scenename_with_extension = candidate + extension
+        try:
+            logging.debug('BAZARR guessing video object using scene name: %s', scenename_with_extension)
+            return parse_video(scenename_with_extension, hints=hints, dry_run=True)
+        except Exception as error:
+            last_error = error
+
+    logging.warning("BAZARR could not parse the scene name %r (%s); falling back to the on-disk "
+                    "filename for subtitle search", scene_name, last_error)
+    return None
 
 
 def _get_download_code3(subtitle):

--- a/tests/bazarr/test_get_video_scenename_fallback.py
+++ b/tests/bazarr/test_get_video_scenename_fallback.py
@@ -1,0 +1,105 @@
+"""Regression tests for get_video scene-name handling (issue #198).
+
+Some indexers store a URL-encoded release title as the scene name
+(e.g. ``Rick%20and%20Morty%20S09E02%20...``). guessit can't parse that and
+subliminal raises ``GuessingError``. Before the fix, that exception was caught
+by the single outer ``except`` in ``get_video`` and the whole function returned
+``None`` - discarding the perfectly good Video already parsed from the on-disk
+filename and aborting subtitle search entirely.
+
+The desired behaviour:
+  * an unparsable scene name must never discard the on-disk parse; fall back to
+    the on-disk Video instead of returning None.
+  * a merely URL-encoded scene name should be URL-decoded and retried so we
+    still harvest its hints (release group, codec, ...).
+"""
+from unittest.mock import patch
+
+from subliminal.video import Episode
+
+try:
+    from subliminal.exceptions import GuessingError
+except ImportError:  # older subliminal
+    GuessingError = ValueError
+
+
+PATH = "/tv/Rick and Morty (2013)/Season 09/Rick and Morty (2013) - S09E02 - Ricks Days Seven Nights [HDTV-1080p][AC3 5.1][x265]-ELiTE.mkv"
+# Scene name as stored by the indexer, without extension (get_video appends the
+# on-disk file's extension itself).
+ENCODED_SCENE = "Rick%20and%20Morty%20S09E02%201080p%20x265-ELiTE%20%5B%20UIndex.org%20%5D"
+
+
+def _on_disk_episode():
+    ep = Episode(PATH, "Rick and Morty", season=9, episodes=[2])
+    ep.release_group = None
+    ep.video_codec = None
+    return ep
+
+
+def _scene_episode():
+    ep = Episode("scene", "Rick and Morty", season=9, episodes=[2])
+    ep.release_group = "ELiTE"
+    ep.video_codec = "H.265"
+    return ep
+
+
+def test_unparsable_scene_name_falls_back_to_on_disk_video():
+    """A scene name guessit can't parse must not nuke the on-disk parse."""
+    import subtitles.utils as u
+
+    on_disk = _on_disk_episode()
+
+    def fake_parse_video(name, hints=None, skip_hashing=False, dry_run=False, providers=None):
+        if not dry_run:
+            return on_disk          # the real on-disk file parses fine
+        raise GuessingError(f"Insufficient data to process the guess for {name!r}")
+
+    with patch.object(u, "parse_video", side_effect=fake_parse_video), \
+            patch.object(u, "registered_refiners", {}):
+        result = u.get_video(PATH, "Rick and Morty", "garbage_scene_name_no_episode",
+                             providers=["dummy"], media_type="series")
+
+    assert result is on_disk, "get_video should return the on-disk Video, not None"
+
+
+def test_url_encoded_scene_name_is_decoded_and_refines_video():
+    """A URL-encoded scene name should be decoded, retried, and used to refine."""
+    import subtitles.utils as u
+
+    on_disk = _on_disk_episode()
+    scene = _scene_episode()
+    decoded_names = []
+
+    def fake_parse_video(name, hints=None, skip_hashing=False, dry_run=False, providers=None):
+        if not dry_run:
+            return on_disk
+        if "%" in name:                      # encoded form: guessit gives up
+            raise GuessingError(f"Insufficient data to process the guess for {name!r}")
+        decoded_names.append(name)           # decoded form: parses fine
+        return scene
+
+    with patch.object(u, "parse_video", side_effect=fake_parse_video), \
+            patch.object(u, "registered_refiners", {}):
+        result = u.get_video(PATH, "Rick and Morty", ENCODED_SCENE,
+                             providers=["dummy"], media_type="series")
+
+    assert result is on_disk
+    # release_group was empty on the on-disk parse and should be filled from the
+    # decoded scene name.
+    assert result.release_group == "ELiTE"
+    assert decoded_names, "scene name should have been retried URL-decoded"
+    assert all("%" not in n for n in decoded_names)
+
+
+def test_real_guessit_recovers_url_encoded_scene_name():
+    """End to end with the real guessit/subliminal stack: the encoded name fails
+    raw but the helper recovers it once URL-decoded (no mocking of parse_video)."""
+    import subtitles.utils as u
+
+    hints = {"title": "Rick and Morty", "type": "episode"}
+    video = u._parse_scenename_video(ENCODED_SCENE, ".mkv", hints)
+
+    assert video is not None, "URL-decoding should let guessit parse the scene name"
+    assert video.series == "Rick and Morty"
+    assert video.episodes == [2]
+    assert video.release_group == "ELiTE"


### PR DESCRIPTION
## Problem

`get_video()` parsed the scene name in the *same* `try` block as the on-disk file. When the scene name is unparsable — notably the URL-encoded release titles some indexers store (e.g. `Rick%20and%20Morty%20S09E02%201080p%20x265-ELiTE%20%5B%20UIndex.org%20%5D`) — guessit can't tokenize it and subliminal raises `GuessingError`. The single outer `except` swallowed that and returned `None`, **discarding the perfectly good Video already parsed from the on-disk filename** and aborting the search. Symptom: the Search button spins, then returns zero results, and automatic search never fires.

Reported in LavX/bazarr#198.

## Fix

- New `_parse_scenename_video()` helper: try the scene name as-is, retry it **URL-decoded**, and return `None` on failure instead of throwing.
- `get_video()` only refines when the helper succeeds, so a bad scene name now **degrades gracefully to the on-disk parse** instead of nuking it. The on-disk filename is frequently the better source anyway — in the reported example it even recovers `source=HDTV`, which the scene name lacks.
- URL-decoding also lets us still harvest hints (release group, codec) from encoded names that would otherwise be unparsable.

The fix lives entirely inside `get_video()`, so every caller (download, manual, compat) benefits.

## Tests

`tests/bazarr/test_get_video_scenename_fallback.py`:
- unparsable scene name → falls back to the on-disk Video (not `None`)
- URL-encoded scene name → decoded, retried, and used to refine (`release_group` recovered)
- end-to-end against the **real** guessit/subliminal stack: the encoded name fails raw but is recovered once decoded

Backend suite + `ruff` green locally; frontend type/lint/format/build/tests green; deployed to the test instance and verified a single clean boot.

Closes LavX/bazarr#198
