### PR TITLE
Per-instance subzero mods (download/upload/manual paths)

### DIFF
--- a/bazarr/subtitles/download.py
+++ b/bazarr/subtitles/download.py
@@ -25,7 +25,8 @@ from .processing import process_subtitle
 @update_pools
 def generate_subtitles(path, languages, audio_language, sceneName, title, media_type, profile_id,
                        forced_minimum_score=None, is_upgrade=False, check_if_still_required=False,
-                       previous_subtitles_to_delete=None, job_id=None, fallback_allowed=False):
+                       previous_subtitles_to_delete=None, job_id=None, fallback_allowed=False,
+                       arr_instance_id=None):
     if not languages:
         return None
 
@@ -59,7 +60,7 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
         min_score, max_score, scores = _get_scores(media_type, minimum_score_movie, minimum_score)
 
         from subtitles.tools.mods import get_subzero_mods
-        subz_mods = get_subzero_mods()
+        subz_mods = get_subzero_mods(arr_instance_id)
         saved_any = False
 
         if providers:

--- a/bazarr/subtitles/manual.py
+++ b/bazarr/subtitles/manual.py
@@ -152,7 +152,7 @@ def manual_search(path, profile_id, providers, sceneName, title, media_type):
 
 @update_pools
 def manual_download_subtitle(path, audio_language, hi, forced, subtitle, provider, sceneName, title, media_type,
-                             use_original_format, profile_id, job_id=None):
+                             use_original_format, profile_id, job_id=None, arr_instance_id=None):
     logging.debug(f'BAZARR Manually downloading Subtitles for this file: {path}')  # noqa: G004
 
     if settings.general.utf8_encode:
@@ -176,7 +176,7 @@ def manual_download_subtitle(path, audio_language, hi, forced, subtitle, provide
         subtitle.use_original_format = True
 
     from subtitles.tools.mods import get_subzero_mods
-    subtitle.mods = get_subzero_mods()
+    subtitle.mods = get_subzero_mods(arr_instance_id)
     video = get_video(force_unicode(path), title, sceneName, providers={provider}, media_type=media_type)
     if video:
         try:
@@ -270,7 +270,8 @@ def episode_manually_download_specific_subtitle(sonarr_series_id, sonarr_episode
     try:
         result = manual_download_subtitle(episodePath, audio_language, hi, forced, subtitle, selected_provider,
                                           sceneName, title, 'series', use_original_format,
-                                          profile_id=get_profile_id(episode_id=sonarr_episode_id), job_id=job_id)
+                                          profile_id=get_profile_id(episode_id=sonarr_episode_id), job_id=job_id,
+                                          arr_instance_id=arr_instance_id)
     except OSError:
         return 'Unable to save subtitles file', 500
     else:
@@ -324,7 +325,8 @@ def movie_manually_download_specific_subtitle(radarr_id, hi, forced, use_origina
     try:
         result = manual_download_subtitle(moviePath, audio_language, hi, forced, subtitle, selected_provider,
                                           sceneName, title, 'movie', use_original_format,
-                                          profile_id=get_profile_id(movie_id=radarr_id), job_id=job_id)
+                                          profile_id=get_profile_id(movie_id=radarr_id), job_id=job_id,
+                                          arr_instance_id=arr_instance_id)
     except OSError:
         return 'Unable to save subtitles file', 500
     else:

--- a/bazarr/subtitles/mass_download/movies.py
+++ b/bazarr/subtitles/mass_download/movies.py
@@ -105,7 +105,8 @@ def movies_download_subtitles(no, job_id=None, job_sub_function=False, arr_insta
                                              'movie',
                                              movie.profileId,
                                              check_if_still_required=True,
-                                             job_id=job_id):
+                                             job_id=job_id,
+                                             arr_instance_id=arr_instance_id):
                 if result:
                     if isinstance(result, tuple) and len(result):
                         result = result[0]
@@ -170,7 +171,7 @@ def movie_download_specific_subtitles(radarr_id, language, hi, forced, job_id=No
     try:
         result = list(generate_subtitles(moviePath, [(language, hi, forced)], audio_language,
                                          sceneName, title, 'movie', profile_id=get_profile_id(movie_id=radarr_id),
-                                         job_id=job_id))
+                                         job_id=job_id, arr_instance_id=arr_instance_id))
         if isinstance(result, list) and len(result):
             result = result[0]
             if isinstance(result, tuple) and len(result):

--- a/bazarr/subtitles/mass_download/series.py
+++ b/bazarr/subtitles/mass_download/series.py
@@ -172,7 +172,8 @@ def episode_download_subtitles(no, job_id=None, job_sub_function=False, provider
                                              episode.profileId,
                                              check_if_still_required=True,
                                              job_id=job_id,
-                                             fallback_allowed=fallback_allowed):
+                                             fallback_allowed=fallback_allowed,
+                                             arr_instance_id=arr_instance_id):
                 if result:
                     if isinstance(result, tuple) and len(result):
                         result = result[0]
@@ -249,7 +250,7 @@ def episode_download_specific_subtitles(sonarr_series_id, sonarr_episode_id, lan
     try:
         result = list(generate_subtitles(episodePath, [(language, hi, forced)], audio_language, sceneName,
                                          title, 'series', profile_id=get_profile_id(episode_id=sonarr_episode_id),
-                                         job_id=job_id))
+                                         job_id=job_id, arr_instance_id=arr_instance_id))
         if isinstance(result, list) and len(result):
             result = result[0]
             if isinstance(result, tuple) and len(result):

--- a/bazarr/subtitles/tools/mods.py
+++ b/bazarr/subtitles/tools/mods.py
@@ -22,21 +22,39 @@ def has_remove_hi(mods):
     return any(m == 'remove_HI' or m.startswith('remove_HI(') for m in (mods or []))
 
 
-def with_keep_lyrics(mods):
+def with_keep_lyrics(mods, arr_instance_id=None):
     """Rewrite the Remove HI mod to preserve song lyrics when the setting is on.
 
     The preference is encoded as a subzero mod parameter so it travels through
     the (settings-agnostic) subtitle modification pipeline.
     See https://github.com/LavX/bazarr/issues/225
+
+    When ``arr_instance_id`` is given the preserve-lyrics preference resolves
+    against that instance's per-instance override, falling back to the global
+    setting (#227). A None instance keeps the legacy global-only behaviour.
     """
-    if not mods or not settings.general.subzero_mods_keep_lyrics:
+    from arr_instances.resolution import resolve_subtitle_setting
+    keep_lyrics = resolve_subtitle_setting(
+        arr_instance_id, "general.subzero_mods_keep_lyrics",
+        settings.general.subzero_mods_keep_lyrics)
+    if not mods or not keep_lyrics:
         return mods
     return ['remove_HI(keep_lyrics=1)' if m == 'remove_HI' else m for m in mods]
 
 
-def get_subzero_mods():
-    """Configured subzero mods with the preserve-song-lyrics preference applied."""
-    return with_keep_lyrics(get_array_from(settings.general.subzero_mods))
+def get_subzero_mods(arr_instance_id=None):
+    """Configured subzero mods with the preserve-song-lyrics preference applied.
+
+    With ``arr_instance_id`` the configured mods + keep-lyrics preference resolve
+    against that instance's overrides (#227). The per-instance value is stored as
+    a list; the global value is a comma-separated string, so both shapes are
+    normalised here. A None instance preserves the legacy global behaviour.
+    """
+    from arr_instances.resolution import resolve_subtitle_setting
+    configured = resolve_subtitle_setting(
+        arr_instance_id, "general.subzero_mods", settings.general.subzero_mods)
+    mods = configured if isinstance(configured, list) else get_array_from(configured)
+    return with_keep_lyrics(mods, arr_instance_id)
 
 
 MOD_LABELS = {

--- a/bazarr/subtitles/upgrade.py
+++ b/bazarr/subtitles/upgrade.py
@@ -163,7 +163,8 @@ def upgrade_episodes_subtitles(job_id=None, sonarr_series_ids=None, sonarr_serie
                                          is_upgrade=True,
                                          previous_subtitles_to_delete=path_mappings.path_replace(
                                              episode['subtitles_path']),
-                                         job_id=job_id))
+                                         job_id=job_id,
+                                         arr_instance_id=episode['arr_instance_id']))
 
         if result:
             if isinstance(result, list) and len(result):
@@ -306,7 +307,8 @@ def upgrade_movies_subtitles(job_id=None, radarr_ids=None, radarr_filters=None, 
                                          is_upgrade=True,
                                          previous_subtitles_to_delete=path_mappings.path_replace_movie(
                                              movie['subtitles_path']),
-                                         job_id=job_id))
+                                         job_id=job_id,
+                                         arr_instance_id=movie['arr_instance_id']))
         if result:
             if isinstance(result, list) and len(result):
                 result = result[0]

--- a/bazarr/subtitles/upload.py
+++ b/bazarr/subtitles/upload.py
@@ -108,7 +108,7 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
     from subtitles.tools.mods import get_subzero_mods
     sub = Subtitle(
         lang_obj,
-        mods=get_subzero_mods(),
+        mods=get_subzero_mods(arr_instance_id),
         original_format=use_original_format
     )
 

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -182,7 +182,8 @@ def _wanted_movie(movie, providers_list, job_id=None):
                                      movie.profileId,
                                      check_if_still_required=True,
                                      job_id=job_id,
-                                     fallback_allowed=settings.general.use_whisper_fallback):
+                                     fallback_allowed=settings.general.use_whisper_fallback,
+                                     arr_instance_id=arr_instance_id):
 
         if result:
             found_any = True

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -189,7 +189,8 @@ def _wanted_episode(episode, providers_list, job_id=None):
                                      episode.profileId,
                                      check_if_still_required=True,
                                      job_id=job_id,
-                                     fallback_allowed=settings.general.use_whisper_fallback):
+                                     fallback_allowed=settings.general.use_whisper_fallback,
+                                     arr_instance_id=arr_instance_id):
         if result:
             found_any = True
             if isinstance(result, tuple) and len(result):

--- a/tests/bazarr/test_subzero_keep_lyrics.py
+++ b/tests/bazarr/test_subzero_keep_lyrics.py
@@ -1,8 +1,11 @@
 # coding=utf-8
 # Helper coverage for the preserve-song-lyrics option.
 # See https://github.com/LavX/bazarr/issues/225
+import pytest
+
 from app.config import settings
-from subtitles.tools.mods import has_remove_hi, with_keep_lyrics
+from arr_instances import resolution
+from subtitles.tools.mods import get_subzero_mods, has_remove_hi, with_keep_lyrics
 
 
 def test_has_remove_hi_plain():
@@ -40,3 +43,67 @@ def test_with_keep_lyrics_on_without_remove_hi_is_noop(monkeypatch):
 def test_with_keep_lyrics_empty(monkeypatch):
     monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", True)
     assert with_keep_lyrics([]) == []
+
+
+# --- Per-instance overrides (#227) -----------------------------------------
+# resolve_subtitle_setting checks the in-memory cache before any DB read, so a
+# seeded cache entry exercises the real per-instance branch without a session.
+@pytest.fixture
+def seed_instance_settings():
+    seeded = []
+
+    def _seed(blob, instance_id=4242):
+        resolution._subtitle_settings_cache[instance_id] = blob
+        seeded.append(instance_id)
+        return instance_id
+
+    yield _seed
+    resolution.clear_subtitle_settings_cache()
+
+
+def test_with_keep_lyrics_instance_override_on_beats_global_off(seed_instance_settings, monkeypatch):
+    monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", False)
+    iid = seed_instance_settings({"general": {"subzero_mods_keep_lyrics": True}})
+    assert with_keep_lyrics(["remove_HI", "common"], iid) == [
+        "remove_HI(keep_lyrics=1)",
+        "common",
+    ]
+
+
+def test_with_keep_lyrics_instance_override_off_beats_global_on(seed_instance_settings, monkeypatch):
+    monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", True)
+    iid = seed_instance_settings({"general": {"subzero_mods_keep_lyrics": False}})
+    assert with_keep_lyrics(["remove_HI", "common"], iid) == ["remove_HI", "common"]
+
+
+def test_with_keep_lyrics_instance_without_key_falls_back_to_global(seed_instance_settings, monkeypatch):
+    monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", True)
+    iid = seed_instance_settings({"general": {}})
+    assert with_keep_lyrics(["remove_HI"], iid) == ["remove_HI(keep_lyrics=1)"]
+
+
+def test_get_subzero_mods_uses_instance_list(seed_instance_settings, monkeypatch):
+    monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", False)
+    iid = seed_instance_settings({"general": {"subzero_mods": ["remove_HI", "OCR_fixes"]}})
+    assert get_subzero_mods(iid) == ["remove_HI", "OCR_fixes"]
+
+
+def test_get_subzero_mods_instance_list_applies_instance_keep_lyrics(seed_instance_settings):
+    iid = seed_instance_settings({"general": {
+        "subzero_mods": ["remove_HI", "common"],
+        "subzero_mods_keep_lyrics": True,
+    }})
+    assert get_subzero_mods(iid) == ["remove_HI(keep_lyrics=1)", "common"]
+
+
+def test_get_subzero_mods_instance_without_override_uses_global(seed_instance_settings, monkeypatch):
+    monkeypatch.setattr(settings.general, "subzero_mods", "remove_HI,common")
+    monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", False)
+    iid = seed_instance_settings({"subsync": {"subsync_threshold": 90}})
+    assert get_subzero_mods(iid) == ["remove_HI", "common"]
+
+
+def test_get_subzero_mods_none_instance_uses_global(monkeypatch):
+    monkeypatch.setattr(settings.general, "subzero_mods", "remove_HI,common")
+    monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", False)
+    assert get_subzero_mods(None) == ["remove_HI", "common"]


### PR DESCRIPTION
## What

Activates **per-instance subzero mods** on top of the per-instance subtitle settings foundation. `get_subzero_mods()` and `with_keep_lyrics()` now resolve `general.subzero_mods` and `general.subzero_mods_keep_lyrics` against the owning Sonarr/Radarr instance's overrides (stored under `options["subtitle_settings"]`), falling back to the global settings when an instance has no override.

A `None` instance returns the global values unchanged, so single-instance installs and any path that does not yet pass an instance id behave exactly as before.

## How

`arr_instance_id` is threaded end-to-end through the subtitle acquisition paths:

- `generate_subtitles(..., arr_instance_id=None)` forwards it to `get_subzero_mods(arr_instance_id)`.
- All eight `generate_subtitles` call sites pass the owning instance id they already hold from the instance-scoped orchestration: wanted (series/movies), upgrade (series/movies), and mass-download (series/movies, both the bulk and specific-subtitle entry points).
- Manual download: `manual_download_subtitle` gains the param and the two specific-download wrappers forward the id they already receive from the API layer.
- Manual upload: `manual_upload_subtitle` forwards its existing `arr_instance_id` param.

## Tests

TDD: seven new tests in `test_subzero_keep_lyrics.py` cover the per-instance override (on/off beating the global), fall-back to global for an unset key, the stored-list vs global-CSV normalisation, and the `None`-instance global path. The cache is seeded directly so the resolver exercises its real per-instance branch without a DB session.

Full backend guard list runs green locally (489 passed), plus the mass-op / action-scoping / local-id suites (99 passed).

## Scope note

The manual "apply mods" action (`subtitles_apply_mods`) re-applies user-selected mods to an existing subtitle; its mod list comes from the user, not from settings, so only its `keep_lyrics` rewrite is instance-relevant. That thin edge is deferred to a follow-up to keep this PR focused on the acquisition paths.

Part of the per-instance subtitle settings work: https://github.com/LavX/bazarr/issues/227