### PR TITLE
Per-instance post-processing on manual uploads

### DIFF
--- a/bazarr/subtitles/upload.py
+++ b/bazarr/subtitles/upload.py
@@ -47,8 +47,12 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
 
     single = settings.general.single_language
 
-    use_postprocessing = settings.general.use_postprocessing
-    postprocessing_cmd = settings.general.postprocessing_cmd
+    # Resolve post-processing against the owning instance (#227) so a per-instance
+    # override applies to manual uploads too, matching the download path. Manual
+    # uploads are not score-gated, so the threshold values are ignored here.
+    from subtitles.processing import _postprocessing_config
+    use_postprocessing, postprocessing_cmd, _, _ = _postprocessing_config(
+        media_type, arr_instance_id)
 
     chmod = int(settings.general.chmod, 8) if not sys.platform.startswith(
         'win') and settings.general.chmod_enabled else None


### PR DESCRIPTION
## What

Closes a coverage gap in the per-instance subtitle settings feature: a per-instance **post-processing** override (`use_postprocessing` / `postprocessing_cmd`) had no effect on **manually uploaded** subtitles.

## Why

`manual_upload_subtitle()` read both values straight from the global config, then ran the post-processing command on that basis, even though the owning `arr_instance_id` was already a parameter and used everywhere else in the same function (mods, sync, notify, history). The automatic download path resolves these per-instance via `_postprocessing_config`, so the two paths diverged for the same instance.

## How

Route the manual-upload path through the same `_postprocessing_config(media_type, arr_instance_id)` helper the download path uses, so both compute the post-processing config identically from the owning instance (global fallback when unset). Manual uploads are not score-gated, so the resolved threshold values are intentionally ignored.

## Tests

The resolution logic is already covered by `test_processing_postprocessing.py` (the reused helper). Local guard-list subset green (123 passed), ruff clean.

## How it was found

An end-to-end coverage audit (4 parallel auditors over the post-processing / subsync / subzero-mods / other-paths categories) examined ~70 reads of the overridable settings; this manual-upload post-processing site was the only real gap. The remaining flagged item is the already-tracked `subtitles_apply_mods` `keep_lyrics` edge (mods are user-chosen there; only `keep_lyrics` is instance-relevant).

Part of the per-instance subtitle settings work: https://github.com/LavX/bazarr/issues/227