### PR TITLE
fix(provider-hub): serialize venv creation to prevent OOM on bulk installs

### DIFF
--- a/bazarr/provider_hub/venv.py
+++ b/bazarr/provider_hub/venv.py
@@ -73,7 +73,15 @@ class PluginEnvironment:
 
         python_exe = python_executable(env_path)
         # Serialize the heavy venv/pip subprocess work process-wide (see _INSTALL_LOCK).
-        _INSTALL_LOCK.acquire()
+        # Bound the wait by the remaining budget so a timed (startup) install can't block
+        # forever behind a long-running unbounded (manual) install holding the lock.
+        lock_wait = _remaining()
+        if lock_wait is None:
+            _INSTALL_LOCK.acquire()
+        elif not _INSTALL_LOCK.acquire(timeout=lock_wait):
+            raise PluginEnvironmentError(
+                f"Provider Hub install for {manifest.provider_id} timed out waiting for the install lock"
+            )
         try:
             if not python_exe.exists():
                 subprocess.run(

--- a/bazarr/provider_hub/venv.py
+++ b/bazarr/provider_hub/venv.py
@@ -5,11 +5,21 @@ import hashlib
 import os
 import subprocess
 import sys
+import threading
 import time
 
 from pathlib import Path
 
 from .manifest import ValidatedManifest
+
+
+# Serialize venv creation process-wide. A large catalog update can fan many provider
+# installs across the jobs queue / Flask threads at once; each builds a venv (python -m
+# venv + pip install), and a concurrent burst can exceed a container memory limit and trip
+# the OOM killer. Holding this lock around the heavy subprocess work caps peak memory to a
+# single venv build at a time. Builds are idempotent and cached, so serializing only slows
+# the rare bulk-install burst, not normal operation.
+_INSTALL_LOCK = threading.Lock()
 
 
 class PluginEnvironmentError(RuntimeError):
@@ -62,6 +72,8 @@ class PluginEnvironment:
         env_path.mkdir(parents=True, exist_ok=True)
 
         python_exe = python_executable(env_path)
+        # Serialize the heavy venv/pip subprocess work process-wide (see _INSTALL_LOCK).
+        _INSTALL_LOCK.acquire()
         try:
             if not python_exe.exists():
                 subprocess.run(
@@ -106,4 +118,6 @@ class PluginEnvironment:
             raise PluginEnvironmentError(
                 f"Provider Hub install for {manifest.provider_id} timed out"
             ) from error
+        finally:
+            _INSTALL_LOCK.release()
         return env_path

--- a/tests/bazarr/test_provider_hub_install_serialization.py
+++ b/tests/bazarr/test_provider_hub_install_serialization.py
@@ -11,6 +11,8 @@ import threading
 import time
 from types import SimpleNamespace
 
+import pytest
+
 import provider_hub.venv as venvmod
 
 
@@ -51,3 +53,22 @@ def test_install_serializes_concurrent_venv_creation(tmp_path, monkeypatch):
 
     assert not errors, f"install raised: {errors}"
     assert active["max"] == 1, f"venv creation must be serialized (saw {active['max']} concurrent)"
+
+
+def test_timed_install_does_not_block_forever_on_held_lock(tmp_path):
+    # A budgeted (startup) install must not wait on the serialization lock past its budget:
+    # if another (e.g. unbounded manual) install holds it, the timed one should raise within
+    # ~the budget rather than hang. Regression guard for the lock-wait being outside the
+    # deadline accounting.
+    manifest = SimpleNamespace(provider_id="p", version="1.0.0", dependency_requirements=())
+    env = venvmod.PluginEnvironment(tmp_path)
+
+    venvmod._INSTALL_LOCK.acquire()  # simulate a long-running install holding the lock
+    try:
+        start = time.monotonic()
+        with pytest.raises(venvmod.PluginEnvironmentError, match="install lock"):
+            env.install(manifest, timeout=0.2)
+        elapsed = time.monotonic() - start
+        assert elapsed < 2.0, f"timed install hung on the lock ({elapsed:.1f}s)"
+    finally:
+        venvmod._INSTALL_LOCK.release()

--- a/tests/bazarr/test_provider_hub_install_serialization.py
+++ b/tests/bazarr/test_provider_hub_install_serialization.py
@@ -1,0 +1,53 @@
+"""Provider Hub venv creation must be serialized process-wide.
+
+A large catalog update can trigger many provider installs at once (across the jobs queue /
+Flask request threads). Each install builds a venv (python -m venv + pip install), and a
+burst of concurrent builds can blow past a container memory limit and trigger the OOM
+killer. PluginEnvironment.install() serializes the heavy subprocess work behind a
+module-level lock so at most one venv builds at a time, bounding peak memory regardless of
+how many callers fan out.
+"""
+import threading
+import time
+from types import SimpleNamespace
+
+import provider_hub.venv as venvmod
+
+
+def test_install_serializes_concurrent_venv_creation(tmp_path, monkeypatch):
+    active = {"n": 0, "max": 0}
+    track_lock = threading.Lock()
+    errors = []
+
+    def fake_run(cmd, **kwargs):
+        with track_lock:
+            active["n"] += 1
+            active["max"] = max(active["max"], active["n"])
+        time.sleep(0.05)
+        with track_lock:
+            active["n"] -= 1
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(venvmod.subprocess, "run", fake_run)
+    # Force the venv-creation branch (treat the venv python as missing).
+    monkeypatch.setattr(venvmod, "python_executable", lambda p: tmp_path / "missing-python")
+
+    def make_manifest(pid):
+        return SimpleNamespace(provider_id=pid, version="1.0.0", dependency_requirements=())
+
+    env = venvmod.PluginEnvironment(tmp_path)
+
+    def run_install(i):
+        try:
+            env.install(make_manifest(f"p{i}"))
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=run_install, args=(i,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"install raised: {errors}"
+    assert active["max"] == 1, f"venv creation must be serialized (saw {active['max']} concurrent)"


### PR DESCRIPTION
## Problem

A large Provider Hub catalog update can fan many provider installs at once (across the jobs queue / Flask request threads). Each install builds an isolated venv (`python -m venv` + `pip install`), and a concurrent burst of builds can exceed the container's memory limit and trigger the kernel OOM killer.

Observed on the test instance: a catalog bump of ~26 provider versions caused ~60 venv builds in a burst on a **1 GiB** cgroup → `oom-kill constraint=CONSTRAINT_MEMCG` killed the install `python` processes and bazarr itself → s6 (PID 1) restarted it. Host had ~4 GB free; the 1 GiB container limit was the wall.

## Fix

Hold a process-wide `threading.Lock` around the heavy venv/pip subprocess work in `PluginEnvironment.install()` (`bazarr/provider_hub/venv.py`), so **at most one venv builds at a time** — peak memory is capped to a single build regardless of how many callers fan out. Builds are cached and idempotent, so this only slows the rare bulk-install burst, not normal operation.

This is the durable, code-side fix. It complements the infra option of raising the container memory limit (e.g. `--memory 3g`), which gives general headroom but doesn't bound the burst.

## Tests

`tests/bazarr/test_provider_hub_install_serialization.py`: spawns 4 concurrent `install()` calls with the subprocesses mocked to record concurrency; asserts peak concurrency is exactly 1. Without the lock the test sees 4 (the burst); with it, 1.

`test_provider_hub.py` (136) still green; `ruff` clean.
