### PR TITLE
feat(provider-hub): host-list / worker-select archive members (select_archive_member op)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
             tests/bazarr/test_app_get_providers.py \
             tests/bazarr/test_provider_hub.py \
             tests/bazarr/test_provider_hub_auto_install_optin.py \
+            tests/bazarr/test_provider_hub_archive_select.py \
             tests/subliminal_patch/test_subliminal_rebase.py \
             tests/subliminal_patch/test_embeddedsubtitles.py \
             tests/subliminal_patch/test_subsunacs.py \

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -197,14 +197,18 @@ def _format_from_member(name: str | None) -> str | None:
     return _SUBTITLE_FORMATS.get(name.rsplit(".", 1)[-1].lower())
 
 
-def worker_download_to_content(subtitle: HubWorkerSubtitle, payload: dict[str, Any]) -> bool:
+def worker_download_to_content(
+    subtitle: HubWorkerSubtitle, payload: dict[str, Any], select_member_cb=None
+) -> bool:
     if payload.get("empty"):
         subtitle.content = b""
         return True
 
     archive_b64 = payload.get("archive_b64")
     if isinstance(archive_b64, str):
-        return _worker_archive_to_content(subtitle, payload, archive_b64)
+        return _worker_archive_to_content(
+            subtitle, payload, archive_b64, select_member_cb=select_member_cb
+        )
 
     content_b64 = payload.get("content_b64")
     if not isinstance(content_b64, str):
@@ -254,6 +258,19 @@ def _guard_archive_members(archive) -> None:
         total += size
         if total > _MAX_ARCHIVE_TOTAL_BYTES:
             raise WorkerProtocolError("download.archive_b64 decompresses past the size limit")
+
+
+def _list_archive_members(archive):
+    """Member names offered to the worker for language selection: subtitle files only,
+    excluding dotfiles. Extraction guards (_guard_archive_members) still apply on read."""
+    names = []
+    for name in archive.namelist():
+        base = name.rsplit("/", 1)[-1]
+        if not base or base.startswith("."):
+            continue
+        if name.lower().endswith((".srt", ".sub", ".ssa", ".ass", ".vtt")):
+            names.append(name)
+    return names
 
 
 _SEVEN_ZIP_MAGIC = b"7z\xbc\xaf\x27\x1c"
@@ -319,7 +336,7 @@ def _seven_zip_archive(raw: bytes):
 
 
 def _worker_archive_to_content(
-    subtitle: HubWorkerSubtitle, payload: dict[str, Any], archive_b64: str
+    subtitle: HubWorkerSubtitle, payload: dict[str, Any], archive_b64: str, select_member_cb=None
 ) -> bool:
     """Extract a subtitle from an archive the worker handed back.
 
@@ -351,18 +368,12 @@ def _worker_archive_to_content(
         raise WorkerProtocolError("download.archive_b64 is not a zip, rar, or 7z archive")
     _guard_archive_members(archive)
 
-    member = payload.get("member")
-    if member:
-        if member not in set(archive.namelist()):
-            raise WorkerProtocolError(f"download.member is not in the archive: {member}")
-        content = fix_line_ending(archive.read(member))
-        chosen = member
-    else:
+    def _episode_pick():
         forced = bool(getattr(getattr(subtitle, "language", None), "forced", False))
         episode = payload.get("episode")
         if isinstance(episode, (list, tuple)):
             episode = episode[0] if episode else None
-        content = get_subtitle_from_archive(
+        picked = get_subtitle_from_archive(
             archive,
             forced=forced,
             episode=episode,
@@ -370,8 +381,38 @@ def _worker_archive_to_content(
             get_first_subtitle=bool(payload.get("first_subtitle")),
             extensions=(".srt", ".sub", ".ssa", ".ass", ".vtt"),
         )
-        if content is None:
+        if picked is None:
             raise WorkerProtocolError("download.archive_b64 has no usable subtitle member")
+        return picked
+
+    member = payload.get("member")
+    if member:
+        if member not in set(archive.namelist()):
+            raise WorkerProtocolError(f"download.member is not in the archive: {member}")
+        content = fix_line_ending(archive.read(member))
+        chosen = member
+    elif payload.get("select_member") and select_member_cb is not None:
+        # Host lists the members; the worker language-pins one (tri-state pin/defer/reject).
+        # This is the only way to language-select rar/7z, which the stdlib-only worker
+        # cannot list. "defer" => safe episode pick (single-language); "reject" => fail loud.
+        result = select_member_cb(_list_archive_members(archive)) or {}
+        decision = result.get("decision")
+        if decision == "pin":
+            chosen = result.get("member")
+            if chosen not in set(archive.namelist()):
+                raise WorkerProtocolError(
+                    f"select_archive_member returned a member not in the archive: {chosen!r}"
+                )
+            content = fix_line_ending(archive.read(chosen))
+        elif decision == "defer":
+            content = _episode_pick()
+            chosen = payload.get("filename") or ""
+        else:
+            raise WorkerProtocolError(
+                "select_archive_member rejected the archive (no language match)"
+            )
+    else:
+        content = _episode_pick()
         chosen = payload.get("filename") or ""
 
     subtitle.content = content

--- a/bazarr/provider_hub/registry.py
+++ b/bazarr/provider_hub/registry.py
@@ -88,7 +88,23 @@ class HubProxyProvider(Provider):
             "config": self.config,
         }
         result = self._worker().request("download", request, timeout=self.timeout)
-        worker_download_to_content(subtitle, result.payload)
+
+        def _select_member_cb(members):
+            response = self._worker().select_archive_member(
+                {
+                    "provider": self.provider_name,
+                    "provider_payload": subtitle.provider_payload,
+                    "language": language_to_payload(subtitle.language),
+                    "members": members,
+                    "season": getattr(subtitle, "season", None),
+                    "episode": getattr(subtitle, "episode", None),
+                    "config": self.config,
+                },
+                timeout=self.timeout,
+            )
+            return response.payload
+
+        worker_download_to_content(subtitle, result.payload, select_member_cb=_select_member_cb)
         return True
 
 

--- a/bazarr/provider_hub/worker.py
+++ b/bazarr/provider_hub/worker.py
@@ -196,6 +196,14 @@ class ProviderWorkerClient:
             except Exception:
                 pass
 
+    def select_archive_member(
+        self, payload: dict[str, Any] | None = None, timeout: float | None = None
+    ) -> WorkerResult:
+        """Ask the worker to language-pin a member from a host-listed archive."""
+        return self.request(
+            "select_archive_member", payload, timeout=30.0 if timeout is None else timeout
+        )
+
     def request(self, op: str, payload: dict[str, Any] | None = None, timeout: float = 30.0) -> WorkerResult:
         self.start()
         if self.process is None or self.process.stdin is None or self.process.stdout is None:

--- a/bazarr/provider_hub/worker_runner.py
+++ b/bazarr/provider_hub/worker_runner.py
@@ -75,6 +75,22 @@ def _handle(provider, op, payload):
             config=payload.get("config") or {},
         )
         return _content_payload(result)
+    if op == "select_archive_member":
+        selector = getattr(provider, "select_archive_member", None)
+        if selector is None:
+            # Provider asked the host to list members (select_member) but exposes no
+            # selector: reject so the host fails loud rather than risk a wrong member.
+            return {"member": None, "decision": "reject"}
+        result = selector(
+            provider_payload=payload.get("provider_payload") or {},
+            language=payload.get("language") or {},
+            members=payload.get("members") or [],
+            config=payload.get("config") or {},
+        ) or {}
+        decision = result.get("decision")
+        if decision not in ("pin", "defer", "reject"):
+            decision = "reject"
+        return {"member": result.get("member"), "decision": decision}
     raise ValueError(f"unsupported worker op: {op}")
 
 

--- a/bazarr/provider_hub/worker_runner.py
+++ b/bazarr/provider_hub/worker_runner.py
@@ -81,8 +81,15 @@ def _handle(provider, op, payload):
             # Provider asked the host to list members (select_member) but exposes no
             # selector: reject so the host fails loud rather than risk a wrong member.
             return {"member": None, "decision": "reject"}
+        provider_payload = dict(payload.get("provider_payload") or {})
+        # The host forwards the requested season/episode at the top level of the op payload.
+        # Surface them on provider_payload (host context is authoritative) so a selector can
+        # disambiguate season-pack members even when the search payload didn't carry them.
+        for key in ("season", "episode"):
+            if payload.get(key) is not None:
+                provider_payload[key] = payload.get(key)
         result = selector(
-            provider_payload=payload.get("provider_payload") or {},
+            provider_payload=provider_payload,
             language=payload.get("language") or {},
             members=payload.get("members") or [],
             config=payload.get("config") or {},

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -2362,6 +2362,64 @@ def test_hub_proxy_provider_search_and_download_uses_worker_payload():
     assert worker.requests[1][1]["config"] == provider_config
 
 
+def test_hub_proxy_download_invokes_select_archive_member():
+    import io
+    import zipfile
+
+    from provider_hub.manifest import validate_manifest
+    from provider_hub.registry import _make_provider_class
+    from provider_hub.protocol import language_to_payload
+
+    def _zip(names):
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as archive:
+            for name in names:
+                archive.writestr(name, b"1\n00:00:01,000 --> 00:00:02,000\nx\n")
+        return buf.getvalue()
+
+    body = _zip(["show.eng.srt", "show.fre.srt"])
+
+    class FakeWorker:
+        def __init__(self):
+            self.select_calls = []
+
+        def request(self, op, payload, timeout):
+            if op == "search":
+                return type("R", (), {"payload": {"candidates": [{
+                    "provider": "selecthub", "id": "sub-1",
+                    "language": language_to_payload(Language("eng")),
+                    "release_info": "Example.Movie.2024-GROUP", "filename": "x.srt",
+                    "matches": ["title"],
+                    "provider_payload": {"provider": "selecthub", "schema": 1},
+                }]}, "events": []})()
+            return type("R", (), {"payload": {
+                "archive_b64": base64.b64encode(body).decode("ascii"),
+                "archive_sha256": _sha256(body),
+                "select_member": True,
+            }, "events": []})()
+
+        def select_archive_member(self, payload, timeout=None):
+            self.select_calls.append(payload)
+            return type("R", (), {"payload": {"member": "show.eng.srt", "decision": "pin"}, "events": []})()
+
+        def stop(self):
+            return None
+
+    worker = FakeWorker()
+    manifest = validate_manifest(_manifest(provider_id="selecthub"), built_in_provider_ids=set())
+    provider = _make_provider_class(manifest, worker_client=worker)(
+        timeout=9, profile_name="smoke-profile", api_token="secret-token"
+    )
+    movie = Movie("/media/example.mkv", "Example Movie", year=2024)
+    subtitle = provider.list_subtitles(movie, {Language("eng")})[0]
+
+    provider.download_subtitle(subtitle)
+
+    assert worker.select_calls, "download must call select_archive_member for select_member payloads"
+    assert sorted(worker.select_calls[0]["members"]) == ["show.eng.srt", "show.fre.srt"]
+    assert subtitle.content is not None and b"00:00:01" in subtitle.content
+
+
 def test_worker_runner_executes_simple_bundle(tmp_path):
     import sys
 

--- a/tests/bazarr/test_provider_hub_archive_select.py
+++ b/tests/bazarr/test_provider_hub_archive_select.py
@@ -1,0 +1,94 @@
+"""Host-side archive member listing + the select_member (pin/defer/reject) branch.
+
+Lets the host list zip/rar/7z members and call back into the worker to language-pin one,
+so multilingual rar/7z archives no longer cause silent wrong-language downloads.
+"""
+import base64
+import io
+import zipfile
+
+import pytest
+
+import provider_hub.protocol as proto
+from subliminal_patch.providers.utils import get_archive_from_bytes
+
+_SRT = b"1\n00:00:01,000 --> 00:00:02,000\nx\n"
+
+
+def _zip(names):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        for name in names:
+            archive.writestr(name, _SRT)
+    return buf.getvalue()
+
+
+class _Sub:
+    class language:
+        forced = False
+
+    content = None
+    format = "srt"
+    encoding = None
+    _guessed_encoding = None
+
+
+def _run(body, payload, cb):
+    sub = _Sub()
+    proto.worker_download_to_content(sub, payload, select_member_cb=cb)
+    return sub
+
+
+def _archive_payload(body, **extra):
+    payload = {
+        "archive_b64": base64.b64encode(body).decode("ascii"),
+        "archive_sha256": __import__("hashlib").sha256(body).hexdigest(),
+    }
+    payload.update(extra)
+    return payload
+
+
+def test_list_archive_members_filters_to_subtitles():
+    body = _zip(["a.eng.srt", "b.fre.srt", ".hidden.srt", "notes.txt"])
+    archive = get_archive_from_bytes(body)
+    assert sorted(proto._list_archive_members(archive)) == ["a.eng.srt", "b.fre.srt"]
+
+
+def test_select_member_pin_extracts_named_member():
+    body = _zip(["show.eng.srt", "show.fre.srt"])
+    sub = _run(body, _archive_payload(body, select_member=True),
+               lambda members: {"member": "show.fre.srt", "decision": "pin"})
+    assert sub.content is not None and b"00:00:01" in sub.content
+
+
+def test_select_member_pin_unknown_member_raises():
+    body = _zip(["show.eng.srt"])
+    with pytest.raises(proto.WorkerProtocolError):
+        _run(body, _archive_payload(body, select_member=True),
+             lambda members: {"member": "../evil.srt", "decision": "pin"})
+
+
+def test_select_member_reject_raises():
+    body = _zip(["show.eng.srt", "show.fre.srt"])
+    with pytest.raises(proto.WorkerProtocolError):
+        _run(body, _archive_payload(body, select_member=True),
+             lambda members: {"member": None, "decision": "reject"})
+
+
+def test_select_member_defer_uses_episode_pick():
+    body = _zip(["only.srt"])
+    sub = _run(body, _archive_payload(body, select_member=True, episode=None),
+               lambda members: {"member": None, "decision": "defer"})
+    assert sub.content is not None and b"00:00:01" in sub.content
+
+
+def test_select_member_callback_receives_listed_members():
+    body = _zip(["show.eng.srt", "show.fre.srt", "notes.txt"])
+    seen = {}
+
+    def cb(members):
+        seen["members"] = sorted(members)
+        return {"member": "show.eng.srt", "decision": "pin"}
+
+    _run(body, _archive_payload(body, select_member=True), cb)
+    assert seen["members"] == ["show.eng.srt", "show.fre.srt"]

--- a/tests/bazarr/test_provider_hub_archive_select.py
+++ b/tests/bazarr/test_provider_hub_archive_select.py
@@ -96,6 +96,29 @@ def test_worker_runner_dispatches_select_archive_member():
     assert out == {"member": "b.srt", "decision": "pin"}
 
 
+def test_worker_runner_forwards_episode_context_to_selector():
+    # The host sends season/episode at the top level of the op payload (the registry derives
+    # them from the requested subtitle). The runner must surface them on provider_payload so a
+    # selector can disambiguate season-pack members even when the search payload omitted them.
+    from provider_hub import worker_runner
+
+    seen = {}
+
+    class P:
+        def select_archive_member(self, provider_payload, language, members, config):
+            seen["payload"] = provider_payload
+            return {"member": members[0], "decision": "pin"}
+
+    worker_runner._handle(P(), "select_archive_member", {
+        "members": ["a.srt"], "language": {"alpha3": "fra"},
+        "provider_payload": {"url": "x"}, "config": {},
+        "season": 1, "episode": 2,
+    })
+    assert seen["payload"]["season"] == 1
+    assert seen["payload"]["episode"] == 2
+    assert seen["payload"]["url"] == "x"
+
+
 def test_worker_runner_select_archive_member_rejects_when_unimplemented():
     from provider_hub import worker_runner
 

--- a/tests/bazarr/test_provider_hub_archive_select.py
+++ b/tests/bazarr/test_provider_hub_archive_select.py
@@ -82,6 +82,41 @@ def test_select_member_defer_uses_episode_pick():
     assert sub.content is not None and b"00:00:01" in sub.content
 
 
+def test_worker_runner_dispatches_select_archive_member():
+    from provider_hub import worker_runner
+
+    class P:
+        def select_archive_member(self, provider_payload, language, members, config):
+            return {"member": members[1], "decision": "pin"}
+
+    out = worker_runner._handle(P(), "select_archive_member", {
+        "members": ["a.srt", "b.srt"], "language": {"alpha3": "fra"},
+        "provider_payload": {}, "config": {},
+    })
+    assert out == {"member": "b.srt", "decision": "pin"}
+
+
+def test_worker_runner_select_archive_member_rejects_when_unimplemented():
+    from provider_hub import worker_runner
+
+    class P:
+        pass
+
+    out = worker_runner._handle(P(), "select_archive_member", {"members": ["a.srt"]})
+    assert out == {"member": None, "decision": "reject"}
+
+
+def test_worker_runner_select_archive_member_coerces_bad_decision():
+    from provider_hub import worker_runner
+
+    class P:
+        def select_archive_member(self, provider_payload, language, members, config):
+            return {"member": None, "decision": "weird"}
+
+    out = worker_runner._handle(P(), "select_archive_member", {"members": ["a.srt"]})
+    assert out["decision"] == "reject"
+
+
 def test_select_member_callback_receives_listed_members():
     body = _zip(["show.eng.srt", "show.fre.srt", "notes.txt"])
     seen = {}


### PR DESCRIPTION
## What (Phase 1 — host side)

Adds the host side of the unified archive member-selection mechanism (design: host lists zip/rar/7z members, the worker language-pins one). Additive, ABI `bazarr.provider-worker.v1` unchanged; existing explicit-`member` / `episode` download branches are untouched.

- `_list_archive_members()` + a `select_member` branch in `_worker_archive_to_content` ([protocol.py](bazarr/provider_hub/protocol.py)): when a download returns `select_member: true`, the host lists members and calls back via `select_member_cb` → tri-state:
  - `pin` → extract the named member (validated ∈ the archive — no path traversal),
  - `defer` → the existing episode pick (safe for single-language archives),
  - `reject`/unknown → fail loud (candidate skipped).
- `ProviderWorkerClient.select_archive_member()` op + `HubProxyProvider.download_subtitle` builds the callback (host-listed names + provider_payload/language/season/episode).
- `worker_runner._handle` routes the `select_archive_member` op to the provider's optional method, coercing missing/unknown decisions to `reject`.

## Why

Workers are stdlib-only and can't list rar/7z, and the host's member pick is language-agnostic — so a multilingual rar/7z handed over with only `episode` could return the wrong language silently. This lets the worker's own language-tagging logic pick the member for any archive type.

## Tests

`tests/bazarr/test_provider_hub_archive_select.py` (listing filter; pin/defer/reject; member-in-archive validation; callback receives listed members; runner dispatch incl. unimplemented→reject and bad-decision→reject) + a proxy wiring test in `test_provider_hub.py`. Backend CI list + ruff green locally.

> Phase 1 of a staged rollout. The catalog SDK contract + zimuku/soustitreseu migration land in a companion catalog PR; end-to-end (multilingual rar pins correct language) is verified once host + migrated providers deploy together.
