### PR TITLE
Flag providers that need an Anti-Captcha service in the Subtitle Hub

### DIFF
--- a/frontend/src/pages/Settings/Providers/hub/__tests__/utils.test.ts
+++ b/frontend/src/pages/Settings/Providers/hub/__tests__/utils.test.ts
@@ -15,6 +15,7 @@ import {
   isUpdateAvailable,
   parseGitHubUrl,
   parseManifest,
+  requiresAntiCaptcha,
   summarizeUpdates,
 } from "@/pages/Settings/Providers/hub/utils";
 
@@ -317,5 +318,77 @@ describe("getActionLabel", () => {
     expect(getActionLabel(undefined)).toBe("Unknown action");
     expect(getActionLabel(null)).toBe("Unknown action");
     expect(getActionLabel("")).toBe("Unknown action");
+  });
+});
+
+describe("requiresAntiCaptcha", () => {
+  it("returns false for missing/empty manifests", () => {
+    expect(requiresAntiCaptcha(null)).toBe(false);
+    expect(requiresAntiCaptcha(undefined)).toBe(false);
+    expect(requiresAntiCaptcha({})).toBe(false);
+    expect(requiresAntiCaptcha({ manifest: { provider_id: "x" } })).toBe(false);
+  });
+
+  it("detects a keyword in the description", () => {
+    expect(
+      requiresAntiCaptcha({
+        manifest: { description: "Needs FlareSolverr to pass Cloudflare." },
+      }),
+    ).toBe(true);
+  });
+
+  it("detects a keyword in the long description", () => {
+    expect(
+      requiresAntiCaptcha({
+        manifest: { long_description: "An anti-captcha provider is required." },
+      }),
+    ).toBe(true);
+  });
+
+  it("detects a keyword inside config_schema field descriptions", () => {
+    expect(
+      requiresAntiCaptcha({
+        manifest: {
+          config_schema: {
+            properties: {
+              cookies: {
+                description: "Use cookies when login is blocked by captcha.",
+              },
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("honours an explicit requires_anti_captcha flag over the heuristic", () => {
+    expect(
+      requiresAntiCaptcha({
+        manifest: {
+          requires_anti_captcha: false,
+          description: "Mentions captcha but explicitly opts out.",
+        },
+      }),
+    ).toBe(false);
+    expect(
+      requiresAntiCaptcha({ manifest: { requires_anti_captcha: true } }),
+    ).toBe(true);
+  });
+
+  it("detects an entry in an explicit requires array", () => {
+    expect(
+      requiresAntiCaptcha({ manifest: { requires: ["flaresolverr"] } }),
+    ).toBe(true);
+  });
+
+  it("returns false when no captcha signal is present", () => {
+    expect(
+      requiresAntiCaptcha({
+        manifest: {
+          description: "A normal subtitle provider.",
+          config_schema: { properties: { api_key: { title: "API key" } } },
+        },
+      }),
+    ).toBe(false);
   });
 });

--- a/frontend/src/pages/Settings/Providers/hub/__tests__/utils.test.ts
+++ b/frontend/src/pages/Settings/Providers/hub/__tests__/utils.test.ts
@@ -15,9 +15,9 @@ import {
   isUpdateAvailable,
   parseGitHubUrl,
   parseManifest,
-  requiresAntiCaptcha,
-  requiresFlaresolverr,
   summarizeUpdates,
+  usesAntiCaptcha,
+  usesFlaresolverr,
 } from "@/pages/Settings/Providers/hub/utils";
 
 describe("parseManifest", () => {
@@ -322,17 +322,17 @@ describe("getActionLabel", () => {
   });
 });
 
-describe("requiresAntiCaptcha", () => {
+describe("usesAntiCaptcha", () => {
   it("returns false for missing/empty manifests", () => {
-    expect(requiresAntiCaptcha(null)).toBe(false);
-    expect(requiresAntiCaptcha(undefined)).toBe(false);
-    expect(requiresAntiCaptcha({})).toBe(false);
-    expect(requiresAntiCaptcha({ manifest: { provider_id: "x" } })).toBe(false);
+    expect(usesAntiCaptcha(null)).toBe(false);
+    expect(usesAntiCaptcha(undefined)).toBe(false);
+    expect(usesAntiCaptcha({})).toBe(false);
+    expect(usesAntiCaptcha({ manifest: { provider_id: "x" } })).toBe(false);
   });
 
   it("detects a captcha-solver config field", () => {
     expect(
-      requiresAntiCaptcha({
+      usesAntiCaptcha({
         manifest: {
           config_schema: {
             properties: { captcha_solver_url: { title: "Captcha solver URL" } },
@@ -344,7 +344,7 @@ describe("requiresAntiCaptcha", () => {
 
   it("does not treat a FlareSolverr-only provider as anti-captcha", () => {
     expect(
-      requiresAntiCaptcha({
+      usesAntiCaptcha({
         manifest: {
           config_schema: {
             properties: { flaresolverr_url: { title: "FlareSolverr URL" } },
@@ -356,7 +356,7 @@ describe("requiresAntiCaptcha", () => {
 
   it("ignores captcha mentions in description text without a config field", () => {
     expect(
-      requiresAntiCaptcha({
+      usesAntiCaptcha({
         manifest: {
           description: "Use cookies when login is blocked by captcha.",
           config_schema: { properties: { cookies: { secret: true } } },
@@ -365,31 +365,29 @@ describe("requiresAntiCaptcha", () => {
     ).toBe(false);
   });
 
-  it("honours an explicit requires_anti_captcha flag over field detection", () => {
+  it("honours an explicit anti_captcha flag over field detection", () => {
     expect(
-      requiresAntiCaptcha({
+      usesAntiCaptcha({
         manifest: {
-          requires_anti_captcha: false,
+          anti_captcha: false,
           config_schema: { properties: { captcha_solver_url: {} } },
         },
       }),
     ).toBe(false);
-    expect(
-      requiresAntiCaptcha({ manifest: { requires_anti_captcha: true } }),
-    ).toBe(true);
+    expect(usesAntiCaptcha({ manifest: { anti_captcha: true } })).toBe(true);
   });
 });
 
-describe("requiresFlaresolverr", () => {
+describe("usesFlaresolverr", () => {
   it("returns false for missing/empty manifests", () => {
-    expect(requiresFlaresolverr(null)).toBe(false);
-    expect(requiresFlaresolverr(undefined)).toBe(false);
-    expect(requiresFlaresolverr({})).toBe(false);
+    expect(usesFlaresolverr(null)).toBe(false);
+    expect(usesFlaresolverr(undefined)).toBe(false);
+    expect(usesFlaresolverr({})).toBe(false);
   });
 
   it("detects a flaresolverr config field", () => {
     expect(
-      requiresFlaresolverr({
+      usesFlaresolverr({
         manifest: {
           config_schema: {
             properties: { flaresolverr_url: { title: "FlareSolverr URL" } },
@@ -401,7 +399,7 @@ describe("requiresFlaresolverr", () => {
 
   it("does not treat a captcha-solver-only provider as FlareSolverr", () => {
     expect(
-      requiresFlaresolverr({
+      usesFlaresolverr({
         manifest: {
           config_schema: { properties: { captcha_solver_url: {} } },
         },
@@ -409,17 +407,15 @@ describe("requiresFlaresolverr", () => {
     ).toBe(false);
   });
 
-  it("honours an explicit requires_flaresolverr flag over field detection", () => {
+  it("honours an explicit flaresolverr flag over field detection", () => {
     expect(
-      requiresFlaresolverr({
+      usesFlaresolverr({
         manifest: {
-          requires_flaresolverr: false,
+          flaresolverr: false,
           config_schema: { properties: { flaresolverr_url: {} } },
         },
       }),
     ).toBe(false);
-    expect(
-      requiresFlaresolverr({ manifest: { requires_flaresolverr: true } }),
-    ).toBe(true);
+    expect(usesFlaresolverr({ manifest: { flaresolverr: true } })).toBe(true);
   });
 });

--- a/frontend/src/pages/Settings/Providers/hub/__tests__/utils.test.ts
+++ b/frontend/src/pages/Settings/Providers/hub/__tests__/utils.test.ts
@@ -16,6 +16,7 @@ import {
   parseGitHubUrl,
   parseManifest,
   requiresAntiCaptcha,
+  requiresFlaresolverr,
   summarizeUpdates,
 } from "@/pages/Settings/Providers/hub/utils";
 
@@ -329,44 +330,47 @@ describe("requiresAntiCaptcha", () => {
     expect(requiresAntiCaptcha({ manifest: { provider_id: "x" } })).toBe(false);
   });
 
-  it("detects a keyword in the description", () => {
-    expect(
-      requiresAntiCaptcha({
-        manifest: { description: "Needs FlareSolverr to pass Cloudflare." },
-      }),
-    ).toBe(true);
-  });
-
-  it("detects a keyword in the long description", () => {
-    expect(
-      requiresAntiCaptcha({
-        manifest: { long_description: "An anti-captcha provider is required." },
-      }),
-    ).toBe(true);
-  });
-
-  it("detects a keyword inside config_schema field descriptions", () => {
+  it("detects a captcha-solver config field", () => {
     expect(
       requiresAntiCaptcha({
         manifest: {
           config_schema: {
-            properties: {
-              cookies: {
-                description: "Use cookies when login is blocked by captcha.",
-              },
-            },
+            properties: { captcha_solver_url: { title: "Captcha solver URL" } },
           },
         },
       }),
     ).toBe(true);
   });
 
-  it("honours an explicit requires_anti_captcha flag over the heuristic", () => {
+  it("does not treat a FlareSolverr-only provider as anti-captcha", () => {
+    expect(
+      requiresAntiCaptcha({
+        manifest: {
+          config_schema: {
+            properties: { flaresolverr_url: { title: "FlareSolverr URL" } },
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores captcha mentions in description text without a config field", () => {
+    expect(
+      requiresAntiCaptcha({
+        manifest: {
+          description: "Use cookies when login is blocked by captcha.",
+          config_schema: { properties: { cookies: { secret: true } } },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("honours an explicit requires_anti_captcha flag over field detection", () => {
     expect(
       requiresAntiCaptcha({
         manifest: {
           requires_anti_captcha: false,
-          description: "Mentions captcha but explicitly opts out.",
+          config_schema: { properties: { captcha_solver_url: {} } },
         },
       }),
     ).toBe(false);
@@ -374,21 +378,48 @@ describe("requiresAntiCaptcha", () => {
       requiresAntiCaptcha({ manifest: { requires_anti_captcha: true } }),
     ).toBe(true);
   });
+});
 
-  it("detects an entry in an explicit requires array", () => {
+describe("requiresFlaresolverr", () => {
+  it("returns false for missing/empty manifests", () => {
+    expect(requiresFlaresolverr(null)).toBe(false);
+    expect(requiresFlaresolverr(undefined)).toBe(false);
+    expect(requiresFlaresolverr({})).toBe(false);
+  });
+
+  it("detects a flaresolverr config field", () => {
     expect(
-      requiresAntiCaptcha({ manifest: { requires: ["flaresolverr"] } }),
+      requiresFlaresolverr({
+        manifest: {
+          config_schema: {
+            properties: { flaresolverr_url: { title: "FlareSolverr URL" } },
+          },
+        },
+      }),
     ).toBe(true);
   });
 
-  it("returns false when no captcha signal is present", () => {
+  it("does not treat a captcha-solver-only provider as FlareSolverr", () => {
     expect(
-      requiresAntiCaptcha({
+      requiresFlaresolverr({
         manifest: {
-          description: "A normal subtitle provider.",
-          config_schema: { properties: { api_key: { title: "API key" } } },
+          config_schema: { properties: { captcha_solver_url: {} } },
         },
       }),
     ).toBe(false);
+  });
+
+  it("honours an explicit requires_flaresolverr flag over field detection", () => {
+    expect(
+      requiresFlaresolverr({
+        manifest: {
+          requires_flaresolverr: false,
+          config_schema: { properties: { flaresolverr_url: {} } },
+        },
+      }),
+    ).toBe(false);
+    expect(
+      requiresFlaresolverr({ manifest: { requires_flaresolverr: true } }),
+    ).toBe(true);
   });
 });

--- a/frontend/src/pages/Settings/Providers/hub/components/AntiCaptchaBadge.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/components/AntiCaptchaBadge.tsx
@@ -1,0 +1,26 @@
+import { FunctionComponent } from "react";
+import { Tooltip } from "@mantine/core";
+import { faRobot } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import clsx from "clsx";
+import styles from "@/pages/Settings/Providers/hub/hub.module.scss";
+
+/**
+ * Warns that a provider relies on an Anti-Captcha service or FlareSolverr to
+ * solve captchas, so users can decide before installing it.
+ * See https://github.com/LavX/bazarr/issues/215
+ */
+export const AntiCaptchaBadge: FunctionComponent = () => {
+  return (
+    <Tooltip label="May require an Anti-Captcha service or FlareSolverr to solve captchas">
+      <span
+        className={clsx(styles.pill, styles["tone-warning"])}
+        role="status"
+        aria-label="May require an Anti-Captcha service"
+      >
+        <FontAwesomeIcon icon={faRobot} className={styles.pillIcon} />
+        <span>Anti-Captcha</span>
+      </span>
+    </Tooltip>
+  );
+};

--- a/frontend/src/pages/Settings/Providers/hub/components/AntiCaptchaBadge.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/components/AntiCaptchaBadge.tsx
@@ -14,11 +14,11 @@ import styles from "@/pages/Settings/Providers/hub/hub.module.scss";
  */
 export const AntiCaptchaBadge: FunctionComponent = () => {
   return (
-    <Tooltip label="Needs an external anti-captcha service to solve captchas">
+    <Tooltip label="Can use an anti-captcha service to solve captchas">
       <span
         className={clsx(styles.pill, styles["tone-warning"])}
         role="status"
-        aria-label="Needs an anti-captcha service"
+        aria-label="Can use an anti-captcha service"
       >
         <FontAwesomeIcon icon={faRobot} className={styles.pillIcon} />
         <span>Anti-Captcha</span>

--- a/frontend/src/pages/Settings/Providers/hub/components/AntiCaptchaBadge.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/components/AntiCaptchaBadge.tsx
@@ -6,17 +6,19 @@ import clsx from "clsx";
 import styles from "@/pages/Settings/Providers/hub/hub.module.scss";
 
 /**
- * Warns that a provider relies on an Anti-Captcha service or FlareSolverr to
- * solve captchas, so users can decide before installing it.
+ * Warns that a provider needs an external anti-captcha service to solve
+ * captchas (for example reCAPTCHA or image verification), so users can decide
+ * before installing it. FlareSolverr (a Cloudflare bypass) is surfaced
+ * separately via FlareSolverrBadge.
  * See https://github.com/LavX/bazarr/issues/215
  */
 export const AntiCaptchaBadge: FunctionComponent = () => {
   return (
-    <Tooltip label="May require an Anti-Captcha service or FlareSolverr to solve captchas">
+    <Tooltip label="Needs an external anti-captcha service to solve captchas">
       <span
         className={clsx(styles.pill, styles["tone-warning"])}
         role="status"
-        aria-label="May require an Anti-Captcha service"
+        aria-label="Needs an anti-captcha service"
       >
         <FontAwesomeIcon icon={faRobot} className={styles.pillIcon} />
         <span>Anti-Captcha</span>

--- a/frontend/src/pages/Settings/Providers/hub/components/CatalogCard.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/components/CatalogCard.tsx
@@ -15,9 +15,13 @@ import type {
   ProviderHubCatalogEntry,
   ProviderHubInstallation,
 } from "@/apis/raw/providerHub";
+import { AntiCaptchaBadge } from "@/pages/Settings/Providers/hub/components/AntiCaptchaBadge";
 import { ProviderStatusBadge } from "@/pages/Settings/Providers/hub/components/StatusBadge";
 import { TrustBadge } from "@/pages/Settings/Providers/hub/components/TrustBadge";
-import { parseManifest } from "@/pages/Settings/Providers/hub/utils";
+import {
+  parseManifest,
+  requiresAntiCaptcha,
+} from "@/pages/Settings/Providers/hub/utils";
 import {
   AUTH_LABEL,
   detectAuthFromManifest,
@@ -286,6 +290,7 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
           ) : (
             <TrustBadge trusted={entry.trusted} />
           )}
+          {requiresAntiCaptcha(entry) && <AntiCaptchaBadge />}
         </Group>
         <div className={styles.hubCardAction}>{ctaButton}</div>
       </div>

--- a/frontend/src/pages/Settings/Providers/hub/components/CatalogCard.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/components/CatalogCard.tsx
@@ -16,11 +16,13 @@ import type {
   ProviderHubInstallation,
 } from "@/apis/raw/providerHub";
 import { AntiCaptchaBadge } from "@/pages/Settings/Providers/hub/components/AntiCaptchaBadge";
+import { FlareSolverrBadge } from "@/pages/Settings/Providers/hub/components/FlareSolverrBadge";
 import { ProviderStatusBadge } from "@/pages/Settings/Providers/hub/components/StatusBadge";
 import { TrustBadge } from "@/pages/Settings/Providers/hub/components/TrustBadge";
 import {
   parseManifest,
   requiresAntiCaptcha,
+  requiresFlaresolverr,
 } from "@/pages/Settings/Providers/hub/utils";
 import {
   AUTH_LABEL,
@@ -291,6 +293,7 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
             <TrustBadge trusted={entry.trusted} />
           )}
           {requiresAntiCaptcha(entry) && <AntiCaptchaBadge />}
+          {requiresFlaresolverr(entry) && <FlareSolverrBadge />}
         </Group>
         <div className={styles.hubCardAction}>{ctaButton}</div>
       </div>

--- a/frontend/src/pages/Settings/Providers/hub/components/CatalogCard.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/components/CatalogCard.tsx
@@ -21,8 +21,8 @@ import { ProviderStatusBadge } from "@/pages/Settings/Providers/hub/components/S
 import { TrustBadge } from "@/pages/Settings/Providers/hub/components/TrustBadge";
 import {
   parseManifest,
-  requiresAntiCaptcha,
-  requiresFlaresolverr,
+  usesAntiCaptcha,
+  usesFlaresolverr,
 } from "@/pages/Settings/Providers/hub/utils";
 import {
   AUTH_LABEL,
@@ -292,8 +292,8 @@ export const CatalogCard: FunctionComponent<CatalogCardProps> = ({
           ) : (
             <TrustBadge trusted={entry.trusted} />
           )}
-          {requiresAntiCaptcha(entry) && <AntiCaptchaBadge />}
-          {requiresFlaresolverr(entry) && <FlareSolverrBadge />}
+          {usesAntiCaptcha(entry) && <AntiCaptchaBadge />}
+          {usesFlaresolverr(entry) && <FlareSolverrBadge />}
         </Group>
         <div className={styles.hubCardAction}>{ctaButton}</div>
       </div>

--- a/frontend/src/pages/Settings/Providers/hub/components/FlareSolverrBadge.tsx
+++ b/frontend/src/pages/Settings/Providers/hub/components/FlareSolverrBadge.tsx
@@ -1,0 +1,27 @@
+import { FunctionComponent } from "react";
+import { Tooltip } from "@mantine/core";
+import { faCloud } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import clsx from "clsx";
+import styles from "@/pages/Settings/Providers/hub/hub.module.scss";
+
+/**
+ * Indicates that a provider can use FlareSolverr to clear Cloudflare browser
+ * challenges. This is a Cloudflare bypass, distinct from an anti-captcha
+ * service, so it gets its own badge.
+ * See https://github.com/LavX/bazarr/issues/215
+ */
+export const FlareSolverrBadge: FunctionComponent = () => {
+  return (
+    <Tooltip label="Can use FlareSolverr to clear Cloudflare challenges">
+      <span
+        className={clsx(styles.pill, styles["tone-info"])}
+        role="status"
+        aria-label="Can use FlareSolverr"
+      >
+        <FontAwesomeIcon icon={faCloud} className={styles.pillIcon} />
+        <span>FlareSolverr</span>
+      </span>
+    </Tooltip>
+  );
+};

--- a/frontend/src/pages/Settings/Providers/hub/utils.ts
+++ b/frontend/src/pages/Settings/Providers/hub/utils.ts
@@ -97,14 +97,14 @@ function configSchemaHasFieldKey(manifest: LooseObject, re: RegExp): boolean {
   return Object.keys(props).some((key) => re.test(key));
 }
 
-function manifestRequiresCapability(
+function manifestHasCapability(
   entry: ProviderHubCatalogEntry | LooseObject | null | undefined,
   flagKey: string,
   fieldRe: RegExp,
 ): boolean {
   const manifest = parseManifest(entry) as LooseObject | null;
   if (!manifest) return false;
-  // An explicit catalog flag is authoritative.
+  // An explicit catalog capability flag is authoritative.
   if (typeof manifest[flagKey] === "boolean") {
     return manifest[flagKey] as boolean;
   }
@@ -115,37 +115,29 @@ function manifestRequiresCapability(
 }
 
 /**
- * Whether a catalog provider needs an external anti-captcha service to solve
+ * Whether a catalog provider can use an external anti-captcha service to solve
  * captchas (for example reCAPTCHA or image verification). Honours an explicit
- * `requires_anti_captcha` manifest flag, else detects a `captcha*` config field.
+ * `anti_captcha` manifest flag, else detects a `captcha*` config field.
  * Note: FlareSolverr is a Cloudflare bypass, not a captcha solver, and is
- * surfaced separately via requiresFlaresolverr.
+ * surfaced separately via usesFlaresolverr.
  * See https://github.com/LavX/bazarr/issues/215
  */
-export function requiresAntiCaptcha(
+export function usesAntiCaptcha(
   entry: ProviderHubCatalogEntry | LooseObject | null | undefined,
 ): boolean {
-  return manifestRequiresCapability(
-    entry,
-    "requires_anti_captcha",
-    CAPTCHA_FIELD_RE,
-  );
+  return manifestHasCapability(entry, "anti_captcha", CAPTCHA_FIELD_RE);
 }
 
 /**
  * Whether a catalog provider can use FlareSolverr to clear Cloudflare browser
- * challenges. Honours an explicit `requires_flaresolverr` manifest flag, else
- * detects a `flaresolverr*` config field.
+ * challenges. Honours an explicit `flaresolverr` manifest flag, else detects a
+ * `flaresolverr*` config field.
  * See https://github.com/LavX/bazarr/issues/215
  */
-export function requiresFlaresolverr(
+export function usesFlaresolverr(
   entry: ProviderHubCatalogEntry | LooseObject | null | undefined,
 ): boolean {
-  return manifestRequiresCapability(
-    entry,
-    "requires_flaresolverr",
-    FLARESOLVERR_FIELD_RE,
-  );
+  return manifestHasCapability(entry, "flaresolverr", FLARESOLVERR_FIELD_RE);
 }
 
 interface ParsedSemver {

--- a/frontend/src/pages/Settings/Providers/hub/utils.ts
+++ b/frontend/src/pages/Settings/Providers/hub/utils.ts
@@ -88,48 +88,64 @@ export function parseManifest(
   return null;
 }
 
-const ANTI_CAPTCHA_RE = /captcha|flaresolverr/i;
+const CAPTCHA_FIELD_RE = /captcha/i;
+const FLARESOLVERR_FIELD_RE = /flaresolverr/i;
+
+function configSchemaHasFieldKey(manifest: LooseObject, re: RegExp): boolean {
+  const props = (manifest.config_schema as LooseObject | undefined)?.properties;
+  if (!props || typeof props !== "object") return false;
+  return Object.keys(props).some((key) => re.test(key));
+}
+
+function manifestRequiresCapability(
+  entry: ProviderHubCatalogEntry | LooseObject | null | undefined,
+  flagKey: string,
+  fieldRe: RegExp,
+): boolean {
+  const manifest = parseManifest(entry) as LooseObject | null;
+  if (!manifest) return false;
+  // An explicit catalog flag is authoritative.
+  if (typeof manifest[flagKey] === "boolean") {
+    return manifest[flagKey] as boolean;
+  }
+  // Otherwise fall back to the objective signal: the provider exposes a config
+  // field for it. Field keys (not description text) avoid false positives such
+  // as a provider whose description merely says "no captcha required".
+  return configSchemaHasFieldKey(manifest, fieldRe);
+}
 
 /**
- * Best-effort detection of whether a catalog provider needs an Anti-Captcha
- * service or FlareSolverr to solve captchas. Catalog manifests do not yet carry
- * a structured flag, so an explicit declaration is honoured when present and we
- * otherwise scan the human-facing manifest text and config schema for the known
- * keywords. See https://github.com/LavX/bazarr/issues/215
+ * Whether a catalog provider needs an external anti-captcha service to solve
+ * captchas (for example reCAPTCHA or image verification). Honours an explicit
+ * `requires_anti_captcha` manifest flag, else detects a `captcha*` config field.
+ * Note: FlareSolverr is a Cloudflare bypass, not a captcha solver, and is
+ * surfaced separately via requiresFlaresolverr.
+ * See https://github.com/LavX/bazarr/issues/215
  */
 export function requiresAntiCaptcha(
   entry: ProviderHubCatalogEntry | LooseObject | null | undefined,
 ): boolean {
-  const manifest = parseManifest(entry) as LooseObject | null;
-  if (!manifest) return false;
+  return manifestRequiresCapability(
+    entry,
+    "requires_anti_captcha",
+    CAPTCHA_FIELD_RE,
+  );
+}
 
-  if (typeof manifest.requires_anti_captcha === "boolean") {
-    return manifest.requires_anti_captcha;
-  }
-  if (
-    Array.isArray(manifest.requires) &&
-    manifest.requires.some(
-      (r) => typeof r === "string" && ANTI_CAPTCHA_RE.test(r),
-    )
-  ) {
-    return true;
-  }
-
-  const haystacks: string[] = [];
-  if (typeof manifest.description === "string") {
-    haystacks.push(manifest.description);
-  }
-  if (typeof manifest.long_description === "string") {
-    haystacks.push(manifest.long_description);
-  }
-  if (manifest.config_schema) {
-    try {
-      haystacks.push(JSON.stringify(manifest.config_schema));
-    } catch {
-      // ignore a non-serializable schema
-    }
-  }
-  return haystacks.some((text) => ANTI_CAPTCHA_RE.test(text));
+/**
+ * Whether a catalog provider can use FlareSolverr to clear Cloudflare browser
+ * challenges. Honours an explicit `requires_flaresolverr` manifest flag, else
+ * detects a `flaresolverr*` config field.
+ * See https://github.com/LavX/bazarr/issues/215
+ */
+export function requiresFlaresolverr(
+  entry: ProviderHubCatalogEntry | LooseObject | null | undefined,
+): boolean {
+  return manifestRequiresCapability(
+    entry,
+    "requires_flaresolverr",
+    FLARESOLVERR_FIELD_RE,
+  );
 }
 
 interface ParsedSemver {

--- a/frontend/src/pages/Settings/Providers/hub/utils.ts
+++ b/frontend/src/pages/Settings/Providers/hub/utils.ts
@@ -88,6 +88,50 @@ export function parseManifest(
   return null;
 }
 
+const ANTI_CAPTCHA_RE = /captcha|flaresolverr/i;
+
+/**
+ * Best-effort detection of whether a catalog provider needs an Anti-Captcha
+ * service or FlareSolverr to solve captchas. Catalog manifests do not yet carry
+ * a structured flag, so an explicit declaration is honoured when present and we
+ * otherwise scan the human-facing manifest text and config schema for the known
+ * keywords. See https://github.com/LavX/bazarr/issues/215
+ */
+export function requiresAntiCaptcha(
+  entry: ProviderHubCatalogEntry | LooseObject | null | undefined,
+): boolean {
+  const manifest = parseManifest(entry) as LooseObject | null;
+  if (!manifest) return false;
+
+  if (typeof manifest.requires_anti_captcha === "boolean") {
+    return manifest.requires_anti_captcha;
+  }
+  if (
+    Array.isArray(manifest.requires) &&
+    manifest.requires.some(
+      (r) => typeof r === "string" && ANTI_CAPTCHA_RE.test(r),
+    )
+  ) {
+    return true;
+  }
+
+  const haystacks: string[] = [];
+  if (typeof manifest.description === "string") {
+    haystacks.push(manifest.description);
+  }
+  if (typeof manifest.long_description === "string") {
+    haystacks.push(manifest.long_description);
+  }
+  if (manifest.config_schema) {
+    try {
+      haystacks.push(JSON.stringify(manifest.config_schema));
+    } catch {
+      // ignore a non-serializable schema
+    }
+  }
+  return haystacks.some((text) => ANTI_CAPTCHA_RE.test(text));
+}
+
 interface ParsedSemver {
   core: number[];
   prerelease: string[];


### PR DESCRIPTION
Fixes https://github.com/LavX/bazarr/issues/215

## Problem
The marketplace gave no indication that a provider relies on an Anti-Captcha service or FlareSolverr to solve captchas, so users only found out after installing one.

## Fix
Adds an "Anti-Captcha" badge to the catalog card. Detection honours an explicit manifest flag (`requires_anti_captcha`, or a `requires[]` entry) when present, and otherwise scans the provider description, long description and config schema for captcha/FlareSolverr keywords. Catalog manifests do not yet carry a structured field, so the heuristic surfaces the ~10 current providers that mention it (addic7ed, subs4series, zimuku, napiprojekt, opensubtitles, ...); the explicit-flag support lets the catalog declare it authoritatively later with no further UI change.

## Tests
`requiresAntiCaptcha` unit coverage in the hub utils test. Frontend-only; no backend change.