### PR TITLE
Per-instance post-processing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
             tests/bazarr/test_arr_local_id_cutover_migration.py \
             tests/bazarr/test_jobs_queue_progress.py \
             tests/bazarr/test_processing_sync_substep.py \
+            tests/bazarr/test_processing_postprocessing.py \
             tests/bazarr/test_sync_progress_report.py \
             tests/bazarr/test_subsync_engines.py \
             tests/bazarr/test_subzero_keep_lyrics.py \

--- a/bazarr/subtitles/processing.py
+++ b/bazarr/subtitles/processing.py
@@ -215,11 +215,30 @@ def _trigger_combine(video_path, media_type, radarr_id, series_id, episode_id):
         logging.exception("BAZARR error in _trigger_combine")
 
 
+def _postprocessing_config(media_type, arr_instance_id):
+    """Resolve the post-processing settings for a download, honouring the owning
+    instance's per-instance overrides (#227) with global fallback. The threshold
+    is coerced to int because the global value may be stored as a string."""
+    from arr_instances.resolution import resolve_subtitle_setting as _resolve
+    use_pp = _resolve(arr_instance_id, "general.use_postprocessing",
+                      settings.general.use_postprocessing)
+    cmd = _resolve(arr_instance_id, "general.postprocessing_cmd",
+                   settings.general.postprocessing_cmd)
+    if media_type == 'series':
+        use_threshold = _resolve(arr_instance_id, "general.use_postprocessing_threshold",
+                                 settings.general.use_postprocessing_threshold)
+        threshold = int(_resolve(arr_instance_id, "general.postprocessing_threshold",
+                                 settings.general.postprocessing_threshold))
+    else:
+        use_threshold = _resolve(arr_instance_id, "general.use_postprocessing_threshold_movie",
+                                 settings.general.use_postprocessing_threshold_movie)
+        threshold = int(_resolve(arr_instance_id, "general.postprocessing_threshold_movie",
+                                 settings.general.postprocessing_threshold_movie))
+    return use_pp, cmd, use_threshold, threshold
+
+
 def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_upgrade=False, is_manual=False,
                      job_id=None):
-    use_postprocessing = settings.general.use_postprocessing
-    postprocessing_cmd = settings.general.postprocessing_cmd
-
     downloaded_provider = subtitle.provider_name
     uploader = subtitle.uploader
     release_info = subtitle.release_info
@@ -264,6 +283,7 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
             return
         series_id = episode_metadata.sonarrSeriesId
         episode_id = episode_metadata.sonarrEpisodeId
+        owner_instance_id = episode_metadata.arr_instance_id
 
         if sync_checker(subtitle) is True:
             from .sync import sync_subtitles
@@ -286,6 +306,7 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
             return
         series_id = ""
         episode_id = movie_metadata.radarrId
+        owner_instance_id = movie_metadata.arr_instance_id
 
         if sync_checker(subtitle) is True:
             from .sync import sync_subtitles
@@ -299,18 +320,13 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
                            arr_instance_id=movie_metadata.arr_instance_id,
                            owns_job_progress=False)
 
+    use_postprocessing, postprocessing_cmd, use_pp_threshold, pp_threshold = _postprocessing_config(
+        media_type, owner_instance_id)
     if use_postprocessing is True:
         command = pp_replace(postprocessing_cmd, path, downloaded_path, downloaded_language, downloaded_language_code2,
                              downloaded_language_code3, audio_language, audio_language_code2, audio_language_code3,
                              percent_score, subtitle_id, downloaded_provider, uploader, release_info, series_id,
                              episode_id)
-
-        if media_type == 'series':
-            use_pp_threshold = settings.general.use_postprocessing_threshold
-            pp_threshold = int(settings.general.postprocessing_threshold)
-        else:
-            use_pp_threshold = settings.general.use_postprocessing_threshold_movie
-            pp_threshold = int(settings.general.postprocessing_threshold_movie)
 
         if not use_pp_threshold or (use_pp_threshold and percent_score < pp_threshold):
             logging.debug(f"BAZARR Using post-processing command: {command}")  # noqa: G004

--- a/tests/bazarr/test_processing_postprocessing.py
+++ b/tests/bazarr/test_processing_postprocessing.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+# Per-instance post-processing resolution (#227).
+# The helper resolves the six post-processing settings against the owning
+# Sonarr/Radarr instance's overrides, falling back to the global config.
+import pytest
+
+from app.config import settings
+from arr_instances import resolution
+from subtitles.processing import _postprocessing_config
+
+
+@pytest.fixture
+def seed_instance_settings():
+    def _seed(blob, instance_id=7777):
+        resolution._subtitle_settings_cache[instance_id] = blob
+        return instance_id
+
+    yield _seed
+    resolution.clear_subtitle_settings_cache()
+
+
+def test_global_when_no_instance(monkeypatch):
+    monkeypatch.setattr(settings.general, "use_postprocessing", True)
+    monkeypatch.setattr(settings.general, "postprocessing_cmd", "/global.sh")
+    monkeypatch.setattr(settings.general, "use_postprocessing_threshold", True)
+    monkeypatch.setattr(settings.general, "postprocessing_threshold", 80)
+    assert _postprocessing_config("series", None) == (True, "/global.sh", True, 80)
+
+
+def test_instance_override_series(seed_instance_settings, monkeypatch):
+    monkeypatch.setattr(settings.general, "use_postprocessing", False)
+    monkeypatch.setattr(settings.general, "postprocessing_cmd", "/global.sh")
+    iid = seed_instance_settings({"general": {
+        "use_postprocessing": True,
+        "postprocessing_cmd": "/instance.sh",
+        "use_postprocessing_threshold": True,
+        "postprocessing_threshold": 60,
+    }})
+    assert _postprocessing_config("series", iid) == (True, "/instance.sh", True, 60)
+
+
+def test_instance_movie_uses_movie_threshold(seed_instance_settings, monkeypatch):
+    monkeypatch.setattr(settings.general, "use_postprocessing", True)
+    monkeypatch.setattr(settings.general, "postprocessing_cmd", "/global.sh")
+    iid = seed_instance_settings({"general": {
+        "use_postprocessing_threshold_movie": True,
+        "postprocessing_threshold_movie": 45,
+    }})
+    use_pp, cmd, use_th, th = _postprocessing_config("movie", iid)
+    assert use_th is True and th == 45
+
+
+def test_instance_without_threshold_override_falls_back_to_global(seed_instance_settings, monkeypatch):
+    monkeypatch.setattr(settings.general, "use_postprocessing_threshold", True)
+    monkeypatch.setattr(settings.general, "postprocessing_threshold", 75)
+    iid = seed_instance_settings({"general": {"use_postprocessing": True}})
+    use_pp, cmd, use_th, th = _postprocessing_config("series", iid)
+    assert use_pp is True and use_th is True and th == 75
+
+
+def test_threshold_coerced_to_int(seed_instance_settings, monkeypatch):
+    # the global value may be stored as a string; the helper must return an int
+    monkeypatch.setattr(settings.general, "postprocessing_threshold", "90")
+    iid = seed_instance_settings({"general": {}})
+    _, _, _, th = _postprocessing_config("series", iid)
+    assert th == 90 and isinstance(th, int)


### PR DESCRIPTION
## What

Activates **per-instance post-processing** on top of the per-instance subtitle settings foundation. After a subtitle is downloaded, `process_subtitle()` now resolves the six post-processing settings against the owning Sonarr/Radarr instance's overrides (stored under `options["subtitle_settings"]["general"]`), falling back to the global config:

- `use_postprocessing`
- `postprocessing_cmd`
- `use_postprocessing_threshold` / `postprocessing_threshold` (series)
- `use_postprocessing_threshold_movie` / `postprocessing_threshold_movie` (movies)

## How

The owning instance is the media's `arr_instance_id`, which `process_subtitle` already loads from the DB for the sync and notify/rescan steps. So resolution uses that authoritative owner directly: **`process_subtitle` keeps its signature and no call sites change.** A `None` owner returns the global values, so single-instance installs are unaffected.

The logic is extracted into a small `_postprocessing_config(media_type, arr_instance_id)` helper, which also coerces the threshold to `int` (the global value may be stored as a string).

## Tests

TDD: five new tests in `test_processing_postprocessing.py` cover the global-when-no-instance path, instance overrides for series, the movie threshold pair, fall-back to global for an unset threshold key, and int coercion. Added to the CI guard list. Local guard-list run green (291 passed).

## Scope note

The manual "apply mods" action (`subtitles_apply_mods`) applies user-selected mods to an existing subtitle and its `keep_lyrics` rewrite still uses the global setting; that thin edge is tracked as a separate follow-up.

Part of the per-instance subtitle settings work: https://github.com/LavX/bazarr/issues/227