### PR TITLE
fix(provider-hub): persist release-augmented matches so hub subtitles score consistently

### DIFF
--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -72,7 +72,12 @@ class HubWorkerSubtitle(Subtitle):
                 logger.debug(
                     "provider_hub: release-based match update failed", exc_info=True
                 )
-        self.matches = matches
+        # Cache an independent copy, NOT the returned object: compute_score mutates the
+        # set it is handed in place (adds hearing_impaired and equivalent matches), and
+        # the caller passes our return value straight to it. Sharing the object would
+        # leak those scoring-only mutations into the download-phase cache (e.g. bypassing
+        # a force-HI skip). The cache is the release-augmented, pre-scoring set.
+        self.matches = set(matches)
         return matches
 
 

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -50,7 +50,18 @@ class HubWorkerSubtitle(Subtitle):
         return self.worker_id
 
     def get_matches(self, video):
-        matches = set(self.matches or set())
+        # The worker sends a lean match set (self.matches); the release-info matches are
+        # computed here, in the host, against the real video. Derive from a frozen base so
+        # repeat calls are idempotent, then PERSIST the augmented set back onto self.matches.
+        # download_best_subtitles reuses the cached subtitle.matches instead of re-calling
+        # get_matches, so without this write it would score hub subtitles on the lean set
+        # only - under-scoring them and disagreeing with the listing phase that scores via
+        # get_matches (which mis-fires the 'language satisfied' early-exit).
+        base = getattr(self, "_worker_matches", None)
+        if base is None:
+            base = set(self.matches or set())
+            self._worker_matches = base
+        matches = set(base)
         release_info = getattr(self, "release_info", None)
         if release_info:
             try:
@@ -61,6 +72,7 @@ class HubWorkerSubtitle(Subtitle):
                 logger.debug(
                     "provider_hub: release-based match update failed", exc_info=True
                 )
+        self.matches = matches
         return matches
 
 

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -316,6 +316,51 @@ def test_worker_protocol_round_trips_language_video_and_download_payload():
     assert candidate.content == content
 
 
+def test_hub_subtitle_release_matches_persist_for_download_scoring():
+    """Regression: the listing phase (list_subtitles_prioritized) scores a candidate
+    via get_matches(), which augments the worker's lean matches with release-info
+    matches; the download phase (download_best_subtitles) instead reuses the cached
+    subtitle.matches. If get_matches doesn't persist the augmented set, the two phases
+    score the SAME subtitle differently: listing sees the release matches and may flag
+    the language 'satisfied' (early-exit), while download re-reads the lean cache,
+    under-scores the subtitle, and rejects it. Net effect: search stops on a candidate
+    download then discards. get_matches must persist the augmented matches so the cache
+    download reads matches what listing scored."""
+    from provider_hub.protocol import candidate_from_worker, language_to_payload
+
+    movie = Movie(
+        "/media/Clue.1985.1080p.BluRay.Remux.AVC.DTS-HD.MA.mkv",
+        "Clue",
+        year=1985,
+        source="Blu-ray",
+        video_codec="H.264",
+        imdb_id="tt0088930",
+    )
+    candidate = candidate_from_worker(
+        provider_name="opensubtitles",
+        payload={
+            "provider": "opensubtitles",
+            "id": "sub-clue",
+            "language": language_to_payload(Language("hun")),
+            "release_info": "Clue 1985 720p BluRay x264 EbP",
+            "matches": ["title", "year", "imdb_id"],  # lean worker-computed set
+            "provider_payload": {"provider": "opensubtitles", "schema": 1},
+        },
+    )
+    worker_matches = set(candidate.matches)
+
+    # Listing phase: get_matches augments the worker set with release-based matches.
+    listing_matches = candidate.get_matches(movie)
+    assert listing_matches > worker_matches, (
+        "release_info should add at least one match (e.g. source/video_codec); "
+        f"got {listing_matches} from base {worker_matches}"
+    )
+
+    # Download phase reads the cached candidate.matches. It MUST equal the set the
+    # listing phase scored, or the two phases disagree and the early-exit misfires.
+    assert candidate.matches == listing_matches
+
+
 def _hub_candidate(worker_id="sub-arch"):
     from provider_hub.protocol import candidate_from_worker, language_to_payload
 

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -360,6 +360,17 @@ def test_hub_subtitle_release_matches_persist_for_download_scoring():
     # listing phase scored, or the two phases disagree and the early-exit misfires.
     assert candidate.matches == listing_matches
 
+    # The returned set is handed straight to compute_score, which mutates it in place
+    # (adds hearing_impaired and equivalent matches). Those scoring-only mutations must
+    # NOT leak into the cached candidate.matches the download phase reads, or e.g. a
+    # force-HI skip in download_best_subtitles can be bypassed. The cache must be an
+    # independent copy, not the same object handed to scoring.
+    assert "hearing_impaired" not in listing_matches  # guard: not added by get_matches
+    listing_matches.add("hearing_impaired")
+    assert "hearing_impaired" not in candidate.matches, (
+        "scoring mutations on the returned set leaked into the cached matches"
+    )
+
 
 def _hub_candidate(worker_id="sub-arch"):
     from provider_hub.protocol import candidate_from_worker, language_to_payload


### PR DESCRIPTION
## Problem

A manual/auto subtitle search would stop after the first provider that returned *any* candidate for a language, then report "no subtitles found" even when that candidate looked like a strong match. Reproduced on the test server with **Clue (1985)** (Hungarian): the search stopped after OpenSubtitles and downloaded nothing.

## Root cause

`HubWorkerSubtitle.get_matches()` starts from the worker-provided lean match set (`self.matches`, e.g. `{title, year, imdb_id}`), augments it with release-info matches (`source`, `edition`, `video_codec`, ...) computed host-side against the real video, and returns the union, **but never writes the augmented set back to `self.matches`**.

The two scoring phases then disagree for hub-provider subtitles:

- **Listing** (`list_subtitles_prioritized`) scores via `get_matches()` and sees the **augmented** set (Clue: score 163) -> marks the language "satisfied" -> early-exits.
- **Download** (`download_best_subtitles`) reuses the cached `self.matches` and sees only the **lean** set (Clue: score 101) -> below the 70% `min_score` (126/180) -> rejected.

Net effect: the search stops on a candidate that download then discards, and hub-provider subtitles are systematically under-scored at acceptance time (their release matches are dropped).

## Fix

Persist the release-augmented matches onto `self.matches` in `get_matches()`, derived from a frozen worker base so repeat calls stay idempotent. The cached set that `download_best_subtitles` reads now equals what the listing phase scored. Hub subtitles carry their release matches into acceptance scoring, the satisfied/early-exit decision agrees with the download decision, and a genuinely good match is downloaded instead of discarded.

## Verification

- TDD: added `test_hub_subtitle_release_matches_persist_for_download_scoring` (RED before fix: `self.matches` stayed lean while `get_matches` returned the augmented set; GREEN after).
- `ruff check .` clean; `tests/bazarr/test_provider_hub.py` 138/138.
- End-to-end on the test server: Clue (1985) HU now scores **163 in both phases** and downloads (`Saving ... Clue.1985...HuN-Sm.hu.srt`). Previously 163 listing / 101 download -> rejected.

No change to non-hub providers (they do not pre-populate `self.matches`, so they already scored via `get_matches` in both phases).