### PR TITLE
Add option to preserve song lyrics when removing hearing impaired content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,10 +166,13 @@ jobs:
             tests/bazarr/test_processing_sync_substep.py \
             tests/bazarr/test_sync_progress_report.py \
             tests/bazarr/test_subsync_engines.py \
+            tests/bazarr/test_subzero_keep_lyrics.py \
             tests/subliminal_patch/test_subliminal_rebase.py \
             tests/subliminal_patch/test_embeddedsubtitles.py \
             tests/subliminal_patch/test_subsunacs.py \
             tests/subliminal_patch/test_filebot_refiner.py \
+            tests/subliminal_patch/test_mods.py \
+            tests/subliminal_patch/test_mods_keep_lyrics.py \
             -v --tb=short
 
       - name: pytest cross-instance isolation guards (isolated per file)

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -174,6 +174,7 @@ validators = [
     Validator('general.wanted_search_frequency_movie', must_exist=True, default=6, is_type_of=int,
               is_in=[6, 12, 24, 168, ONE_HUNDRED_YEARS_IN_HOURS]),
     Validator('general.subzero_mods', must_exist=True, default='', is_type_of=str),
+    Validator('general.subzero_mods_keep_lyrics', must_exist=True, default=False, is_type_of=bool),
     Validator('general.dont_notify_manual_actions', must_exist=True, default=False, is_type_of=bool),
     Validator('general.notify_if_nothing_is_missing_for_signalr_event', must_exist=True, default=False, is_type_of=bool),
     Validator('general.hi_extension', must_exist=True, default='hi', is_type_of=str, is_in=['hi', 'cc', 'sdh']),

--- a/bazarr/subtitles/download.py
+++ b/bazarr/subtitles/download.py
@@ -11,7 +11,7 @@ from subzero.language import Language
 from subliminal_patch.core import save_subtitles
 from subliminal_patch.core_persistent import download_best_subtitles
 
-from app.config import settings, get_array_from
+from app.config import settings
 from app.database import TableEpisodes, TableMovies, database, select, get_profiles_list
 from utilities.path_mappings import path_mappings
 from utilities.helper import get_target_folder, force_unicode
@@ -58,7 +58,8 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
         minimum_score_movie = settings.general.minimum_score_movie
         min_score, max_score, scores = _get_scores(media_type, minimum_score_movie, minimum_score)
 
-        subz_mods = get_array_from(settings.general.subzero_mods)
+        from subtitles.tools.mods import get_subzero_mods
+        subz_mods = get_subzero_mods()
         saved_any = False
 
         if providers:

--- a/bazarr/subtitles/manual.py
+++ b/bazarr/subtitles/manual.py
@@ -12,7 +12,7 @@ from subliminal_patch.core_persistent import list_all_subtitles, download_subtit
 from subliminal_patch.score import compute_score, DEFAULT_SCORES
 
 from languages.get_languages import alpha3_from_alpha2
-from app.config import settings, get_array_from
+from app.config import settings
 from utilities.helper import get_target_folder, force_unicode
 from utilities.path_mappings import path_mappings
 from app.database import (database, get_profiles_list, select, TableEpisodes, TableShows, get_audio_profile_languages,
@@ -175,7 +175,8 @@ def manual_download_subtitle(path, audio_language, hi, forced, subtitle, provide
     if use_original_format in (1, "1", "True", True):
         subtitle.use_original_format = True
 
-    subtitle.mods = get_array_from(settings.general.subzero_mods)
+    from subtitles.tools.mods import get_subzero_mods
+    subtitle.mods = get_subzero_mods()
     video = get_video(force_unicode(path), title, sceneName, providers={provider}, media_type=media_type)
     if video:
         try:

--- a/bazarr/subtitles/tools/mods.py
+++ b/bazarr/subtitles/tools/mods.py
@@ -8,11 +8,35 @@ from subliminal_patch.subtitle import Subtitle
 from subliminal_patch.core import get_subtitle_path
 from subzero.language import Language
 
-from app.config import settings
+from app.config import settings, get_array_from
 from app.jobs_queue import jobs_queue
 from languages.custom_lang import CustomLanguage
 from languages.get_languages import alpha3_from_alpha2
 from subtitles.indexer.utils import get_external_subtitles_path
+
+
+def has_remove_hi(mods):
+    """Whether the Remove HI mod is present, tolerating its parameterized form
+    (e.g. remove_HI(keep_lyrics=1)). See https://github.com/LavX/bazarr/issues/225
+    """
+    return any(m == 'remove_HI' or m.startswith('remove_HI(') for m in (mods or []))
+
+
+def with_keep_lyrics(mods):
+    """Rewrite the Remove HI mod to preserve song lyrics when the setting is on.
+
+    The preference is encoded as a subzero mod parameter so it travels through
+    the (settings-agnostic) subtitle modification pipeline.
+    See https://github.com/LavX/bazarr/issues/225
+    """
+    if not mods or not settings.general.subzero_mods_keep_lyrics:
+        return mods
+    return ['remove_HI(keep_lyrics=1)' if m == 'remove_HI' else m for m in mods]
+
+
+def get_subzero_mods():
+    """Configured subzero mods with the preserve-song-lyrics preference applied."""
+    return with_keep_lyrics(get_array_from(settings.general.subzero_mods))
 
 
 MOD_LABELS = {
@@ -102,6 +126,7 @@ def apply_subtitle_mods(language, subtitle_path, mods, video_path,
 
 
 def subtitles_apply_mods(language, subtitle_path, mods, video_path):
+    mods = with_keep_lyrics(mods)
     language = alpha3_from_alpha2(language)
     custom = CustomLanguage.from_value(language, "alpha3")
     if custom is None:
@@ -120,7 +145,7 @@ def subtitles_apply_mods(language, subtitle_path, mods, video_path):
 
     content = sub.get_modified_content(format=sub.format)
     if content:
-        if hasattr(sub, 'mods') and isinstance(sub.mods, list) and 'remove_HI' in sub.mods:
+        if hasattr(sub, 'mods') and isinstance(sub.mods, list) and has_remove_hi(sub.mods):
             # get the modded subtitles path if the subtitles are alongside the video
             modded_subtitles_path_if_alongside_video = get_subtitle_path(
                 video_path,

--- a/bazarr/subtitles/upload.py
+++ b/bazarr/subtitles/upload.py
@@ -12,7 +12,7 @@ from subliminal_patch.score import MAX_SCORES
 from pysubs2.formats import get_format_identifier
 
 from languages.get_languages import language_from_alpha3, alpha2_from_alpha3, alpha3_from_alpha2
-from app.config import settings, get_array_from
+from app.config import settings
 from utilities.helper import get_target_folder, force_unicode
 from utilities.post_processing import pp_replace, set_chmod
 from utilities.path_mappings import path_mappings
@@ -105,9 +105,10 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
     else:
         audio_language = {'name': '', 'code2': '', 'code3': ''}
 
+    from subtitles.tools.mods import get_subzero_mods
     sub = Subtitle(
         lang_obj,
-        mods=get_array_from(settings.general.subzero_mods),
+        mods=get_subzero_mods(),
         original_format=use_original_format
     )
 

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -1354,7 +1354,7 @@ def save_subtitles(file_path, subtitles, single=False, directory=None, chmod=Non
         # When the remove_HI mod is applied the saved file no longer carries HI cues, so clear
         # the HI flags as well, not just the filename tag. Downstream history/DB recording reads
         # these attributes; leaving them set records a stripped subtitle as hearing-impaired.
-        if subtitle.mods and 'remove_HI' in subtitle.mods:
+        if subtitle.mods and any(m == 'remove_HI' or m.startswith('remove_HI(') for m in subtitle.mods):
             if hasattr(subtitle, 'hearing_impaired'):
                 subtitle.hearing_impaired = False
             if hasattr(subtitle, 'language') and hasattr(subtitle.language, 'hi'):

--- a/custom_libs/subzero/modification/mods/hearing_impaired.py
+++ b/custom_libs/subzero/modification/mods/hearing_impaired.py
@@ -23,7 +23,9 @@ class FullBracketEntryProcessor(NReProcessor):
         return content
 
 
-_HI_WORD_RE = re.compile(r'[^\W\d_]', re.UNICODE)
+# Any alphanumeric content (letters incl. non-Latin/CJK, or digits) marks a line
+# as real content rather than pure decoration.
+_HI_CONTENT_RE = re.compile(r'[^\W_]', re.UNICODE)
 _MUSIC_SYMBOL_RE = re.compile(r'[*#¶♫♪]')
 
 
@@ -34,10 +36,11 @@ class MusicEntryProcessor(NReProcessor):
     Song lyrics are legitimate subtitle content; the default Remove HI behaviour
     strips them along with the music notes. When keep_lyrics is set, this
     processor only touches lines that actually bear a music symbol (its normal
-    scope): such a line is preserved if it carries words (any letter, incl.
-    non-Latin such as CJK) and dropped if it is only symbols/decoration. Lines
-    without a music symbol are returned untouched, so unrelated letter-free lines
-    (numbers, punctuation) are never collateral. A sung lyric and a descriptive
+    scope): such a line is preserved if it carries any alphanumeric content
+    (letters -- incl. non-Latin such as CJK -- or numbers, e.g. a count-in like
+    "1 2 3 4") and dropped only if it is purely symbols/punctuation decoration.
+    Lines without a music symbol are returned untouched, so unrelated content
+    (numbers, punctuation) is never collateral. A sung lyric and a descriptive
     cue (e.g. "MUSIC", "ominous music") both have words and cannot be told apart
     reliably, so the cue text is kept too: the point of the option is to never
     drop a real lyric. Bracket-wrapped lines (e.g. "[music]") are descriptions by
@@ -53,8 +56,9 @@ class MusicEntryProcessor(NReProcessor):
                 return content
             # Decide per line (not via the entry-wide regex) so a symbol-only
             # line in a multi-line cue does not drag the lyric line with it:
-            # keep music-note lines with words, drop symbol-only decoration.
-            return content if _HI_WORD_RE.search(text) else ""
+            # keep music-note lines with alphanumeric content, drop pure
+            # symbol/punctuation decoration.
+            return content if _HI_CONTENT_RE.search(text) else ""
         return super(MusicEntryProcessor, self).process(content, debug=debug, **kwargs)
 
 

--- a/custom_libs/subzero/modification/mods/hearing_impaired.py
+++ b/custom_libs/subzero/modification/mods/hearing_impaired.py
@@ -23,18 +23,40 @@ class FullBracketEntryProcessor(NReProcessor):
         return content
 
 
+_MUSIC_SYMBOLS_RE = re.compile(r'[*#¶♫♪]')
+_MUSIC_CUE_KEYWORDS_RE = re.compile(r'\b(?:music|instrumental|fanfare|jingle)\b', re.IGNORECASE)
+
+
+def _is_music_cue(text):
+    """Whether a music-note line describes a sound rather than carrying lyrics.
+
+    Used only when keep_lyrics is set: a music *cue* (an all-caps sound
+    description like "MUSIC", or a phrase such as "ominous music") is still
+    hearing-impaired content and should be removed, while genuine song lyrics
+    are preserved. See https://github.com/LavX/bazarr/issues/225
+    """
+    inner = _MUSIC_SYMBOLS_RE.sub('', text or '').strip(" \t->~[]()")
+    if not inner:
+        return True  # decoration only, no lyrics
+    letters = [c for c in inner if c.isalpha()]
+    if letters and all(c.isupper() for c in letters):
+        return True  # all-caps sound description
+    return bool(_MUSIC_CUE_KEYWORDS_RE.search(inner))
+
+
 class MusicEntryProcessor(NReProcessor):
     """Removes lyric lines decorated with music symbols, unless the mod was asked
     to keep them via the keep_lyrics arg (remove_HI(keep_lyrics=1)).
 
     Song lyrics are legitimate subtitle content; the default Remove HI behaviour
-    strips them along with the music notes. See
+    strips them along with the music notes. When keeping lyrics, music *cues*
+    (sound descriptions) are still removed. See
     https://github.com/LavX/bazarr/issues/225
     """
-    def process(self, content, debug=False, keep_lyrics=None, **kwargs):
-        if keep_lyrics:
+    def process(self, content, debug=False, keep_lyrics=None, entry=None, **kwargs):
+        if keep_lyrics and not _is_music_cue(content):
             return content
-        return super(MusicEntryProcessor, self).process(content, debug=debug, **kwargs)
+        return super(MusicEntryProcessor, self).process(content, debug=debug, entry=entry, **kwargs)
 
 
 class HearingImpaired(SubtitleTextModification):

--- a/custom_libs/subzero/modification/mods/hearing_impaired.py
+++ b/custom_libs/subzero/modification/mods/hearing_impaired.py
@@ -23,6 +23,20 @@ class FullBracketEntryProcessor(NReProcessor):
         return content
 
 
+class MusicEntryProcessor(NReProcessor):
+    """Removes lyric lines decorated with music symbols, unless the mod was asked
+    to keep them via the keep_lyrics arg (remove_HI(keep_lyrics=1)).
+
+    Song lyrics are legitimate subtitle content; the default Remove HI behaviour
+    strips them along with the music notes. See
+    https://github.com/LavX/bazarr/issues/225
+    """
+    def process(self, content, debug=False, keep_lyrics=None, **kwargs):
+        if keep_lyrics:
+            return content
+        return super(MusicEntryProcessor, self).process(content, debug=debug, **kwargs)
+
+
 class HearingImpaired(SubtitleTextModification):
     identifier = "remove_HI"
     description = "Remove Hearing Impaired tags"
@@ -112,9 +126,9 @@ class HearingImpaired(SubtitleTextModification):
         NReProcessor(re.compile(r'(?u)(^%(t)s[*#¶♫♪\s]*%(t)s[*#¶♫♪\s]+%(t)s[*#¶♫♪\s]*%(t)s$)' % {"t": TAG}),
                      "", name="HI_music_symbols_only"),
 
-        # remove music entries
-        NReProcessor(re.compile(r'(?ums)(^[-\s>~]*[*#¶♫♪]+\s*.+|.+\s*[*#¶♫♪]+\s*$|.+\s*[*#¶♫♪]+[)\]])'),
-                     "", name="HI_music", entry=True),
+        # remove music entries (song lyrics); skipped when keep_lyrics is set
+        MusicEntryProcessor(re.compile(r'(?ums)(^[-\s>~]*[*#¶♫♪]+\s*.+|.+\s*[*#¶♫♪]+\s*$|.+\s*[*#¶♫♪]+[)\]])'),
+                            "", name="HI_music", entry=True),
     ]
 
 

--- a/custom_libs/subzero/modification/mods/hearing_impaired.py
+++ b/custom_libs/subzero/modification/mods/hearing_impaired.py
@@ -23,40 +23,22 @@ class FullBracketEntryProcessor(NReProcessor):
         return content
 
 
-_MUSIC_SYMBOLS_RE = re.compile(r'[*#¶♫♪]')
-_MUSIC_CUE_KEYWORDS_RE = re.compile(r'\b(?:music|instrumental|fanfare|jingle)\b', re.IGNORECASE)
-
-
-def _is_music_cue(text):
-    """Whether a music-note line describes a sound rather than carrying lyrics.
-
-    Used only when keep_lyrics is set: a music *cue* (an all-caps sound
-    description like "MUSIC", or a phrase such as "ominous music") is still
-    hearing-impaired content and should be removed, while genuine song lyrics
-    are preserved. See https://github.com/LavX/bazarr/issues/225
-    """
-    inner = _MUSIC_SYMBOLS_RE.sub('', text or '').strip(" \t->~[]()")
-    if not inner:
-        return True  # decoration only, no lyrics
-    letters = [c for c in inner if c.isalpha()]
-    if letters and all(c.isupper() for c in letters):
-        return True  # all-caps sound description
-    return bool(_MUSIC_CUE_KEYWORDS_RE.search(inner))
-
-
 class MusicEntryProcessor(NReProcessor):
-    """Removes lyric lines decorated with music symbols, unless the mod was asked
+    """Removes music-note lines (the HI_music processor), unless the mod was asked
     to keep them via the keep_lyrics arg (remove_HI(keep_lyrics=1)).
 
     Song lyrics are legitimate subtitle content; the default Remove HI behaviour
-    strips them along with the music notes. When keeping lyrics, music *cues*
-    (sound descriptions) are still removed. See
-    https://github.com/LavX/bazarr/issues/225
+    strips them along with the music notes. When keep_lyrics is set we preserve
+    every music-note line: a sung lyric and a descriptive cue (e.g. "MUSIC",
+    "ominous music", or an all-caps line) cannot be told apart reliably, and the
+    whole point of the option is to never drop a real lyric. Bare music-symbol
+    lines with no text are still removed by the separate HI_music_symbols_only
+    processor. See https://github.com/LavX/bazarr/issues/225
     """
-    def process(self, content, debug=False, keep_lyrics=None, entry=None, **kwargs):
-        if keep_lyrics and not _is_music_cue(content):
+    def process(self, content, debug=False, keep_lyrics=None, **kwargs):
+        if keep_lyrics:
             return content
-        return super(MusicEntryProcessor, self).process(content, debug=debug, entry=entry, **kwargs)
+        return super(MusicEntryProcessor, self).process(content, debug=debug, **kwargs)
 
 
 class HearingImpaired(SubtitleTextModification):

--- a/custom_libs/subzero/modification/mods/hearing_impaired.py
+++ b/custom_libs/subzero/modification/mods/hearing_impaired.py
@@ -23,20 +23,26 @@ class FullBracketEntryProcessor(NReProcessor):
         return content
 
 
+_HI_WORD_RE = re.compile(r'[^\W\d_]', re.UNICODE)
+
+
 class MusicEntryProcessor(NReProcessor):
     """Removes music-note lines (the HI_music processor), unless the mod was asked
     to keep them via the keep_lyrics arg (remove_HI(keep_lyrics=1)).
 
     Song lyrics are legitimate subtitle content; the default Remove HI behaviour
-    strips them along with the music notes. When keep_lyrics is set we preserve
-    every music-note line: a sung lyric and a descriptive cue (e.g. "MUSIC",
-    "ominous music", or an all-caps line) cannot be told apart reliably, and the
-    whole point of the option is to never drop a real lyric. Bare music-symbol
-    lines with no text are still removed by the separate HI_music_symbols_only
-    processor. See https://github.com/LavX/bazarr/issues/225
+    strips them along with the music notes. When keep_lyrics is set we preserve a
+    music-note line only if it carries actual words (any letter, incl. non-Latin
+    such as CJK). Lines that are just symbols/dashes/punctuation are still
+    dropped as decoration. A sung lyric and a descriptive cue (e.g. "MUSIC",
+    "ominous music") both have words and cannot be told apart reliably, so the
+    cue text is kept too: the whole point of the option is to never drop a real
+    lyric. Bracket-wrapped lines (e.g. "[music]") are descriptions by subtitle
+    convention and are removed earlier by HI_brackets, before this processor.
+    See https://github.com/LavX/bazarr/issues/225
     """
     def process(self, content, debug=False, keep_lyrics=None, **kwargs):
-        if keep_lyrics:
+        if keep_lyrics and _HI_WORD_RE.search(content or ""):
             return content
         return super(MusicEntryProcessor, self).process(content, debug=debug, **kwargs)
 

--- a/custom_libs/subzero/modification/mods/hearing_impaired.py
+++ b/custom_libs/subzero/modification/mods/hearing_impaired.py
@@ -27,6 +27,9 @@ class FullBracketEntryProcessor(NReProcessor):
 # as real content rather than pure decoration.
 _HI_CONTENT_RE = re.compile(r'[^\W_]', re.UNICODE)
 _MUSIC_SYMBOL_RE = re.compile(r'[*#¶♫♪]')
+# SSA/ASS override tags ({\i1}, {\an8}, {\c&H..&}, ...) carry letters/digits that
+# must not be mistaken for lyric content when testing a line.
+_OVERRIDE_TAG_RE = re.compile(r'\{[^}]*\}')
 
 
 class MusicEntryProcessor(NReProcessor):
@@ -57,8 +60,10 @@ class MusicEntryProcessor(NReProcessor):
             # Decide per line (not via the entry-wide regex) so a symbol-only
             # line in a multi-line cue does not drag the lyric line with it:
             # keep music-note lines with alphanumeric content, drop pure
-            # symbol/punctuation decoration.
-            return content if _HI_CONTENT_RE.search(text) else ""
+            # symbol/punctuation decoration. Strip override tags first so their
+            # letters/digits (e.g. {\i1}) are not counted as content.
+            stripped = _OVERRIDE_TAG_RE.sub('', text)
+            return content if _HI_CONTENT_RE.search(stripped) else ""
         return super(MusicEntryProcessor, self).process(content, debug=debug, **kwargs)
 
 

--- a/custom_libs/subzero/modification/mods/hearing_impaired.py
+++ b/custom_libs/subzero/modification/mods/hearing_impaired.py
@@ -24,6 +24,7 @@ class FullBracketEntryProcessor(NReProcessor):
 
 
 _HI_WORD_RE = re.compile(r'[^\W\d_]', re.UNICODE)
+_MUSIC_SYMBOL_RE = re.compile(r'[*#¶♫♪]')
 
 
 class MusicEntryProcessor(NReProcessor):
@@ -31,23 +32,29 @@ class MusicEntryProcessor(NReProcessor):
     to keep them via the keep_lyrics arg (remove_HI(keep_lyrics=1)).
 
     Song lyrics are legitimate subtitle content; the default Remove HI behaviour
-    strips them along with the music notes. When keep_lyrics is set we preserve a
-    music-note line only if it carries actual words (any letter, incl. non-Latin
-    such as CJK). Lines that are just symbols/dashes/punctuation are still
-    dropped as decoration. A sung lyric and a descriptive cue (e.g. "MUSIC",
-    "ominous music") both have words and cannot be told apart reliably, so the
-    cue text is kept too: the whole point of the option is to never drop a real
-    lyric. Bracket-wrapped lines (e.g. "[music]") are descriptions by subtitle
-    convention and are removed earlier by HI_brackets, before this processor.
+    strips them along with the music notes. When keep_lyrics is set, this
+    processor only touches lines that actually bear a music symbol (its normal
+    scope): such a line is preserved if it carries words (any letter, incl.
+    non-Latin such as CJK) and dropped if it is only symbols/decoration. Lines
+    without a music symbol are returned untouched, so unrelated letter-free lines
+    (numbers, punctuation) are never collateral. A sung lyric and a descriptive
+    cue (e.g. "MUSIC", "ominous music") both have words and cannot be told apart
+    reliably, so the cue text is kept too: the point of the option is to never
+    drop a real lyric. Bracket-wrapped lines (e.g. "[music]") are descriptions by
+    subtitle convention and are removed earlier by HI_brackets.
     See https://github.com/LavX/bazarr/issues/225
     """
     def process(self, content, debug=False, keep_lyrics=None, **kwargs):
         if keep_lyrics:
-            # Decide per line, not via the entry-wide HI_music regex: a
-            # symbol-only line inside a multi-line event would otherwise drag the
-            # whole event (the lyric line included) into removal. Keep lines that
-            # carry words (lyrics); drop pure symbol/dash/punctuation lines.
-            return content if _HI_WORD_RE.search(content or "") else ""
+            text = content or ""
+            # Only music-note lines are in this processor's scope; leave anything
+            # else (it would not match the HI_music regex anyway) untouched.
+            if not _MUSIC_SYMBOL_RE.search(text):
+                return content
+            # Decide per line (not via the entry-wide regex) so a symbol-only
+            # line in a multi-line cue does not drag the lyric line with it:
+            # keep music-note lines with words, drop symbol-only decoration.
+            return content if _HI_WORD_RE.search(text) else ""
         return super(MusicEntryProcessor, self).process(content, debug=debug, **kwargs)
 
 

--- a/custom_libs/subzero/modification/mods/hearing_impaired.py
+++ b/custom_libs/subzero/modification/mods/hearing_impaired.py
@@ -42,8 +42,12 @@ class MusicEntryProcessor(NReProcessor):
     See https://github.com/LavX/bazarr/issues/225
     """
     def process(self, content, debug=False, keep_lyrics=None, **kwargs):
-        if keep_lyrics and _HI_WORD_RE.search(content or ""):
-            return content
+        if keep_lyrics:
+            # Decide per line, not via the entry-wide HI_music regex: a
+            # symbol-only line inside a multi-line event would otherwise drag the
+            # whole event (the lyric line included) into removal. Keep lines that
+            # carry words (lyrics); drop pure symbol/dash/punctuation lines.
+            return content if _HI_WORD_RE.search(content or "") else ""
         return super(MusicEntryProcessor, self).process(content, debug=debug, **kwargs)
 
 

--- a/frontend/src/pages/Settings/Subtitles/index.tsx
+++ b/frontend/src/pages/Settings/Subtitles/index.tsx
@@ -366,6 +366,15 @@ const SettingsSubtitlesView: FunctionComponent = () => {
           hearing impaired people.
         </Message>
         <Check
+          label="Preserve Song Lyrics"
+          settingKey="settings-general-subzero_mods_keep_lyrics"
+        ></Check>
+        <Message>
+          When removing hearing impaired content, keep song lyrics that are
+          marked with music note symbols (♪, ♫). Only applies when Hearing
+          Impaired removal is enabled.
+        </Message>
+        <Check
           label="Remove Tags"
           settingOptions={{ onLoaded: SubzeroModification("remove_tags") }}
           settingKey="subzero-remove_tags"

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -68,6 +68,7 @@ declare namespace Settings {
     subfolder: string;
     subfolder_custom?: string;
     subzero_mods?: string[];
+    subzero_mods_keep_lyrics?: boolean;
     subzero_color_selection?: string;
     update_restart: boolean;
     upgrade_frequency: number;

--- a/tests/bazarr/test_subzero_keep_lyrics.py
+++ b/tests/bazarr/test_subzero_keep_lyrics.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+# Helper coverage for the preserve-song-lyrics option.
+# See https://github.com/LavX/bazarr/issues/225
+from app.config import settings
+from subtitles.tools.mods import has_remove_hi, with_keep_lyrics
+
+
+def test_has_remove_hi_plain():
+    assert has_remove_hi(["remove_HI", "OCR_fixes"])
+
+
+def test_has_remove_hi_parameterized():
+    assert has_remove_hi(["remove_HI(keep_lyrics=1)", "common"])
+
+
+def test_has_remove_hi_absent():
+    assert not has_remove_hi(["OCR_fixes", "common"])
+    assert not has_remove_hi([])
+    assert not has_remove_hi(None)
+
+
+def test_with_keep_lyrics_off_is_noop(monkeypatch):
+    monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", False)
+    assert with_keep_lyrics(["remove_HI", "common"]) == ["remove_HI", "common"]
+
+
+def test_with_keep_lyrics_on_rewrites_remove_hi(monkeypatch):
+    monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", True)
+    assert with_keep_lyrics(["remove_HI", "common"]) == [
+        "remove_HI(keep_lyrics=1)",
+        "common",
+    ]
+
+
+def test_with_keep_lyrics_on_without_remove_hi_is_noop(monkeypatch):
+    monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", True)
+    assert with_keep_lyrics(["common", "OCR_fixes"]) == ["common", "OCR_fixes"]
+
+
+def test_with_keep_lyrics_empty(monkeypatch):
+    monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", True)
+    assert with_keep_lyrics([]) == []

--- a/tests/subliminal_patch/test_mods_keep_lyrics.py
+++ b/tests/subliminal_patch/test_mods_keep_lyrics.py
@@ -89,3 +89,16 @@ def test_keep_lyrics_preserves_all_music_note_text_lines(languages):
     assert "HAPPY BIRTHDAY TO YOU" in out               # all-caps lyric kept
     assert "I can still hear the music playing" in out  # lyric mentioning music kept
     assert "We are the champions my friend" in out      # plain lyric kept
+
+
+def test_keep_lyrics_drops_symbol_line_within_multiline_event(languages):
+    """A symbol-only line sharing a multi-line cue with a lyric is dropped on its
+    own; the lyric line in the same cue must survive (not be dragged into the
+    entry-wide removal). Regression for the Codex review on
+    https://github.com/LavX/bazarr/pull/229
+    """
+    srt = "1\n00:00:01,000 --> 00:00:02,000\n♪ We are the champions ♪\n♪♪\n"
+    out = _modified(languages, ["remove_HI(keep_lyrics=1)"], srt=srt)
+    assert "We are the champions" in out                # lyric in the multi-line cue kept
+    lines = [line.strip() for line in out.splitlines()]
+    assert "♪♪" not in lines                            # symbol-only line dropped

--- a/tests/subliminal_patch/test_mods_keep_lyrics.py
+++ b/tests/subliminal_patch/test_mods_keep_lyrics.py
@@ -1,0 +1,56 @@
+# coding=utf-8
+# Coverage for the "preserve song lyrics" option of the Remove HI mod.
+# See https://github.com/LavX/bazarr/issues/225
+
+from subliminal_patch import Subtitle
+
+
+SRT = (
+    "1\n"
+    "00:00:01,000 --> 00:00:02,000\n"
+    "[door creaks]\n"
+    "\n"
+    "2\n"
+    "00:00:03,000 --> 00:00:04,000\n"
+    "♪ We are the champions my friend ♪\n"
+    "\n"
+    "3\n"
+    "00:00:05,000 --> 00:00:06,000\n"
+    "JOHN: Hello there\n"
+    "\n"
+    "4\n"
+    "00:00:07,000 --> 00:00:08,000\n"
+    "♪♪\n"
+)
+
+
+def _modified(languages, mods):
+    sub = Subtitle(languages["en"], mods=mods, original_format=True)
+    sub.content = SRT.encode("utf-8")
+    assert sub.is_valid()
+    content = sub.get_modified_content(format="srt")
+    return content.decode("utf-8") if content else ""
+
+
+def test_remove_hi_strips_song_lyrics_by_default(languages):
+    out = _modified(languages, ["remove_HI"])
+    assert "champions" not in out      # music-note lyric line removed (legacy behaviour)
+    assert "door creaks" not in out    # bracketed cue removed
+    assert "JOHN:" not in out          # speaker label removed
+    assert "Hello there" in out        # actual dialogue kept
+
+
+def test_remove_hi_keep_lyrics_preserves_song_lyrics(languages):
+    out = _modified(languages, ["remove_HI(keep_lyrics=1)"])
+    assert "We are the champions my friend" in out  # lyric line preserved
+    assert "door creaks" not in out                 # non-lyric HI cue still removed
+    assert "JOHN:" not in out                        # speaker label still removed
+    assert "Hello there" in out                      # dialogue still kept
+
+
+def test_keep_lyrics_still_drops_bare_music_symbol_lines(languages):
+    """A line that is only decorative music symbols carries no lyrics, so it is
+    removed even when lyrics are preserved."""
+    out = _modified(languages, ["remove_HI(keep_lyrics=1)"])
+    lines = [line.strip() for line in out.splitlines()]
+    assert "♪♪" not in lines

--- a/tests/subliminal_patch/test_mods_keep_lyrics.py
+++ b/tests/subliminal_patch/test_mods_keep_lyrics.py
@@ -56,17 +56,19 @@ def test_keep_lyrics_still_drops_bare_music_symbol_lines(languages):
     assert "♪♪" not in lines
 
 
-def test_keep_lyrics_still_drops_music_cue_descriptions(languages):
-    """Music *descriptions* (cues) are hearing-impaired content, not lyrics, so
-    they are removed even when lyrics are preserved. Regression for the Codex
-    review on https://github.com/LavX/bazarr/pull/229
+def test_keep_lyrics_preserves_all_music_note_text_lines(languages):
+    """A music-note line carrying text is preserved when keeping lyrics, even if
+    it looks like a description: a sung lyric and a cue cannot be told apart
+    reliably, and over-removing was the bug being fixed (the heuristic dropped
+    all-caps lyrics like "HAPPY BIRTHDAY" and lyrics containing "music").
+    See the Codex review on https://github.com/LavX/bazarr/pull/229
     """
     srt = (
-        "1\n00:00:01,000 --> 00:00:02,000\n♪ MUSIC ♪\n\n"
-        "2\n00:00:03,000 --> 00:00:04,000\n♪ ominous music ♪\n\n"
+        "1\n00:00:01,000 --> 00:00:02,000\n♪ HAPPY BIRTHDAY TO YOU ♪\n\n"
+        "2\n00:00:03,000 --> 00:00:04,000\n♪ I can still hear the music playing ♪\n\n"
         "3\n00:00:05,000 --> 00:00:06,000\n♪ We are the champions my friend ♪\n"
     )
     out = _modified(languages, ["remove_HI(keep_lyrics=1)"], srt=srt)
-    assert "MUSIC" not in out                          # all-caps cue removed
-    assert "ominous music" not in out                  # lowercase music cue removed
-    assert "We are the champions my friend" in out     # genuine lyric preserved
+    assert "HAPPY BIRTHDAY TO YOU" in out               # all-caps lyric kept
+    assert "I can still hear the music playing" in out  # lyric mentioning music kept
+    assert "We are the champions my friend" in out      # plain lyric kept

--- a/tests/subliminal_patch/test_mods_keep_lyrics.py
+++ b/tests/subliminal_patch/test_mods_keep_lyrics.py
@@ -56,6 +56,23 @@ def test_keep_lyrics_still_drops_bare_music_symbol_lines(languages):
     assert "♪♪" not in lines
 
 
+def test_keep_lyrics_drops_decorated_symbol_only_lines(languages):
+    """Symbol-only lines decorated with dashes/spaces carry no words, so they are
+    still dropped while a real lyric in the same file is kept. Regression for the
+    Codex review on https://github.com/LavX/bazarr/pull/229
+    """
+    srt = (
+        "1\n00:00:01,000 --> 00:00:02,000\n- ♪♪\n\n"
+        "2\n00:00:03,000 --> 00:00:04,000\n> ♪ ♪\n\n"
+        "3\n00:00:05,000 --> 00:00:06,000\n♪ We are the champions ♪\n"
+    )
+    out = _modified(languages, ["remove_HI(keep_lyrics=1)"], srt=srt)
+    lines = [line.strip() for line in out.splitlines()]
+    assert "- ♪♪" not in lines              # decorated symbol-only line dropped
+    assert "> ♪ ♪" not in lines             # decorated symbol-only line dropped
+    assert "We are the champions" in out    # real lyric preserved
+
+
 def test_keep_lyrics_preserves_all_music_note_text_lines(languages):
     """A music-note line carrying text is preserved when keeping lyrics, even if
     it looks like a description: a sung lyric and a cue cannot be told apart

--- a/tests/subliminal_patch/test_mods_keep_lyrics.py
+++ b/tests/subliminal_patch/test_mods_keep_lyrics.py
@@ -91,6 +91,21 @@ def test_keep_lyrics_preserves_all_music_note_text_lines(languages):
     assert "We are the champions my friend" in out      # plain lyric kept
 
 
+def test_keep_lyrics_leaves_non_music_letterless_lines(languages):
+    """Lines without a music symbol are outside this processor's scope and must
+    survive even when they have no letters (e.g. a year). Regression for the
+    Codex review on https://github.com/LavX/bazarr/pull/229
+    """
+    srt = (
+        "1\n00:00:01,000 --> 00:00:02,000\n1939\n\n"
+        "2\n00:00:03,000 --> 00:00:04,000\n♪♪\n"
+    )
+    out = _modified(languages, ["remove_HI(keep_lyrics=1)"], srt=srt)
+    assert "1939" in out                    # non-music letterless line kept
+    lines = [line.strip() for line in out.splitlines()]
+    assert "♪♪" not in lines                # music symbol-only line still dropped
+
+
 def test_keep_lyrics_drops_symbol_line_within_multiline_event(languages):
     """A symbol-only line sharing a multi-line cue with a lyric is dropped on its
     own; the lyric line in the same cue must survive (not be dragged into the

--- a/tests/subliminal_patch/test_mods_keep_lyrics.py
+++ b/tests/subliminal_patch/test_mods_keep_lyrics.py
@@ -106,6 +106,28 @@ def test_keep_lyrics_leaves_non_music_letterless_lines(languages):
     assert "♪♪" not in lines                # music symbol-only line still dropped
 
 
+def test_music_processor_strips_override_tags_for_content_check():
+    """SSA/ASS override tags ({\\i1}, {\\an8}, ...) must not count as lyric
+    content: a tag-wrapped decoration line is dropped, a tag-wrapped lyric is
+    kept, and a non-music line is left untouched. Regression for the Codex review
+    on https://github.com/LavX/bazarr/pull/229
+    """
+    import re as _re
+
+    from subzero.modification.mods.hearing_impaired import MusicEntryProcessor
+
+    proc = MusicEntryProcessor(_re.compile(r"x"), "", name="test", entry=True)
+    # tag-wrapped pure decoration -> dropped (tag chars must not read as content)
+    assert proc.process("{\\i1}♪♪{\\i0}", keep_lyrics=1) == ""
+    assert proc.process("{\\an8}{\\i1}♪ ♪{\\i0}", keep_lyrics=1) == ""
+    # tag-wrapped real lyric -> kept verbatim
+    assert (
+        proc.process("{\\i1}♪ HAPPY ♪{\\i0}", keep_lyrics=1) == "{\\i1}♪ HAPPY ♪{\\i0}"
+    )
+    # non-music line (no music symbol) -> untouched even though it has tags
+    assert proc.process("{\\i1}1939{\\i0}", keep_lyrics=1) == "{\\i1}1939{\\i0}"
+
+
 def test_keep_lyrics_preserves_numeric_music_lines(languages):
     """A music-note line whose content is numeric (e.g. a count-in) is real
     content, not pure decoration, so it is preserved. Regression for the Codex

--- a/tests/subliminal_patch/test_mods_keep_lyrics.py
+++ b/tests/subliminal_patch/test_mods_keep_lyrics.py
@@ -24,9 +24,9 @@ SRT = (
 )
 
 
-def _modified(languages, mods):
+def _modified(languages, mods, srt=SRT):
     sub = Subtitle(languages["en"], mods=mods, original_format=True)
-    sub.content = SRT.encode("utf-8")
+    sub.content = srt.encode("utf-8")
     assert sub.is_valid()
     content = sub.get_modified_content(format="srt")
     return content.decode("utf-8") if content else ""
@@ -54,3 +54,19 @@ def test_keep_lyrics_still_drops_bare_music_symbol_lines(languages):
     out = _modified(languages, ["remove_HI(keep_lyrics=1)"])
     lines = [line.strip() for line in out.splitlines()]
     assert "♪♪" not in lines
+
+
+def test_keep_lyrics_still_drops_music_cue_descriptions(languages):
+    """Music *descriptions* (cues) are hearing-impaired content, not lyrics, so
+    they are removed even when lyrics are preserved. Regression for the Codex
+    review on https://github.com/LavX/bazarr/pull/229
+    """
+    srt = (
+        "1\n00:00:01,000 --> 00:00:02,000\n♪ MUSIC ♪\n\n"
+        "2\n00:00:03,000 --> 00:00:04,000\n♪ ominous music ♪\n\n"
+        "3\n00:00:05,000 --> 00:00:06,000\n♪ We are the champions my friend ♪\n"
+    )
+    out = _modified(languages, ["remove_HI(keep_lyrics=1)"], srt=srt)
+    assert "MUSIC" not in out                          # all-caps cue removed
+    assert "ominous music" not in out                  # lowercase music cue removed
+    assert "We are the champions my friend" in out     # genuine lyric preserved

--- a/tests/subliminal_patch/test_mods_keep_lyrics.py
+++ b/tests/subliminal_patch/test_mods_keep_lyrics.py
@@ -106,6 +106,21 @@ def test_keep_lyrics_leaves_non_music_letterless_lines(languages):
     assert "♪♪" not in lines                # music symbol-only line still dropped
 
 
+def test_keep_lyrics_preserves_numeric_music_lines(languages):
+    """A music-note line whose content is numeric (e.g. a count-in) is real
+    content, not pure decoration, so it is preserved. Regression for the Codex
+    review on https://github.com/LavX/bazarr/pull/229
+    """
+    srt = (
+        "1\n00:00:01,000 --> 00:00:02,000\n♪ 1 2 3 4 ♪\n\n"
+        "2\n00:00:03,000 --> 00:00:04,000\n♪♪\n"
+    )
+    out = _modified(languages, ["remove_HI(keep_lyrics=1)"], srt=srt)
+    assert "1 2 3 4" in out                 # numeric music-note line kept
+    lines = [line.strip() for line in out.splitlines()]
+    assert "♪♪" not in lines                # pure decoration still dropped
+
+
 def test_keep_lyrics_drops_symbol_line_within_multiline_event(languages):
     """A symbol-only line sharing a multi-line cue with a lyric is dropped on its
     own; the lyric line in the same cue must survive (not be dragged into the


### PR DESCRIPTION
Fixes https://github.com/LavX/bazarr/issues/225

## Problem
The Remove HI mod strips song-lyric lines decorated with music-note symbols along with genuine HI cues, removing wanted text with no way to opt out.

## Fix
Adds a "Preserve Song Lyrics" subtitle setting (`general.subzero_mods_keep_lyrics`). When enabled, the Remove HI mod keeps lyric lines (still dropping bare, text-free music-symbol lines and all other HI content). The preference travels through the settings-agnostic subzero pipeline as a mod parameter, `remove_HI(keep_lyrics=1)`:

- subzero `MusicEntryProcessor` honours the `keep_lyrics` arg.
- a centralized `get_subzero_mods()` / `with_keep_lyrics()` helper rewrites the mod when the setting is on; used by the download, manual and upload paths and the manual mods tool.
- the two `remove_HI in mods` membership checks (modded output path, HI-cue flag clearing) tolerate the parameterized form.

## Tests
subzero behaviour (`test_mods_keep_lyrics.py`) and helper logic (`test_subzero_keep_lyrics.py`); both registered in the CI guard list.