### PR TITLE
fix(provider-hub): register Montenegrin (cnr) and survive unknown language codes

### DIFF
--- a/bazarr/init.py
+++ b/bazarr/init.py
@@ -138,6 +138,10 @@ write_config()
 # would drop it from enabled_providers. main.py runs activate_staged_
 # installations() later, but that's already past this filter.
 from subliminal_patch.extensions import provider_registry  # noqa: E402
+# Register ISO 639-3 languages missing from babelfish's bundled snapshot (e.g. Montenegrin
+# "cnr") before any Language() is constructed below, so providers declaring them resolve.
+from languages.extra import register_extra_languages  # noqa: E402
+register_extra_languages()
 provider_hub_registration_ok = True
 # Auto-install official-catalog versions of enabled built-in providers so the
 # catalog becomes the canonical provider source. Staged here so the

--- a/bazarr/languages/extra.py
+++ b/bazarr/languages/extra.py
@@ -6,11 +6,14 @@ babelfish ships a pre-2017 iso-639-3 table that lacks some codes - notably Monte
 startup so they resolve like any other language across subzero, subliminal, the Provider
 Hub registry, and the UI. Idempotent and safe to call repeatedly.
 
-Registration touches three babelfish internals because they are built once at import:
-  * LANGUAGE_MATRIX / LANGUAGES  - so Language("cnr") constructs;
-  * NameConverter.SYMBOLS        - so .name / fromname work (it's a class-level dict
-                                   built from LANGUAGE_MATRIX at module import);
-  * language_converters cache    - cleared so already-loaded converters rebuild.
+Registration touches several structures that are built once at import:
+  * LANGUAGE_MATRIX / LANGUAGES        - so Language("cnr") constructs;
+  * NameConverter.SYMBOLS              - so .name / fromname work (it's a class-level dict
+                                         built from LANGUAGE_MATRIX at module import);
+  * language_converters cache          - cleared so already-loaded converters rebuild;
+  * subzero FULL_LANGUAGE_LIST/ALPHA3b - so external-subtitle suffix stripping recognises
+                                         ".cnr" (subzero.language builds these from the
+                                         pre-patch matrix when imported before this runs).
 """
 from __future__ import annotations
 
@@ -93,3 +96,31 @@ def register_extra_languages() -> None:
             language_converters.converters.pop("name", None)
         except Exception:
             logger.exception("Failed to refresh babelfish name converter")
+
+    # Always refresh subzero's cached language lists (idempotent). subzero.language builds
+    # them from LANGUAGE_MATRIX at import, which - via subliminal_patch.extensions - happens
+    # before this runs at startup, so the lists would otherwise miss our codes regardless of
+    # whether this particular call added anything to babelfish.
+    _refresh_subzero_language_lists()
+
+
+def _refresh_subzero_language_lists() -> None:
+    # _search_external_subtitles strips a trailing ".<lang>" from a filename only when the
+    # token is in subzero.language.FULL_LANGUAGE_LIST, so an external file like "Movie.cnr.srt"
+    # is skipped under strict matching unless "cnr" is in that list. The list is a plain
+    # module-level list built once at import; append our alpha3 codes in place. Only patch if
+    # subzero.language is already imported - if it is imported later it builds from the
+    # now-patched matrix and includes the codes anyway.
+    import sys
+
+    sl = sys.modules.get("subzero.language")
+    if sl is None:
+        return
+    try:
+        for alpha3, _alpha2, _settings_code2, _name in _EXTRA_LANGUAGES:
+            for list_name in ("ALPHA3b_LIST", "FULL_LANGUAGE_LIST"):
+                lst = getattr(sl, list_name, None)
+                if isinstance(lst, list) and alpha3 not in lst:
+                    lst.append(alpha3)
+    except Exception:
+        logger.exception("Failed to refresh subzero language lists")

--- a/bazarr/languages/extra.py
+++ b/bazarr/languages/extra.py
@@ -1,0 +1,74 @@
+# coding=utf-8
+"""Register ISO 639-3 languages missing from babelfish's bundled data snapshot.
+
+babelfish ships a pre-2017 iso-639-3 table that lacks some codes - notably Montenegrin
+("cnr"), added to ISO 639-3 in 2017 - so Language("cnr") raises. We register them at
+startup so they resolve like any other language across subzero, subliminal, the Provider
+Hub registry, and the UI. Idempotent and safe to call repeatedly.
+
+Registration touches three babelfish internals because they are built once at import:
+  * LANGUAGE_MATRIX / LANGUAGES  - so Language("cnr") constructs;
+  * NameConverter.SYMBOLS        - so .name / fromname work (it's a class-level dict
+                                   built from LANGUAGE_MATRIX at module import);
+  * language_converters cache    - cleared so already-loaded converters rebuild.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# (alpha3, alpha2, name)
+_EXTRA_LANGUAGES = [
+    ("cnr", "", "Montenegrin"),
+]
+
+
+def register_extra_languages() -> None:
+    try:
+        from babelfish import language as babelfish_language
+        from babelfish import language_converters
+        from babelfish.converters.name import NameConverter
+    except Exception:  # pragma: no cover - babelfish is always available
+        return
+
+    matrix = getattr(babelfish_language, "LANGUAGE_MATRIX", None)
+    known = getattr(babelfish_language, "LANGUAGES", None)
+    if not matrix or known is None:
+        return
+
+    iso_language = getattr(babelfish_language, "IsoLanguage", None) or type(matrix[0])
+
+    added = False
+    for alpha3, alpha2, name in _EXTRA_LANGUAGES:
+        if alpha3 in known:
+            continue
+        try:
+            matrix.append(
+                iso_language(
+                    alpha3=alpha3,
+                    alpha3b="",
+                    alpha3t="",
+                    alpha2=alpha2,
+                    scope="I",
+                    type="L",
+                    name=name,
+                    comment="",
+                )
+            )
+            known.add(alpha3)
+            if name:
+                NameConverter.SYMBOLS[alpha3] = name
+            added = True
+            logger.debug("Registered extra language %s (%s)", alpha3, name)
+        except Exception:
+            logger.exception("Failed to register extra language %s", alpha3)
+
+    if added:
+        # Drop ONLY the cached name converter so it rebuilds from the updated SYMBOLS.
+        # Clearing the whole cache would also evict converters guessit relies on, which
+        # disrupts release parsing elsewhere in the process.
+        try:
+            language_converters.converters.pop("name", None)
+        except Exception:
+            logger.exception("Failed to refresh babelfish name converter")

--- a/bazarr/languages/extra.py
+++ b/bazarr/languages/extra.py
@@ -58,6 +58,13 @@ def register_extra_languages() -> None:
         if alpha3 in known:
             continue
         try:
+            # alpha3b/alpha3t (ISO 639-2 bibliographic/terminologic) are intentionally empty:
+            # cnr is a 639-3-only code with no 639-2 assignment, exactly like the ~7455 other
+            # 639-3-only languages babelfish ships with empty 3b/3t. Reverse lookups for cnr go
+            # through Language()/fromalpha3/fromietf/fromname (all work post-registration);
+            # fromalpha3b is not the lookup path for 639-3 codes and raises for every such
+            # language. Faking 3b/3t='cnr' would be the only inconsistency in the matrix and is
+            # covered against by test_montenegrin_alpha3b_is_unset_matching_babelfish_convention.
             matrix.append(
                 iso_language(
                     alpha3=alpha3,

--- a/bazarr/languages/extra.py
+++ b/bazarr/languages/extra.py
@@ -18,10 +18,24 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-# (alpha3, alpha2, name)
+# (alpha3, babelfish alpha2, settings code2, name)
+#
+# babelfish alpha2 is the real ISO 639-1 code (empty when none exists).
+# settings code2 is the 2-letter key Bazarr's settings/profile UI uses to list and enable
+# a language; since cnr has no ISO 639-1 code we assign a synthetic one ("me", matching
+# Montenegro) so Montenegrin is selectable in profiles - otherwise the languages table
+# (which only ingests ISO 639-1 languages) would never get a row for it.
 _EXTRA_LANGUAGES = [
-    ("cnr", "", "Montenegrin"),
+    ("cnr", "", "me", "Montenegrin"),
 ]
+
+
+def extra_settings_language_rows() -> list[dict]:
+    """Rows to add to TableSettingsLanguages so these languages are selectable in profiles."""
+    return [
+        {"code3": alpha3, "code2": settings_code2, "name": name}
+        for alpha3, _alpha2, settings_code2, name in _EXTRA_LANGUAGES
+    ]
 
 
 def register_extra_languages() -> None:
@@ -40,7 +54,7 @@ def register_extra_languages() -> None:
     iso_language = getattr(babelfish_language, "IsoLanguage", None) or type(matrix[0])
 
     added = False
-    for alpha3, alpha2, name in _EXTRA_LANGUAGES:
+    for alpha3, alpha2, _settings_code2, name in _EXTRA_LANGUAGES:
         if alpha3 in known:
             continue
         try:

--- a/bazarr/languages/get_languages.py
+++ b/bazarr/languages/get_languages.py
@@ -32,6 +32,16 @@ def load_language_in_db():
     # Insert custom languages in database table
     CustomLanguage.register(TableSettingsLanguages)
 
+    # Insert extra ISO 639-3 languages missing from pycountry's alpha2-gated list
+    # (e.g. Montenegrin "cnr") so they are selectable in profiles.
+    from .extra import extra_settings_language_rows
+    extra_rows = [{**row, 'enabled': 0} for row in extra_settings_language_rows()]
+    if extra_rows:
+        database.execute(
+            insert(TableSettingsLanguages)
+            .values(extra_rows)
+            .on_conflict_do_nothing())
+
     # Create languages dictionary for faster conversion than calling database
     create_languages_dict()
 

--- a/bazarr/provider_hub/registry.py
+++ b/bazarr/provider_hub/registry.py
@@ -93,6 +93,7 @@ class HubProxyProvider(Provider):
 
 
 def _languages_from_manifest(manifest):
+    import logging
     from subzero.language import Language
 
     languages = set()
@@ -100,7 +101,15 @@ def _languages_from_manifest(manifest):
         try:
             languages.add(Language.fromietf(code))
         except Exception:
-            languages.add(Language(code))
+            try:
+                languages.add(Language(code))
+            except Exception:
+                # A single code babelfish doesn't know (e.g. "cnr") must not drop the
+                # whole provider during registration: skip it, keep the valid ones.
+                logging.getLogger(__name__).warning(
+                    "Provider Hub: skipping unsupported language %r in manifest for %s",
+                    code, getattr(manifest, "provider_id", "?"),
+                )
     return languages
 
 

--- a/tests/bazarr/test_extra_languages.py
+++ b/tests/bazarr/test_extra_languages.py
@@ -57,6 +57,24 @@ def test_montenegrin_alpha3b_is_unset_matching_babelfish_convention():
         Language.fromalpha3b("cnr")
 
 
+def test_register_extra_languages_refreshes_subzero_suffix_list():
+    # subzero.language builds FULL_LANGUAGE_LIST from babelfish's matrix at import time, which
+    # (via subliminal_patch.extensions) happens before register_extra_languages() at startup.
+    # If we don't patch it in place, _search_external_subtitles won't recognise the trailing
+    # ".cnr" of an external file like "Movie.cnr.srt" and skips it under strict matching.
+    import subzero.language as sl
+
+    register_extra_languages()
+
+    assert "cnr" in sl.FULL_LANGUAGE_LIST
+    # Exercise the actual suffix-stripping path the matcher uses.
+    stripped = sl.ENDSWITH_LANGUAGECODE_RE.sub(
+        lambda m: "" if str(m.group(1)).lower() in sl.FULL_LANGUAGE_LIST else m.group(0),
+        "Movie.cnr",
+    )
+    assert stripped == "Movie"
+
+
 def test_extra_settings_language_rows_makes_montenegrin_selectable():
     # cnr has no ISO 639-1 code, so it needs an explicit settings-languages row with a
     # synthetic code2 to be selectable in profiles (load_language_in_db only ingests

--- a/tests/bazarr/test_extra_languages.py
+++ b/tests/bazarr/test_extra_languages.py
@@ -1,0 +1,22 @@
+"""Montenegrin ("cnr") was added to ISO 639-3 in 2017 but is missing from babelfish's
+bundled data snapshot, so Language("cnr") raises. register_extra_languages() registers it
+at startup so it resolves like any other language.
+"""
+from languages.extra import register_extra_languages
+from subzero.language import Language
+
+
+def test_register_extra_languages_adds_montenegrin():
+    register_extra_languages()  # idempotent
+
+    lang = Language("cnr")
+    assert lang.alpha3 == "cnr"
+    assert lang.name == "Montenegrin"
+    # resolvable via IETF parsing too
+    assert Language.fromietf("cnr").alpha3 == "cnr"
+
+
+def test_register_extra_languages_is_idempotent():
+    register_extra_languages()
+    register_extra_languages()
+    assert Language("cnr").alpha3 == "cnr"

--- a/tests/bazarr/test_extra_languages.py
+++ b/tests/bazarr/test_extra_languages.py
@@ -2,8 +2,11 @@
 bundled data snapshot, so Language("cnr") raises. register_extra_languages() registers it
 at startup so it resolves like any other language.
 """
+import pytest
+from babelfish.exceptions import LanguageReverseError
+
 from languages.extra import extra_settings_language_rows, register_extra_languages
-from subzero.language import Language
+from subzero.language import Language, language_from_stream
 
 
 def test_register_extra_languages_adds_montenegrin():
@@ -20,6 +23,38 @@ def test_register_extra_languages_is_idempotent():
     register_extra_languages()
     register_extra_languages()
     assert Language("cnr").alpha3 == "cnr"
+
+
+def test_montenegrin_resolves_through_real_lookup_paths():
+    # cnr is an ISO 639-3-only code with no ISO 639-2 (bibliographic/terminologic) code. Like
+    # the ~7455 other 639-3-only languages in babelfish's matrix, its alpha3b/alpha3t stay
+    # empty, so Language.fromalpha3b('cnr') raises *by design*. The reverse-lookup paths Bazarr
+    # actually uses all resolve cnr after registration.
+    register_extra_languages()
+
+    assert Language("cnr").name == "Montenegrin"
+    assert Language.fromietf("cnr").alpha3 == "cnr"
+    assert Language.fromname("Montenegrin").alpha3 == "cnr"
+    # subzero's stream-language reverse path (fromietf -> fromalpha3t -> fromalpha3b) resolves
+    # cnr on the first hop, so the empty alpha3b/alpha3t never matter here.
+    assert language_from_stream("cnr").alpha3 == "cnr"
+
+
+def test_montenegrin_alpha3b_is_unset_matching_babelfish_convention():
+    # Guard against a well-meaning "fix" that populates alpha3b/alpha3t with 'cnr': that would
+    # make cnr the only 639-3-only language in the matrix carrying a bogus ISO 639-2 code, and
+    # fromalpha3b is not the lookup path for 639-3 codes anyway (it fails for every 639-3-only
+    # language, not just cnr). Real cnr lookups go through Language()/fromietf/fromname.
+    from babelfish import language as babelfish_language
+
+    register_extra_languages()
+
+    entry = next((e for e in babelfish_language.LANGUAGE_MATRIX if e.alpha3 == "cnr"), None)
+    assert entry is not None
+    assert entry.alpha3b == ""
+    assert entry.alpha3t == ""
+    with pytest.raises(LanguageReverseError):
+        Language.fromalpha3b("cnr")
 
 
 def test_extra_settings_language_rows_makes_montenegrin_selectable():

--- a/tests/bazarr/test_extra_languages.py
+++ b/tests/bazarr/test_extra_languages.py
@@ -2,7 +2,7 @@
 bundled data snapshot, so Language("cnr") raises. register_extra_languages() registers it
 at startup so it resolves like any other language.
 """
-from languages.extra import register_extra_languages
+from languages.extra import extra_settings_language_rows, register_extra_languages
 from subzero.language import Language
 
 
@@ -20,3 +20,14 @@ def test_register_extra_languages_is_idempotent():
     register_extra_languages()
     register_extra_languages()
     assert Language("cnr").alpha3 == "cnr"
+
+
+def test_extra_settings_language_rows_makes_montenegrin_selectable():
+    # cnr has no ISO 639-1 code, so it needs an explicit settings-languages row with a
+    # synthetic code2 to be selectable in profiles (load_language_in_db only ingests
+    # ISO 639-1 languages otherwise).
+    rows = extra_settings_language_rows()
+    cnr = next((r for r in rows if r["code3"] == "cnr"), None)
+    assert cnr is not None
+    assert cnr["code2"] == "me"
+    assert cnr["name"] == "Montenegrin"

--- a/tests/bazarr/test_provider_hub_language_fallback.py
+++ b/tests/bazarr/test_provider_hub_language_fallback.py
@@ -1,0 +1,33 @@
+"""Provider Hub registry must not drop a whole provider over one bad language code.
+
+A manifest can declare a language babelfish doesn't know. In
+registry._languages_from_manifest the fallback `Language(code)` sat unguarded inside the
+`except`, so an unresolvable code raised and propagated, making
+register_active_provider_classes skip the entire provider. The unsupported code should be
+skipped while the valid ones still resolve. (Montenegrin "cnr" specifically is now
+registered at startup - see test_extra_languages - so a clearly-invalid code is used here.)
+"""
+from types import SimpleNamespace
+
+import provider_hub.registry as registry
+from subzero.language import Language
+
+
+def test_unsupported_language_code_is_skipped_not_fatal():
+    manifest = SimpleNamespace(
+        languages=["eng", "zzz", "srp", "hrv"],
+        provider_id="someprovider",
+    )
+
+    # Sanity: the offending code really is unsupported by babelfish.
+    try:
+        Language("zzz")
+        raise AssertionError("expected Language('zzz') to be unsupported")
+    except ValueError:
+        pass
+
+    languages = registry._languages_from_manifest(manifest)  # must not raise
+
+    alpha3 = {lang.alpha3 for lang in languages}
+    assert "zzz" not in alpha3, "unsupported code must be dropped"
+    assert {"eng", "srp", "hrv"}.issubset(alpha3), "valid codes must still resolve"


### PR DESCRIPTION
## Problem

`babelfish==0.6.1` (its latest release) bundles a pre-2017 ISO 639-3 snapshot that lacks Montenegrin (`cnr`, added to ISO 639-3 in 2017), so `Language("cnr")` raises `ValueError`. A Provider Hub provider that declares it (e.g. `prijevodionline`, languages `["cnr","hbs","hrv","srp"]`) was **dropped entirely** during registration, because the fallback `Language(code)` in `registry._languages_from_manifest` sat unguarded inside the `except` — the `cnr` failure propagated and `register_active_provider_classes` skipped the whole provider (the other three codes were fine).

## Fix

- **Register `cnr` at startup** ([bazarr/languages/extra.py](bazarr/languages/extra.py), called from [init.py](bazarr/init.py)): append it to babelfish's runtime `LANGUAGE_MATRIX`/`LANGUAGES`, add it to `NameConverter.SYMBOLS`, and refresh **only** the `name` converter (clearing the whole converter cache would evict converters guessit relies on). It then resolves like any other language across subzero/subliminal/the registry/the UI.
- **Guard the per-code fallback** in `_languages_from_manifest`: any code babelfish still doesn't know is skipped (logged) instead of dropping the provider, so the valid languages survive.

The two layers are complementary: `cnr` now works, and any *other* unknown code degrades gracefully.

> Note: bumping babelfish isn't an option (0.6.1 is the latest and still ships the stale data). A courtesy upstream issue to refresh babelfish's ISO 639-3 data is being filed separately; this patch can be removed if/when that ever lands.

## Tests

- `test_extra_languages.py`: `cnr` resolves (`alpha3`, `.name = "Montenegrin"`, `fromietf`); registration is idempotent.
- `test_provider_hub_language_fallback.py`: a manifest with an unknown code still resolves its valid languages and doesn't raise.

Bazarr-side suite green (203 incl. `test_provider_hub.py` back to 136); `ruff` clean. Deployed to the test instance and verified: `prijevodionline` now appears in the registered providers list, with **zero** "skipping … cnr" errors and zero `cnr` ValueErrors in the boot log.
