### PR TITLE
Detect forced embedded subtitle tracks from the title tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
             tests/bazarr/test_sync_progress_report.py \
             tests/bazarr/test_subsync_engines.py \
             tests/bazarr/test_utilities_video_analyzer.py \
+            tests/bazarr/test_embedded_subtitle_extraction.py \
             tests/subliminal_patch/test_subliminal_rebase.py \
             tests/subliminal_patch/test_embeddedsubtitles.py \
             tests/subliminal_patch/test_subsunacs.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
             tests/bazarr/test_processing_sync_substep.py \
             tests/bazarr/test_sync_progress_report.py \
             tests/bazarr/test_subsync_engines.py \
+            tests/bazarr/test_utilities_video_analyzer.py \
             tests/subliminal_patch/test_subliminal_rebase.py \
             tests/subliminal_patch/test_embeddedsubtitles.py \
             tests/subliminal_patch/test_subsunacs.py \

--- a/bazarr/subtitles/tools/translate/batch.py
+++ b/bazarr/subtitles/tools/translate/batch.py
@@ -11,7 +11,7 @@ from app.event_handler import event_stream
 from arr_instances.resolution import scoped
 from utilities.path_mappings import path_mappings
 from utilities.binaries import get_binary
-from utilities.video_analyzer import parse_video_metadata, _handle_alpha3
+from utilities.video_analyzer import parse_video_metadata, _handle_alpha3, _title_is_forced
 from languages.get_languages import alpha3_from_alpha2
 from subtitles.indexer.series import store_subtitles
 from subtitles.indexer.movies import store_subtitles_movie
@@ -431,9 +431,14 @@ def extract_embedded_subtitle(
 
         track_alpha3 = _handle_alpha3(track)
         if track_alpha3 == target_alpha3:
+            # knowit only reports forced from the disposition flag, so apply the
+            # same title heuristic used at indexing time, otherwise a forced
+            # request would extract a regular track named "Forced".
+            # See https://github.com/LavX/bazarr/issues/162
+            track_forced = track.get("forced", False) or _title_is_forced(track.get("name", ""))
             if (
                 track.get("hearing_impaired", False) == hi
-                and track.get("forced", False) == forced
+                and track_forced == forced
             ):
                 exact_track = track_id
                 break

--- a/bazarr/utilities/video_analyzer.py
+++ b/bazarr/utilities/video_analyzer.py
@@ -21,10 +21,16 @@ from knowit.api import know, KnowitException
 # plain track. Mirror the title heuristic here so those tracks are stored as
 # forced. See https://github.com/LavX/bazarr/issues/162
 _FORCED_TITLE_RE = re.compile(r"\bforced\b", re.IGNORECASE)
+# Titles like "Non-Forced" / "Not Forced" / "Unforced" distinguish a full track
+# from the forced-only one and must NOT be treated as forced.
+_NEGATED_FORCED_RE = re.compile(r"\b(?:non|not|un)[\s-]*forced\b", re.IGNORECASE)
 
 
 def _title_is_forced(title):
-    return bool(_FORCED_TITLE_RE.search(title or ""))
+    text = title or ""
+    if _NEGATED_FORCED_RE.search(text):
+        return False
+    return bool(_FORCED_TITLE_RE.search(text))
 
 
 def _handle_alpha3(detected_language: dict):

--- a/bazarr/utilities/video_analyzer.py
+++ b/bazarr/utilities/video_analyzer.py
@@ -3,6 +3,7 @@ import ast
 import logging
 import os
 import pickle
+import re
 
 from app.config import settings
 from app.database import TableEpisodes, TableMovies, database, update, select
@@ -12,6 +13,18 @@ from languages.get_languages import language_from_alpha2, language_from_alpha3, 
 from utilities.path_mappings import path_mappings
 
 from knowit.api import know, KnowitException
+
+
+# knowit derives a subtitle track's hearing-impaired flag from the track title
+# (via trakit) but has no equivalent rule for forced tracks, so an encode that
+# labels a track title="Forced" while leaving disposition.forced=0 is read as a
+# plain track. Mirror the title heuristic here so those tracks are stored as
+# forced. See https://github.com/LavX/bazarr/issues/162
+_FORCED_TITLE_RE = re.compile(r"\bforced\b", re.IGNORECASE)
+
+
+def _title_is_forced(title):
+    return bool(_FORCED_TITLE_RE.search(title or ""))
 
 
 def _handle_alpha3(detected_language: dict):
@@ -67,7 +80,7 @@ def embedded_subs_reader(file, file_size, episode_file_id=None, movie_file_id=No
             if not language:
                 continue
 
-            forced = detected_language.get("forced", False)
+            forced = detected_language.get("forced", False) or _title_is_forced(name)
             hearing_impaired = detected_language.get("hearing_impaired", False)
             codec = detected_language.get("format")  # or None
             subtitles_list.append([language, forced, hearing_impaired, codec])
@@ -187,7 +200,7 @@ def subtitles_sync_references(subtitles_path, sonarr_episode_id=None, radarr_mov
                     alpha3 = _handle_alpha3(detected_language)
                     language = language_from_alpha3(alpha3)
 
-                forced = detected_language.get("forced", False)
+                forced = detected_language.get("forced", False) or _title_is_forced(name)
                 hearing_impaired = detected_language.get("hearing_impaired", False)
 
                 references_dict['embedded_subtitles_tracks'].append(

--- a/bazarr/utilities/video_analyzer.py
+++ b/bazarr/utilities/video_analyzer.py
@@ -20,10 +20,13 @@ from knowit.api import know, KnowitException
 # labels a track title="Forced" while leaving disposition.forced=0 is read as a
 # plain track. Mirror the title heuristic here so those tracks are stored as
 # forced. See https://github.com/LavX/bazarr/issues/162
-_FORCED_TITLE_RE = re.compile(r"\bforced\b", re.IGNORECASE)
-# Titles like "Non-Forced" / "Not Forced" / "Unforced" distinguish a full track
-# from the forced-only one and must NOT be treated as forced.
-_NEGATED_FORCED_RE = re.compile(r"\b(?:non|not|un)[\s-]*forced\b", re.IGNORECASE)
+# Match the word "forced" delimited by anything that is not a letter, so
+# space-, bracket-, dash- and underscore-separated titles ("English Forced",
+# "[Forced]", "English_Forced") all match, while "enforced"/"reinforced" do not.
+_FORCED_TITLE_RE = re.compile(r"(?<![a-z])forced(?![a-z])", re.IGNORECASE)
+# Titles like "Non-Forced" / "Not Forced" / "Non_Forced" / "Unforced" distinguish
+# a full track from the forced-only one and must NOT be treated as forced.
+_NEGATED_FORCED_RE = re.compile(r"(?<![a-z])(?:non|not|un)[\s_-]*forced(?![a-z])", re.IGNORECASE)
 
 
 def _title_is_forced(title):

--- a/tests/bazarr/test_embedded_subtitle_extraction.py
+++ b/tests/bazarr/test_embedded_subtitle_extraction.py
@@ -900,3 +900,63 @@ def test_path_mapped_install_extraction_location(monkeypatch, tmp_path):
         f"ffmpeg should receive the FS (mapped) path '{fs_path}', "
         f"got '{ffmpeg_video_arg}'"
     )
+
+
+def test_forced_track_selected_by_title(tmp_path):
+    """A forced request selects the track titled "Forced" even when its
+    disposition.forced flag is unset.
+
+    Why: knowit only reports forced from the disposition flag, so without the
+    title heuristic the extractor fell back to the first language-only track and
+    extracted the regular subtitle for a forced request. Regression for the
+    Codex review on https://github.com/LavX/bazarr/pull/228
+    """
+    from subtitles.tools.translate.batch import extract_embedded_subtitle
+
+    metadata = {
+        "ffprobe": {
+            "subtitle": [
+                {"format": "subrip", "language": "eng"},                    # index 0, regular
+                {"format": "subrip", "language": "eng", "name": "Forced"},   # index 1, forced by title
+            ]
+        }
+    }
+    media_row = MagicMock(movie_file_id=1, file_size=1024)
+    captured = {}
+
+    def fake_ffmpeg(cmd, **kwargs):
+        captured["cmd"] = cmd
+        out_path = cmd[-1]
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        with open(out_path, "w") as f:
+            f.write("1\n00:00:01,000 --> 00:00:02,000\nHi\n")
+        result = MagicMock()
+        result.returncode = 0
+        return result
+
+    with (
+        patch("subtitles.tools.translate.batch.database") as mock_db,
+        patch(
+            "subtitles.tools.translate.batch.parse_video_metadata",
+            return_value=metadata,
+        ),
+        patch("subtitles.tools.translate.batch._handle_alpha3", return_value="eng"),
+        patch("subtitles.tools.translate.batch.alpha3_from_alpha2", return_value="eng"),
+        patch(
+            "subtitles.tools.translate.batch.get_binary", return_value="/usr/bin/ffmpeg"
+        ),
+        patch("app.get_args.args") as mock_args,
+        patch("subprocess.run", side_effect=fake_ffmpeg),
+    ):
+        mock_db.execute.return_value.first.return_value = media_row
+        mock_args.config_dir = str(tmp_path)
+
+        result = extract_embedded_subtitle(
+            "/fake/movie.mkv", "en", "movie", forced=True
+        )
+
+    assert result is not None
+    assert "0:s:1" in captured["cmd"], (
+        f"forced request should map the title-forced track (index 1), "
+        f"got cmd: {captured['cmd']}"
+    )

--- a/tests/bazarr/test_utilities_video_analyzer.py
+++ b/tests/bazarr/test_utilities_video_analyzer.py
@@ -274,6 +274,10 @@ def test_embedded_audio_reader(mediainfo_data, video_file):
         ("English SDH", False),
         ("enforced", False),       # must not match inside another word
         ("Reinforced track", False),
+        ("Non-Forced", False),     # negated form, distinguishes the full track
+        ("Not Forced", False),
+        ("Unforced", False),
+        ("English Non-Forced", False),
     ],
 )
 def test_title_is_forced(title, expected):

--- a/tests/bazarr/test_utilities_video_analyzer.py
+++ b/tests/bazarr/test_utilities_video_analyzer.py
@@ -258,3 +258,77 @@ def test_embedded_audio_reader(mediainfo_data, video_file):
     ):
         result = video_analyzer.embedded_audio_reader(video_file, 1e6)
         assert {"pob", "por"} == set(result)
+
+
+@pytest.mark.parametrize(
+    "title,expected",
+    [
+        ("Forced", True),
+        ("forced", True),
+        ("Forced Subtitles", True),
+        ("English Forced", True),
+        ("[Forced]", True),
+        ("English (Forced)", True),
+        ("", False),
+        ("English", False),
+        ("English SDH", False),
+        ("enforced", False),       # must not match inside another word
+        ("Reinforced track", False),
+    ],
+)
+def test_title_is_forced(title, expected):
+    assert video_analyzer._title_is_forced(title) is expected
+
+
+def test_embedded_subs_reader_forced_from_title(video_file):
+    """A track titled "Forced" with disposition.forced=0 must be stored as forced.
+
+    knowit detects hearing-impaired from the title (via trakit) but has no rule
+    that applies trakit's forced detection, so forced tracks that rely on the
+    title tag instead of disposition.forced are otherwise lost. See
+    https://github.com/LavX/bazarr/issues/162
+    """
+    from unittest.mock import patch
+
+    data = {
+        "subtitle": [
+            {"language": Language("eng"), "format": "SubRip", "forced": False,
+             "hearing_impaired": False, "name": "Forced"},
+            {"language": Language("eng"), "format": "SubRip", "forced": False,
+             "hearing_impaired": False, "name": ""},
+            {"language": Language("eng"), "format": "SubRip", "forced": False,
+             "hearing_impaired": True, "name": "SDH"},
+        ],
+        "audio": [],
+    }
+    with patch(
+        "utilities.video_analyzer.parse_video_metadata",
+        return_value={"mediainfo": data},
+    ), patch(
+        "utilities.video_analyzer.alpha3_from_alpha2", return_value=None
+    ):
+        result = video_analyzer.embedded_subs_reader(video_file, 1e6)
+        assert ["eng", True, False, "SubRip"] in result   # forced derived from title
+        assert ["eng", False, False, "SubRip"] in result  # plain track stays non-forced
+        assert ["eng", False, True, "SubRip"] in result   # hi untouched by the forced heuristic
+
+
+def test_embedded_subs_reader_disposition_forced_preserved(video_file):
+    """A track already flagged forced by disposition stays forced regardless of title."""
+    from unittest.mock import patch
+
+    data = {
+        "subtitle": [
+            {"language": Language("eng"), "format": "SubRip", "forced": True,
+             "hearing_impaired": False, "name": "English"},
+        ],
+        "audio": [],
+    }
+    with patch(
+        "utilities.video_analyzer.parse_video_metadata",
+        return_value={"mediainfo": data},
+    ), patch(
+        "utilities.video_analyzer.alpha3_from_alpha2", return_value=None
+    ):
+        result = video_analyzer.embedded_subs_reader(video_file, 1e6)
+        assert ["eng", True, False, "SubRip"] in result

--- a/tests/bazarr/test_utilities_video_analyzer.py
+++ b/tests/bazarr/test_utilities_video_analyzer.py
@@ -278,6 +278,10 @@ def test_embedded_audio_reader(mediainfo_data, video_file):
         ("Not Forced", False),
         ("Unforced", False),
         ("English Non-Forced", False),
+        ("English_Forced", True),  # underscore-separated title
+        ("eng_forced", True),
+        ("Non_Forced", False),     # negated, underscore-separated
+        ("English_Non_Forced", False),
     ],
 )
 def test_title_is_forced(title, expected):


### PR DESCRIPTION
Fixes https://github.com/LavX/bazarr/issues/162

## Problem
Encodes that label a subtitle track `title="Forced"` but leave `disposition.forced=0` were stored as a plain language code (`en`), indistinguishable from the regular track. SDH tracks work because knowit derives hearing-impaired from the title (via trakit), but knowit has no equivalent rule for forced, so forced detection was bound to the disposition flag only.

## Fix
Mirror the existing hearing-impaired behaviour by deriving `forced` from the track title in `embedded_subs_reader` and `subtitles_sync_references`, using a word-boundary, case-insensitive match (`\bforced\b`). The check is additive (`forced = disposition OR title`), so disposition-flagged tracks are unaffected.

## Tests
Adds `tests/bazarr/test_utilities_video_analyzer.py` coverage (title matching incl. `[Forced]`, `English Forced`, negative `enforced`/`reinforced`; reader integration) and registers it in the CI guard list.