### PR TITLE
feat(ui): add "What's New" version wizard

### DIFF
--- a/frontend/src/App/Navbar.module.scss
+++ b/frontend/src/App/Navbar.module.scss
@@ -2,6 +2,8 @@
   padding: 8px;
   background: transparent;
   border-right: none;
+  display: flex;
+  flex-direction: column;
 }
 
 .navInner {
@@ -9,9 +11,22 @@
   border: 1px solid var(--bz-border-card);
   border-radius: var(--bz-radius-xl);
   padding: 12px;
-  height: 100%;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
   scrollbar-width: none;
+}
+
+.navFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 8px 12px;
+  background: var(--bz-surface-base);
+  border: 1px solid var(--bz-border-card);
+  border-radius: var(--bz-radius-lg);
 }
 
 .groupLabel {

--- a/frontend/src/App/Navbar.tsx
+++ b/frontend/src/App/Navbar.tsx
@@ -7,11 +7,24 @@ import React, {
   useState,
 } from "react";
 import { matchPath, NavLink, RouteObject, useLocation } from "react-router";
-import { AppShell, Badge, Collapse, Stack, Text } from "@mantine/core";
+import {
+  ActionIcon,
+  AppShell,
+  Badge,
+  Collapse,
+  Stack,
+  Text,
+  Tooltip,
+} from "@mantine/core";
 import { useHover } from "@mantine/hooks";
-import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
+import { faGift, IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import clsx from "clsx";
+import { useSystemStatus } from "@/apis/hooks";
+import {
+  hasWhatsNew,
+  useOpenWhatsNew,
+} from "@/components/modals/useWhatsNewAutoOpen";
 import { useNavbar } from "@/contexts/Navbar";
 import { useRouteItems } from "@/Router";
 import { CustomRouteObject, Route } from "@/Router/type";
@@ -122,6 +135,9 @@ const AppNavbar: FunctionComponent = () => {
   const [selection, select] = useState<string | null>(null);
 
   const routes = useRouteItems();
+  const { data: status } = useSystemStatus();
+  const openWhatsNew = useOpenWhatsNew();
+  const showWhatsNew = hasWhatsNew();
 
   const { pathname } = useLocation();
   useEffect(() => {
@@ -167,6 +183,22 @@ const AppNavbar: FunctionComponent = () => {
             })}
           </Stack>
         </Selection.Provider>
+      </div>
+      <div className={styles.navFooter}>
+        <Text size="xs" c="var(--bz-text-tertiary)" truncate>
+          {status?.bazarr_version ?? ""}
+        </Text>
+        {showWhatsNew && (
+          <Tooltip label="What's new" position="top" withArrow>
+            <ActionIcon
+              variant="subtle"
+              aria-label="What's new"
+              onClick={openWhatsNew}
+            >
+              <FontAwesomeIcon icon={faGift} />
+            </ActionIcon>
+          </Tooltip>
+        )}
       </div>
     </AppShell.Navbar>
   );

--- a/frontend/src/App/index.tsx
+++ b/frontend/src/App/index.tsx
@@ -33,6 +33,7 @@ import api from "@/apis/raw";
 import AppNavbar from "@/App/Navbar";
 import logoSrc from "@/assets/images/logo_no_orb128.png";
 import ErrorBoundary from "@/components/ErrorBoundary";
+import { useWhatsNewAutoOpen } from "@/components/modals/useWhatsNewAutoOpen";
 import NavbarProvider from "@/contexts/Navbar";
 import OnlineProvider from "@/contexts/Online";
 import { notification } from "@/modules/task";
@@ -40,6 +41,7 @@ import CriticalError from "@/pages/errors/CriticalError";
 import { RouterNames } from "@/Router/RouterNames";
 import { Environment } from "@/utilities";
 import { consumeRestartReloadPending } from "@/utilities/restart";
+import { registerAppNavigate } from "@/utilities/whatsNew";
 import AppHeader from "./Header";
 import styleVars from "@/assets/_variables.module.scss";
 
@@ -54,6 +56,12 @@ interface SupervisorStatus {
 const App: FunctionComponent = () => {
   const navigate = useNavigate();
 
+  // Expose a live navigate to the What's New modal (it renders outside the Router, and the
+  // router is rebuilt on data changes, so a captured navigate would go stale).
+  useEffect(() => {
+    registerAppNavigate(navigate);
+  }, [navigate]);
+
   const [criticalError, setCriticalError] = useState<string | null>(null);
   const [navbar, setNavbar] = useState(false);
   const [online, setOnline] = useState(false);
@@ -64,6 +72,10 @@ const App: FunctionComponent = () => {
   const queryClient = useQueryClient();
   const settings = useSystemSettings();
   const settingsLoaded = settings.data !== undefined;
+
+  // Show the "What's New" wizard once after upgrading, but only once authenticated and
+  // loaded (settingsLoaded) so it never appears over the login screen.
+  useWhatsNewAutoOpen(settingsLoaded);
 
   // Stream supervisor status via SSE during startup.
   // When backend reports "running", invalidate the settings cache to trigger

--- a/frontend/src/components/modals/WhatsNewModal.tsx
+++ b/frontend/src/components/modals/WhatsNewModal.tsx
@@ -1,0 +1,136 @@
+import { FunctionComponent, useState } from "react";
+import {
+  Box,
+  Button,
+  Center,
+  Group,
+  Image,
+  Stack,
+  Text,
+  Title,
+  UnstyledButton,
+} from "@mantine/core";
+import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import type { WhatsNewSlide } from "@/data/whatsNew";
+import { useModals, withModal } from "@/modules/modals";
+import { navigateApp } from "@/utilities/whatsNew";
+
+export interface WhatsNewViewProps {
+  version: string;
+  slides: WhatsNewSlide[];
+  /**
+   * Navigation callback for slide CTAs. Defaults to the live app-navigate bridge; modals
+   * render outside the Router so the modal can't use `useNavigate()` itself. Overridable
+   * for testing.
+   */
+  onNavigate?: (to: string) => void;
+}
+
+export const WhatsNewView: FunctionComponent<WhatsNewViewProps> = ({
+  version,
+  slides,
+  onNavigate = navigateApp,
+}) => {
+  const [index, setIndex] = useState(0);
+  const { closeSelf } = useModals();
+
+  if (slides.length === 0) {
+    return null;
+  }
+
+  const slide = slides[index];
+  const isFirst = index === 0;
+  const isLast = index === slides.length - 1;
+  const goTo = (next: number) =>
+    setIndex(Math.max(0, Math.min(slides.length - 1, next)));
+
+  return (
+    <Stack gap="md">
+      <Text size="xs" c="var(--bz-text-tertiary)">
+        What&apos;s new in Bazarr+ {version}
+      </Text>
+
+      <Center mih={120}>
+        {slide.image ? (
+          <Image
+            src={slide.image}
+            alt={slide.title}
+            mah={180}
+            fit="contain"
+            radius="md"
+          />
+        ) : slide.icon ? (
+          <FontAwesomeIcon
+            icon={slide.icon}
+            size="3x"
+            style={{ color: "var(--bz-text-primary)" }}
+          />
+        ) : null}
+      </Center>
+
+      <Title order={4}>{slide.title}</Title>
+      <Text c="var(--bz-text-secondary)">{slide.body}</Text>
+
+      {slide.cta ? (
+        <Button
+          variant="light"
+          rightSection={<FontAwesomeIcon icon={faArrowRight} />}
+          onClick={() => {
+            const to = slide.cta!.to;
+            closeSelf();
+            // Navigate on the next tick so the router transition isn't aborted by this
+            // modal subtree unmounting (otherwise the URL changes but the view doesn't).
+            window.setTimeout(() => onNavigate?.(to), 0);
+          }}
+        >
+          {slide.cta.label}
+        </Button>
+      ) : null}
+
+      <Group justify="center" gap="xs" mt="xs">
+        {slides.map((s, i) => (
+          <UnstyledButton
+            key={`${s.title}-${i}`}
+            aria-label={`Go to update ${i + 1}`}
+            aria-current={i === index}
+            onClick={() => goTo(i)}
+          >
+            <Box
+              w={8}
+              h={8}
+              style={{
+                borderRadius: 9999,
+                backgroundColor:
+                  i === index
+                    ? "var(--bz-text-primary)"
+                    : "var(--bz-text-disabled)",
+                transition: "background-color var(--bz-duration-fast)",
+              }}
+            />
+          </UnstyledButton>
+        ))}
+      </Group>
+
+      <Group justify="space-between" mt="xs">
+        <Button
+          variant="default"
+          disabled={isFirst}
+          onClick={() => goTo(index - 1)}
+        >
+          Back
+        </Button>
+        {isLast ? (
+          <Button onClick={() => closeSelf()}>Got it</Button>
+        ) : (
+          <Button onClick={() => goTo(index + 1)}>Next</Button>
+        )}
+      </Group>
+    </Stack>
+  );
+};
+
+export const WhatsNewModal = withModal(WhatsNewView, "whats-new", {
+  size: "md",
+  title: "What's New",
+});

--- a/frontend/src/components/modals/__tests__/WhatsNewModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/WhatsNewModal.test.tsx
@@ -1,0 +1,82 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { WhatsNewView } from "@/components/modals/WhatsNewModal";
+import type { WhatsNewSlide } from "@/data/whatsNew";
+import { customRender, screen, waitFor } from "@/tests";
+
+const SLIDES: WhatsNewSlide[] = [
+  { title: "Combined subtitles", body: "Merge multiple SRTs into one track." },
+  {
+    title: "Provider Hub opt-in",
+    body: "Startup auto-install is now off by default.",
+    cta: { label: "Open Settings", to: "/settings/general" },
+  },
+];
+
+describe("WhatsNewView wizard", () => {
+  it("starts on the first slide with Back disabled", () => {
+    customRender(<WhatsNewView version="2.4.0" slides={SLIDES} />);
+
+    expect(screen.getByText("Combined subtitles")).toBeInTheDocument();
+    expect(screen.queryByText("Provider Hub opt-in")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /back/i })).toBeDisabled();
+  });
+
+  it("renders one progress dot per slide", () => {
+    customRender(<WhatsNewView version="2.4.0" slides={SLIDES} />);
+    expect(
+      screen.getAllByRole("button", { name: /go to update/i }),
+    ).toHaveLength(SLIDES.length);
+  });
+
+  it("advances with Next and goes back with Back", async () => {
+    const user = userEvent.setup();
+    customRender(<WhatsNewView version="2.4.0" slides={SLIDES} />);
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    expect(screen.getByText("Provider Hub opt-in")).toBeInTheDocument();
+    expect(screen.queryByText("Combined subtitles")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /back/i }));
+    expect(screen.getByText("Combined subtitles")).toBeInTheDocument();
+  });
+
+  it("shows a finish button (not Next) on the last slide", async () => {
+    const user = userEvent.setup();
+    customRender(<WhatsNewView version="2.4.0" slides={SLIDES} />);
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+
+    expect(
+      screen.queryByRole("button", { name: /next/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /got it/i })).toBeInTheDocument();
+  });
+
+  it("renders the slide CTA when present", async () => {
+    const user = userEvent.setup();
+    customRender(<WhatsNewView version="2.4.0" slides={SLIDES} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Open Settings" }),
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    expect(
+      screen.getByRole("button", { name: "Open Settings" }),
+    ).toBeInTheDocument();
+  });
+
+  it("invokes onNavigate with the CTA target when the CTA is clicked", async () => {
+    const user = userEvent.setup();
+    const onNavigate = vi.fn();
+    customRender(
+      <WhatsNewView version="2.4.0" slides={SLIDES} onNavigate={onNavigate} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /next/i }));
+    await user.click(screen.getByRole("button", { name: "Open Settings" }));
+    await waitFor(() =>
+      expect(onNavigate).toHaveBeenCalledWith("/settings/general"),
+    );
+  });
+});

--- a/frontend/src/components/modals/__tests__/useWhatsNewAutoOpen.test.tsx
+++ b/frontend/src/components/modals/__tests__/useWhatsNewAutoOpen.test.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent } from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useWhatsNewAutoOpen } from "@/components/modals/useWhatsNewAutoOpen";
-import { customRender, screen, waitFor } from "@/tests";
+import { customRender, screen } from "@/tests";
 
 const Harness: FunctionComponent<{ enabled: boolean }> = ({ enabled }) => {
   useWhatsNewAutoOpen(enabled);
@@ -19,8 +19,6 @@ describe("useWhatsNewAutoOpen", () => {
 
   it("auto-opens once enabled and the version is unseen", async () => {
     customRender(<Harness enabled />);
-    await waitFor(() =>
-      expect(screen.getByText("Distribution Hub")).toBeInTheDocument(),
-    );
+    expect(await screen.findByText("Distribution Hub")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/modals/__tests__/useWhatsNewAutoOpen.test.tsx
+++ b/frontend/src/components/modals/__tests__/useWhatsNewAutoOpen.test.tsx
@@ -1,0 +1,26 @@
+import { FunctionComponent } from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useWhatsNewAutoOpen } from "@/components/modals/useWhatsNewAutoOpen";
+import { customRender, screen, waitFor } from "@/tests";
+
+const Harness: FunctionComponent<{ enabled: boolean }> = ({ enabled }) => {
+  useWhatsNewAutoOpen(enabled);
+  return null;
+};
+
+describe("useWhatsNewAutoOpen", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("does not auto-open while disabled (e.g. on the login screen)", async () => {
+    customRender(<Harness enabled={false} />);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.queryByText("Distribution Hub")).not.toBeInTheDocument();
+  });
+
+  it("auto-opens once enabled and the version is unseen", async () => {
+    customRender(<Harness enabled />);
+    await waitFor(() =>
+      expect(screen.getByText("Distribution Hub")).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/components/modals/useWhatsNewAutoOpen.ts
+++ b/frontend/src/components/modals/useWhatsNewAutoOpen.ts
@@ -1,0 +1,66 @@
+import { useCallback, useEffect, useRef } from "react";
+import { WhatsNewModal } from "@/components/modals/WhatsNewModal";
+import { getWhatsNewSlides, latestWhatsNewVersion } from "@/data/whatsNew";
+import { useModals } from "@/modules/modals";
+import {
+  getSeenWhatsNewVersion,
+  markWhatsNewSeen,
+  shouldAutoOpenWhatsNew,
+} from "@/utilities/whatsNew";
+
+/** Whether there is any "What's New" content for the current build. */
+export function hasWhatsNew(): boolean {
+  return getWhatsNewSlides(latestWhatsNewVersion).length > 0;
+}
+
+/** Returns a callback that opens the wizard for the latest version on demand. */
+export function useOpenWhatsNew() {
+  const { openContextModal } = useModals();
+  return useCallback(() => {
+    const slides = getWhatsNewSlides(latestWhatsNewVersion);
+    if (slides.length === 0) {
+      return;
+    }
+    openContextModal(WhatsNewModal, {
+      version: latestWhatsNewVersion,
+      slides,
+    });
+  }, [openContextModal]);
+}
+
+/**
+ * Auto-opens the wizard once when the stored "seen" token is missing or older than the
+ * latest version. Marks the version seen at open time, which also keeps React StrictMode's
+ * double-invoke from stacking two modals. Users can re-open later from System > Status.
+ */
+/**
+ * Auto-opens the wizard once after upgrading. `enabled` should be true only once the app
+ * is authenticated and loaded (e.g. settings have loaded) so the wizard never appears over
+ * the login screen. Marks the version seen at open time so it shows at most once.
+ */
+export function useWhatsNewAutoOpen(enabled: boolean) {
+  const { openContextModal } = useModals();
+  const opened = useRef(false);
+  useEffect(() => {
+    if (!enabled || opened.current) {
+      return;
+    }
+    const slides = getWhatsNewSlides(latestWhatsNewVersion);
+    if (
+      !shouldAutoOpenWhatsNew(
+        getSeenWhatsNewVersion(),
+        latestWhatsNewVersion,
+        slides.length,
+      )
+    ) {
+      opened.current = true;
+      return;
+    }
+    opened.current = true;
+    markWhatsNewSeen(latestWhatsNewVersion);
+    openContextModal(WhatsNewModal, {
+      version: latestWhatsNewVersion,
+      slides,
+    });
+  }, [enabled, openContextModal]);
+}

--- a/frontend/src/data/whatsNew.ts
+++ b/frontend/src/data/whatsNew.ts
@@ -1,0 +1,59 @@
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import {
+  faLayerGroup,
+  faStore,
+  faTowerBroadcast,
+  faWandMagicSparkles,
+} from "@fortawesome/free-solid-svg-icons";
+
+export interface WhatsNewSlide {
+  /** Short headline for the change. */
+  title: string;
+  /** One to three lines describing it. */
+  body: string;
+  /** Optional imported asset URL; takes priority over `icon`. */
+  image?: string;
+  /** Optional FontAwesome icon shown when there is no image. */
+  icon?: IconDefinition;
+  /** Optional deep-link to the relevant page ("Take me there"). */
+  cta?: { label: string; to: string };
+}
+
+/**
+ * The release being announced. The maintainer bumps this (and adds an entry below) when
+ * cutting a release. Kept as an explicit token so the wizard never has to parse the
+ * fork's `version + YYMMDD` runtime string.
+ */
+export const latestWhatsNewVersion = "2.4.0";
+
+export const whatsNew: Record<string, WhatsNewSlide[]> = {
+  "2.4.0": [
+    {
+      title: "Distribution Hub",
+      body: "Serve subtitles through a multi-tenant API with named keys, tiers, and per-key usage metering.",
+      icon: faTowerBroadcast,
+      cta: { label: "Open Distribution Hub", to: "/distribution-hub" },
+    },
+    {
+      title: "Provider Hub auto-install is now opt-in",
+      body: "Built-in providers are no longer replaced by catalog versions at startup unless you enable it. Manual install from the Marketplace always works.",
+      icon: faStore,
+      cta: { label: "Open General settings", to: "/settings/general" },
+    },
+    {
+      title: "Combined subtitles",
+      body: "Merge subtitles from multiple languages into a single track for side-by-side viewing.",
+      icon: faLayerGroup,
+      cta: { label: "Open Subtitles settings", to: "/settings/subtitles" },
+    },
+    {
+      title: "Smarter subtitle matching",
+      body: "When a release name can't be parsed, Bazarr now falls back to the on-disk filename instead of giving up, so more searches succeed.",
+      icon: faWandMagicSparkles,
+    },
+  ],
+};
+
+export function getWhatsNewSlides(version: string): WhatsNewSlide[] {
+  return whatsNew[version] ?? [];
+}

--- a/frontend/src/data/whatsNew.ts
+++ b/frontend/src/data/whatsNew.ts
@@ -35,8 +35,8 @@ export const whatsNew: Record<string, WhatsNewSlide[]> = {
       cta: { label: "Open Distribution Hub", to: "/distribution-hub" },
     },
     {
-      title: "Provider Hub auto-install is now opt-in",
-      body: "Built-in providers are no longer replaced by catalog versions at startup unless you enable it. Manual install from the Marketplace always works.",
+      title: "Provider Hub auto-install",
+      body: "Opt in to automatically replace built-in providers with their Provider Hub catalog versions at startup. Off by default; manual install from the Marketplace always works.",
       icon: faStore,
       cta: { label: "Open General settings", to: "/settings/general" },
     },

--- a/frontend/src/pages/System/Status/index.tsx
+++ b/frontend/src/pages/System/Status/index.tsx
@@ -36,6 +36,10 @@ import { useSystemHealth, useSystemStatus } from "@/apis/hooks";
 import { useInstanceName } from "@/apis/hooks/site";
 import api from "@/apis/raw";
 import { QueryOverlay } from "@/components/async";
+import {
+  hasWhatsNew,
+  useOpenWhatsNew,
+} from "@/components/modals/useWhatsNewAutoOpen";
 import { GithubRepoRoot } from "@/constants";
 import { Environment, useInterval } from "@/utilities";
 import {
@@ -112,6 +116,8 @@ const InfoContainer: FunctionComponent<
 const SystemStatusView: FunctionComponent = () => {
   const health = useSystemHealth();
   const { data: status } = useSystemStatus();
+  const openWhatsNew = useOpenWhatsNew();
+  const showWhatsNew = hasWhatsNew();
 
   const [uptime, setUptime] = useState<string>();
 
@@ -171,7 +177,16 @@ const SystemStatusView: FunctionComponent = () => {
           <Space />
         </Stack>
         <InfoContainer title="About">
-          <Row title="Bazarr Version">{status?.bazarr_version}</Row>
+          <Row title="Bazarr Version">
+            <Group gap="sm">
+              {status?.bazarr_version}
+              {showWhatsNew && (
+                <Anchor component="button" type="button" onClick={openWhatsNew}>
+                  What&apos;s new
+                </Anchor>
+              )}
+            </Group>
+          </Row>
           {status?.package_version !== "" && (
             <Row title="Package Version">{status?.package_version}</Row>
           )}

--- a/frontend/src/utilities/__tests__/whatsNew.test.ts
+++ b/frontend/src/utilities/__tests__/whatsNew.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getSeenWhatsNewVersion,
+  markWhatsNewSeen,
+  navigateApp,
+  registerAppNavigate,
+  shouldAutoOpenWhatsNew,
+  WHATS_NEW_SEEN_KEY,
+} from "@/utilities/whatsNew";
+
+describe("whats-new auto-open logic", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("shows when no token is stored (no-token -> show)", () => {
+    expect(shouldAutoOpenWhatsNew(null, "2.4.0", 3)).toBe(true);
+  });
+
+  it("does not show when the seen token equals the latest version", () => {
+    expect(shouldAutoOpenWhatsNew("2.4.0", "2.4.0", 3)).toBe(false);
+  });
+
+  it("shows when the seen token differs from the latest version", () => {
+    expect(shouldAutoOpenWhatsNew("2.3.0", "2.4.0", 3)).toBe(true);
+  });
+
+  it("does not show when there are no slides for the latest version", () => {
+    expect(shouldAutoOpenWhatsNew(null, "2.4.0", 0)).toBe(false);
+  });
+
+  it("persists and reads the seen version", () => {
+    expect(getSeenWhatsNewVersion()).toBeNull();
+    markWhatsNewSeen("2.4.0");
+    expect(getSeenWhatsNewVersion()).toBe("2.4.0");
+    expect(localStorage.getItem(WHATS_NEW_SEEN_KEY)).toBe("2.4.0");
+  });
+});
+
+describe("app navigate bridge", () => {
+  it("routes navigateApp through the registered navigate function", () => {
+    const nav = vi.fn();
+    registerAppNavigate(nav);
+    navigateApp("/distribution-hub");
+    expect(nav).toHaveBeenCalledWith("/distribution-hub");
+  });
+
+  it("is a no-op once unregistered", () => {
+    const nav = vi.fn();
+    registerAppNavigate(nav);
+    registerAppNavigate(null);
+    navigateApp("/series");
+    expect(nav).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utilities/whatsNew.ts
+++ b/frontend/src/utilities/whatsNew.ts
@@ -1,0 +1,49 @@
+/**
+ * Client-side state for the "What's New" wizard.
+ *
+ * Pure helpers only (no React / modal / data imports) so this module stays trivially
+ * importable and unit-testable. The auto-open hook that wires these to the modal lives
+ * in `components/modals/useWhatsNewAutoOpen.ts`.
+ */
+
+export const WHATS_NEW_SEEN_KEY = "bazarr-whats-new-seen";
+
+export function getSeenWhatsNewVersion(): string | null {
+  return localStorage.getItem(WHATS_NEW_SEEN_KEY);
+}
+
+export function markWhatsNewSeen(version: string): void {
+  localStorage.setItem(WHATS_NEW_SEEN_KEY, version);
+}
+
+/**
+ * Whether the wizard should auto-open on load. Shows once per latest version: when a
+ * stored token is absent (fresh install or first build with the feature) or differs from
+ * the latest version, and there is at least one slide to show.
+ */
+export function shouldAutoOpenWhatsNew(
+  seen: string | null,
+  latest: string,
+  slideCount: number,
+): boolean {
+  return slideCount > 0 && seen !== latest;
+}
+
+/**
+ * Live navigation bridge for the wizard.
+ *
+ * The modal renders outside the Router (via the app-wide ModalsProvider), and the app's
+ * browser router is rebuilt whenever route data changes (see Router/index.tsx), so a
+ * `navigate` captured at open time goes stale and updates the URL without changing the
+ * view. Instead, a component inside the current Router (App) registers its live `navigate`
+ * here, and the modal resolves it at click time.
+ */
+let appNavigateFn: ((to: string) => void) | null = null;
+
+export function registerAppNavigate(fn: ((to: string) => void) | null): void {
+  appNavigateFn = fn;
+}
+
+export function navigateApp(to: string): void {
+  appNavigateFn?.(to);
+}


### PR DESCRIPTION
## What

A paginated "What's New" modal that announces per-release highlights, one change per slide (Back / Next, progress dots, optional image or icon, optional "Take me there" CTA).

## How it works

- **Authored content** in a version-keyed frontend file, [frontend/src/data/whatsNew.ts](frontend/src/data/whatsNew.ts): bump `latestWhatsNewVersion` and add an entry per release. Seeded with the v2.4.0 highlights.
- **Auto-opens once** per new version (localStorage seen-token vs latest), **gated on `settingsLoaded`** so it never appears over the login screen.
- **Re-openable** from **System → Status** ("What's new" link) and from a **version + gift icon in the navbar footer** (bottom of the left menu).
- **Latest version only** — does not accumulate skipped versions.

## Notable fix

Slide CTAs navigate via a small **live app-navigate bridge** resolved at click time. The modal renders outside the Router (app-wide `ModalsProvider`), and the browser router is rebuilt whenever route data changes (see the `// TODO: Move this outside the function component scope` in [Router/index.tsx](frontend/src/Router/index.tsx)). A `navigate` captured at modal-open time goes stale against the rebuilt router, so it changed the URL without actually navigating ("stuck on the current page"). App registers its live `navigate` into the bridge; the modal calls it at click time. The App-render test also caught an earlier crash from calling `useNavigate()` inside the modal (no Router context), now avoided.

## Tests

`whatsNew.test.ts`, `WhatsNewModal.test.tsx`, `useWhatsNewAutoOpen.test.tsx`:
- auto-open gate incl. the **login case** (disabled → does not open)
- wizard navigation (Next/Back/dots, Finish on last slide)
- CTA callback fires with the target route
- the navigate bridge routes through the registered function and no-ops once unregistered

Frontend type/lint/format/build + 547 unit tests green locally. Deployed to the test instance and verified: no popup on login, navbar footer shows version + gift icon, and first-click CTA navigation works.
