### PR TITLE
feat(provider-hub): make startup auto-install of catalog providers opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
             tests/bazarr/test_signalrcore_compat.py \
             tests/bazarr/test_app_get_providers.py \
             tests/bazarr/test_provider_hub.py \
+            tests/bazarr/test_provider_hub_auto_install_optin.py \
             tests/subliminal_patch/test_subliminal_rebase.py \
             tests/subliminal_patch/test_embeddedsubtitles.py \
             tests/subliminal_patch/test_subsunacs.py \

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -155,6 +155,7 @@ validators = [
     Validator('general.multithreading', must_exist=True, default=True, is_type_of=bool),
     Validator('general.chmod_enabled', must_exist=True, default=False, is_type_of=bool),
     Validator('general.enable_strm_support', must_exist=True, default=False, is_type_of=bool),
+    Validator('general.provider_hub_auto_install', must_exist=True, default=False, is_type_of=bool),
     Validator('general.chmod', must_exist=True, default='0640', is_type_of=str),
     Validator('general.subfolder', must_exist=True, default='current', is_type_of=str),
     Validator('general.subfolder_custom', must_exist=True, default='', is_type_of=str),

--- a/bazarr/provider_hub/service.py
+++ b/bazarr/provider_hub/service.py
@@ -512,6 +512,14 @@ def autoinstall_enabled_builtins() -> list[str]:
     if os.environ.get("BAZARR_DISABLE_PROVIDER_AUTOINSTALL"):
         return []
 
+    # Opt-in (default off): replacing built-in providers with their catalog versions at
+    # startup is automatic only when the user enables it. Manual Marketplace install/replace
+    # is unaffected, and turning this off never uninstalls already-active plugins.
+    from app.config import settings
+    if not getattr(settings.general, "provider_hub_auto_install", False):
+        logger.debug("Provider Hub startup auto-install disabled (opt-in off); skipping")
+        return []
+
     logger.info("Provider Hub startup auto-install: reconciling enabled providers against the official catalog")
 
     try:

--- a/frontend/src/pages/Settings/General/index.tsx
+++ b/frontend/src/pages/Settings/General/index.tsx
@@ -252,6 +252,18 @@ const SettingsGeneralView: FunctionComponent = () => {
       <Section header="External Integrations">
         <ExternalWebhookSelector />
       </Section>
+      <Section header="Provider Hub">
+        <Check
+          label="Auto-install catalog versions on startup"
+          settingKey="settings-general-provider_hub_auto_install"
+        ></Check>
+        <Message>
+          When enabled, Bazarr replaces enabled built-in providers with their
+          official Provider Hub catalog versions at startup. Off by default.
+          Installing or replacing providers manually from the Provider Hub
+          Marketplace always works regardless of this setting.
+        </Message>
+      </Section>
       <Section header="Proxy">
         <Selector
           clearable

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -14,6 +14,15 @@ from subliminal.video import Movie
 from subliminal_patch.core import Episode
 
 
+@pytest.fixture(autouse=True)
+def _enable_provider_hub_auto_install(monkeypatch):
+    # Startup auto-install is opt-in (default off). These tests predate that gate and
+    # exercise the install path, so enable the flag for the whole module. The OFF behavior
+    # is covered separately in test_provider_hub_auto_install_optin.py.
+    from app.config import settings
+    monkeypatch.setattr(settings.general, "provider_hub_auto_install", True, raising=False)
+
+
 def _sha256(value):
     import hashlib
     return hashlib.sha256(value).hexdigest()

--- a/tests/bazarr/test_provider_hub_auto_install_optin.py
+++ b/tests/bazarr/test_provider_hub_auto_install_optin.py
@@ -1,0 +1,59 @@
+"""Provider Hub startup auto-install is opt-in (default off).
+
+Auto-installing official-catalog versions of enabled built-in providers at startup
+used to run unconditionally (only an undocumented env var could stop it). It is now
+gated behind `settings.general.provider_hub_auto_install`, default False, so a fresh
+install uses the built-ins until the user opts in. The behavior is non-destructive:
+the gate only prevents *new* staging; it never uninstalls/reverts anything.
+"""
+import provider_hub.service as svc
+from app.config import settings
+
+
+def test_provider_hub_auto_install_defaults_false():
+    """The new opt-in config key exists and defaults to False."""
+    assert settings.general.provider_hub_auto_install is False
+
+
+def test_autoinstall_skipped_when_optin_off(monkeypatch):
+    """With the opt-in off, the function returns early without touching state."""
+    monkeypatch.delenv("BAZARR_DISABLE_PROVIDER_AUTOINSTALL", raising=False)
+    monkeypatch.setattr(settings.general, "provider_hub_auto_install", False, raising=False)
+
+    calls = []
+    monkeypatch.setattr(svc, "load_state", lambda *a, **k: calls.append("load_state") or {})
+
+    result = svc.autoinstall_enabled_builtins()
+
+    assert result == []
+    assert calls == [], "auto-install must not reach load_state when opt-in is off"
+
+
+def test_autoinstall_proceeds_when_optin_on(monkeypatch):
+    """With the opt-in on (and no env kill-switch), the gate passes and work begins."""
+    monkeypatch.delenv("BAZARR_DISABLE_PROVIDER_AUTOINSTALL", raising=False)
+    monkeypatch.setattr(settings.general, "provider_hub_auto_install", True, raising=False)
+
+    reached = []
+    # Return no installations + no enabled providers so the function exits quickly after
+    # the gate without hitting the network; we only care that the gate let it through.
+    monkeypatch.setattr(svc, "load_state", lambda *a, **k: reached.append("load_state") or {"installations": {}})
+    monkeypatch.setattr(svc, "_bazarr_enabled_providers", lambda *a, **k: [])
+
+    svc.autoinstall_enabled_builtins()
+
+    assert reached == ["load_state"], "gate should let execution reach load_state when opt-in is on"
+
+
+def test_env_killswitch_overrides_optin(monkeypatch):
+    """The legacy env kill-switch force-disables even when the opt-in is on."""
+    monkeypatch.setenv("BAZARR_DISABLE_PROVIDER_AUTOINSTALL", "1")
+    monkeypatch.setattr(settings.general, "provider_hub_auto_install", True, raising=False)
+
+    calls = []
+    monkeypatch.setattr(svc, "load_state", lambda *a, **k: calls.append("load_state") or {})
+
+    result = svc.autoinstall_enabled_builtins()
+
+    assert result == []
+    assert calls == []


### PR DESCRIPTION
## Problem

On startup Bazarr+ unconditionally auto-installs the official-catalog version of every enabled built-in provider and lets it shadow ("replace") the built-in. The only way to stop this was an undocumented env var, `BAZARR_DISABLE_PROVIDER_AUTOINSTALL`. There was no user-facing control.

## Change

Make the startup auto-install **opt-in**, off by default.

- **New setting** `general.provider_hub_auto_install` (bool, default `False`) in [bazarr/app/config.py](bazarr/app/config.py).
- **Gate** the single startup staging function `autoinstall_enabled_builtins()` in [bazarr/provider_hub/service.py](bazarr/provider_hub/service.py) on that setting, right after the existing env kill-switch.
- **Toggle** added to **Settings → General → Provider Hub** ([frontend/src/pages/Settings/General/index.tsx](frontend/src/pages/Settings/General/index.tsx)).

### Behavior

- **Non-destructive.** When off, no new catalog versions are staged at startup. Providers already installed/active from a previous boot are left untouched (`activate_staged_installations()` / `register_active_provider_classes()` are unchanged), and manual Provider Hub Marketplace install/replace works regardless of the setting.
- `BAZARR_DISABLE_PROVIDER_AUTOINSTALL` remains as a hard ops override (force-disables even when the setting is on).
- Existing installs that already auto-replaced keep working after upgrade; they just won't auto-install *new* ones unless the toggle is enabled.

## Tests

`tests/bazarr/test_provider_hub_auto_install_optin.py`:
- default config value is `False`
- opt-in off → `autoinstall_enabled_builtins()` returns `[]` and never reaches `load_state`
- opt-in on → gate passes and execution proceeds
- env kill-switch overrides the opt-in

Backend ruff + suite green; frontend type/lint/format/build green. Deployed to the test instance and confirmed the live boot log skips auto-install with the default-off setting (`service:520 - ... auto-install disabled (opt-in off); skipping`).
