### PR TITLE
fix(deps): bump react-router to 7.17.0 (clears 4 Dependabot alerts + brace-expansion)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,7 @@
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-markdown": "^10.1.0",
-        "react-router": "^7.13.1",
+        "react-router": "^7.17.0",
         "react-timeago": "^8.3.0",
         "socket.io-client": "^4.8.3",
         "wavesurfer.js": "^7.12.5"
@@ -5770,9 +5770,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10766,9 +10766,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
-      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-markdown": "^10.1.0",
-    "react-router": "^7.13.1",
+    "react-router": "^7.17.0",
     "react-timeago": "^8.3.0",
     "socket.io-client": "^4.8.3",
     "wavesurfer.js": "^7.12.5"


### PR DESCRIPTION
Resolves all open Dependabot alerts on react-router by moving ^7.13.1 to ^7.17.0 (matching upstream): two DoS (GHSA-rxv8-25v2-qmq8, GHSA-8x6r-g9mw-2r78), open redirect (GHSA-2j2x-hqr9-3h42), and turbo-stream arbitrary-constructor (GHSA-49rj-9fvp-4h2h). npm audit fix also clears the transitive brace-expansion DoS (GHSA-jxxr-4gwj-5jf2). npm audit now reports 0 vulnerabilities; frontend build verified.