### PR TITLE
Per-instance subsync (audio synchronization)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
             tests/bazarr/test_processing_postprocessing.py \
             tests/bazarr/test_sync_progress_report.py \
             tests/bazarr/test_subsync_engines.py \
+            tests/bazarr/test_sync_instance_overrides.py \
             tests/bazarr/test_subzero_keep_lyrics.py \
             tests/bazarr/test_utilities_video_analyzer.py \
             tests/bazarr/test_embedded_subtitle_extraction.py \

--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -365,9 +365,12 @@ class Subtitles(Resource):
                     reference=args.get("reference")
                     if args.get("reference") not in empty_values
                     else video_path,
+                    # Fall back to None (not the global value) so an unset Max
+                    # Offset resolves the owning instance's per-instance override
+                    # inside sync_subtitles (#227), mirroring enabled_engines below.
                     max_offset_seconds=args.get("max_offset_seconds")
                     if args.get("max_offset_seconds") not in empty_values
-                    else str(settings.subsync.max_offset_seconds),
+                    else None,
                     no_fix_framerate=args.get("no_fix_framerate") == "True",
                     gss=args.get("gss") == "True",
                     output_mode=args.get("output_mode")

--- a/bazarr/subtitles/sync.py
+++ b/bazarr/subtitles/sync.py
@@ -42,6 +42,36 @@ def _sync_progress_total(enabled_engines):
     return max(len(normalize_enabled_engines(configured_engines)), 1)
 
 
+def _resolve_subsync_overrides(arr_instance_id, is_series, enabled_engines, max_offset_seconds):
+    """Resolve the audio-sync settings against the owning instance's per-instance
+    overrides (#227), honouring any explicit caller-supplied values.
+
+    ``enabled_engines``/``max_offset_seconds`` of None mean "not supplied", so the
+    per-instance value (else the global default) applies; a non-None value is an
+    explicit caller override (e.g. the manual sync dialog) and is respected. A
+    None instance returns the global values unchanged. ``max_offset_seconds`` is
+    coerced to a string to match the legacy parameter shape.
+    """
+    from arr_instances.resolution import resolve_subtitle_setting as _resolve
+    use_subsync = _resolve(arr_instance_id, "subsync.use_subsync", settings.subsync.use_subsync)
+    if is_series:
+        use_threshold = _resolve(arr_instance_id, "subsync.use_subsync_threshold",
+                                 settings.subsync.use_subsync_threshold)
+        threshold = _resolve(arr_instance_id, "subsync.subsync_threshold",
+                             settings.subsync.subsync_threshold)
+    else:
+        use_threshold = _resolve(arr_instance_id, "subsync.use_subsync_movie_threshold",
+                                 settings.subsync.use_subsync_movie_threshold)
+        threshold = _resolve(arr_instance_id, "subsync.subsync_movie_threshold",
+                             settings.subsync.subsync_movie_threshold)
+    if enabled_engines is None:
+        enabled_engines = _resolve(arr_instance_id, "subsync.enabled_engines", None)
+    if max_offset_seconds is None:
+        max_offset_seconds = str(_resolve(arr_instance_id, "subsync.max_offset_seconds",
+                                          settings.subsync.max_offset_seconds))
+    return use_subsync, use_threshold, threshold, enabled_engines, max_offset_seconds
+
+
 def _index_keep_all_outputs(video_path, sonarr_series_id=None, sonarr_episode_id=None, radarr_id=None,
                             arr_instance_id=None):
     if sonarr_episode_id:
@@ -103,7 +133,7 @@ def sync_subtitles(video_path,
                    sonarr_episode_id=None,
                    radarr_id=None,
                    job_id=None,
-                   max_offset_seconds=str(settings.subsync.max_offset_seconds),
+                   max_offset_seconds=None,
                    gss=settings.subsync.gss,
                    no_fix_framerate=settings.subsync.no_fix_framerate,
                    reference=None,
@@ -114,7 +144,14 @@ def sync_subtitles(video_path,
                    track_job_progress=True,
                    arr_instance_id=None,
                    owns_job_progress=True):
-    if not settings.subsync.use_subsync and not force_sync:
+    # The audio-sync settings resolve against the owning instance (#227); a None
+    # owner / unset override yields the global value, so legacy paths are
+    # unchanged. The use_subsync gate is evaluated inline via the module-level
+    # helper so NO non-signature local is created before add_job_from_function
+    # below, which re-passes the frame's locals as kwargs on re-invocation.
+    if (not _resolve_subsync_overrides(
+            arr_instance_id, bool(sonarr_episode_id), enabled_engines, max_offset_seconds)[0]
+            and not force_sync):
         logging.debug('BAZARR automatic syncing is disabled in settings. Skipping sync routine.')
         return False
 
@@ -132,6 +169,11 @@ def sync_subtitles(video_path,
         )
         return False
 
+    # Past the enqueue point it is safe to bind locals. Resolve the per-instance
+    # overrides for the real run (the use_subsync gate already passed above).
+    (_, use_subsync_threshold, subsync_threshold,
+     enabled_engines, max_offset_seconds) = _resolve_subsync_overrides(
+        arr_instance_id, bool(sonarr_episode_id), enabled_engines, max_offset_seconds)
     progress_total = _sync_progress_total(enabled_engines)
 
     def report(message, value=None, total=None, name=None):
@@ -149,13 +191,6 @@ def sync_subtitles(video_path,
 
     logging.debug(f'BAZARR automatic syncing is enabled in settings. We\'ll try to sync this '  # noqa: G004
                   f'subtitles: {srt_path}.')
-    if sonarr_episode_id:
-        use_subsync_threshold = settings.subsync.use_subsync_threshold
-        subsync_threshold = settings.subsync.subsync_threshold
-    else:
-        use_subsync_threshold = settings.subsync.use_subsync_movie_threshold
-        subsync_threshold = settings.subsync.subsync_movie_threshold
-
     if not use_subsync_threshold or (use_subsync_threshold and percent_score <= float(subsync_threshold)):
         subsync = SubSyncer()
         sync_kwargs = {

--- a/tests/bazarr/test_sync_instance_overrides.py
+++ b/tests/bazarr/test_sync_instance_overrides.py
@@ -1,0 +1,72 @@
+# coding=utf-8
+# Per-instance subsync resolution (#227).
+# _resolve_subsync_overrides resolves the audio-sync settings against the owning
+# Sonarr/Radarr instance, while honouring any explicit caller-supplied values.
+import pytest
+
+from app.config import settings
+from arr_instances import resolution
+from subtitles.sync import _resolve_subsync_overrides
+
+
+@pytest.fixture
+def seed_instance_settings():
+    def _seed(blob, instance_id=8888):
+        resolution._subtitle_settings_cache[instance_id] = blob
+        return instance_id
+
+    yield _seed
+    resolution.clear_subtitle_settings_cache()
+
+
+def test_global_when_no_instance(monkeypatch):
+    monkeypatch.setattr(settings.subsync, "use_subsync", True)
+    monkeypatch.setattr(settings.subsync, "use_subsync_threshold", True)
+    monkeypatch.setattr(settings.subsync, "subsync_threshold", 96)
+    monkeypatch.setattr(settings.subsync, "max_offset_seconds", 60)
+    use_subsync, use_th, th, engines, max_off = _resolve_subsync_overrides(None, True, None, None)
+    assert use_subsync is True and use_th is True and th == 96
+    assert engines is None          # None => downstream global fallback preserved
+    assert max_off == "60"          # coerced to string like the legacy default
+
+
+def test_instance_use_subsync_override(seed_instance_settings, monkeypatch):
+    monkeypatch.setattr(settings.subsync, "use_subsync", True)
+    iid = seed_instance_settings({"subsync": {"use_subsync": False}})
+    use_subsync, *_ = _resolve_subsync_overrides(iid, True, None, None)
+    assert use_subsync is False
+
+
+def test_series_vs_movie_threshold(seed_instance_settings):
+    iid = seed_instance_settings({"subsync": {
+        "use_subsync_threshold": True, "subsync_threshold": 70,
+        "use_subsync_movie_threshold": True, "subsync_movie_threshold": 40,
+    }})
+    _, use_th_s, th_s, _, _ = _resolve_subsync_overrides(iid, True, None, None)
+    _, use_th_m, th_m, _, _ = _resolve_subsync_overrides(iid, False, None, None)
+    assert (use_th_s, th_s) == (True, 70)
+    assert (use_th_m, th_m) == (True, 40)
+
+
+def test_explicit_engines_win_over_instance(seed_instance_settings):
+    iid = seed_instance_settings({"subsync": {"enabled_engines": ["alass"]}})
+    _, _, _, engines, _ = _resolve_subsync_overrides(iid, True, ["ffsubsync"], None)
+    assert engines == ["ffsubsync"]
+
+
+def test_instance_engines_used_when_caller_passes_none(seed_instance_settings):
+    iid = seed_instance_settings({"subsync": {"enabled_engines": ["alass", "ffsubsync"]}})
+    _, _, _, engines, _ = _resolve_subsync_overrides(iid, True, None, None)
+    assert engines == ["alass", "ffsubsync"]
+
+
+def test_explicit_max_offset_wins(seed_instance_settings):
+    iid = seed_instance_settings({"subsync": {"max_offset_seconds": 600}})
+    _, _, _, _, max_off = _resolve_subsync_overrides(iid, True, None, "120")
+    assert max_off == "120"
+
+
+def test_instance_max_offset_used_when_caller_passes_none(seed_instance_settings):
+    iid = seed_instance_settings({"subsync": {"max_offset_seconds": 300}})
+    _, _, _, _, max_off = _resolve_subsync_overrides(iid, True, None, None)
+    assert max_off == "300"


### PR DESCRIPTION
## What

Activates **per-instance audio synchronization** on top of the per-instance subtitle settings foundation. `sync_subtitles()` now resolves the subsync settings against the owning Sonarr/Radarr instance's overrides (under `options["subtitle_settings"]["subsync"]`), falling back to the global config:

- `use_subsync` (the auto-sync gate)
- `use_subsync_threshold` / `subsync_threshold` (series)
- `use_subsync_movie_threshold` / `subsync_movie_threshold` (movies)
- `enabled_engines` (the sync engine set)
- `max_offset_seconds`

## How

The owner is the `arr_instance_id` already threaded into `sync_subtitles` by the download/upgrade/wanted/mass/manual paths. Resolution lives in a new `_resolve_subsync_overrides(arr_instance_id, is_series, enabled_engines, max_offset_seconds)` helper.

`enabled_engines` and `max_offset_seconds` keep any explicit caller value (e.g. the manual sync dialog or editor) — only an unset (`None`) value resolves to the per-instance/global default. A `None` owner returns the global values, so single-instance installs are unchanged.

The `use_subsync` gate is evaluated **inline** via the helper so that no non-signature local is created before `add_job_from_function` (which re-passes the frame's locals as kwargs on job re-invocation). The existing queue-path-locals guard test covers this exact hazard, and it passes.

The mass-operation path gets per-instance **engines for free** (it omits `enabled_engines` from the sync kwargs when the batch leaves them unset, so the resolver applies). Its `force_sync`/`percent_score=0` make the gate and thresholds moot, and its batch-level `max_offset` is intentional batch semantics (covered by existing mass-op tests), so it is unchanged.

## Tests

TDD: seven new tests in `test_sync_instance_overrides.py` cover the global-no-instance path, the `use_subsync` override, series vs movie thresholds, explicit-engines-win vs instance-engines, and explicit-max-offset-win vs instance-max-offset. Added to the CI guard list. Local guard subset green (123 passed) plus the isolated mass-op suite (63 passed).

Part of the per-instance subtitle settings work: https://github.com/LavX/bazarr/issues/227