### PR TITLE
fix(provider-hub): stop worker display metadata from corrupting subtitle candidates (2.4.0 hotfix)

### DIFF
--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -164,6 +164,36 @@ def video_to_payload(video) -> dict[str, Any]:
     }
 
 
+# Display metadata is worker-controlled and cosmetic. It must never replace the
+# attributes the host derives from the validated payload: language is a babelfish
+# Language (a plain string crashes every .alpha3/.basename access in the pool),
+# matches is a set, scores are numbers, and worker_id/provider_payload are the
+# candidate's identity. id/numeric_id are read-only properties, so an unguarded
+# setattr raises and discards the provider's entire result set.
+_RESERVED_DISPLAY_ATTRS = frozenset({
+    "language",
+    "language_type",
+    "id",
+    "numeric_id",
+    "provider_name",
+    "source_provider",
+    "worker_id",
+    "provider_payload",
+    "matches",
+    "content",
+    "pack_data",
+    "storage_path",
+    "subtitle_path",
+    "score",
+    "score_without_hash",
+    "score_out_of",
+    "hearing_impaired",
+    "foreign_only",
+    "hash_verifiable",
+    "hearing_impaired_verifiable",
+})
+
+
 def candidate_from_worker(provider_name: str, payload: dict[str, Any]) -> HubWorkerSubtitle:
     if not isinstance(payload, dict):
         raise WorkerProtocolError("candidate payload must be an object")
@@ -200,6 +230,17 @@ def candidate_from_worker(provider_name: str, payload: dict[str, Any]) -> HubWor
     display = payload.get("display") or {}
     if isinstance(display, dict):
         for key, value in display.items():
+            if (
+                not isinstance(key, str)
+                or key.startswith("_")
+                or key in _RESERVED_DISPLAY_ATTRS
+            ):
+                logger.debug(
+                    "provider_hub: ignoring reserved display key %r from %s",
+                    key,
+                    provider_name,
+                )
+                continue
             setattr(subtitle, key, value)
 
     return subtitle

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -17,7 +17,7 @@ import requests
 from os import scandir
 from collections import defaultdict
 from bs4 import UnicodeDammit
-from babelfish import LanguageReverseError
+from babelfish import Language as BabelfishLanguage, LanguageReverseError
 from guessit.jsonutils import GuessitEncoder
 from subliminal import refiner_manager
 from concurrent.futures import as_completed
@@ -406,6 +406,14 @@ class SZProviderPool(ProviderPool):
                 if not hasattr(s, 'id') or not hasattr(s, 'language'):
                     logger.warning('Provider %r returned invalid subtitle object (type: %s): %r',
                                    provider, type(s).__name__, s)
+                    continue
+
+                # Scoring and language bookkeeping dereference subtitle.language
+                # (.alpha3/.basename); a degraded value such as a plain string would
+                # abort the whole search, so drop just the broken subtitle here.
+                if not isinstance(s.language, BabelfishLanguage):
+                    logger.warning('Provider %r returned subtitle with invalid language (type: %s): %r',
+                                   provider, type(s.language).__name__, s)
                     continue
 
                 try:

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -4068,3 +4068,102 @@ def test_get_matches_swallows_release_update_errors(monkeypatch):
     matches = candidate.get_matches(movie)
 
     assert matches == {"title", "year"}
+
+
+def test_candidate_display_metadata_cannot_clobber_engine_attributes():
+    # Mirrors the live embeddedsubtitles payload: its display dict carries a plain
+    # string "language" label. Worker-controlled display metadata must never replace
+    # host-derived engine state (language is a babelfish Language, matches a set):
+    # a clobbered language crashes every later .alpha3/.basename access in the pool.
+    from provider_hub.protocol import candidate_from_worker
+
+    candidate = candidate_from_worker(
+        provider_name="embeddedsubtitles",
+        payload={
+            "id": "track-2",
+            "language": {"alpha3": "eng"},
+            "release_info": "Example.Movie.2026.1080p.WEB-DL.x264-GROUP",
+            "matches": ["hash"],
+            "provider_payload": {"provider": "embeddedsubtitles", "stream": 2},
+            "display": {
+                "source": "embedded",
+                "codec": "subrip",
+                "stream": 2,
+                "language": "eng",
+                "default": False,
+                "matches": ["bogus"],
+                "provider_payload": {"hijacked": True},
+                "score": "9000",
+            },
+        },
+    )
+
+    assert isinstance(candidate.language, Language)
+    assert candidate.language.alpha3 == "eng"
+    assert candidate.matches == {"hash"}
+    assert candidate.provider_payload == {"provider": "embeddedsubtitles", "stream": 2}
+    assert candidate.score is None
+    # cosmetic keys still reach the subtitle for UI display
+    assert candidate.source == "embedded"
+    assert candidate.codec == "subrip"
+    assert candidate.stream == 2
+
+
+def test_candidate_display_reserved_and_private_keys_are_ignored():
+    # "id" collides with a read-only property: unguarded, it raises AttributeError and
+    # discards the provider's whole result set. Private names must not be injectable
+    # either (get_matches caches worker matches under _worker_matches).
+    from provider_hub.protocol import candidate_from_worker
+
+    candidate = candidate_from_worker(
+        provider_name="examplehub",
+        payload={
+            "id": "sub-1",
+            "language": {"alpha3": "eng"},
+            "provider_payload": {"provider": "examplehub"},
+            "display": {
+                "id": "spoofed",
+                "worker_id": "spoofed",
+                "_worker_matches": ["leak"],
+            },
+        },
+    )
+
+    assert candidate.id == "examplehub:sub-1"
+    assert candidate.worker_id == "sub-1"
+    assert getattr(candidate, "_worker_matches", None) is None
+
+
+def test_pool_drops_subtitles_whose_language_is_not_a_language_object(monkeypatch):
+    # One malformed subtitle (language degraded to a plain string) must be skipped at
+    # the pool boundary instead of poisoning the whole search: downstream scoring
+    # dereferences subtitle.language.alpha3/.basename and would abort every provider.
+    from subliminal_patch import extensions
+    from subliminal_patch.core import SZProviderPool
+    from subliminal_patch.subtitle import Subtitle as PatchedSubtitle
+
+    good = PatchedSubtitle(Language("eng"), subtitle_id="good-1")
+    bad = PatchedSubtitle(Language("eng"), subtitle_id="bad-1")
+    bad.language = "eng"  # simulate a provider handing back a degraded language
+
+    class FakeGuardProvider(object):
+        languages = {Language("eng")}
+
+        @classmethod
+        def check(cls, video):
+            return True
+
+        def list_subtitles(self, video, languages):
+            return [bad, good]
+
+    monkeypatch.setitem(extensions.provider_registry.providers, "fakeguard", FakeGuardProvider)
+
+    pool = SZProviderPool(providers=["fakeguard"])
+    pool.initialized_providers["fakeguard"] = FakeGuardProvider()
+
+    movie = Movie("/media/example.mkv", "Example Movie", year=2024)
+    movie.fps = None
+
+    out = pool.list_subtitles_provider("fakeguard", movie, {Language("eng")})
+
+    assert out == [good]


### PR DESCRIPTION
## Summary

Hotfix for the 2.4.0 line: every subtitle search and download was failing with `AttributeError: 'str' object has no attribute 'alpha3'` / `'basename'`, and the resulting per-provider failures mass-throttled all providers into WorkerError cooldowns.

## Root cause

`candidate_from_worker` splatted the worker-supplied cosmetic `display` dict onto the subtitle with unfiltered `setattr`. The embeddedsubtitles catalog plugin ships `display.language` as a plain string (`"eng"`), which clobbered the babelfish `Language` object on every candidate it returned. Since embeddedsubtitles has top search priority and matches every local file, each search crashed at the first `.alpha3` / `.basename` dereference in the pool (`core.py` scoring and language bookkeeping), aborting the whole operation.

## Fix

- `candidate_from_worker` ignores reserved engine attributes and private names in `display` payloads: `language`, `matches`, scores, identity fields, and the read-only properties (`id`, `numeric_id`) whose `setattr` raised `AttributeError` and silently dropped the provider's entire result set. Cosmetic keys (`source`, `codec`, `stream`, `uploader`, ...) still pass through for the UI.
- Defense in depth: the provider pool now skips, with a warning, any subtitle whose `language` is not a babelfish `Language`, instead of letting one degraded subtitle abort the entire search.

## Verification

- 3 new regression tests in `tests/bazarr/test_provider_hub.py` (display clobber, reserved/private key injection, pool-boundary skip), each watched failing before the fix
- Full local CI: ruff clean, compat suite 377 passed, CI pytest guard list 265 passed, frontend tsc/lint/format/tests/build green, `build_test.sh` smoke boot green