### PR TITLE
Per-instance subtitle settings UI

### DIFF
--- a/frontend/src/apis/raw/arrInstances.ts
+++ b/frontend/src/apis/raw/arrInstances.ts
@@ -2,6 +2,35 @@ import BaseApi from "./base";
 
 export type ArrKind = "sonarr" | "radarr";
 
+// Per-instance subtitle setting overrides (#227). A present key overrides the
+// corresponding global setting for media owned by this instance; an absent key
+// inherits the global value. The shape mirrors the backend ALLOWED set.
+export interface ArrSubtitleSettingsGeneral {
+  use_postprocessing?: boolean;
+  postprocessing_cmd?: string;
+  use_postprocessing_threshold?: boolean;
+  postprocessing_threshold?: number;
+  use_postprocessing_threshold_movie?: boolean;
+  postprocessing_threshold_movie?: number;
+  subzero_mods?: string[];
+  subzero_mods_keep_lyrics?: boolean;
+}
+
+export interface ArrSubtitleSettingsSubsync {
+  use_subsync?: boolean;
+  use_subsync_threshold?: boolean;
+  subsync_threshold?: number;
+  use_subsync_movie_threshold?: boolean;
+  subsync_movie_threshold?: number;
+  enabled_engines?: string[];
+  max_offset_seconds?: number;
+}
+
+export interface ArrSubtitleSettings {
+  general?: ArrSubtitleSettingsGeneral;
+  subsync?: ArrSubtitleSettingsSubsync;
+}
+
 export interface ArrInstance {
   id: number;
   kind: ArrKind;
@@ -18,6 +47,7 @@ export interface ArrInstance {
   http_timeout: number;
   // The API never returns the key itself, only whether one is stored.
   api_key_set: boolean;
+  subtitle_settings?: ArrSubtitleSettings;
 }
 
 export interface ArrInstanceCreate {
@@ -32,6 +62,7 @@ export interface ArrInstanceCreate {
   http_timeout?: number;
   enabled?: boolean;
   is_default?: boolean;
+  subtitle_settings?: ArrSubtitleSettings;
 }
 
 export type ArrInstanceUpdate = Partial<{
@@ -47,6 +78,7 @@ export type ArrInstanceUpdate = Partial<{
   http_timeout: number;
   enabled: boolean;
   is_default: boolean;
+  subtitle_settings: ArrSubtitleSettings;
 }>;
 
 export interface ArrInstanceTest {

--- a/frontend/src/pages/Settings/Connections/InstanceFormModal.tsx
+++ b/frontend/src/pages/Settings/Connections/InstanceFormModal.tsx
@@ -34,6 +34,7 @@ import type {
   ArrInstanceTest,
   ArrInstanceUpdate,
   ArrKind,
+  ArrSubtitleSettings,
 } from "@/apis/raw/arrInstances";
 import {
   ARR_META,
@@ -41,6 +42,7 @@ import {
   normalizeBaseUrl,
   stripLeadingSlash,
 } from "./meta";
+import SubtitleSettingsOverrides from "./SubtitleSettingsOverrides";
 
 // How a stored API key is treated when editing. The key itself is never sent
 // to the browser, so the form only ever carries a brand new value.
@@ -58,6 +60,7 @@ interface FormValues {
   apiKey: string;
   enabled: boolean;
   isDefault: boolean;
+  subtitleSettings: ArrSubtitleSettings;
 }
 
 function initialValues(
@@ -77,6 +80,7 @@ function initialValues(
       apiKey: "",
       enabled: instance.enabled,
       isDefault: instance.is_default,
+      subtitleSettings: instance.subtitle_settings ?? {},
     };
   }
   return {
@@ -91,6 +95,7 @@ function initialValues(
     apiKey: "",
     enabled: true,
     isDefault: false,
+    subtitleSettings: {},
   };
 }
 
@@ -235,6 +240,9 @@ const InstanceFormModal: FunctionComponent<Props> = ({
       const body: ArrInstanceUpdate = {
         ...common,
         is_default: values.isDefault,
+        // Always sent so clearing every override (an empty object) removes the
+        // stored block server-side; an absent key would instead preserve it.
+        subtitle_settings: values.subtitleSettings,
       };
       if (hasStoredKey) {
         if (keyMode === "replace" && typed.length) {
@@ -270,6 +278,7 @@ const InstanceFormModal: FunctionComponent<Props> = ({
         enabled: common.enabled,
         isDefault: values.isDefault,
         apiKey: typed.length ? typed : undefined,
+        subtitleSettings: values.subtitleSettings,
       });
       create.mutate(body, {
         onSuccess: () => {
@@ -452,6 +461,13 @@ const InstanceFormModal: FunctionComponent<Props> = ({
               {...form.getInputProps("isDefault", { type: "checkbox" })}
             />
           </Group>
+
+          <Divider label="Subtitle settings (optional)" labelPosition="left" />
+
+          <SubtitleSettingsOverrides
+            value={form.values.subtitleSettings}
+            onChange={(next) => form.setFieldValue("subtitleSettings", next)}
+          />
 
           <Divider label="Connection check" labelPosition="left" />
 

--- a/frontend/src/pages/Settings/Connections/SubtitleSettingsOverrides.tsx
+++ b/frontend/src/pages/Settings/Connections/SubtitleSettingsOverrides.tsx
@@ -1,0 +1,220 @@
+import { FunctionComponent } from "react";
+import {
+  Alert,
+  Divider,
+  Group,
+  MultiSelect,
+  NumberInput,
+  SegmentedControl,
+  Select,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import type { ArrSubtitleSettings } from "@/apis/raw/arrInstances";
+import { SUBTITLE_TOOL_ACTIONS } from "@/constants/batch";
+import {
+  syncEngineOptions,
+  syncMaxOffsetSecondsOptions,
+} from "@/pages/Settings/Subtitles/options";
+import {
+  isOverridden,
+  OVERRIDE_FIELDS,
+  overrideDefault,
+  OverrideField,
+  OverrideSection,
+  setOverride,
+} from "./subtitleOverrides";
+
+const SECTION_LABELS: Record<OverrideSection, string> = {
+  general: "Post-processing & modifications",
+  subsync: "Audio synchronization",
+};
+
+const modOptions = SUBTITLE_TOOL_ACTIONS.map(([value, label]) => ({
+  value,
+  label,
+}));
+
+const offsetOptions = syncMaxOffsetSecondsOptions.map((option) => ({
+  value: String(option.value),
+  label: option.label,
+}));
+
+interface ControlProps {
+  field: OverrideField;
+  value: unknown;
+  onChange: (value: unknown) => void;
+}
+
+const OverrideControl: FunctionComponent<ControlProps> = ({
+  field,
+  value,
+  onChange,
+}) => {
+  switch (field.kind) {
+    case "bool":
+      return (
+        <SegmentedControl
+          size="xs"
+          value={value ? "on" : "off"}
+          onChange={(next) => onChange(next === "on")}
+          data={[
+            { value: "on", label: "Enabled" },
+            { value: "off", label: "Disabled" },
+          ]}
+        />
+      );
+    case "percent":
+      return (
+        <NumberInput
+          size="xs"
+          w={110}
+          min={0}
+          max={100}
+          allowDecimal={false}
+          value={typeof value === "number" ? value : 0}
+          onChange={(next) =>
+            onChange(typeof next === "number" ? next : Number(next) || 0)
+          }
+        />
+      );
+    case "text":
+      return (
+        <TextInput
+          size="xs"
+          style={{ flex: 1, minWidth: 220 }}
+          placeholder="/path/to/script.sh"
+          value={typeof value === "string" ? value : ""}
+          onChange={(event) => onChange(event.currentTarget.value)}
+        />
+      );
+    case "engines":
+      return (
+        <MultiSelect
+          size="xs"
+          style={{ flex: 1, minWidth: 220 }}
+          data={syncEngineOptions}
+          placeholder="Select engines"
+          value={Array.isArray(value) ? (value as string[]) : []}
+          onChange={(next) => onChange(next)}
+        />
+      );
+    case "mods":
+      return (
+        <MultiSelect
+          size="xs"
+          style={{ flex: 1, minWidth: 220 }}
+          data={modOptions}
+          placeholder="Select modifications"
+          value={Array.isArray(value) ? (value as string[]) : []}
+          onChange={(next) => onChange(next)}
+        />
+      );
+    case "offset":
+      return (
+        <Select
+          size="xs"
+          w={110}
+          data={offsetOptions}
+          allowDeselect={false}
+          value={value !== undefined ? String(value) : null}
+          onChange={(next) => onChange(next ? Number(next) : undefined)}
+        />
+      );
+    default:
+      return null;
+  }
+};
+
+interface RowProps {
+  field: OverrideField;
+  blob: ArrSubtitleSettings;
+  onChange: (next: ArrSubtitleSettings) => void;
+}
+
+const OverrideRow: FunctionComponent<RowProps> = ({
+  field,
+  blob,
+  onChange,
+}) => {
+  const overridden = isOverridden(blob, field.section, field.key);
+  const section = blob[field.section] as Record<string, unknown> | undefined;
+  const current = overridden ? section?.[field.key] : undefined;
+
+  const toggle = (checked: boolean) =>
+    onChange(
+      setOverride(
+        blob,
+        field.section,
+        field.key,
+        checked ? overrideDefault(field.kind) : undefined,
+      ),
+    );
+
+  const setValue = (next: unknown) =>
+    onChange(setOverride(blob, field.section, field.key, next));
+
+  return (
+    <Group justify="space-between" align="center" wrap="nowrap" gap="md">
+      <Switch
+        size="sm"
+        checked={overridden}
+        onChange={(event) => toggle(event.currentTarget.checked)}
+        label={field.label}
+        styles={{ label: { fontWeight: 500 } }}
+      />
+      {overridden ? (
+        <OverrideControl field={field} value={current} onChange={setValue} />
+      ) : (
+        <Text size="xs" c="dimmed">
+          Inherits global
+        </Text>
+      )}
+    </Group>
+  );
+};
+
+interface Props {
+  value: ArrSubtitleSettings;
+  onChange: (next: ArrSubtitleSettings) => void;
+}
+
+const SubtitleSettingsOverrides: FunctionComponent<Props> = ({
+  value,
+  onChange,
+}) => {
+  const sections: OverrideSection[] = ["general", "subsync"];
+  return (
+    <Stack gap="sm">
+      <Alert
+        variant="light"
+        color="blue"
+        icon={<FontAwesomeIcon icon={faCircleInfo} />}
+      >
+        Override only the settings that should differ for this instance.
+        Everything left off inherits the global Subtitles settings.
+      </Alert>
+      {sections.map((section) => (
+        <Stack key={section} gap="xs">
+          <Divider label={SECTION_LABELS[section]} labelPosition="left" />
+          {OVERRIDE_FIELDS.filter((field) => field.section === section).map(
+            (field) => (
+              <OverrideRow
+                key={field.key}
+                field={field}
+                blob={value}
+                onChange={onChange}
+              />
+            ),
+          )}
+        </Stack>
+      ))}
+    </Stack>
+  );
+};
+
+export default SubtitleSettingsOverrides;

--- a/frontend/src/pages/Settings/Connections/meta.ts
+++ b/frontend/src/pages/Settings/Connections/meta.ts
@@ -7,6 +7,7 @@ import type {
   ArrInstance,
   ArrInstanceCreate,
   ArrKind,
+  ArrSubtitleSettings,
 } from "@/apis/raw/arrInstances";
 import { Environment } from "@/utilities/env";
 
@@ -73,6 +74,7 @@ export function buildArrInstanceCreateBody(
     enabled: boolean;
     isDefault: boolean;
     apiKey?: string;
+    subtitleSettings?: ArrSubtitleSettings;
   },
 ): ArrInstanceCreate {
   const body: ArrInstanceCreate = {
@@ -91,6 +93,14 @@ export function buildArrInstanceCreateBody(
   }
   if (fields.apiKey) {
     body.api_key = fields.apiKey;
+  }
+  // Only sent when at least one override is set; an empty block is omitted so a
+  // new instance starts out fully inheriting the global settings.
+  if (
+    fields.subtitleSettings &&
+    Object.keys(fields.subtitleSettings).length > 0
+  ) {
+    body.subtitle_settings = fields.subtitleSettings;
   }
   return body;
 }

--- a/frontend/src/pages/Settings/Connections/subtitleOverrides.test.ts
+++ b/frontend/src/pages/Settings/Connections/subtitleOverrides.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  isOverridden,
+  OVERRIDE_FIELDS,
+  setOverride,
+} from "./subtitleOverrides";
+
+describe("setOverride", () => {
+  it("adds a key under its section", () => {
+    expect(setOverride({}, "subsync", "subsync_threshold", 80)).toEqual({
+      subsync: { subsync_threshold: 80 },
+    });
+  });
+
+  it("removes the key and prunes the empty section when value is undefined", () => {
+    expect(
+      setOverride(
+        { subsync: { subsync_threshold: 80 } },
+        "subsync",
+        "subsync_threshold",
+        undefined,
+      ),
+    ).toEqual({});
+  });
+
+  it("keeps sibling keys when removing one", () => {
+    const blob = { subsync: { subsync_threshold: 80, use_subsync: true } };
+    expect(setOverride(blob, "subsync", "use_subsync", undefined)).toEqual({
+      subsync: { subsync_threshold: 80 },
+    });
+  });
+
+  it("does not mutate the input blob", () => {
+    const blob = { general: { use_postprocessing: true } };
+    setOverride(blob, "general", "postprocessing_cmd", "/run.sh");
+    expect(blob).toEqual({ general: { use_postprocessing: true } });
+  });
+});
+
+describe("isOverridden", () => {
+  it("is true only when the key is present (regardless of value)", () => {
+    const blob = { general: { use_postprocessing: false } };
+    expect(isOverridden(blob, "general", "use_postprocessing")).toBe(true);
+    expect(isOverridden(blob, "general", "postprocessing_cmd")).toBe(false);
+    expect(isOverridden({}, "subsync", "use_subsync")).toBe(false);
+  });
+});
+
+describe("OVERRIDE_FIELDS", () => {
+  it("covers the general and subsync sections", () => {
+    const general = OVERRIDE_FIELDS.filter((f) => f.section === "general");
+    const subsync = OVERRIDE_FIELDS.filter((f) => f.section === "subsync");
+    expect(general.map((f) => f.key)).toContain("use_postprocessing");
+    expect(general.map((f) => f.key)).toContain("subzero_mods");
+    expect(subsync.map((f) => f.key)).toContain("use_subsync");
+    expect(subsync.map((f) => f.key)).toContain("max_offset_seconds");
+  });
+});

--- a/frontend/src/pages/Settings/Connections/subtitleOverrides.ts
+++ b/frontend/src/pages/Settings/Connections/subtitleOverrides.ts
@@ -1,0 +1,170 @@
+import type { ArrSubtitleSettings } from "@/apis/raw/arrInstances";
+
+// Per-instance subtitle setting overrides (#227). Each field maps to a key under
+// options.subtitle_settings[<section>]; a present key overrides the global value,
+// an absent key inherits it.
+export type OverrideSection = "general" | "subsync";
+
+export type OverrideKind =
+  | "bool"
+  | "percent"
+  | "text"
+  | "engines"
+  | "mods"
+  | "offset";
+
+export interface OverrideField {
+  section: OverrideSection;
+  key: string;
+  label: string;
+  description?: string;
+  kind: OverrideKind;
+}
+
+// The set mirrors the backend ALLOWED dict (arr_instances/subtitle_settings.py).
+export const OVERRIDE_FIELDS: OverrideField[] = [
+  {
+    section: "general",
+    key: "use_postprocessing",
+    label: "Use custom post-processing",
+    kind: "bool",
+  },
+  {
+    section: "general",
+    key: "postprocessing_cmd",
+    label: "Post-processing command",
+    kind: "text",
+  },
+  {
+    section: "general",
+    key: "use_postprocessing_threshold",
+    label: "Limit post-processing by score (series)",
+    kind: "bool",
+  },
+  {
+    section: "general",
+    key: "postprocessing_threshold",
+    label: "Post-processing score threshold (series)",
+    kind: "percent",
+  },
+  {
+    section: "general",
+    key: "use_postprocessing_threshold_movie",
+    label: "Limit post-processing by score (movies)",
+    kind: "bool",
+  },
+  {
+    section: "general",
+    key: "postprocessing_threshold_movie",
+    label: "Post-processing score threshold (movies)",
+    kind: "percent",
+  },
+  {
+    section: "general",
+    key: "subzero_mods",
+    label: "Subtitle modifications",
+    kind: "mods",
+  },
+  {
+    section: "general",
+    key: "subzero_mods_keep_lyrics",
+    label: "Keep lyrics when removing hearing-impaired text",
+    kind: "bool",
+  },
+  {
+    section: "subsync",
+    key: "use_subsync",
+    label: "Automatic subtitle synchronization",
+    kind: "bool",
+  },
+  {
+    section: "subsync",
+    key: "use_subsync_threshold",
+    label: "Limit sync by score (series)",
+    kind: "bool",
+  },
+  {
+    section: "subsync",
+    key: "subsync_threshold",
+    label: "Sync score threshold (series)",
+    kind: "percent",
+  },
+  {
+    section: "subsync",
+    key: "use_subsync_movie_threshold",
+    label: "Limit sync by score (movies)",
+    kind: "bool",
+  },
+  {
+    section: "subsync",
+    key: "subsync_movie_threshold",
+    label: "Sync score threshold (movies)",
+    kind: "percent",
+  },
+  {
+    section: "subsync",
+    key: "enabled_engines",
+    label: "Sync engines",
+    kind: "engines",
+  },
+  {
+    section: "subsync",
+    key: "max_offset_seconds",
+    label: "Maximum offset (seconds)",
+    kind: "offset",
+  },
+];
+
+export function isOverridden(
+  blob: ArrSubtitleSettings,
+  section: OverrideSection,
+  key: string,
+): boolean {
+  const sec = blob[section] as Record<string, unknown> | undefined;
+  return sec !== undefined && key in sec;
+}
+
+// Immutably set (or, when value is undefined, remove) a single override. An
+// emptied section is pruned so the persisted blob never carries dangling
+// sections, matching what the backend merge helper expects.
+export function setOverride(
+  blob: ArrSubtitleSettings,
+  section: OverrideSection,
+  key: string,
+  value: unknown,
+): ArrSubtitleSettings {
+  const current = blob[section] as Record<string, unknown> | undefined;
+  const sec: Record<string, unknown> = { ...(current ?? {}) };
+  if (value === undefined) {
+    delete sec[key];
+  } else {
+    sec[key] = value;
+  }
+  const next = { ...blob } as Record<string, unknown>;
+  if (Object.keys(sec).length > 0) {
+    next[section] = sec;
+  } else {
+    delete next[section];
+  }
+  return next as ArrSubtitleSettings;
+}
+
+// The value an override starts at when the user first enables it.
+export function overrideDefault(kind: OverrideKind): unknown {
+  switch (kind) {
+    case "bool":
+      return true;
+    case "percent":
+      return 90;
+    case "text":
+      return "";
+    case "engines":
+      return ["ffsubsync"];
+    case "mods":
+      return [];
+    case "offset":
+      return 120;
+    default:
+      return undefined;
+  }
+}

--- a/frontend/src/pages/Settings/Subtitles/index.tsx
+++ b/frontend/src/pages/Settings/Subtitles/index.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from "react";
 import { Link } from "react-router";
-import { Code, Space, Table, Text as MantineText } from "@mantine/core";
+import { Anchor, Code, Space, Table, Text as MantineText } from "@mantine/core";
 import {
   Check,
   CollapseBox,
@@ -133,6 +133,17 @@ const commandOptionElements: React.JSX.Element[] = commandOptions.map(
 const SettingsSubtitlesView: FunctionComponent = () => {
   return (
     <Layout name="Subtitles">
+      <Section header="Per-instance overrides">
+        <Message>
+          These settings apply to every Sonarr and Radarr instance by default.
+          To override post-processing, subtitle modifications, or
+          synchronization for a specific instance, edit that instance under{" "}
+          <Anchor component={Link} to="/settings/connections">
+            Settings &gt; Connections
+          </Anchor>
+          .
+        </Message>
+      </Section>
       <Section header="Subtitle File Options">
         <Selector
           label="Subtitle Folder"


### PR DESCRIPTION
## What

The UI for the per-instance subtitle settings feature. Each Sonarr/Radarr instance can now override a defined subset of the global subtitle settings directly in its add/edit form; anything left untouched inherits the global value.

## How

- **`ArrSubtitleSettings` types** added to the instance create/update/read shapes (the backend already returns and accepts `subtitle_settings` since the foundation PR).
- **`subtitleOverrides.ts`** — a pure, unit-tested helper: `OVERRIDE_FIELDS` (the 15 allowed settings, mirroring the backend `ALLOWED` set), plus `isOverridden` / `setOverride` (immutable, prunes emptied sections) / `overrideDefault`.
- **`SubtitleSettingsOverrides.tsx`** — renders an Inherit/Override switch per setting, grouped into "Post-processing & modifications" and "Audio synchronization". Enabling a row reveals the right control (segmented bool, percent input, command text, sync-engine / modification multi-selects, max-offset select) reusing the existing global option lists. These are standalone Mantine controls, not the global `settingKey`-bound widgets.
- **`InstanceFormModal`** holds the block in form state and includes it in the request bodies: create omits an empty block (new instance fully inherits); update always sends it so clearing every override removes the stored block server-side.
- The global **Subtitles settings page** gains a short note linking to Settings > Connections.

## Tests

TDD on the pure helper (`subtitleOverrides.test.ts`): add/remove keys, empty-section pruning, immutability, presence-based `isOverridden`, field coverage. Full frontend suite green locally: `check:ts`, `eslint` (0 errors), `prettier`, `vitest` (601 passed), and `build:ci`.

Completes the per-instance subtitle settings work: https://github.com/LavX/bazarr/issues/227