### PR TITLE
docs: note host-networking FlareSolverr URL across guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Encryption covers both the disk surface (the credentials above, at rest) and key
 ### OpenSubtitles.org (Native Provider Hub Plugin)
 OpenSubtitles.org shut down their XML-RPC API for all third-party apps, VIP included. In v2.4, OpenSubtitles.org is a native Provider Hub plugin. Install "OpenSubtitles.org" from the Provider Hub Marketplace and it scrapes the site in-process using `ai-cloudscraper`, solving the Anubis proof-of-work challenge inline. There is no separate microservice or sidecar container anymore. No API key or VIP subscription needed.
 
-FlareSolverr is strongly recommended. Run a FlareSolverr container and set its `/v1` endpoint in the plugin's **FlareSolverr URL** setting. FlareSolverr is used as a fallback to solve Cloudflare browser challenges when `ai-cloudscraper` is itself challenged. The plugin exposes `flaresolverr_url` and `flaresolverr_timeout_ms` settings. Use `http://flaresolverr:8191/v1` when Bazarr+ and FlareSolverr share a Docker network (the Compose default below), or `http://localhost:8191/v1` if you run Bazarr+ with host networking.
+FlareSolverr is strongly recommended. Run a FlareSolverr container and set its `/v1` endpoint in the plugin's **FlareSolverr URL** setting. FlareSolverr is used as a fallback to solve Cloudflare browser challenges when `ai-cloudscraper` is itself challenged. The plugin exposes `flaresolverr_url` and `flaresolverr_timeout_ms` settings. Use `http://flaresolverr:8191/v1` when Bazarr+ and FlareSolverr share a Docker network (the Compose default below), or `http://localhost:8191/v1` if you run Bazarr+ with host networking (in which case also publish FlareSolverr's `8191:8191` port, or run it on host networking too, so 8191 is reachable on the host loopback).
 
 ### Provider Priority
 Upstream Bazarr queries all subtitle providers simultaneously and picks the highest-scored result. There's no way to prefer one provider over another. This has been [requested for 6 years](https://bazarr.featureupvote.com/suggestions/112323/provider-prioritization) (62 votes), but upstream rejected it as "won't happen," calling it a "major rework" that "would take months of development."
@@ -477,7 +477,7 @@ curl -s -X POST http://localhost:8191/v1 \
 docker logs flaresolverr
 ```
 
-Then confirm the plugin's **FlareSolverr URL** in Settings > Providers: `http://flaresolverr:8191/v1` when Bazarr+ and FlareSolverr share a Docker network, or `http://localhost:8191/v1` if Bazarr+ runs with host networking. A `Name or service not known` error means the `flaresolverr` hostname can't be resolved, which is what happens under host networking; switch the URL to `localhost`.
+Then confirm the plugin's **FlareSolverr URL** in Settings > Providers: `http://flaresolverr:8191/v1` when Bazarr+ and FlareSolverr share a Docker network, or `http://localhost:8191/v1` if Bazarr+ runs with host networking. A `Name or service not known` error means the `flaresolverr` hostname can't be resolved, which is what happens under host networking; switch the URL to `localhost`. If `localhost` then gives a connection error, FlareSolverr's port isn't reachable on the host: publish `8191:8191` on the FlareSolverr service or run it with host networking too.
 
 ### Common Issues
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Encryption covers both the disk surface (the credentials above, at rest) and key
 ### OpenSubtitles.org (Native Provider Hub Plugin)
 OpenSubtitles.org shut down their XML-RPC API for all third-party apps, VIP included. In v2.4, OpenSubtitles.org is a native Provider Hub plugin. Install "OpenSubtitles.org" from the Provider Hub Marketplace and it scrapes the site in-process using `ai-cloudscraper`, solving the Anubis proof-of-work challenge inline. There is no separate microservice or sidecar container anymore. No API key or VIP subscription needed.
 
-FlareSolverr is strongly recommended. Run a FlareSolverr container and set its `/v1` endpoint in the plugin's **FlareSolverr URL** setting. FlareSolverr is used as a fallback to solve Cloudflare browser challenges when `ai-cloudscraper` is itself challenged. The plugin exposes `flaresolverr_url` and `flaresolverr_timeout_ms` settings.
+FlareSolverr is strongly recommended. Run a FlareSolverr container and set its `/v1` endpoint in the plugin's **FlareSolverr URL** setting. FlareSolverr is used as a fallback to solve Cloudflare browser challenges when `ai-cloudscraper` is itself challenged. The plugin exposes `flaresolverr_url` and `flaresolverr_timeout_ms` settings. Use `http://flaresolverr:8191/v1` when Bazarr+ and FlareSolverr share a Docker network (the Compose default below), or `http://localhost:8191/v1` if you run Bazarr+ with host networking.
 
 ### Provider Priority
 Upstream Bazarr queries all subtitle providers simultaneously and picks the highest-scored result. There's no way to prefer one provider over another. This has been [requested for 6 years](https://bazarr.featureupvote.com/suggestions/112323/provider-prioritization) (62 votes), but upstream rejected it as "won't happen," calling it a "major rework" that "would take months of development."
@@ -336,7 +336,8 @@ services:
   # FlareSolverr - recommended for the OpenSubtitles.org plugin.
   # Solves Cloudflare browser challenges when ai-cloudscraper is itself
   # challenged. Set http://flaresolverr:8191/v1 as the FlareSolverr URL
-  # in the OpenSubtitles.org plugin settings.
+  # in the OpenSubtitles.org plugin settings (or http://localhost:8191/v1
+  # if you run Bazarr with host networking).
   flaresolverr:
     image: ghcr.io/flaresolverr/flaresolverr:latest
     container_name: flaresolverr
@@ -412,7 +413,7 @@ The OpenSubtitles.org plugin no longer uses environment variables. Configure its
 
 1. Go to **Settings** > **Providers** and open the Provider Hub Marketplace
 2. Install and enable **"OpenSubtitles.org"** (not OpenSubtitles.com, that's the API version)
-3. In the plugin settings, set the **FlareSolverr URL** to your FlareSolverr container (e.g. `http://flaresolverr:8191/v1`)
+3. In the plugin settings, set the **FlareSolverr URL** to your FlareSolverr container (`http://flaresolverr:8191/v1` on a shared Docker network, or `http://localhost:8191/v1` with host networking)
 4. Save and test with a manual search
 
 ### Enabling AI Translation
@@ -476,7 +477,7 @@ curl -s -X POST http://localhost:8191/v1 \
 docker logs flaresolverr
 ```
 
-Then confirm the plugin's **FlareSolverr URL** is set to `http://flaresolverr:8191/v1` in Settings > Providers.
+Then confirm the plugin's **FlareSolverr URL** in Settings > Providers: `http://flaresolverr:8191/v1` when Bazarr+ and FlareSolverr share a Docker network, or `http://localhost:8191/v1` if Bazarr+ runs with host networking. A `Name or service not known` error means the `flaresolverr` hostname can't be resolved, which is what happens under host networking; switch the URL to `localhost`.
 
 ### Common Issues
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ services:
   # when OpenSubtitles.org returns a Cloudflare browser challenge. After you
   # install the OpenSubtitles.org plugin from the Marketplace, set its
   # "FlareSolverr URL" to http://flaresolverr:8191/v1 in the provider settings.
+  # That hostname resolves because both services share the bazarr-network
+  # bridge defined below. If you instead run Bazarr with host networking
+  # (network_mode: host), use http://localhost:8191/v1 in the plugin settings.
   flaresolverr:
     image: ghcr.io/flaresolverr/flaresolverr:latest
     container_name: flaresolverr

--- a/site/guides/getting-started.html
+++ b/site/guides/getting-started.html
@@ -206,7 +206,7 @@
       </div>
 
       <div class="note">
-        <strong>OpenSubtitles.org:</strong> in v2.4 OpenSubtitles.org is a native <a href="provider-hub.html">Provider Hub</a> plugin you install from the Marketplace. It scrapes the site in-process, so there is no separate scraper container. The FlareSolverr service above is recommended: set its <code>/v1</code> URL (e.g. <code>http://flaresolverr:8191/v1</code>) in the plugin's <strong>FlareSolverr URL</strong> setting so it can solve Cloudflare challenges when needed.
+        <strong>OpenSubtitles.org:</strong> in v2.4 OpenSubtitles.org is a native <a href="provider-hub.html">Provider Hub</a> plugin you install from the Marketplace. It scrapes the site in-process, so there is no separate scraper container. The FlareSolverr service above is recommended: set its <code>/v1</code> URL (e.g. <code>http://flaresolverr:8191/v1</code>) in the plugin's <strong>FlareSolverr URL</strong> setting so it can solve Cloudflare challenges when needed. If you run Bazarr+ with host networking (<code>network_mode: host</code>), use <code>http://localhost:8191/v1</code> instead, since the <code>flaresolverr</code> hostname only resolves on a shared Docker network.
       </div>
 
       <h2 id="first-login">First login</h2>

--- a/site/guides/getting-started.html
+++ b/site/guides/getting-started.html
@@ -206,7 +206,7 @@
       </div>
 
       <div class="note">
-        <strong>OpenSubtitles.org:</strong> in v2.4 OpenSubtitles.org is a native <a href="provider-hub.html">Provider Hub</a> plugin you install from the Marketplace. It scrapes the site in-process, so there is no separate scraper container. The FlareSolverr service above is recommended: set its <code>/v1</code> URL (e.g. <code>http://flaresolverr:8191/v1</code>) in the plugin's <strong>FlareSolverr URL</strong> setting so it can solve Cloudflare challenges when needed. If you run Bazarr+ with host networking (<code>network_mode: host</code>), use <code>http://localhost:8191/v1</code> instead, since the <code>flaresolverr</code> hostname only resolves on a shared Docker network.
+        <strong>OpenSubtitles.org:</strong> in v2.4 OpenSubtitles.org is a native <a href="provider-hub.html">Provider Hub</a> plugin you install from the Marketplace. It scrapes the site in-process, so there is no separate scraper container. The FlareSolverr service above is recommended: set its <code>/v1</code> URL (e.g. <code>http://flaresolverr:8191/v1</code>) in the plugin's <strong>FlareSolverr URL</strong> setting so it can solve Cloudflare challenges when needed. If you run Bazarr+ with host networking (<code>network_mode: host</code>), the <code>flaresolverr</code> hostname stops resolving: use <code>http://localhost:8191/v1</code> and make port 8191 reachable on the host, either by adding a <code>8191:8191</code> ports mapping to the FlareSolverr service above or running it with host networking too.
       </div>
 
       <h2 id="first-login">First login</h2>

--- a/site/guides/migration.html
+++ b/site/guides/migration.html
@@ -167,15 +167,16 @@ image: ghcr.io/lavx/bazarr:latest</code></pre>
           </div>
         </li>
         <li>
-          <strong>Add the companion services.</strong> The only companion service recommended now is FlareSolverr, plus the optional AI translator. OpenSubtitles.org is a native <a href="provider-hub.html">Provider Hub</a> plugin in v2.4: install it from the Marketplace, then point its <strong>FlareSolverr URL</strong> setting at the flaresolverr service below. There is no separate scraper container anymore.
+          <strong>Add the companion services.</strong> The only companion service recommended now is FlareSolverr, plus the optional AI translator. OpenSubtitles.org is a native <a href="provider-hub.html">Provider Hub</a> plugin in v2.4: install it from the Marketplace, then point its <strong>FlareSolverr URL</strong> setting at the flaresolverr service below (<code>http://flaresolverr:8191/v1</code> on a shared Docker network, or <code>http://localhost:8191/v1</code> if Bazarr+ runs with host networking). There is no separate scraper container anymore.
           <div class="code-wrap" style="margin-top: 12px;">
             <div class="code-header">
               <span class="code-lang">docker-compose.yml additions</span>
               <button class="copy-btn" data-copy-from="migration-scraper-code" aria-label="Copy companion services config">Copy</button>
             </div>
             <pre id="migration-scraper-code"><code># Add these services:
-  # Recommended for the OpenSubtitles.org plugin. Set this container's
-  # /v1 URL (http://flaresolverr:8191/v1) in the plugin's FlareSolverr URL.
+  # Recommended for the OpenSubtitles.org and many other plugins. Set this container's
+  # /v1 URL (http://flaresolverr:8191/v1) in the plugin's FlareSolverr URL
+  # (use http://localhost:8191/v1 instead if Bazarr runs with host networking).
   flaresolverr:
     image: ghcr.io/flaresolverr/flaresolverr:latest
     container_name: flaresolverr

--- a/site/guides/migration.html
+++ b/site/guides/migration.html
@@ -167,7 +167,7 @@ image: ghcr.io/lavx/bazarr:latest</code></pre>
           </div>
         </li>
         <li>
-          <strong>Add the companion services.</strong> The only companion service recommended now is FlareSolverr, plus the optional AI translator. OpenSubtitles.org is a native <a href="provider-hub.html">Provider Hub</a> plugin in v2.4: install it from the Marketplace, then point its <strong>FlareSolverr URL</strong> setting at the flaresolverr service below (<code>http://flaresolverr:8191/v1</code> on a shared Docker network, or <code>http://localhost:8191/v1</code> if Bazarr+ runs with host networking). There is no separate scraper container anymore.
+          <strong>Add the companion services.</strong> The only companion service recommended now is FlareSolverr, plus the optional AI translator. OpenSubtitles.org is a native <a href="provider-hub.html">Provider Hub</a> plugin in v2.4: install it from the Marketplace, then point its <strong>FlareSolverr URL</strong> setting at the flaresolverr service below (<code>http://flaresolverr:8191/v1</code> on a shared Docker network, or <code>http://localhost:8191/v1</code> with host networking, in which case also publish FlareSolverr's <code>8191:8191</code> port or run it on host networking too so 8191 is reachable on the host). There is no separate scraper container anymore.
           <div class="code-wrap" style="margin-top: 12px;">
             <div class="code-header">
               <span class="code-lang">docker-compose.yml additions</span>
@@ -175,8 +175,9 @@ image: ghcr.io/lavx/bazarr:latest</code></pre>
             </div>
             <pre id="migration-scraper-code"><code># Add these services:
   # Recommended for the OpenSubtitles.org and many other plugins. Set this container's
-  # /v1 URL (http://flaresolverr:8191/v1) in the plugin's FlareSolverr URL
-  # (use http://localhost:8191/v1 instead if Bazarr runs with host networking).
+  # /v1 URL (http://flaresolverr:8191/v1) in the plugin's FlareSolverr URL. With host
+  # networking use http://localhost:8191/v1 and add a "8191:8191" ports mapping below
+  # (or run flaresolverr on host networking too) so 8191 is reachable on the host.
   flaresolverr:
     image: ghcr.io/flaresolverr/flaresolverr:latest
     container_name: flaresolverr

--- a/site/index.html
+++ b/site/index.html
@@ -402,7 +402,8 @@
 
   # FlareSolverr (recommended): solves Cloudflare challenges for the native
   # OpenSubtitles.org plugin. After installing the plugin from the Marketplace,
-  # set its FlareSolverr URL to http://flaresolverr:8191/v1 in the provider settings.
+  # set its FlareSolverr URL to http://flaresolverr:8191/v1 in the provider settings
+  # (or http://localhost:8191/v1 if you run Bazarr with host networking).
   flaresolverr:
     image: ghcr.io/flaresolverr/flaresolverr:latest
     container_name: flaresolverr

--- a/site/install.sh
+++ b/site/install.sh
@@ -319,7 +319,9 @@ generate_compose() {
   # from the provider settings in the UI (http://flaresolverr:8191/v1), so no env var is
   # wired here; we only make Bazarr wait for FlareSolverr to be healthy when it is enabled.
   # Compose puts both services on the same network, so the flaresolverr hostname resolves.
-  # If you switch Bazarr to host networking, use http://localhost:8191/v1 instead.
+  # If you switch Bazarr to host networking, that hostname stops resolving: use
+  # http://localhost:8191/v1 and make port 8191 reachable on the host, either by adding a
+  # "8191:8191" ports mapping to flaresolverr below or running flaresolverr on host networking too.
   if [[ "$flaresolverr" == "y" ]]; then
     flare_block="
   flaresolverr:

--- a/site/install.sh
+++ b/site/install.sh
@@ -318,6 +318,8 @@ generate_compose() {
   # FlareSolverr service. The native OpenSubtitles.org plugin reads its FlareSolverr URL
   # from the provider settings in the UI (http://flaresolverr:8191/v1), so no env var is
   # wired here; we only make Bazarr wait for FlareSolverr to be healthy when it is enabled.
+  # Compose puts both services on the same network, so the flaresolverr hostname resolves.
+  # If you switch Bazarr to host networking, use http://localhost:8191/v1 instead.
   if [[ "$flaresolverr" == "y" ]]; then
     flare_block="
   flaresolverr:


### PR DESCRIPTION
## What

Every place that documents the FlareSolverr URL (`http://flaresolverr:8191/v1`) now also covers host-networking deployments, which must use `http://localhost:8191/v1` instead.

## Why

The `flaresolverr` Docker-DNS hostname only resolves when Bazarr+ and FlareSolverr share a user-defined bridge network (the Compose default). When Bazarr+ runs with `network_mode: host` / `--network host` (common in *arr stacks), that name does not resolve and the plugin's FlareSolverr call fails instantly with `Name or service not known` — which looks like an unreachable/timed-out FlareSolverr and isn't fixed by restarting the container.

Verified on a host-networked test box: `http://flaresolverr:8191/v1` failed DNS resolution from inside the Bazarr+ container, while `http://localhost:8191/v1` returned `FlareSolverr is ready!` instantly.

## Changes

- **README.md** — FlareSolverr section, the docker-compose example comment, the "Enabling the Provider" step, and the troubleshooting section (now names the exact `Name or service not known` symptom and the fix).
- **docker-compose.yml** — service comment explains the hostname works because both services share the `bazarr-network` bridge.
- **site/install.sh** — `generate_compose()` comment.
- **site/guides/getting-started.html**, **site/guides/migration.html**, **site/index.html** — FlareSolverr setup notes.

Docs-only; no code paths touched. The site copy publishes separately via the master Pages deploy.