### PR TITLE
Honor per-instance keep-lyrics in the apply-mods action

### DIFF
--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -445,6 +445,8 @@ class Subtitles(Resource):
                     subtitle_path=subtitles_path,
                     mods=[action],
                     video_path=video_path,
+                    # Resolve keep-lyrics against the owning instance (#227).
+                    arr_instance_id=arr_instance_id,
                 )
                 postprocess_subtitles(
                     subtitles_path, video_path, media_type, metadata, id,

--- a/bazarr/subtitles/mass_operations.py
+++ b/bazarr/subtitles/mass_operations.py
@@ -468,6 +468,8 @@ def _process_subtitle_item(item, action, options, job_id):
             item['srt_path'],
             [action],
             item['video_path'],
+            # Resolve keep-lyrics against the per-item owning instance (#227).
+            arr_instance_id=item.get('arr_instance_id'),
         )
         return True
     return False

--- a/bazarr/subtitles/tools/mods.py
+++ b/bazarr/subtitles/tools/mods.py
@@ -94,7 +94,8 @@ def apply_subtitle_mods(language, subtitle_path, mods, video_path,
 
     try:
         subtitles_apply_mods(language=language, subtitle_path=subtitle_path,
-                             mods=mods, video_path=video_path)
+                             mods=mods, video_path=video_path,
+                             arr_instance_id=arr_instance_id)
     except Exception:
         jobs_queue.update_job_name(
             job_id=job_id,
@@ -143,8 +144,11 @@ def apply_subtitle_mods(language, subtitle_path, mods, video_path,
     )
 
 
-def subtitles_apply_mods(language, subtitle_path, mods, video_path):
-    mods = with_keep_lyrics(mods)
+def subtitles_apply_mods(language, subtitle_path, mods, video_path, arr_instance_id=None):
+    # The mod list is user-chosen here, so only the keep-lyrics preference is
+    # instance-relevant: resolve it against the media's owning instance (#227).
+    # A None owner keeps the legacy global-only behaviour (single-instance).
+    mods = with_keep_lyrics(mods, arr_instance_id)
     language = alpha3_from_alpha2(language)
     custom = CustomLanguage.from_value(language, "alpha3")
     if custom is None:

--- a/tests/bazarr/test_mass_operations.py
+++ b/tests/bazarr/test_mass_operations.py
@@ -89,7 +89,8 @@ class TestProcessSubtitleItem:
         item = self._make_item()
         result = _process_subtitle_item(item, 'remove_HI', {}, 'test_job')
         assert result is True
-        mock_mods.assert_called_once_with('en', '/subs/test.en.srt', ['remove_HI'], '/video/test.mkv')
+        mock_mods.assert_called_once_with('en', '/subs/test.en.srt', ['remove_HI'],
+                                          '/video/test.mkv', arr_instance_id=None)
 
     @patch('subtitles.mass_operations.subtitles_apply_mods')
     def test_mod_action_ocr_fixes(self, mock_mods):
@@ -97,7 +98,20 @@ class TestProcessSubtitleItem:
         item = self._make_item()
         result = _process_subtitle_item(item, 'OCR_fixes', {}, 'test_job')
         assert result is True
-        mock_mods.assert_called_once_with('en', '/subs/test.en.srt', ['OCR_fixes'], '/video/test.mkv')
+        mock_mods.assert_called_once_with('en', '/subs/test.en.srt', ['OCR_fixes'],
+                                          '/video/test.mkv', arr_instance_id=None)
+
+    @patch('subtitles.mass_operations.subtitles_apply_mods')
+    def test_mod_action_threads_owning_instance(self, mock_mods):
+        # The per-item owning instance must reach subtitles_apply_mods so the
+        # keep-lyrics preference resolves against that instance (#227).
+        from subtitles.mass_operations import _process_subtitle_item
+        item = self._make_item()
+        item['arr_instance_id'] = 7
+        result = _process_subtitle_item(item, 'remove_HI', {}, 'test_job')
+        assert result is True
+        mock_mods.assert_called_once_with('en', '/subs/test.en.srt', ['remove_HI'],
+                                          '/video/test.mkv', arr_instance_id=7)
 
     @patch('subtitles.tools.translate.main.translate_subtitles_file', return_value=True)
     def test_translate_action(self, mock_translate):

--- a/tests/bazarr/test_subzero_keep_lyrics.py
+++ b/tests/bazarr/test_subzero_keep_lyrics.py
@@ -107,3 +107,75 @@ def test_get_subzero_mods_none_instance_uses_global(monkeypatch):
     monkeypatch.setattr(settings.general, "subzero_mods", "remove_HI,common")
     monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", False)
     assert get_subzero_mods(None) == ["remove_HI", "common"]
+
+
+# --- subtitles_apply_mods threads the owning instance (#227) ----------------
+# The manual "apply mods" action lets the user pick the mod list, so only the
+# keep-lyrics preference is instance-relevant. subtitles_apply_mods must resolve
+# it against the media's owning instance instead of the global setting.
+class _RecordingSubtitle:
+    """Captures the mods Subtitle is built with, then short-circuits the write
+    path by reporting no modified content (so no real file I/O happens)."""
+
+    last_mods = None
+
+    def __init__(self, lang_obj, mods=None, original_format=True):
+        self.language = lang_obj
+        self.mods = mods
+        self.format = "srt"
+        self.content = b""
+        _RecordingSubtitle.last_mods = mods
+
+    def is_valid(self):
+        return True
+
+    def get_modified_content(self, format=None):
+        return None
+
+
+@pytest.fixture
+def captured_apply_mods(monkeypatch, tmp_path):
+    from subtitles.tools import mods as mods_module
+
+    _RecordingSubtitle.last_mods = None
+    monkeypatch.setattr(mods_module, "Subtitle", _RecordingSubtitle)
+    # alpha3_from_alpha2 needs the app-loaded languages_dict; stub it since the
+    # language-code conversion is not the behaviour under test here.
+    monkeypatch.setattr(mods_module, "alpha3_from_alpha2", lambda lang: "eng")
+    srt = tmp_path / "movie.en.srt"
+    srt.write_bytes(b"1\n00:00:01,000 --> 00:00:02,000\nhi\n")
+    video = tmp_path / "movie.mkv"
+    video.write_bytes(b"")
+
+    def _apply(arr_instance_id):
+        mods_module.subtitles_apply_mods(
+            language="en",
+            subtitle_path=str(srt),
+            mods=["remove_HI"],
+            video_path=str(video),
+            arr_instance_id=arr_instance_id,
+        )
+        return _RecordingSubtitle.last_mods
+
+    return _apply
+
+
+def test_subtitles_apply_mods_instance_override_on_beats_global_off(
+    captured_apply_mods, seed_instance_settings, monkeypatch
+):
+    monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", False)
+    iid = seed_instance_settings({"general": {"subzero_mods_keep_lyrics": True}})
+    assert captured_apply_mods(iid) == ["remove_HI(keep_lyrics=1)"]
+
+
+def test_subtitles_apply_mods_instance_override_off_beats_global_on(
+    captured_apply_mods, seed_instance_settings, monkeypatch
+):
+    monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", True)
+    iid = seed_instance_settings({"general": {"subzero_mods_keep_lyrics": False}})
+    assert captured_apply_mods(iid) == ["remove_HI"]
+
+
+def test_subtitles_apply_mods_none_instance_uses_global(captured_apply_mods, monkeypatch):
+    monkeypatch.setattr(settings.general, "subzero_mods_keep_lyrics", True)
+    assert captured_apply_mods(None) == ["remove_HI(keep_lyrics=1)"]


### PR DESCRIPTION
Closes the one deferred edge from the per-instance subtitle settings work (https://github.com/LavX/bazarr/issues/227).

## Problem
The manual **apply mods** action (`subtitles_apply_mods`) resolved the preserve-song-lyrics preference from the **global** `subzero_mods_keep_lyrics` setting, ignoring a per-instance override. So a Sonarr/Radarr instance that overrode keep-lyrics had that override respected on download/upload/sync but **not** when the user manually applied the Remove HI mod from the editor or batch.

## Fix
Thread the media owning `arr_instance_id` into `subtitles_apply_mods`, which now resolves keep-lyrics via `with_keep_lyrics(mods, arr_instance_id)`:

- `subtitles_apply_mods(...)` gains an optional `arr_instance_id=None` (a `None` owner keeps the legacy global-only behaviour, so single-instance setups are unchanged).
- Forwarded from all three call sites: the `apply_subtitle_mods` job wrapper, the editor apply-mods API (`api/subtitles/subtitles.py`), and the batch mod path (`mass_operations.py`, per-item owner).

The mod **list** is user-chosen at this action, so only keep-lyrics is instance-relevant here.

## Tests (TDD)
Added to `tests/bazarr/test_subzero_keep_lyrics.py` (already in the CI guard list):
- instance override **on** beats global **off**
- instance override **off** beats global **on**
- `None` owner falls back to global

Watched all three fail first (missing `arr_instance_id` param), then pass.

## Verification
- `ruff check .` clean
- Relevant guard-list tests green locally (subzero/keep-lyrics, post-processing, subsync, action-scoping, subliminal mods): 95 passed