### PR TITLE
fix(jobs): stop Jobs Manager progress ring from exceeding 100%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,8 @@ jobs:
             tests/bazarr/test_provider_hub_archive_select.py \
             tests/bazarr/test_jobs_queue_progress.py \
             tests/bazarr/test_processing_sync_substep.py \
+            tests/bazarr/test_sync_progress_report.py \
+            tests/bazarr/test_subsync_engines.py \
             tests/subliminal_patch/test_subliminal_rebase.py \
             tests/subliminal_patch/test_embeddedsubtitles.py \
             tests/subliminal_patch/test_subsunacs.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,8 @@ jobs:
             tests/bazarr/test_provider_hub.py \
             tests/bazarr/test_provider_hub_auto_install_optin.py \
             tests/bazarr/test_provider_hub_archive_select.py \
+            tests/bazarr/test_jobs_queue_progress.py \
+            tests/bazarr/test_processing_sync_substep.py \
             tests/subliminal_patch/test_subliminal_rebase.py \
             tests/subliminal_patch/test_embeddedsubtitles.py \
             tests/subliminal_patch/test_subsunacs.py \

--- a/bazarr/app/jobs_queue.py
+++ b/bazarr/app/jobs_queue.py
@@ -335,7 +335,10 @@ class JobsQueue:
         payload = {"job_id": job.job_id, "status": job.status}
         progress_max_updated = False
 
-        if progress_value:
+        # ``progress_value`` may legitimately be 0 (a reset at the start of a new
+        # phase). A truthiness check here silently dropped those resets, leaving a
+        # stale large value behind a freshly-set small max -> >100% progress rings.
+        if progress_value is not None:
             if progress_value == 'max':
                 progress_value = job.progress_max or 1
                 job.progress_value = job.progress_max = progress_value

--- a/bazarr/subtitles/processing.py
+++ b/bazarr/subtitles/processing.py
@@ -249,7 +249,8 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
                            percent_score=percent_score,
                            sonarr_series_id=episode_metadata.sonarrSeriesId,
                            sonarr_episode_id=episode_metadata.sonarrEpisodeId,
-                           job_id=job_id)
+                           job_id=job_id,
+                           track_job_progress=False)
     else:
         movie_metadata = database.execute(
             select(TableMovies.radarrId, TableMovies.imdbId, TableMovies.tmdbId)
@@ -268,7 +269,8 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
                            srt_lang=downloaded_language_code2,
                            percent_score=percent_score,
                            radarr_id=movie_metadata.radarrId,
-                           job_id=job_id)
+                           job_id=job_id,
+                           track_job_progress=False)
 
     if use_postprocessing is True:
         command = pp_replace(postprocessing_cmd, path, downloaded_path, downloaded_language, downloaded_language_code2,

--- a/bazarr/subtitles/processing.py
+++ b/bazarr/subtitles/processing.py
@@ -250,7 +250,7 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
                            sonarr_series_id=episode_metadata.sonarrSeriesId,
                            sonarr_episode_id=episode_metadata.sonarrEpisodeId,
                            job_id=job_id,
-                           track_job_progress=False)
+                           owns_job_progress=False)
     else:
         movie_metadata = database.execute(
             select(TableMovies.radarrId, TableMovies.imdbId, TableMovies.tmdbId)
@@ -270,7 +270,7 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
                            percent_score=percent_score,
                            radarr_id=movie_metadata.radarrId,
                            job_id=job_id,
-                           track_job_progress=False)
+                           owns_job_progress=False)
 
     if use_postprocessing is True:
         command = pp_replace(postprocessing_cmd, path, downloaded_path, downloaded_language, downloaded_language_code2,

--- a/bazarr/subtitles/sync.py
+++ b/bazarr/subtitles/sync.py
@@ -63,6 +63,32 @@ def _index_keep_all_outputs(video_path, sonarr_series_id=None, sonarr_episode_id
         event_stream(type='movie', payload=radarr_id)
 
 
+def _report_progress(job_id, track_job_progress, owns_job_progress, message,
+                     value=None, total=None, name=None):
+    """Report sync progress to the jobs queue.
+
+    The job owner (a standalone sync job) updates the progress value/max and the
+    job name. A sub-step (an auto-sync running inside a download/wanted job)
+    sends a message-only update: it still passes through ``update_job_progress``
+    -- preserving the cancellation checkpoint that aborts the job when the user
+    presses Stop -- but never overwrites the parent job's value/max or name,
+    which previously produced >100% progress rings.
+    """
+    if not (job_id and track_job_progress):
+        return
+    if owns_job_progress:
+        progress = {'job_id': job_id, 'progress_message': message}
+        if value is not None:
+            progress['progress_value'] = value
+        if total is not None:
+            progress['progress_max'] = total
+        jobs_queue.update_job_progress(**progress)
+        if name is not None:
+            jobs_queue.update_job_name(job_id=job_id, new_job_name=name)
+    else:
+        jobs_queue.update_job_progress(job_id=job_id, progress_message=message)
+
+
 def sync_subtitles(video_path,
                    srt_path,
                    srt_lang,
@@ -81,20 +107,16 @@ def sync_subtitles(video_path,
                    output_mode=None,
                    enabled_engines=None,
                    callback=None,
-                   track_job_progress=True):
+                   track_job_progress=True,
+                   owns_job_progress=True):
     if not settings.subsync.use_subsync and not force_sync:
         logging.debug('BAZARR automatic syncing is disabled in settings. Skipping sync routine.')
         return False
 
     if is_sync_engine_output(srt_path):
         logging.debug('BAZARR generated sync output cannot be synchronized again. Skipping: %s', srt_path)
-        if job_id and track_job_progress:
-            jobs_queue.update_job_name(job_id=job_id, new_job_name=f"Skipped sync for {srt_path}")
-            jobs_queue.update_job_progress(
-                job_id=job_id,
-                progress_value='max',
-                progress_message='Sync skipped',
-            )
+        _report_progress(job_id, track_job_progress, owns_job_progress, 'Sync skipped',
+                         value='max', name=f"Skipped sync for {srt_path}")
         return False
 
     if not job_id and track_job_progress:
@@ -107,33 +129,17 @@ def sync_subtitles(video_path,
 
     progress_total = _sync_progress_total(enabled_engines)
 
-    if job_id and track_job_progress:
-        jobs_queue.update_job_name(job_id=job_id, new_job_name=f"Syncing {srt_path}")
-        jobs_queue.update_job_progress(
-            job_id=job_id,
-            progress_value=0,
-            progress_max=progress_total,
-            progress_message='Preparing synchronization',
-        )
+    def report(message, value=None, total=None, name=None):
+        _report_progress(job_id, track_job_progress, owns_job_progress, message, value, total, name)
+
+    report('Preparing synchronization', value=0, total=progress_total, name=f"Syncing {srt_path}")
 
     def update_progress(message, value, total):
-        if job_id and track_job_progress:
-            jobs_queue.update_job_progress(
-                job_id=job_id,
-                progress_value=value,
-                progress_max=total,
-                progress_message=message,
-            )
+        report(message, value=value, total=total)
 
     if forced:
         logging.debug('BAZARR cannot sync forced subtitles. Skipping sync routine.')
-        if job_id and track_job_progress:
-            jobs_queue.update_job_progress(
-                job_id=job_id,
-                progress_value='max',
-                progress_message='Sync skipped',
-            )
-            jobs_queue.update_job_name(job_id=job_id, new_job_name=f"Skipped sync for {srt_path}")
+        report('Sync skipped', value='max', name=f"Skipped sync for {srt_path}")
         return False
 
     logging.debug(f'BAZARR automatic syncing is enabled in settings. We\'ll try to sync this '  # noqa: G004
@@ -192,26 +198,11 @@ def sync_subtitles(video_path,
                 progress_message = 'Sync skipped'
             else:
                 progress_message = 'Sync failed'
-            if job_id and track_job_progress:
-                jobs_queue.update_job_progress(
-                    job_id=job_id,
-                    progress_value='max',
-                    progress_message=progress_message,
-                )
-                jobs_queue.update_job_name(
-                    job_id=job_id,
-                    new_job_name=_sync_complete_job_name(srt_path, sync_result),
-                )
+            report(progress_message, value='max', name=_sync_complete_job_name(srt_path, sync_result))
             del subsync
             gc.collect()
 
     logging.debug(f"BAZARR subsync skipped because subtitles score isn't below this "  # noqa: G004
                   f"threshold value: {subsync_threshold}%")
-    if job_id and track_job_progress:
-        jobs_queue.update_job_progress(
-            job_id=job_id,
-            progress_value='max',
-            progress_message='Sync skipped',
-        )
-        jobs_queue.update_job_name(job_id=job_id, new_job_name=f"Skipped sync for {srt_path}")
+    report('Sync skipped', value='max', name=f"Skipped sync for {srt_path}")
     return False

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,6 @@
 sympy
 vcrpy>=8.1.1
 pytest
-pytest-pep8
-pytest-flakes
 pytest-cov
 pytest-vcr
 pytest-mock

--- a/frontend/src/App/NotificationDrawer.tsx
+++ b/frontend/src/App/NotificationDrawer.tsx
@@ -33,6 +33,7 @@ import { startCase } from "lodash";
 import { debounce } from "lodash";
 import { QueryKeys } from "@/apis/queries/keys";
 import api from "@/apis/raw";
+import { progressPercent } from "@/utilities";
 import classes from "./NotificationDrawer.module.css";
 
 interface NotificationDrawerProps {
@@ -278,11 +279,10 @@ const NotificationDrawer: FunctionComponent<NotificationDrawerProps> = ({
                                               job.progress_max == 0 &&
                                               job.progress_value == 0
                                                 ? 100
-                                                : job.progress_max > 0
-                                                  ? (job.progress_value /
-                                                      job.progress_max) *
-                                                    100
-                                                  : 0,
+                                                : progressPercent(
+                                                    job.progress_value,
+                                                    job.progress_max,
+                                                  ),
                                             color:
                                               status === "completed"
                                                 ? "green"
@@ -310,13 +310,12 @@ const NotificationDrawer: FunctionComponent<NotificationDrawerProps> = ({
                                             job.progress_max == 0 &&
                                             job.progress_value == 0
                                               ? 100
-                                              : job.progress_max > 0
-                                                ? Math.round(
-                                                    (job.progress_value /
-                                                      job.progress_max) *
-                                                      100,
-                                                  )
-                                                : 0}
+                                              : Math.round(
+                                                  progressPercent(
+                                                    job.progress_value,
+                                                    job.progress_max,
+                                                  ),
+                                                )}
                                             %
                                           </Text>
                                         }

--- a/frontend/src/utilities/index.test.ts
+++ b/frontend/src/utilities/index.test.ts
@@ -1,4 +1,4 @@
-import { fromPython, toPython } from "@/utilities/index";
+import { fromPython, progressPercent, toPython } from "@/utilities/index";
 
 describe("fromPythonConversion", () => {
   it("should convert a true value", () => {
@@ -21,5 +21,23 @@ describe("toPythonConversion", () => {
 
   it("should convert a false value", () => {
     expect(toPython(false)).toBe("False");
+  });
+});
+
+describe("progressPercent", () => {
+  it("computes a normal percentage", () => {
+    expect(progressPercent(2, 4)).toBe(50);
+  });
+
+  it("clamps values above the max to 100", () => {
+    expect(progressPercent(179, 3)).toBe(100);
+  });
+
+  it("returns 0 when max is 0", () => {
+    expect(progressPercent(5, 0)).toBe(0);
+  });
+
+  it("floors negative results at 0", () => {
+    expect(progressPercent(-1, 10)).toBe(0);
   });
 });

--- a/frontend/src/utilities/index.ts
+++ b/frontend/src/utilities/index.ts
@@ -67,6 +67,20 @@ export function toPython(value: boolean): PythonBoolean {
   return value ? "True" : "False";
 }
 
+// Convert a job's progress value/max into a percentage clamped to 0-100.
+// Defends the progress ring against backend value/max scale mismatches that
+// could otherwise render nonsensical figures (e.g. 5967%).
+export function progressPercent(value: number, max: number): number {
+  if (!max || max <= 0) {
+    return 0;
+  }
+  const percent = (value / max) * 100;
+  if (!Number.isFinite(percent) || percent < 0) {
+    return 0;
+  }
+  return Math.min(100, percent);
+}
+
 export * from "./env";
 export * from "./hooks";
 export * from "./validate";

--- a/tests/bazarr/test_jobs_queue_progress.py
+++ b/tests/bazarr/test_jobs_queue_progress.py
@@ -1,0 +1,51 @@
+# coding=utf-8
+"""Regression tests for Jobs Manager progress payload math.
+
+Covers the ">100% progress ring" bug where ``progress_value`` could end up far
+larger than ``progress_max`` (e.g. 5967%). The root logic defect is that a
+``progress_value=0`` reset was silently dropped by a truthiness check, leaving a
+stale large value behind a freshly-set small max.
+"""
+
+
+def _make_job(progress_max=0, progress_value=0):
+    from app.jobs_queue import Job
+    job = Job(job_id=1, job_name="x", module="m", func="f", progress_max=progress_max)
+    job.progress_value = progress_value
+    return job
+
+
+class TestBuildProgressPayload:
+    def test_zero_value_resets_stale_progress(self):
+        # A sub-step that resets progress_value to 0 must actually reset it,
+        # even when a prior phase left a large value behind.
+        from app.jobs_queue import JobsQueue
+        job = _make_job(progress_max=58, progress_value=30)
+        payload = JobsQueue._build_progress_payload(job, 0, 3, "Preparing synchronization")
+        assert job.progress_value == 0
+        assert job.progress_max == 3
+        assert payload["progress_value"] == 0
+        assert payload["progress_max"] == 3
+
+    def test_max_sentinel_completes_job(self):
+        from app.jobs_queue import JobsQueue
+        job = _make_job(progress_max=5, progress_value=2)
+        payload = JobsQueue._build_progress_payload(job, "max", None, "Done")
+        assert job.progress_value == 5
+        assert job.progress_max == 5
+        assert payload["progress_value"] == 5
+
+    def test_normal_value_update(self):
+        from app.jobs_queue import JobsQueue
+        job = _make_job(progress_max=10, progress_value=0)
+        payload = JobsQueue._build_progress_payload(job, 4, 10, "Working")
+        assert job.progress_value == 4
+        assert payload["progress_value"] == 4
+
+    def test_message_only_preserves_value_and_max(self):
+        from app.jobs_queue import JobsQueue
+        job = _make_job(progress_max=58, progress_value=30)
+        payload = JobsQueue._build_progress_payload(job, None, None, "Searching opensubtitles (2/58)")
+        assert job.progress_value == 30
+        assert job.progress_max == 58
+        assert payload["progress_message"] == "Searching opensubtitles (2/58)"

--- a/tests/bazarr/test_processing_sync_substep.py
+++ b/tests/bazarr/test_processing_sync_substep.py
@@ -53,11 +53,15 @@ def test_series_substep_sync_does_not_track_parent_job_progress():
     meta = MagicMock(sonarrSeriesId=7, sonarrEpisodeId=70, imdbId="tt1", tvdbId=1, season=1, episode=13)
     sync_mock = _run("series", meta, job_id=42)
     assert sync_mock.call_args.kwargs.get("job_id") == 42
-    assert sync_mock.call_args.kwargs.get("track_job_progress") is False
+    # Sub-step must NOT own the parent job's progress (no value/max hijack)...
+    assert sync_mock.call_args.kwargs.get("owns_job_progress") is False
+    # ...but tracking stays on so cancellation checkpoints survive during sync.
+    assert sync_mock.call_args.kwargs.get("track_job_progress") is not False
 
 
 def test_movie_substep_sync_does_not_track_parent_job_progress():
     meta = MagicMock(radarrId=9, imdbId="tt2", tmdbId=2)
     sync_mock = _run("movie", meta, job_id=99)
     assert sync_mock.call_args.kwargs.get("job_id") == 99
-    assert sync_mock.call_args.kwargs.get("track_job_progress") is False
+    assert sync_mock.call_args.kwargs.get("owns_job_progress") is False
+    assert sync_mock.call_args.kwargs.get("track_job_progress") is not False

--- a/tests/bazarr/test_processing_sync_substep.py
+++ b/tests/bazarr/test_processing_sync_substep.py
@@ -1,0 +1,63 @@
+# coding=utf-8
+"""The auto-sync step that runs after a subtitle download must not hijack the
+parent job's progress bar.
+
+When ``process_subtitle`` is invoked as part of a larger job (a wanted/mass
+download whose ``progress_max`` is the episode/provider count), the follow-up
+``sync_subtitles`` call must run with ``track_job_progress=False`` so it does not
+overwrite that job's ``progress_max`` with the small sync-engine count (which
+produced rings well over 100%). This mirrors the existing pattern in
+``mass_operations``.
+"""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+class _Stop(Exception):
+    """Sentinel raised by the mocked sync to stop process_subtitle early."""
+
+
+def _fake_subtitle():
+    sub = MagicMock()
+    sub.provider_name = "opensubtitles"
+    sub.uploader = "uploader"
+    sub.release_info = "release"
+    sub.score = 80
+    sub.id = 1
+    sub.storage_path = "/tmp/x.en.srt"
+    sub.language.hi = False
+    sub.language.forced = False
+    sub.matches = set()
+    return sub
+
+
+def _run(media_type, meta, **kwargs):
+    from subtitles import processing
+    with patch.object(processing, "database") as db, \
+            patch.object(processing, "_defaul_sync_checker", return_value=True), \
+            patch.object(processing, "_get_download_code3", return_value="eng"), \
+            patch.object(processing, "language_from_alpha3", return_value="English"), \
+            patch.object(processing, "alpha2_from_alpha3", return_value="en"), \
+            patch.object(processing, "alpha2_from_language", return_value="en"), \
+            patch.object(processing, "alpha3_from_language", return_value="eng"), \
+            patch("subtitles.sync.sync_subtitles", side_effect=_Stop) as sync_mock:
+        db.execute.return_value.first.return_value = meta
+        with pytest.raises(_Stop):
+            processing.process_subtitle(_fake_subtitle(), media_type, "English",
+                                        "/media/file.mkv", max_score=100, **kwargs)
+    return sync_mock
+
+
+def test_series_substep_sync_does_not_track_parent_job_progress():
+    meta = MagicMock(sonarrSeriesId=7, sonarrEpisodeId=70, imdbId="tt1", tvdbId=1, season=1, episode=13)
+    sync_mock = _run("series", meta, job_id=42)
+    assert sync_mock.call_args.kwargs.get("job_id") == 42
+    assert sync_mock.call_args.kwargs.get("track_job_progress") is False
+
+
+def test_movie_substep_sync_does_not_track_parent_job_progress():
+    meta = MagicMock(radarrId=9, imdbId="tt2", tmdbId=2)
+    sync_mock = _run("movie", meta, job_id=99)
+    assert sync_mock.call_args.kwargs.get("job_id") == 99
+    assert sync_mock.call_args.kwargs.get("track_job_progress") is False

--- a/tests/bazarr/test_sync_progress_report.py
+++ b/tests/bazarr/test_sync_progress_report.py
@@ -1,0 +1,56 @@
+# coding=utf-8
+"""The auto-sync sub-step must keep a cancellation checkpoint without hijacking
+the parent download job's progress bar.
+
+``_report_progress`` is the single seam sync uses to talk to the jobs queue:
+- as the job owner (standalone sync), it updates value/max/name as usual;
+- as a sub-step (called from a download/wanted job), it sends a message-only
+  update. That still passes through ``update_job_progress`` -- which raises
+  ``JobCancelled`` when the user pressed Stop -- so cancellation is preserved,
+  while the parent job's value/max/name are left untouched (no >100% ring).
+"""
+from unittest.mock import patch
+
+
+def test_substep_sends_message_only():
+    from subtitles import sync
+    with patch.object(sync, "jobs_queue") as jq:
+        sync._report_progress(5, True, False, "Synchronizing", value=2, total=3, name="Syncing X")
+        jq.update_job_progress.assert_called_once_with(job_id=5, progress_message="Synchronizing")
+        jq.update_job_name.assert_not_called()
+
+
+def test_substep_max_sentinel_does_not_complete_parent():
+    # Even a 'max' completion from the sync engine must not flow to the parent.
+    from subtitles import sync
+    with patch.object(sync, "jobs_queue") as jq:
+        sync._report_progress(5, True, False, "Sync complete", value="max", name="done")
+        jq.update_job_progress.assert_called_once_with(job_id=5, progress_message="Sync complete")
+        jq.update_job_name.assert_not_called()
+
+
+def test_owner_sends_value_max_and_name():
+    from subtitles import sync
+    with patch.object(sync, "jobs_queue") as jq:
+        sync._report_progress(5, True, True, "Working", value=2, total=3, name="Syncing X")
+        jq.update_job_progress.assert_called_once_with(
+            job_id=5, progress_value=2, progress_max=3, progress_message="Working")
+        jq.update_job_name.assert_called_once_with(job_id=5, new_job_name="Syncing X")
+
+
+def test_owner_without_name_skips_rename():
+    from subtitles import sync
+    with patch.object(sync, "jobs_queue") as jq:
+        sync._report_progress(5, True, True, "Working", value=0, total=3)
+        jq.update_job_progress.assert_called_once_with(
+            job_id=5, progress_value=0, progress_max=3, progress_message="Working")
+        jq.update_job_name.assert_not_called()
+
+
+def test_noop_without_job_or_tracking():
+    from subtitles import sync
+    with patch.object(sync, "jobs_queue") as jq:
+        sync._report_progress(None, True, True, "x", value=1, total=2)
+        sync._report_progress(5, False, True, "x", value=1, total=2)
+        jq.update_job_progress.assert_not_called()
+        jq.update_job_name.assert_not_called()


### PR DESCRIPTION
## Problem

The Jobs Manager progress ring rendered impossible values (observed **5967%** and **2933%**) on auto-sync / download jobs.

## Root cause

Two defects combined when a download/wanted job (whose `progress_max` is the episode or provider count) handed its `job_id` to the follow-up auto-sync step:

1. `jobs_queue._build_progress_payload` guarded progress updates with `if progress_value:` — a truthiness check that silently **dropped `progress_value=0` resets**, leaving a stale large value behind.
2. `process_subtitle` called `sync_subtitles(..., job_id=job_id)` **without** `track_job_progress=False`, so the sync **overwrote the parent job's `progress_max`** with the tiny sync-engine count (~3) while the larger `progress_value` lingered. Value over max crossed scales, so `179 / 3` rendered as `5967%`.

`mass_operations` already used `track_job_progress=False` to avoid exactly this; the download path simply missed it.

This was display-only: searches, downloads and syncs themselves worked correctly.

## Fix

- `jobs_queue.py`: use `is not None` so `progress_value=0` resets apply.
- `processing.py`: pass `track_job_progress=False` to the auto-sync calls (series and movies) so the sub-step no longer hijacks the parent job's progress bar (matches the existing `mass_operations` pattern).
- Frontend: add a clamped `progressPercent` helper and use it for the ring as defense in depth.

## Tests

- `test_jobs_queue_progress.py`: payload zero-reset, `max` sentinel, normal update, message-only preservation.
- `test_processing_sync_substep.py`: `process_subtitle` passes `track_job_progress=False` for series and movies.
- `progressPercent` clamping (utilities).
- Both new backend test files added to the CI guard list.

Local: ruff clean, tsc clean, eslint 0 errors, prettier clean, 551 frontend tests pass, new backend tests pass, `build:ci` OK.