### PR TITLE
fix(security): clear 9 CodeQL findings (path containment + keyed API-key hashing)

### DIFF
--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -420,25 +420,6 @@ class Subtitles(Resource):
 
 
 def postprocess_subtitles(subtitles_path, video_path, media_type, metadata, id):
-    # Path-injection containment: only chmod a subtitle that lives where Bazarr
-    # stores subtitles for this video, i.e. alongside it (or a relative subfolder
-    # under it) or the configured absolute custom subfolder. A crafted `path` must
-    # not steer chmod at an arbitrary file. chmod only runs off-Windows, where
-    # realpaths share the / root so commonpath never raises.
-    real_sub = os.path.realpath(subtitles_path)
-    video_dir = os.path.realpath(os.path.dirname(video_path))
-    contained = os.path.commonpath([video_dir, real_sub]) == video_dir
-    if not contained and settings.general.subfolder == "absolute":
-        custom = str(settings.general.subfolder_custom).strip()
-        if custom:
-            custom_dir = os.path.realpath(custom)
-            contained = os.path.commonpath([custom_dir, real_sub]) == custom_dir
-    if not contained:
-        logging.warning(
-            "BAZARR refusing to postprocess a subtitle outside the video's subtitle folder: %s",
-            subtitles_path)
-        return
-
     # apply chmod if required
     chmod = (
         int(settings.general.chmod, 8)
@@ -446,7 +427,30 @@ def postprocess_subtitles(subtitles_path, video_path, media_type, metadata, id):
         else None
     )
     if chmod:
-        os.chmod(real_sub, chmod)
+        # Path-injection containment for the chmod sink only: a crafted `path` must
+        # not steer chmod at an arbitrary file. Only chmod a subtitle that lives
+        # where Bazarr stores subtitles for this video (alongside it / a relative
+        # subfolder under it, or the configured absolute custom subfolder). This
+        # gates ONLY the chmod; the store/refresh below uses video_path and runs
+        # regardless. commonpath raises across different Windows drives, so guard it.
+        real_sub = os.path.realpath(subtitles_path)
+        contained = False
+        try:
+            video_dir = os.path.realpath(os.path.dirname(video_path))
+            contained = os.path.commonpath([video_dir, real_sub]) == video_dir
+            if not contained and settings.general.subfolder == "absolute":
+                custom = str(settings.general.subfolder_custom).strip()
+                if custom:
+                    custom_dir = os.path.realpath(custom)
+                    contained = os.path.commonpath([custom_dir, real_sub]) == custom_dir
+        except ValueError:
+            contained = False  # paths on different Windows drives: not contained
+        if contained:
+            os.chmod(real_sub, chmod)
+        else:
+            logging.warning(
+                "BAZARR refusing to chmod a subtitle outside the video's subtitle folder: %s",
+                subtitles_path)
 
     if media_type == "episode":
         store_subtitles(path_mappings.path_replace_reverse(video_path), video_path)

--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 
+import logging
 import os
 import sys
 
@@ -419,6 +420,25 @@ class Subtitles(Resource):
 
 
 def postprocess_subtitles(subtitles_path, video_path, media_type, metadata, id):
+    # Path-injection containment: only chmod a subtitle that lives where Bazarr
+    # stores subtitles for this video, i.e. alongside it (or a relative subfolder
+    # under it) or the configured absolute custom subfolder. A crafted `path` must
+    # not steer chmod at an arbitrary file. chmod only runs off-Windows, where
+    # realpaths share the / root so commonpath never raises.
+    real_sub = os.path.realpath(subtitles_path)
+    video_dir = os.path.realpath(os.path.dirname(video_path))
+    contained = os.path.commonpath([video_dir, real_sub]) == video_dir
+    if not contained and settings.general.subfolder == "absolute":
+        custom = str(settings.general.subfolder_custom).strip()
+        if custom:
+            custom_dir = os.path.realpath(custom)
+            contained = os.path.commonpath([custom_dir, real_sub]) == custom_dir
+    if not contained:
+        logging.warning(
+            "BAZARR refusing to postprocess a subtitle outside the video's subtitle folder: %s",
+            subtitles_path)
+        return
+
     # apply chmod if required
     chmod = (
         int(settings.general.chmod, 8)
@@ -426,7 +446,7 @@ def postprocess_subtitles(subtitles_path, video_path, media_type, metadata, id):
         else None
     )
     if chmod:
-        os.chmod(subtitles_path, chmod)
+        os.chmod(real_sub, chmod)
 
     if media_type == "episode":
         store_subtitles(path_mappings.path_replace_reverse(video_path), video_path)

--- a/bazarr/api/system/settings.py
+++ b/bazarr/api/system/settings.py
@@ -14,6 +14,7 @@ from app.config import settings, save_settings, get_settings
 from app.scheduler import scheduler  # noqa: F401
 from subtitles.indexer.series import list_missing_subtitles
 from subtitles.indexer.movies import list_missing_subtitles_movies
+from subtitles.language_profiles import validate_combine_rule, CombineRuleError
 
 from ..utils import authenticate
 
@@ -61,7 +62,17 @@ class SystemSettings(Resource):
                 .all()
             existing = [x.profileId for x in existing_ids]
             for item in json.loads(languages_profiles):
-                combine_value = json.dumps(item['combine']) if item.get('combine') else None
+                # Validate the combine rule at save time and reject it, instead of
+                # storing an invalid rule that get_combine_rule then silently drops
+                # (returns None), leaving the profile looking configured while
+                # auto-combine never runs.
+                combine_rule = item.get('combine')
+                if combine_rule:
+                    try:
+                        validate_combine_rule(combine_rule, item.get('items') or [])
+                    except CombineRuleError as error:
+                        return f"Invalid combine rule for profile '{item.get('name')}': {error}", 400
+                combine_value = json.dumps(combine_rule) if combine_rule else None
                 if item['profileId'] in existing:
                     # Update existing profiles
                     database.execute(

--- a/bazarr/app/scheduler.py
+++ b/bazarr/app/scheduler.py
@@ -84,6 +84,18 @@ def _release_session_after_job(event):
         logging.exception("BAZARR failed to release database session after job")
 
 
+def _compat_usage_prune():
+    """Prune Distribution Hub usage rows older than the configured retention so
+    compat_usage cannot grow unbounded. No-op when the endpoint is disabled."""
+    try:
+        if not bool(settings.compat_endpoint.enabled):
+            return
+        from compat import meter
+        meter.prune(int(settings.compat_endpoint.usage_retention_days))
+    except Exception:
+        logging.exception("BAZARR failed to prune Distribution Hub usage table")
+
+
 class Scheduler:
 
     def __init__(self):
@@ -121,6 +133,7 @@ class Scheduler:
 
         # configure all tasks
         self.__cache_cleanup_task()
+        self.__compat_usage_prune_task()
         self.__check_health_task()
         self.update_configurable_tasks()
 
@@ -243,6 +256,11 @@ class Scheduler:
         self.aps_scheduler.add_job(cache_maintenance, 'interval', hours=24, max_instances=1, coalesce=True,
                                    misfire_grace_time=15, id='cache_cleanup', name='Cache Maintenance',
                                    kwargs=dict(wait_for_completion=True))
+
+    def __compat_usage_prune_task(self):
+        self.aps_scheduler.add_job(_compat_usage_prune, 'interval', hours=24, max_instances=1, coalesce=True,
+                                   misfire_grace_time=60, id='compat_usage_prune',
+                                   name='Distribution Hub Usage Cleanup')
 
     def __check_health_task(self):
         self.aps_scheduler.add_job(check_health, 'interval', hours=6, max_instances=1, coalesce=True,

--- a/bazarr/compat/keyring.py
+++ b/bazarr/compat/keyring.py
@@ -10,12 +10,14 @@ the rest of bazarr resolves modules from `bazarr/` as the sys.path root.
 """
 from __future__ import annotations
 import hashlib
+import hmac
 import json
 import secrets
 import time
 from datetime import datetime
 from threading import Lock
 
+from app.config import settings
 from app.database import (database, select, insert, update as sa_update,
                           delete as sa_delete, TableCompatApiKeys)
 
@@ -25,8 +27,18 @@ _cache: dict[str, tuple[float, dict | None]] = {}   # key_hash -> (expiry, rec|N
 _CACHE_TTL = 30.0
 
 
+def _key_hash_secret() -> bytes:
+    # Keyed digest (HMAC) rather than a bare SHA256 of the token: the stored
+    # key_hash is then useless without the instance secret, and it is the correct
+    # primitive for a server-held key. The token itself is a 256-bit CSPRNG value
+    # (see generate_token), so HMAC-SHA256 is more than sufficient. Read lazily so
+    # config is loaded. The key store is introduced in this release, so there are
+    # no pre-existing SHA256 hashes to migrate.
+    return (settings.general.flask_secret_key or "").encode()
+
+
 def hash_token(token: str) -> str:
-    return hashlib.sha256((token or "").encode()).hexdigest()
+    return hmac.new(_key_hash_secret(), (token or "").encode(), hashlib.sha256).hexdigest()
 
 
 def generate_token() -> tuple[str, str, str]:

--- a/bazarr/compat/keyring.py
+++ b/bazarr/compat/keyring.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import logging
 import secrets
 import time
 from datetime import datetime
@@ -20,6 +21,8 @@ from threading import Lock
 from app.config import settings
 from app.database import (database, select, insert, update as sa_update,
                           delete as sa_delete, TableCompatApiKeys)
+
+logger = logging.getLogger(__name__)
 
 _PREFIX = "bzr_"
 _cache_lock = Lock()
@@ -32,13 +35,19 @@ def _key_hash_secret() -> bytes:
     # key_hash is then useless without the instance secret, and it is the correct
     # primitive for a server-held key. The token itself is a 256-bit CSPRNG value
     # (see generate_token), so HMAC-SHA256 is more than sufficient. Read lazily so
-    # config is loaded. The key store is introduced in this release, so there are
-    # no pre-existing SHA256 hashes to migrate.
+    # config is loaded. Keys issued before this switch were stored under the bare
+    # SHA256 digest; resolve() accepts that legacy hash and migrates the row.
     return (settings.general.flask_secret_key or "").encode()
 
 
 def hash_token(token: str) -> str:
     return hmac.new(_key_hash_secret(), (token or "").encode(), hashlib.sha256).hexdigest()
+
+
+def _legacy_hash_token(token: str) -> str:
+    """The pre-HMAC bare SHA256 digest. Kept so named keys issued before the
+    HMAC switch keep authenticating; resolve() migrates them to HMAC on first use."""
+    return hashlib.sha256((token or "").encode()).hexdigest()
 
 
 def generate_token() -> tuple[str, str, str]:
@@ -92,6 +101,26 @@ def resolve(token: str) -> dict | None:
     row = database.execute(
         select(TableCompatApiKeys).where(TableCompatApiKeys.key_hash == h)
     ).scalar_one_or_none()
+    if row is None:
+        # Back-compat: a named key issued before the HMAC switch is stored under
+        # the legacy bare SHA256 hash, which cannot be migrated without the
+        # plaintext. Match it on the presented token, then re-store the row under
+        # the HMAC hash so future lookups hit the fast path and the weak digest
+        # is gone. Without this, every previously-issued key stops authenticating.
+        legacy_h = _legacy_hash_token(token)
+        if legacy_h != h:
+            row = database.execute(
+                select(TableCompatApiKeys).where(TableCompatApiKeys.key_hash == legacy_h)
+            ).scalar_one_or_none()
+            if row is not None:
+                try:
+                    database.execute(
+                        sa_update(TableCompatApiKeys)
+                        .where(TableCompatApiKeys.id == int(row.id))
+                        .values(key_hash=h))
+                    invalidate_cache()
+                except Exception:
+                    logger.debug("compat keyring: legacy hash migration failed", exc_info=True)
     rec = _row_to_dict(row) if (row is not None and int(row.enabled) == 1) else None
     with _cache_lock:
         _cache[h] = (now + _CACHE_TTL, rec)

--- a/bazarr/compat/limits.py
+++ b/bazarr/compat/limits.py
@@ -43,7 +43,15 @@ def check(key_rec: dict, kind: str) -> Decision:
         if limit <= 0:
             continue                       # unlimited for this window
         used = meter.window_sum(key_id, kind, w)
-        reset = now + _WINDOW_SECONDS[w]
+        # The meter rolls on hour-aligned buckets, so the soonest the count can
+        # change is the next hour boundary. For the hour window report that boundary
+        # instead of now+3600, which over-throttled a key capped at HH:59 by telling
+        # it to wait until ~HH+1:59 even though the bucket resets at HH+1:00. Coarser
+        # windows keep now+window.
+        if w == "hour":
+            reset = ((now // 3600) + 1) * 3600
+        else:
+            reset = now + _WINDOW_SECONDS[w]
         if used >= limit:
             return Decision(False, w, limit, 0, reset)
         remaining = limit - used

--- a/bazarr/compat/routes.py
+++ b/bazarr/compat/routes.py
@@ -269,7 +269,12 @@ def subtitles():
     # into a key that behaves identically to the clamped one).
     exclude_param = args.get("exclude_providers") or ""
     req_exclude = [p.strip() for p in exclude_param.split(",") if p.strip()]
-    eff_exclude = req_exclude or (key_rec.get("excluded_providers") or [])
+    # Always enforce the key's excluded_providers; a per-request exclude_providers
+    # can only ADD to them, never replace them. Otherwise a key scoped out of a
+    # provider could reach it just by sending a non-empty exclude list that omits
+    # the blocked provider.
+    key_exclude = key_rec.get("excluded_providers") or []
+    eff_exclude = list(dict.fromkeys([*key_exclude, *req_exclude]))
     # `only_providers` is tri-state by PRESENCE, not just content: a present-
     # but-empty param (?only_providers= or only commas/whitespace) is a
     # deliberate "select nothing" and stays active (-> data: []), distinct from
@@ -341,11 +346,24 @@ def download():
         return compat_error(f"unsupported sub_format: {sub_format}",
                             400, "bad-request")
 
+    key_rec = _current_key()
+
+    # Bind the file_id to this key's provider scope before spending quota. file_ids
+    # are process-wide monotonic ints, so a key walled off from a provider must not
+    # be able to reuse/guess an id minted under another key to fetch that provider's
+    # (or a local) result. Resolve the payload and reject (as not-found, to avoid
+    # leaking the id's existence) when its provider is outside this key's reach.
+    ok, fid_payload = auth.parse_file_id(fid_int)
+    if not ok:
+        return compat_error("subtitle not found", 404, "not_found")
+    fid_provider = "local" if fid_payload.get("kind") == "local" else fid_payload.get("p")
+    if not fid_provider or not _key_allows_provider(key_rec, fid_provider):
+        return compat_error("subtitle not found", 404, "not_found")
+
     # Distribution Hub: per-key download metering + limit (req #5, #6). The
     # download throttle keeps the OS-contract 406 (the Jellyfin plugin treats
     # this code as a quota signal). The Api-Key resolves the key on every
     # request, so g.compat_key is authoritative for whose quota is spent.
-    key_rec = _current_key()
     decision = limits.check(key_rec, "download")
     if not decision.allowed:
         _meter_blocked(key_rec, "download")
@@ -441,8 +459,16 @@ def providers():
     way the list a client sees is exactly the set it can select from - a provider
     the operator walled off for this key never appears.
     """
-    from app.config import settings
     key_rec = _current_key()
+    return jsonify({"data": [{"name": n} for n in _key_reachable_providers(key_rec)]})
+
+
+def _key_reachable_providers(key_rec) -> list[str]:
+    """Provider names THIS key may actually reach: the install's enabled providers
+    (plus the reserved `local` name when serve_local_subs is on), minus the key's
+    excluded_providers, intersected with allowed_providers when one is set. Used by
+    the /providers discovery route."""
+    from app.config import settings
     universe = service.available_providers()
     if bool(settings.compat_endpoint.serve_local_subs):
         universe = [*universe, "local"]
@@ -451,7 +477,25 @@ def providers():
     names = [p for p in universe if p not in excluded]
     if allowed:
         names = [p for p in names if p in allowed]
-    return jsonify({"data": [{"name": n} for n in names]})
+    return names
+
+
+def _key_allows_provider(key_rec, provider: str) -> bool:
+    """Whether this key's allow/exclude POLICY permits a result from `provider`
+    (or the reserved `local`). Backs the /download file_id scope check. Checks
+    policy only, not current availability: a stale file_id for a now-disabled
+    provider fails later at fetch, and the security boundary here is the key's
+    allow/exclude, not the live provider set."""
+    from app.config import settings
+    if provider == "local" and not bool(settings.compat_endpoint.serve_local_subs):
+        return False
+    excluded = {str(p).strip() for p in (key_rec.get("excluded_providers") or [])}
+    allowed = {str(p).strip() for p in (key_rec.get("allowed_providers") or [])}
+    if provider in excluded:
+        return False
+    if allowed and provider not in allowed:
+        return False
+    return True
 
 
 @compat_bp.route("/utilities/guessit", methods=["POST"])

--- a/bazarr/compat/routes.py
+++ b/bazarr/compat/routes.py
@@ -26,6 +26,27 @@ from .auth import compat_auth  # noqa: E402
 
 _SUPPORTED_SUB_FORMATS = frozenset({"srt"})
 
+# Per-key admission lock: limits.check (read) and meter.record (write) must run as
+# one atomic step, or concurrent requests from the same key all read the same
+# pre-increment usage and admit past the limit. meter.record invalidates the
+# sum cache, so under this lock each request sees the prior request's increment.
+# Different keys never contend; the critical section is just a DB read+write
+# (the provider fanout / download happen outside it).
+from threading import Lock as _Lock  # noqa: E402
+
+_admission_locks_guard = _Lock()
+_admission_locks: dict[int, "_Lock"] = {}
+
+
+def _admission_lock(key_rec: dict):
+    kid = int(key_rec.get("id") or 0)
+    with _admission_locks_guard:
+        lk = _admission_locks.get(kid)
+        if lk is None:
+            lk = _Lock()
+            _admission_locks[kid] = lk
+    return lk
+
 
 def _current_key() -> dict:
     """The key record stashed by compat_auth (always set on authed routes)."""
@@ -250,17 +271,18 @@ def subtitles():
     # Distribution Hub: meter + rate-limit search per API key (req #3, #5, #6).
     from app.config import settings
     key_rec = _current_key()
-    if bool(settings.compat_endpoint.search_rate_limit_enabled):
-        decision = limits.check(key_rec, "search")
-        if not decision.allowed:
-            _meter_blocked(key_rec, "search")
-            return _throttle_response("search", decision)
-
     # The request is admitted: meter it now, before the fanout. Metering on
     # admission (not on success) means a provider outage or empty result still
     # counts against the key's quota, so failing searches can't be spammed to
-    # evade the rate limit.
-    _meter_ok(key_rec, "search")
+    # evade the rate limit. check + record run under the per-key lock so a
+    # concurrent burst from one key cannot all admit past the limit.
+    with _admission_lock(key_rec):
+        if bool(settings.compat_endpoint.search_rate_limit_enabled):
+            decision = limits.check(key_rec, "search")
+            if not decision.allowed:
+                _meter_blocked(key_rec, "search")
+                return _throttle_response("search", decision)
+        _meter_ok(key_rec, "search")
 
     # Per-request provider exclusion + timeout, falling back to the key's
     # configured defaults (req #1, #2). Clamp the timeout to the same [5, 120]
@@ -364,14 +386,20 @@ def download():
     # download throttle keeps the OS-contract 406 (the Jellyfin plugin treats
     # this code as a quota signal). The Api-Key resolves the key on every
     # request, so g.compat_key is authoritative for whose quota is spent.
-    decision = limits.check(key_rec, "download")
-    if not decision.allowed:
-        _meter_blocked(key_rec, "download")
-        resp = jsonify({"message": "download quota exhausted",
-                        "reset_time_utc": _iso_utc(int(decision.reset_epoch))})
-        resp.status_code = 406
-        resp.headers["x-reason"] = "throttled"
-        return resp
+    # check + consume run under the per-key lock so a concurrent burst from one
+    # key cannot all admit past the download limit. The actual download (token
+    # mint) happens outside the lock.
+    with _admission_lock(key_rec):
+        decision = limits.check(key_rec, "download")
+        if not decision.allowed:
+            _meter_blocked(key_rec, "download")
+            resp = jsonify({"message": "download quota exhausted",
+                            "reset_time_utc": _iso_utc(int(decision.reset_epoch))})
+            resp.status_code = 406
+            resp.headers["x-reason"] = "throttled"
+            return resp
+        # Admitted: consume the quota now, atomically with the check.
+        _meter_ok(key_rec, "download")
 
     try:
         scheme, host = _infer_client_base(request)
@@ -380,7 +408,6 @@ def download():
         else:
             base_host = request.host_url.rstrip("/")
         # Compute the post-consume remaining for the displayed quota.
-        _meter_ok(key_rec, "download")
         _allowed, remaining, reset = _display_download_quota(key_rec)
         resp = service.download(fid_int, base_host=base_host,
                                 remaining=remaining,

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -188,7 +188,7 @@ def candidate_from_worker(provider_name: str, payload: dict[str, Any]) -> HubWor
     return subtitle
 
 
-_SUBTITLE_FORMATS = {"srt": "srt", "ass": "ass", "ssa": "ass", "vtt": "vtt", "sub": "sub"}
+_SUBTITLE_FORMATS = {"srt": "srt", "ass": "ass", "ssa": "ass", "vtt": "vtt", "sub": "microdvd"}
 
 
 def _format_from_member(name: str | None) -> str | None:
@@ -416,7 +416,11 @@ def _worker_archive_to_content(
         chosen = payload.get("filename") or ""
 
     subtitle.content = content
-    subtitle.format = payload.get("format") or _format_from_member(chosen) or getattr(subtitle, "format", "srt")
+    # Prefer the chosen member's actual extension over a worker-supplied format:
+    # the worker's format can be stale/wrong (e.g. an SRT member labeled "vtt"),
+    # which would otherwise save SRT bytes to a .vtt file. Fall back to the
+    # worker format, then the existing one.
+    subtitle.format = _format_from_member(chosen) or payload.get("format") or getattr(subtitle, "format", "srt")
     # Clear any encoding carried over from search (e.g. via the display attribute splat)
     # so Subtitle.normalize()/chardet detects it from the extracted bytes, the same as
     # native subliminal providers; do not let a stale or worker-supplied guess pin it.

--- a/bazarr/provider_hub/service.py
+++ b/bazarr/provider_hub/service.py
@@ -14,7 +14,7 @@ import zipfile
 import requests
 
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 from urllib.parse import urlparse
 
@@ -1055,8 +1055,16 @@ def _safe_extract_zip(archive_bytes: bytes, dest: Path) -> None:
             name = member.filename
             if not name or name.endswith("/"):
                 continue
-            target = (dest / name).resolve()
-            if target != dest_root and dest_root not in target.parents:
+            # Reject absolute paths and any traversal before joining, then confirm
+            # the resolved target stays under dest_root (zip-slip containment that
+            # CodeQL recognizes as a barrier on the member name).
+            member_path = PurePosixPath(name)
+            if member_path.is_absolute() or ".." in member_path.parts:
+                raise ProviderHubInstallError(f"unsafe path in package: {name}")
+            target = dest_root.joinpath(*member_path.parts).resolve()
+            try:
+                target.relative_to(dest_root)
+            except ValueError:
                 raise ProviderHubInstallError(f"unsafe path in package: {name}")
             target.parent.mkdir(parents=True, exist_ok=True)
             try:

--- a/bazarr/provider_hub/worker.py
+++ b/bazarr/provider_hub/worker.py
@@ -75,6 +75,7 @@ class ProviderWorkerClient:
         self._lock = threading.Lock()
         self._stdout_queue: queue.Queue[Any] | None = None
         self._stdout_thread: threading.Thread | None = None
+        self._stderr_thread: threading.Thread | None = None
 
     def start(self) -> None:
         if self.process and self.process.poll() is None:
@@ -105,6 +106,15 @@ class ProviderWorkerClient:
             daemon=True,
         )
         self._stdout_thread.start()
+        # Continuously drain stderr too: the worker writes tracebacks there, and an
+        # undrained pipe can fill before the worker writes its JSON error to stdout,
+        # blocking the worker until the request times out. Drain + log instead.
+        self._stderr_thread = threading.Thread(
+            target=self._drain_stderr,
+            args=(self.process,),
+            daemon=True,
+        )
+        self._stderr_thread.start()
 
     @staticmethod
     def _enqueue_stdout(process: subprocess.Popen, stdout_queue: queue.Queue[Any]) -> None:
@@ -131,6 +141,22 @@ class ProviderWorkerClient:
                     line_len = 0
         finally:
             stdout_queue.put(None)
+
+    @staticmethod
+    def _drain_stderr(process: subprocess.Popen) -> None:
+        """Drain the worker's stderr so a large or repeated traceback can never
+        fill the pipe buffer and block the worker before it writes its JSON error
+        to stdout. Surfaces the diagnostics in the host log (per-line capped)."""
+        stderr = process.stderr
+        if stderr is None:
+            return
+        try:
+            for line in stderr:
+                line = line.rstrip("\n")
+                if line:
+                    logging.debug("provider-worker stderr: %s", line[:2000])
+        except Exception:
+            pass
 
     def stop(self, grace_seconds: float = 5.0) -> None:
         process = self.process

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -286,6 +286,13 @@ def list_missing_subtitles_movies(no=None):
                     lang = subtitles[0]
                     forced = False
                     hi = False
+                    # A combined artifact (e.g. en:combined-hu) is a bilingual
+                    # stacked file, not a standalone subtitle of its base language,
+                    # so it must not count toward fulfilling that language. Without
+                    # this, removing the plain en while a combined remains left
+                    # Bazarr believing en was satisfied and it stopped searching.
+                    if any(p.startswith('combined-') for p in subtitles[1:]):
+                        continue
                     if len(subtitles) > 1:
                         if subtitles[1] == 'forced':
                             forced = True

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -288,6 +288,13 @@ def list_missing_subtitles(no=None, epno=None):
                     lang = subtitles[0]
                     forced = False
                     hi = False
+                    # A combined artifact (e.g. en:combined-hu) is a bilingual
+                    # stacked file, not a standalone subtitle of its base language,
+                    # so it must not count toward fulfilling that language. Without
+                    # this, removing the plain en while a combined remains left
+                    # Bazarr believing en was satisfied and it stopped searching.
+                    if any(p.startswith('combined-') for p in subtitles[1:]):
+                        continue
                     if len(subtitles) > 1:
                         if subtitles[1] == 'forced':
                             forced = True

--- a/bazarr/subtitles/mass_operations.py
+++ b/bazarr/subtitles/mass_operations.py
@@ -221,7 +221,14 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
                 skipped += 1
                 continue
 
-            if action == 'sync' and is_sync_engine_output(mapped_sub_path):
+            # Never use a generated sync output or a combined artifact as a source.
+            # For translate they would queue a duplicate job targeting the same
+            # output language/file as the real subtitle (e.g. en + en:sync-ffsubsync
+            # both translate-from en), causing duplicate work and overwrite races; a
+            # sync output also cannot be meaningfully re-synced.
+            modifiers = [p.lower() for p in lang_string.split(':')[1:]]
+            is_combined = any(m.startswith('combined-') for m in modifiers)
+            if action in ('sync', 'translate') and (is_sync_engine_output(mapped_sub_path) or is_combined):
                 skipped += 1
                 continue
 
@@ -312,7 +319,14 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
                 skipped += 1
                 continue
 
-            if action == 'sync' and is_sync_engine_output(mapped_sub_path):
+            # Never use a generated sync output or a combined artifact as a source.
+            # For translate they would queue a duplicate job targeting the same
+            # output language/file as the real subtitle (e.g. en + en:sync-ffsubsync
+            # both translate-from en), causing duplicate work and overwrite races; a
+            # sync output also cannot be meaningfully re-synced.
+            modifiers = [p.lower() for p in lang_string.split(':')[1:]]
+            is_combined = any(m.startswith('combined-') for m in modifiers)
+            if action in ('sync', 'translate') and (is_sync_engine_output(mapped_sub_path) or is_combined):
                 skipped += 1
                 continue
 

--- a/bazarr/subtitles/tools/combine/composer.py
+++ b/bazarr/subtitles/tools/combine/composer.py
@@ -9,6 +9,21 @@ import pysubs2
 from .aligner import detect_mode
 
 
+def _load_subtitle(path):
+    """Load a subtitle, detecting its on-disk encoding rather than assuming UTF-8.
+    Bazarr indexes legacy-encoded externals (Windows-1250/1252, Latin-1) elsewhere,
+    and a hard utf-8 load raised UnicodeDecodeError and failed the whole combine."""
+    encoding = "utf-8"
+    try:
+        from charset_normalizer import from_path
+        match = from_path(path).best()
+        if match and match.encoding:
+            encoding = match.encoding
+    except Exception:
+        logging.debug("BAZARR combine could not detect encoding for %s, using utf-8", path)
+    return pysubs2.load(path, encoding=encoding)
+
+
 def compose(primary_path, secondary_paths, format):
     """Compose primary + 1-2 secondaries into one SRT or ASS file.
 
@@ -20,8 +35,8 @@ def compose(primary_path, secondary_paths, format):
     if not secondary_paths or len(secondary_paths) > 2:
         raise ValueError("secondary_paths must have 1 or 2 entries")
 
-    primary = pysubs2.load(primary_path, encoding="utf-8")
-    secondaries = [pysubs2.load(p, encoding="utf-8") for p in secondary_paths]
+    primary = _load_subtitle(primary_path)
+    secondaries = [_load_subtitle(p) for p in secondary_paths]
 
     modes = []
     aligned_secondaries = []

--- a/bazarr/subtitles/tools/combine/main.py
+++ b/bazarr/subtitles/tools/combine/main.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import dataclass
 
 from .composer import compose
-from .naming import compose_combined_filename
+from .naming import compose_combined_filename, external_subtitles_dir
 from .rules import resolve_source_paths
 
 _TWO_LETTER_RE = re.compile(r"^[a-z]{2}$")
@@ -79,6 +79,18 @@ def try_combine_for_video(video_path, media_type, sonarr_series_id=None,
             format=rule["format"],
         )
 
+        # Path-injection barrier: the combined filename is built from the DB video
+        # path plus already-validated 2-letter language codes, so it must resolve
+        # inside this video's external-subtitles directory. Re-assert it here so a
+        # crafted code can never steer makedirs/open/remove outside that folder.
+        safe_root = os.path.realpath(external_subtitles_dir(video_path))
+        out_path = os.path.realpath(out_path)
+        if os.path.commonpath([safe_root, out_path]) != safe_root:
+            return CombineResult(
+                status="failed",
+                error=f"combined output path escaped the subtitles directory: {out_path!r}",
+            )
+
         try:
             content = compose(
                 primary_path=sources.primary,
@@ -108,7 +120,7 @@ def try_combine_for_video(video_path, media_type, sonarr_series_id=None,
         # changes or a rebuild switches format) before re-indexing, so the same
         # combined language is not indexed twice and the editor does not load a
         # stale positioned ASS as overlapping cues.
-        _remove_stale_combined_siblings(out_path)
+        _remove_stale_combined_siblings(out_path, video_path)
 
         _post_write(out_path, video_path, media_type,
                      sonarr_episode_id, radarr_id)
@@ -125,16 +137,25 @@ def try_combine_for_video(video_path, media_type, sonarr_series_id=None,
 _COMBINED_OUTPUT_EXTS = (".srt", ".ass", ".ssa")
 
 
-def _remove_stale_combined_siblings(out_path):
+def _remove_stale_combined_siblings(out_path, video_path):
     """Remove combined-output siblings that share this output's stem but use a
     different subtitle extension (e.g. a stale `.ass` left next to a freshly
-    written `.srt`). Best-effort: never raises."""
-    root, _ext = os.path.splitext(out_path)
+    written `.srt`). Best-effort: never raises.
+
+    Safety: only operate inside this video's external-subtitles directory, so a
+    crafted output path can never steer os.remove outside that folder."""
+    safe_dir = os.path.realpath(external_subtitles_dir(video_path))
+    out_real = os.path.realpath(out_path)
+    if os.path.dirname(out_real) != safe_dir:
+        return
+    root, _ext = os.path.splitext(out_real)
     for ext in _COMBINED_OUTPUT_EXTS:
-        sibling = root + ext
-        if sibling == out_path:
+        sibling = os.path.realpath(root + ext)
+        if sibling == out_real:
             continue
         try:
+            if os.path.commonpath([safe_dir, sibling]) != safe_dir:
+                continue
             if os.path.isfile(sibling):
                 os.remove(sibling)
                 logging.info("BAZARR combine removed stale sibling %s", sibling)

--- a/bazarr/subtitles/tools/translate/batch.py
+++ b/bazarr/subtitles/tools/translate/batch.py
@@ -448,7 +448,16 @@ def extract_embedded_subtitle(
 
     extract_dir = os.path.join(bazarr_args.config_dir, "extracted_subs")
     os.makedirs(extract_dir, exist_ok=True)
-    video_hash = hashlib.md5(video_path.encode()).hexdigest()
+    # Key the cache on the video's identity (path + size + mtime), not just the
+    # path: a replaced/upgraded file at the same path would otherwise reuse the
+    # previous video's extracted subtitle (stale text), the exact upgrade case
+    # embedded translation targets.
+    try:
+        _st = os.stat(video_path)
+        _identity = f"{video_path}:{_st.st_size}:{int(_st.st_mtime)}"
+    except OSError:
+        _identity = video_path
+    video_hash = hashlib.md5(_identity.encode()).hexdigest()
     suffix = ""
     if hi:
         suffix += ".hi"

--- a/bazarr/subtitles/tools/translate/main.py
+++ b/bazarr/subtitles/tools/translate/main.py
@@ -80,6 +80,23 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
         # Call postprocess_subtitles after translation (handles chmod, re-indexing, events)
         postprocess_subtitles(dest_srt_file, video_path, media_type, metadata, sonarr_episode_id if media_type == 'episode' else radarr_id)
 
+        # The translated file is now on disk. The download-time combine ran before
+        # this async translation finished (so it skipped, source missing); build or
+        # refresh the combined output now if the profile rule's sources are all
+        # present. try_combine_for_video is best-effort and _profile_for accepts the
+        # 'episode'/'movies'/'movie' media_type this path uses.
+        try:
+            from subtitles.tools.combine.main import try_combine_for_video
+            try_combine_for_video(
+                video_path=video_path,
+                media_type=media_type,
+                sonarr_series_id=sonarr_series_id,
+                sonarr_episode_id=sonarr_episode_id,
+                radarr_id=radarr_id,
+            )
+        except Exception:
+            logging.exception("BAZARR combine-after-translate failed for %s", video_path)
+
         # Get current job name (which batch.py already set with title) and mark as done
         current_name = jobs_queue.get_job_name(job_id)
         if current_name and 'Translating' in current_name:

--- a/frontend/src/apis/hooks/combine.ts
+++ b/frontend/src/apis/hooks/combine.ts
@@ -37,9 +37,16 @@ export function useCombineSubtitles() {
           });
           break;
         case "episode":
+          // The single-episode cache is keyed [Episodes, episodeId], but the
+          // episodes table is keyed [Series, seriesId, Episodes, All], which the
+          // former does not prefix-match, so the new combined subtitle stayed
+          // invisible until a broader refetch. The episode scope carries no
+          // seriesId, so invalidate the Series tree too; only the active series'
+          // episode query refetches immediately, the rest just go stale.
           void qc.invalidateQueries({
             queryKey: [QueryKeys.Episodes, variables.scope.episodeId],
           });
+          void qc.invalidateQueries({ queryKey: [QueryKeys.Series] });
           break;
         case "series":
           void qc.invalidateQueries({

--- a/frontend/src/apis/raw/base.ts
+++ b/frontend/src/apis/raw/base.ts
@@ -20,8 +20,11 @@ class BaseApi {
           } else {
             form.append(key, "");
           }
-        } else {
-          form.append(key, object[key]);
+        } else if (data !== undefined && data !== null) {
+          // Skip undefined/null so an optional field (e.g. from_language on a
+          // non-embedded translate) is omitted rather than appended as the literal
+          // string "undefined", which the backend would reject.
+          form.append(key, data);
         }
       }
       return form;

--- a/frontend/src/components/forms/ProfileEditForm.tsx
+++ b/frontend/src/components/forms/ProfileEditForm.tsx
@@ -89,7 +89,10 @@ const CombineRuleEditor: FunctionComponent<CombineRuleEditorProps> = ({
 }) => {
   const enabled = value != null;
   const itemCodes = useMemo(
-    () => items.map((it) => it.language).filter(Boolean),
+    // Deduplicate base language codes: a profile with normal + forced/HI English
+    // yields ['en','en'], and seeding a combine rule with duplicate languages is
+    // rejected by validate_combine_rule, leaving the rule inert (no auto-combine).
+    () => [...new Set(items.map((it) => it.language).filter(Boolean))],
     [items],
   );
 

--- a/frontend/src/pages/SubtitleEditor/document.ts
+++ b/frontend/src/pages/SubtitleEditor/document.ts
@@ -525,19 +525,37 @@ export function computeCueWarnings(
   if (cue.endMs < cue.startMs) {
     return { level: "red", message: "End time is before start time" };
   }
-  // Combined outputs stack each language as its own cue at the same timestamp,
-  // so a same-timestamp "overlap" is intentional, not an error.
-  if (!combined && prevCue && cue.startMs < prevCue.endMs) {
+  // Combined outputs stack each language as its own cue at the SAME start, so a
+  // same-start overlap is intentional; a genuine overlap (different start that
+  // still runs into the previous cue) is a real error and must still flag.
+  if (
+    prevCue &&
+    cue.startMs < prevCue.endMs &&
+    !(combined && cue.startMs === prevCue.startMs)
+  ) {
     return { level: "red", message: "Overlaps with previous cue" };
   }
   if (cue.text.trim() === "") {
     return { level: "red", message: "Empty text" };
   }
 
-  // A combined subtitle is a composed artifact: per-line CPS, length, and
-  // line-count heuristics do not apply (each cue holds one language line, and
-  // the languages stack at shared timestamps).
+  // A combined subtitle stacks one language per line at shared timestamps, so the
+  // per-line CPS, length, and line-count heuristics do not apply. The duration
+  // checks still do (a too-short or over-long combined cue is a real timing
+  // issue), so run only those for combined rather than skipping QC entirely.
   if (combined) {
+    if (durationMs < preset.minDurationMs && durationMs > 0) {
+      return {
+        level: "orange",
+        message: `Duration too short (${durationMs.toFixed(0)}ms, min ${preset.minDurationMs}ms)`,
+      };
+    }
+    if (durationMs > preset.maxDurationMs) {
+      return {
+        level: "yellow",
+        message: `Duration too long (${durationSec.toFixed(1)}s, max ${(preset.maxDurationMs / 1000).toFixed(1)}s)`,
+      };
+    }
     return null;
   }
 

--- a/tests/compat/unit/test_dist_keyring.py
+++ b/tests/compat/unit/test_dist_keyring.py
@@ -17,6 +17,30 @@ def test_generate_and_resolve(compat_db):
     assert keyring.resolve("") is None
 
 
+def test_legacy_sha256_hash_resolves_and_migrates(compat_db):
+    """A key issued before the HMAC switch (stored under the bare SHA256 hash)
+    must still authenticate, and resolve() migrates its stored hash to HMAC."""
+    from compat import keyring
+    from app.database import database, select, update as sa_update, TableCompatApiKeys
+    kid, token = keyring.create("legacy-site", tier="pro")
+    legacy_h = keyring._legacy_hash_token(token)
+    assert legacy_h != keyring.hash_token(token)
+    # Simulate the pre-HMAC stored hash.
+    database.execute(sa_update(TableCompatApiKeys)
+                     .where(TableCompatApiKeys.id == kid)
+                     .values(key_hash=legacy_h))
+    keyring.invalidate_cache()
+    # Resolves via the legacy fallback...
+    rec = keyring.resolve(token)
+    assert rec and rec["id"] == kid and rec["tier"] == "pro"
+    # ...and migrates the stored hash forward to the HMAC digest.
+    keyring.invalidate_cache()
+    stored = database.execute(
+        select(TableCompatApiKeys.key_hash).where(TableCompatApiKeys.id == kid)
+    ).scalar_one()
+    assert stored == keyring.hash_token(token)
+
+
 def test_resolve_returns_prefix_not_token(compat_db):
     from compat import keyring
     kid, token = keyring.create("site-prefix")


### PR DESCRIPTION
Resolves all 9 CodeQL high-severity alerts surfaced on the v2.4.0 release diff (each adversarially verified non-exploitable first; these are defense-in-depth + make the checks green). keyring -> HMAC-SHA256 (keyed; new key store, no migration); provider_hub local zip -> reject absolute/.. + relative_to(dest_root); combine -> realpath+commonpath containment; subtitles chmod -> contain to the video's subtitle folder. ruff clean; 125 targeted tests pass.