### PR TITLE
Archive uploads + drag-and-drop in the subtitle upload modal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
             tests/bazarr/test_subsync_engines.py \
             tests/bazarr/test_sync_instance_overrides.py \
             tests/bazarr/test_subzero_keep_lyrics.py \
+            tests/bazarr/test_archive_extraction.py \
             tests/bazarr/test_utilities_video_analyzer.py \
             tests/bazarr/test_embedded_subtitle_extraction.py \
             tests/subliminal_patch/test_subliminal_rebase.py \

--- a/bazarr/api/subtitles/__init__.py
+++ b/bazarr/api/subtitles/__init__.py
@@ -5,6 +5,7 @@ from .subtitles_info import api_ns_subtitles_info
 from .batch import api_ns_batch
 from .content import api_ns_subtitle_content
 from .subtitles_contents import api_ns_subtitle_contents
+from .archive import api_ns_subtitle_archive
 
 
 api_ns_list_subtitles = [
@@ -13,4 +14,5 @@ api_ns_list_subtitles = [
     api_ns_batch,
     api_ns_subtitle_content,
     api_ns_subtitle_contents,
+    api_ns_subtitle_archive,
 ]

--- a/bazarr/api/subtitles/archive.py
+++ b/bazarr/api/subtitles/archive.py
@@ -2,7 +2,7 @@
 
 import base64
 
-from flask import jsonify, make_response
+from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource, reqparse
 from werkzeug.datastructures import FileStorage
 
@@ -41,6 +41,11 @@ class SubtitleArchive(Resource):
         base64 so the frontend can rebuild them into the normal per-file upload
         flow, where the user assigns language/forced/HI per file.
         """
+        # Reject an oversized upload from the declared length before parse_args
+        # spools the whole multipart body to disk/memory.
+        if request.content_length and request.content_length > MAX_ARCHIVE_SIZE:
+            return 'Archive is too large.', 400
+
         args = self.post_request_parser.parse_args()
         uploaded = args.get('file')
         filename = uploaded.filename or ''

--- a/bazarr/api/subtitles/archive.py
+++ b/bazarr/api/subtitles/archive.py
@@ -48,7 +48,9 @@ class SubtitleArchive(Resource):
         if not is_archive(filename):
             return 'Unsupported archive type. Use .zip, .rar or .7z.', 400
 
-        data = uploaded.read()
+        # Read at most one byte past the cap so an oversized upload is rejected
+        # without buffering the whole thing into memory.
+        data = uploaded.read(MAX_ARCHIVE_SIZE + 1)
         if len(data) > MAX_ARCHIVE_SIZE:
             return 'Archive is too large.', 400
 

--- a/bazarr/api/subtitles/archive.py
+++ b/bazarr/api/subtitles/archive.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+
+import base64
+
+from flask import jsonify, make_response
+from flask_restx import Namespace, Resource, reqparse
+from werkzeug.datastructures import FileStorage
+
+from subtitles.tools.archives import (
+    ArchiveError,
+    extract_subtitles_from_archive,
+    is_archive,
+)
+
+from ..utils import authenticate
+
+api_ns_subtitle_archive = Namespace(
+    'SubtitleArchive',
+    description='Extract subtitle files from an uploaded compressed archive')
+
+# Cap the uploaded archive itself; the extractor caps the uncompressed payload.
+MAX_ARCHIVE_SIZE = 50 * 1024 * 1024  # 50 MiB
+
+
+@api_ns_subtitle_archive.route('subtitles/archive')
+class SubtitleArchive(Resource):
+    post_request_parser = reqparse.RequestParser()
+    post_request_parser.add_argument(
+        'file', type=FileStorage, location='files', required=True,
+        help='Compressed archive (.zip/.rar/.7z) of subtitle files')
+
+    @authenticate
+    @api_ns_subtitle_archive.doc(parser=post_request_parser)
+    @api_ns_subtitle_archive.response(200, 'Success')
+    @api_ns_subtitle_archive.response(400, 'Not a valid or supported archive')
+    @api_ns_subtitle_archive.response(401, 'Not Authenticated')
+    def post(self):
+        """Extract subtitle files from an uploaded archive (#233).
+
+        Returns the contained subtitle files (non-subtitle entries discarded) as
+        base64 so the frontend can rebuild them into the normal per-file upload
+        flow, where the user assigns language/forced/HI per file.
+        """
+        args = self.post_request_parser.parse_args()
+        uploaded = args.get('file')
+        filename = uploaded.filename or ''
+
+        if not is_archive(filename):
+            return 'Unsupported archive type. Use .zip, .rar or .7z.', 400
+
+        data = uploaded.read()
+        if len(data) > MAX_ARCHIVE_SIZE:
+            return 'Archive is too large.', 400
+
+        try:
+            extracted = extract_subtitles_from_archive(filename, data)
+        except ArchiveError as e:
+            return str(e), 400
+
+        files = [
+            {'name': name,
+             'content': base64.b64encode(content).decode('ascii')}
+            for name, content in extracted
+        ]
+        return make_response(jsonify({'files': files, 'count': len(files)}), 200)

--- a/bazarr/subtitles/tools/archives.py
+++ b/bazarr/subtitles/tools/archives.py
@@ -58,7 +58,8 @@ def _guarded(entries):
     total = 0
     for name, declared_size, read in entries:
         if len(out) >= _MAX_ENTRIES:
-            break
+            raise ArchiveError(
+                f"Archive contains more than {_MAX_ENTRIES} subtitle files.")
         total += declared_size or 0
         if total > _MAX_TOTAL_BYTES:
             raise ArchiveError("Archive expands beyond the allowed size limit.")
@@ -109,25 +110,39 @@ def _extract_rar(data):
 
 def _extract_7z(data):
     import py7zr
+    from py7zr.exceptions import ArchiveError as Py7zError
+    from py7zr.exceptions import PasswordRequired
     from py7zr.io import BufferOverflow, BytesIOFactory
     # Extract into memory (never to disk) so a traversal member name cannot
-    # escape onto the filesystem; the factory caps total memory. Only the
-    # subtitle members are targeted so non-subtitle files are never inflated.
+    # escape onto the filesystem. Only the subtitle members are targeted so
+    # non-subtitle files are never inflated. py7zr's BytesIOFactory limit is
+    # per-output-object, not cumulative, so enforce the entry and total-size
+    # budgets from the header BEFORE extracting anything.
     factory = BytesIOFactory(_MAX_TOTAL_BYTES)
     try:
         with py7zr.SevenZipFile(BytesIO(data), 'r') as zf:
-            targets = [name for name in zf.getnames() if _keep(name)]
-            if not targets:
+            members = [fi for fi in zf.list()
+                       if not fi.is_directory and _keep(fi.filename)]
+            if not members:
                 return []
+            if len(members) > _MAX_ENTRIES:
+                raise ArchiveError(
+                    f"Archive contains more than {_MAX_ENTRIES} subtitle files.")
+            if sum(fi.uncompressed or 0 for fi in members) > _MAX_TOTAL_BYTES:
+                raise ArchiveError(
+                    "Archive expands beyond the allowed size limit.")
             zf.reset()
-            zf.extract(targets=targets, factory=factory)
+            zf.extract(targets=[fi.filename for fi in members], factory=factory)
+    except ArchiveError:
+        raise
+    except PasswordRequired as e:
+        raise ArchiveError("Encrypted 7z archives are not supported.") from e
     except BufferOverflow as e:
         raise ArchiveError("Archive expands beyond the allowed size limit.") from e
-    except py7zr.exceptions.ArchiveError as e:
+    except Py7zError as e:
         raise ArchiveError(f"Could not read 7z archive: {e}") from e
-    items = list(factory.products.items())[:_MAX_ENTRIES]
     return [(os.path.basename(name.replace('\\', '/')), bio.read())
-            for name, bio in items]
+            for name, bio in factory.products.items()]
 
 
 def extract_subtitles_from_archive(filename, data):

--- a/bazarr/subtitles/tools/archives.py
+++ b/bazarr/subtitles/tools/archives.py
@@ -45,64 +45,89 @@ def _keep(name):
     return _is_subtitle(base)
 
 
-def _collect(pairs):
-    """Apply the per-archive guards to an iterable of (name, content) pairs and
-    return [(basename, content), ...]. ``basename`` defuses zip-slip paths."""
+def _guarded(entries):
+    """Read subtitle entries lazily under the per-archive caps.
+
+    ``entries`` yields ``(name, declared_size, read)`` where ``read()`` returns
+    the member bytes. The declared (uncompressed) size is checked BEFORE the
+    member is inflated so a single bomb member cannot blow past the budget, and
+    the entry count is capped. Returns ``[(basename, content), ...]``;
+    ``basename`` defuses zip-slip paths.
+    """
     out = []
     total = 0
-    for name, content in pairs:
+    for name, declared_size, read in entries:
         if len(out) >= _MAX_ENTRIES:
             break
-        total += len(content)
+        total += declared_size or 0
         if total > _MAX_TOTAL_BYTES:
             raise ArchiveError("Archive expands beyond the allowed size limit.")
-        out.append((os.path.basename(name.replace('\\', '/')), content))
+        out.append((os.path.basename(name.replace('\\', '/')), read()))
     return out
+
+
+def _read_member(reader, info, label):
+    """Read one archive member, mapping any read failure (encrypted member,
+    CRC error, truncated data, ...) to ArchiveError instead of leaking the
+    backend library's own exception type."""
+    try:
+        return reader(info)
+    except ArchiveError:
+        raise
+    except Exception as e:
+        raise ArchiveError(f"Could not read {label} member: {e}") from e
 
 
 def _extract_zip(data):
     try:
-        with zipfile.ZipFile(BytesIO(data)) as zf:
-            return _collect(
-                (info.filename, zf.read(info))
-                for info in zf.infolist()
-                if not info.is_dir() and _keep(info.filename)
-            )
+        zf = zipfile.ZipFile(BytesIO(data))
     except zipfile.BadZipFile as e:
         raise ArchiveError(f"Not a valid zip archive: {e}") from e
+    with zf:
+        return _guarded(
+            (info.filename, info.file_size,
+             lambda info=info: _read_member(zf.read, info, "zip"))
+            for info in zf.infolist()
+            if not info.is_dir() and _keep(info.filename)
+        )
 
 
 def _extract_rar(data):
     import rarfile
     try:
-        with rarfile.RarFile(BytesIO(data)) as rf:
-            return _collect(
-                (info.filename, rf.read(info))
-                for info in rf.infolist()
-                if not info.is_dir() and _keep(info.filename)
-            )
+        rf = rarfile.RarFile(BytesIO(data))
     except rarfile.Error as e:
         raise ArchiveError(f"Could not read rar archive: {e}") from e
+    with rf:
+        return _guarded(
+            (info.filename, info.file_size,
+             lambda info=info: _read_member(rf.read, info, "rar"))
+            for info in rf.infolist()
+            if not info.is_dir() and _keep(info.filename)
+        )
 
 
 def _extract_7z(data):
     import py7zr
     from py7zr.io import BufferOverflow, BytesIOFactory
     # Extract into memory (never to disk) so a traversal member name cannot
-    # escape onto the filesystem; the factory also caps total memory.
+    # escape onto the filesystem; the factory caps total memory. Only the
+    # subtitle members are targeted so non-subtitle files are never inflated.
     factory = BytesIOFactory(_MAX_TOTAL_BYTES)
     try:
         with py7zr.SevenZipFile(BytesIO(data), 'r') as zf:
-            zf.extractall(factory=factory)
+            targets = [name for name in zf.getnames() if _keep(name)]
+            if not targets:
+                return []
+            zf.reset()
+            zf.extract(targets=targets, factory=factory)
     except BufferOverflow as e:
         raise ArchiveError("Archive expands beyond the allowed size limit.") from e
     except py7zr.exceptions.ArchiveError as e:
         raise ArchiveError(f"Could not read 7z archive: {e}") from e
-    return _collect(
-        (name, bio.read())
-        for name, bio in factory.products.items()
-        if _keep(name)
-    )
+    items = list(factory.products.items())[:_MAX_ENTRIES]
+    return [(os.path.basename(name.replace('\\', '/')), bio.read())
+            for name, bio in items]
 
 
 def extract_subtitles_from_archive(filename, data):

--- a/bazarr/subtitles/tools/archives.py
+++ b/bazarr/subtitles/tools/archives.py
@@ -1,0 +1,122 @@
+# coding=utf-8
+"""Extract subtitle files out of an uploaded archive (.zip/.rar/.7z).
+
+Users can upload a compressed file instead of pre-extracting it; we pull out
+just the subtitle entries and discard everything else, then feed each one
+through the normal per-file upload flow.
+See https://github.com/LavX/bazarr/issues/233
+"""
+import os
+import zipfile
+from io import BytesIO
+
+ARCHIVE_EXTENSIONS = ('.zip', '.rar', '.7z')
+
+# Guards against archive bombs: cap how many subtitle entries we return and the
+# total uncompressed payload we hold in memory.
+_MAX_ENTRIES = 500
+_MAX_TOTAL_BYTES = 100 * 1024 * 1024  # 100 MiB
+
+
+class ArchiveError(Exception):
+    """Raised when an archive is unsupported, corrupt, or unreadable."""
+
+
+def is_archive(filename):
+    """Whether ``filename`` looks like a supported archive by extension."""
+    return bool(filename) and filename.lower().endswith(ARCHIVE_EXTENSIONS)
+
+
+def _is_subtitle(name):
+    # Mirror the upload endpoint's accepted set so extracted files pass the same
+    # validation. Imported lazily to avoid importing the heavy provider stack.
+    from subliminal_patch.core import SUBTITLE_EXTENSIONS
+    return name.lower().endswith(tuple(SUBTITLE_EXTENSIONS))
+
+
+def _keep(name):
+    """A returnable subtitle entry: a real subtitle file, not a directory or a
+    macOS resource-fork sidecar (the ``__MACOSX/._name`` entries zip adds)."""
+    if not name or name.endswith('/'):
+        return False
+    base = os.path.basename(name.replace('\\', '/'))
+    if not base or base.startswith('._') or '__MACOSX' in name.split('/'):
+        return False
+    return _is_subtitle(base)
+
+
+def _collect(pairs):
+    """Apply the per-archive guards to an iterable of (name, content) pairs and
+    return [(basename, content), ...]. ``basename`` defuses zip-slip paths."""
+    out = []
+    total = 0
+    for name, content in pairs:
+        if len(out) >= _MAX_ENTRIES:
+            break
+        total += len(content)
+        if total > _MAX_TOTAL_BYTES:
+            raise ArchiveError("Archive expands beyond the allowed size limit.")
+        out.append((os.path.basename(name.replace('\\', '/')), content))
+    return out
+
+
+def _extract_zip(data):
+    try:
+        with zipfile.ZipFile(BytesIO(data)) as zf:
+            return _collect(
+                (info.filename, zf.read(info))
+                for info in zf.infolist()
+                if not info.is_dir() and _keep(info.filename)
+            )
+    except zipfile.BadZipFile as e:
+        raise ArchiveError(f"Not a valid zip archive: {e}") from e
+
+
+def _extract_rar(data):
+    import rarfile
+    try:
+        with rarfile.RarFile(BytesIO(data)) as rf:
+            return _collect(
+                (info.filename, rf.read(info))
+                for info in rf.infolist()
+                if not info.is_dir() and _keep(info.filename)
+            )
+    except rarfile.Error as e:
+        raise ArchiveError(f"Could not read rar archive: {e}") from e
+
+
+def _extract_7z(data):
+    import py7zr
+    from py7zr.io import BufferOverflow, BytesIOFactory
+    # Extract into memory (never to disk) so a traversal member name cannot
+    # escape onto the filesystem; the factory also caps total memory.
+    factory = BytesIOFactory(_MAX_TOTAL_BYTES)
+    try:
+        with py7zr.SevenZipFile(BytesIO(data), 'r') as zf:
+            zf.extractall(factory=factory)
+    except BufferOverflow as e:
+        raise ArchiveError("Archive expands beyond the allowed size limit.") from e
+    except py7zr.exceptions.ArchiveError as e:
+        raise ArchiveError(f"Could not read 7z archive: {e}") from e
+    return _collect(
+        (name, bio.read())
+        for name, bio in factory.products.items()
+        if _keep(name)
+    )
+
+
+def extract_subtitles_from_archive(filename, data):
+    """Return ``[(basename, content_bytes), ...]`` for the subtitle entries in
+    the archive ``data``, discarding directories and non-subtitle files.
+
+    ``filename`` selects the format by extension. Raises :class:`ArchiveError`
+    for an unsupported extension or a corrupt/unreadable archive.
+    """
+    lower = (filename or "").lower()
+    if lower.endswith('.zip'):
+        return _extract_zip(data)
+    if lower.endswith('.rar'):
+        return _extract_rar(data)
+    if lower.endswith('.7z'):
+        return _extract_7z(data)
+    raise ArchiveError(f"Unsupported archive type: {filename}")

--- a/frontend/src/apis/hooks/subtitles.ts
+++ b/frontend/src/apis/hooks/subtitles.ts
@@ -189,6 +189,9 @@ export function useSubtitleInfos(names: string[]) {
     queryKey: [QueryKeys.Subtitles, QueryKeys.Infos, names],
 
     queryFn: () => api.subtitles.info(names),
+    // Skip the request when there are no files yet (e.g. while an initial
+    // archive selection is still being extracted).
+    enabled: names.length > 0,
   });
 }
 

--- a/frontend/src/apis/raw/subtitles.ts
+++ b/frontend/src/apis/raw/subtitles.ts
@@ -99,9 +99,30 @@ export interface UpgradableResponse {
   seriesKeys?: UpgradableSeriesKey[];
 }
 
+export interface ArchiveExtractedFile {
+  name: string;
+  // base64-encoded file content
+  content: string;
+}
+
+export interface ArchiveExtractResponse {
+  files: ArchiveExtractedFile[];
+  count: number;
+}
+
 class SubtitlesApi extends BaseApi {
   constructor() {
     super("/subtitles");
+  }
+
+  // Upload a compressed archive (.zip/.rar/.7z) and get back the contained
+  // subtitle files (non-subtitle entries discarded) so they can be added to
+  // the manual-upload flow. See LavX/bazarr issue #233.
+  async extractArchive(file: File): Promise<ArchiveExtractResponse> {
+    const response = await this.post<ArchiveExtractResponse>("/archive", {
+      file,
+    });
+    return response.data;
   }
 
   async getRefTracksByEpisodeId(

--- a/frontend/src/components/forms/MovieUploadForm.tsx
+++ b/frontend/src/components/forms/MovieUploadForm.tsx
@@ -1,4 +1,10 @@
-import React, { FunctionComponent, useEffect, useMemo } from "react";
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   Button,
   Divider,
@@ -7,7 +13,9 @@ import {
   Stack,
   Text,
 } from "@mantine/core";
+import { Dropzone } from "@mantine/dropzone";
 import { useForm } from "@mantine/form";
+import { showNotification } from "@mantine/notifications";
 import {
   faCheck,
   faCircleNotch,
@@ -19,12 +27,15 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ColumnDef } from "@tanstack/react-table";
 import { isString, uniqBy } from "lodash";
 import { useMovieSubtitleModification } from "@/apis/hooks";
+import api from "@/apis/raw";
 import { subtitlesTypeOptions } from "@/components/forms/uploadFormSelectorTypes";
-import { Action, Selector } from "@/components/inputs";
+import { Action, DropContent, Selector } from "@/components/inputs";
 import SimpleTable from "@/components/tables/SimpleTable";
 import TextPopover from "@/components/TextPopover";
 import { useModals, withModal } from "@/modules/modals";
+import { notification } from "@/modules/task";
 import { useArrayAction, useSelectorOptions } from "@/utilities";
+import { expandArchives, isArchiveFile } from "@/utilities/archives";
 import FormUtils from "@/utilities/form";
 import {
   useLanguageProfileBy,
@@ -98,19 +109,27 @@ const MovieUploadForm: FunctionComponent<Props> = ({
     [languages],
   );
 
+  const buildRow = useCallback(
+    (file: File): SubtitleFile => {
+      const row: SubtitleFile = {
+        file,
+        language: defaultLanguage,
+        forced: defaultLanguage?.forced ?? false,
+        hi: defaultLanguage?.hi ?? false,
+      };
+      return { ...row, validateResult: validator(movie, row) };
+    },
+    [defaultLanguage, movie],
+  );
+
+  const [processing, setProcessing] = useState(false);
+  const [ready, setReady] = useState(false);
+
   const form = useForm({
     initialValues: {
-      files: files
-        .map<SubtitleFile>((file) => ({
-          file,
-          language: defaultLanguage,
-          forced: defaultLanguage?.forced ?? false,
-          hi: defaultLanguage?.hi ?? false,
-        }))
-        .map<SubtitleFile>((v) => ({
-          ...v,
-          validateResult: validator(movie, v),
-        })),
+      // Archives are expanded asynchronously on mount; start with the plain
+      // subtitle files so the common case renders instantly.
+      files: files.filter((file) => !isArchiveFile(file)).map(buildRow),
     },
     validate: {
       files: FormUtils.validation((values: SubtitleFile[]) => {
@@ -126,11 +145,64 @@ const MovieUploadForm: FunctionComponent<Props> = ({
     },
   });
 
+  // Add dropped/selected files: archives (#233) are extracted on the backend
+  // and replaced by their subtitle entries; plain files pass through.
+  const addFiles = useCallback(
+    async (incoming: File[]) => {
+      if (incoming.length === 0) {
+        return;
+      }
+      if (incoming.some(isArchiveFile)) {
+        setProcessing(true);
+      }
+      const { files: expanded, errors } = await expandArchives(
+        incoming,
+        (file) => api.subtitles.extractArchive(file),
+      );
+      if (errors.length > 0) {
+        showNotification(
+          notification.warn(
+            "Could not extract some archives",
+            errors.join(", "),
+          ),
+        );
+      }
+      if (expanded.length > 0) {
+        form.setValues((values) => ({
+          ...values,
+          files: [...(values.files ?? []), ...expanded.map(buildRow)],
+        }));
+      }
+      setProcessing(false);
+    },
+    [form, buildRow],
+  );
+
+  // Expand any archives in the initially-provided files once on mount, then
+  // arm the empty-close guard below.
   useEffect(() => {
-    if (form.values.files.length <= 0) {
+    let cancelled = false;
+    const archives = files.filter(isArchiveFile);
+    void (async () => {
+      if (archives.length > 0) {
+        await addFiles(archives);
+      }
+      if (!cancelled) {
+        setReady(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // Only the initially-provided files matter here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (ready && form.values.files.length <= 0) {
       modals.closeSelf();
     }
-  }, [form.values.files.length, modals]);
+  }, [ready, form.values.files.length, modals]);
 
   const action = useArrayAction<SubtitleFile>((fn) => {
     form.setValues((values) => {
@@ -319,6 +391,13 @@ const MovieUploadForm: FunctionComponent<Props> = ({
       })}
     >
       <Stack className="table-long-break">
+        <Dropzone
+          onDrop={(dropped) => void addFiles(dropped)}
+          loading={processing}
+          multiple
+        >
+          <DropContent></DropContent>
+        </Dropzone>
         <SimpleTable columns={columns} data={form.values.files}></SimpleTable>
         <Divider></Divider>
         <Button type="submit">Upload</Button>

--- a/frontend/src/components/forms/MovieUploadForm.tsx
+++ b/frontend/src/components/forms/MovieUploadForm.tsx
@@ -400,7 +400,13 @@ const MovieUploadForm: FunctionComponent<Props> = ({
         </Dropzone>
         <SimpleTable columns={columns} data={form.values.files}></SimpleTable>
         <Divider></Divider>
-        <Button type="submit">Upload</Button>
+        <Button
+          type="submit"
+          loading={processing}
+          disabled={processing || form.values.files.length === 0}
+        >
+          Upload
+        </Button>
       </Stack>
     </form>
   );

--- a/frontend/src/components/forms/SeriesUploadForm.tsx
+++ b/frontend/src/components/forms/SeriesUploadForm.tsx
@@ -1,4 +1,10 @@
-import React, { FunctionComponent, useEffect, useMemo } from "react";
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   Button,
   Divider,
@@ -7,7 +13,9 @@ import {
   Stack,
   Text,
 } from "@mantine/core";
+import { Dropzone } from "@mantine/dropzone";
 import { useForm } from "@mantine/form";
+import { showNotification } from "@mantine/notifications";
 import {
   faCheck,
   faCircleNotch,
@@ -23,12 +31,15 @@ import {
   useEpisodeSubtitleModification,
   useSubtitleInfos,
 } from "@/apis/hooks";
+import api from "@/apis/raw";
 import { subtitlesTypeOptions } from "@/components/forms/uploadFormSelectorTypes";
-import { Action, Selector } from "@/components/inputs";
+import { Action, DropContent, Selector } from "@/components/inputs";
 import SimpleTable from "@/components/tables/SimpleTable";
 import TextPopover from "@/components/TextPopover";
 import { useModals, withModal } from "@/modules/modals";
+import { notification } from "@/modules/task";
 import { useArrayAction, useSelectorOptions } from "@/utilities";
+import { expandArchives, isArchiveFile } from "@/utilities/archives";
 import FormUtils from "@/utilities/form";
 import {
   useLanguageProfileBy,
@@ -110,20 +121,27 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
     [languages],
   );
 
+  const buildRow = useCallback(
+    (file: File): SubtitleFile => {
+      const row: SubtitleFile = {
+        file,
+        language: defaultLanguage,
+        forced: defaultLanguage?.forced ?? false,
+        hi: defaultLanguage?.hi ?? false,
+        episode: null,
+      };
+      return { ...row, validateResult: validator(row) };
+    },
+    [defaultLanguage],
+  );
+
+  const [processing, setProcessing] = useState(false);
+
   const form = useForm({
     initialValues: {
-      files: files
-        .map<SubtitleFile>((file) => ({
-          file,
-          language: defaultLanguage,
-          forced: defaultLanguage?.forced ?? false,
-          hi: defaultLanguage?.hi ?? false,
-          episode: null,
-        }))
-        .map<SubtitleFile>((file) => ({
-          ...file,
-          validateResult: validator(file),
-        })),
+      // Archives are expanded asynchronously on mount; start with the plain
+      // subtitle files so the common case renders instantly.
+      files: files.filter((file) => !isArchiveFile(file)).map(buildRow),
     },
     validate: {
       files: FormUtils.validation(
@@ -140,6 +158,49 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
     },
   });
 
+  // Add dropped/selected files: archives (#233) are extracted on the backend
+  // and replaced by their subtitle entries; plain files pass through.
+  const addFiles = useCallback(
+    async (incoming: File[]) => {
+      if (incoming.length === 0) {
+        return;
+      }
+      if (incoming.some(isArchiveFile)) {
+        setProcessing(true);
+      }
+      const { files: expanded, errors } = await expandArchives(
+        incoming,
+        (file) => api.subtitles.extractArchive(file),
+      );
+      if (errors.length > 0) {
+        showNotification(
+          notification.warn(
+            "Could not extract some archives",
+            errors.join(", "),
+          ),
+        );
+      }
+      if (expanded.length > 0) {
+        form.setValues((values) => ({
+          ...values,
+          files: [...(values.files ?? []), ...expanded.map(buildRow)],
+        }));
+      }
+      setProcessing(false);
+    },
+    [form, buildRow],
+  );
+
+  // Expand any archives in the initially-provided files once on mount.
+  useEffect(() => {
+    const archives = files.filter(isArchiveFile);
+    if (archives.length > 0) {
+      void addFiles(archives);
+    }
+    // Only the initially-provided files matter here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const action = useArrayAction<SubtitleFile>((fn) => {
     form.setValues((values) => {
       const newFiles = fn(values.files ?? []);
@@ -150,7 +211,12 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
     });
   });
 
-  const names = useMemo(() => files.map((v) => v.name), [files]);
+  // Derived from the live rows (not just the initial prop) so files added via
+  // the dropzone or extracted from an archive also get episode auto-matched.
+  const names = useMemo(
+    () => form.values.files.map((v) => v.file.name),
+    [form.values.files],
+  );
   const infos = useSubtitleInfos(names);
 
   // Auto assign episode if available
@@ -391,6 +457,13 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
       })}
     >
       <Stack className="table-long-break">
+        <Dropzone
+          onDrop={(dropped) => void addFiles(dropped)}
+          loading={processing}
+          multiple
+        >
+          <DropContent></DropContent>
+        </Dropzone>
         <SimpleTable columns={columns} data={form.values.files}></SimpleTable>
         <Divider></Divider>
         <Button type="submit">Upload</Button>

--- a/frontend/src/components/forms/SeriesUploadForm.tsx
+++ b/frontend/src/components/forms/SeriesUploadForm.tsx
@@ -466,7 +466,13 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
         </Dropzone>
         <SimpleTable columns={columns} data={form.values.files}></SimpleTable>
         <Divider></Divider>
-        <Button type="submit">Upload</Button>
+        <Button
+          type="submit"
+          loading={processing}
+          disabled={processing || form.values.files.length === 0}
+        >
+          Upload
+        </Button>
       </Stack>
     </form>
   );

--- a/frontend/src/utilities/archives.test.ts
+++ b/frontend/src/utilities/archives.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { base64ToFile, expandArchives, isArchiveFile } from "./archives";
+
+function file(name: string, content = "x"): File {
+  return new File([content], name);
+}
+
+describe("isArchiveFile", () => {
+  it("detects supported archive extensions case-insensitively", () => {
+    expect(isArchiveFile(file("pack.zip"))).toBe(true);
+    expect(isArchiveFile(file("pack.RAR"))).toBe(true);
+    expect(isArchiveFile(file("Season 1.7z"))).toBe(true);
+  });
+
+  it("rejects non-archives", () => {
+    expect(isArchiveFile(file("movie.srt"))).toBe(false);
+    expect(isArchiveFile(file("noext"))).toBe(false);
+  });
+});
+
+describe("base64ToFile", () => {
+  it("decodes base64 content into a File with the given name", async () => {
+    const f = base64ToFile("movie.srt", btoa("hello world"));
+    expect(f.name).toBe("movie.srt");
+    expect(await f.text()).toBe("hello world");
+  });
+});
+
+describe("expandArchives", () => {
+  it("passes plain subtitle files through untouched", async () => {
+    const plain = file("movie.srt", "sub");
+    const extract = vi.fn();
+    const { files, errors } = await expandArchives([plain], extract);
+    expect(files).toEqual([plain]);
+    expect(errors).toEqual([]);
+    expect(extract).not.toHaveBeenCalled();
+  });
+
+  it("replaces an archive with its extracted subtitle files", async () => {
+    const archive = file("pack.zip", "zipbytes");
+    const extract = vi.fn().mockResolvedValue({
+      count: 2,
+      files: [
+        { name: "a.srt", content: btoa("aaa") },
+        { name: "b.ass", content: btoa("bbb") },
+      ],
+    });
+    const { files, errors } = await expandArchives([archive], extract);
+    expect(extract).toHaveBeenCalledWith(archive);
+    expect(files.map((f) => f.name)).toEqual(["a.srt", "b.ass"]);
+    expect(await files[0].text()).toBe("aaa");
+    expect(errors).toEqual([]);
+  });
+
+  it("records the archive name when extraction fails, keeping other files", async () => {
+    const archive = file("bad.zip", "x");
+    const plain = file("ok.srt", "ok");
+    const extract = vi.fn().mockRejectedValue(new Error("boom"));
+    const { files, errors } = await expandArchives([archive, plain], extract);
+    expect(files).toEqual([plain]);
+    expect(errors).toEqual(["bad.zip"]);
+  });
+});

--- a/frontend/src/utilities/archives.ts
+++ b/frontend/src/utilities/archives.ts
@@ -1,0 +1,47 @@
+import { ArchiveExtractResponse } from "@/apis/raw/subtitles";
+
+// Compressed formats the backend can extract subtitle files from (#233).
+export const ARCHIVE_EXTENSIONS = [".zip", ".rar", ".7z"] as const;
+
+export function isArchiveFile(file: File): boolean {
+  const name = file.name.toLowerCase();
+  return ARCHIVE_EXTENSIONS.some((ext) => name.endsWith(ext));
+}
+
+// Rebuild a File from the base64 payload the extract endpoint returns, so it
+// flows through the existing per-file upload path unchanged.
+export function base64ToFile(name: string, base64: string): File {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new File([bytes], name);
+}
+
+// Expand a dropped/selected file list: archives are sent to the extractor and
+// replaced by their contained subtitle files; plain files pass through. The
+// name of any archive that fails to extract is returned in `errors` so the
+// caller can surface it without aborting the rest.
+export async function expandArchives(
+  files: File[],
+  extract: (file: File) => Promise<ArchiveExtractResponse>,
+): Promise<{ files: File[]; errors: string[] }> {
+  const out: File[] = [];
+  const errors: string[] = [];
+  for (const file of files) {
+    if (!isArchiveFile(file)) {
+      out.push(file);
+      continue;
+    }
+    try {
+      const response = await extract(file);
+      for (const entry of response.files) {
+        out.push(base64ToFile(entry.name, entry.content));
+      }
+    } catch {
+      errors.push(file.name);
+    }
+  }
+  return { files: out, errors };
+}

--- a/tests/bazarr/test_archive_extraction.py
+++ b/tests/bazarr/test_archive_extraction.py
@@ -1,0 +1,99 @@
+# coding=utf-8
+"""Extraction of subtitle files from uploaded archives (.zip/.rar/.7z).
+
+See https://github.com/LavX/bazarr/issues/233 - users upload a compressed file
+and Bazarr extracts the subtitle entries, discarding everything else.
+"""
+import zipfile
+from io import BytesIO
+
+import py7zr
+import pytest
+
+from subtitles.tools.archives import (
+    ArchiveError,
+    extract_subtitles_from_archive,
+    is_archive,
+)
+
+
+def _zip(entries):
+    """Build an in-memory zip. entries: list of (arcname, bytes|None);
+    None marks a directory entry."""
+    buf = BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        for name, data in entries:
+            if data is None:
+                z.writestr(name + "/", b"")
+            else:
+                z.writestr(name, data)
+    return buf.getvalue()
+
+
+def _7z(entries):
+    buf = BytesIO()
+    with py7zr.SevenZipFile(buf, "w") as z:
+        for name, data in entries:
+            z.writestr(data, name)
+    return buf.getvalue()
+
+
+def test_is_archive_by_extension():
+    assert is_archive("pack.zip")
+    assert is_archive("pack.RAR")
+    assert is_archive("Season 1.7z")
+    assert not is_archive("movie.srt")
+    assert not is_archive("noext")
+
+
+def test_zip_keeps_subtitles_and_discards_other_files():
+    data = _zip([
+        ("movie.srt", b"sub-one"),
+        ("subs/movie.es.ass", b"sub-two"),
+        ("poster.jpg", b"img"),
+        ("info.nfo", b"nfo"),
+    ])
+    result = extract_subtitles_from_archive("pack.zip", data)
+    assert sorted(n for n, _ in result) == ["movie.es.ass", "movie.srt"]
+    by_name = dict(result)
+    assert by_name["movie.srt"] == b"sub-one"
+    assert by_name["movie.es.ass"] == b"sub-two"
+
+
+def test_zip_directory_entries_are_skipped():
+    data = _zip([("subs", None), ("subs/a.srt", b"x")])
+    result = extract_subtitles_from_archive("pack.zip", data)
+    assert [n for n, _ in result] == ["a.srt"]
+
+
+def test_zip_slip_paths_reduced_to_basename():
+    data = _zip([("../../etc/evil.srt", b"x")])
+    result = extract_subtitles_from_archive("pack.zip", data)
+    assert result == [("evil.srt", b"x")]
+
+
+def test_macosx_resource_forks_discarded():
+    data = _zip([("__MACOSX/._movie.srt", b"junk"), ("movie.srt", b"real")])
+    result = extract_subtitles_from_archive("pack.zip", data)
+    assert result == [("movie.srt", b"real")]
+
+
+def test_zip_with_no_subtitles_returns_empty():
+    data = _zip([("readme.md", b"x"), ("cover.png", b"y")])
+    assert extract_subtitles_from_archive("pack.zip", data) == []
+
+
+def test_sevenzip_keeps_only_subtitles():
+    data = _7z([("a.srt", b"alpha"), ("b.png", b"beta")])
+    result = extract_subtitles_from_archive("pack.7z", data)
+    assert result == [("a.srt", b"alpha")]
+
+
+def test_corrupt_archive_raises_archive_error():
+    with pytest.raises(ArchiveError):
+        extract_subtitles_from_archive("pack.zip", b"this is not a zip")
+
+
+def test_unsupported_extension_raises_archive_error():
+    with pytest.raises(ArchiveError):
+        extract_subtitles_from_archive("pack.tar.gz", b"whatever")

--- a/tests/bazarr/test_archive_extraction.py
+++ b/tests/bazarr/test_archive_extraction.py
@@ -98,6 +98,43 @@ def test_zip_total_size_cap_raises(monkeypatch):
         extract_subtitles_from_archive("pack.zip", data)
 
 
+def test_sevenzip_total_size_cap_raises(monkeypatch):
+    from subtitles.tools import archives
+
+    monkeypatch.setattr(archives, "_MAX_TOTAL_BYTES", 16)
+    data = _7z([("big.srt", b"x" * 64)])
+    with pytest.raises(ArchiveError):
+        extract_subtitles_from_archive("pack.7z", data)
+
+
+def test_zip_entry_cap_raises(monkeypatch):
+    from subtitles.tools import archives
+
+    monkeypatch.setattr(archives, "_MAX_ENTRIES", 1)
+    data = _zip([("a.srt", b"a"), ("b.srt", b"b")])
+    with pytest.raises(ArchiveError):
+        extract_subtitles_from_archive("pack.zip", data)
+
+
+def test_sevenzip_entry_cap_raises(monkeypatch):
+    from subtitles.tools import archives
+
+    monkeypatch.setattr(archives, "_MAX_ENTRIES", 1)
+    data = _7z([("a.srt", b"a"), ("b.srt", b"b")])
+    with pytest.raises(ArchiveError):
+        extract_subtitles_from_archive("pack.7z", data)
+
+
+def test_encrypted_sevenzip_raises_archive_error():
+    import py7zr
+
+    buf = BytesIO()
+    with py7zr.SevenZipFile(buf, "w", password="secret") as z:
+        z.writestr(b"hello", "a.srt")
+    with pytest.raises(ArchiveError):
+        extract_subtitles_from_archive("pack.7z", buf.getvalue())
+
+
 def test_corrupt_archive_raises_archive_error():
     with pytest.raises(ArchiveError):
         extract_subtitles_from_archive("pack.zip", b"this is not a zip")

--- a/tests/bazarr/test_archive_extraction.py
+++ b/tests/bazarr/test_archive_extraction.py
@@ -89,6 +89,15 @@ def test_sevenzip_keeps_only_subtitles():
     assert result == [("a.srt", b"alpha")]
 
 
+def test_zip_total_size_cap_raises(monkeypatch):
+    from subtitles.tools import archives
+
+    monkeypatch.setattr(archives, "_MAX_TOTAL_BYTES", 16)
+    data = _zip([("big.srt", b"x" * 64)])
+    with pytest.raises(ArchiveError):
+        extract_subtitles_from_archive("pack.zip", data)
+
+
 def test_corrupt_archive_raises_archive_error():
     with pytest.raises(ArchiveError):
         extract_subtitles_from_archive("pack.zip", b"this is not a zip")


### PR DESCRIPTION
Closes two manual-upload gaps reported on the fork.

## #232 — Drag-and-drop in the upload modal
The manual-upload modal lost its dropzone in the Bazarr+ UI rewrite (https://github.com/LavX/bazarr/issues/232). Added an in-modal Mantine `Dropzone` to both the Movie and Series upload forms, so files can be dropped (or picked) directly into the open modal. Dropped files become rows just like the initial selection.

## #233 — Compressed subtitle uploads
Accept `.zip`/`.rar`/`.7z` (https://github.com/LavX/bazarr/issues/233):

- **Backend:** new `extract_subtitles_from_archive` helper (`subtitles/tools/archives.py`) extracts subtitle entries and discards everything else. It is zip-slip safe (returned names are basenames; 7z extraction is in-memory, never to disk), skips directories and macOS `__MACOSX` resource forks, and is capped by entry count (500) and total uncompressed size (100 MiB). New `POST /api/subtitles/archive` endpoint (50 MiB upload cap) returns the extracted files as base64.
- **Frontend:** dropping/selecting an archive sends it to the endpoint; the returned subtitle files are rebuilt into the existing per-file upload flow, where the user assigns language/forced/HI per file. For series, episode auto-matching now runs over the live rows, so a whole-season archive gets its episodes matched by filename.

Uses the existing `SUBTITLE_EXTENSIONS` set so extracted files pass the same validation as a direct upload. Single-instance and existing flows are unchanged.

## Tests
- Backend: `tests/bazarr/test_archive_extraction.py` (9 tests, in CI guard list) — zip/7z extraction, discard non-subs, zip-slip → basename, `__MACOSX` skip, empty archive, corrupt/unsupported → `ArchiveError`. TDD.
- Frontend: `src/utilities/archives.test.ts` (6 tests) — `isArchiveFile`, `base64ToFile`, `expandArchives` (passthrough / expand / per-archive error).

## Local CI
- Backend: `ruff check .` clean; archive tests green.
- Frontend: `check:ts`, `check` (eslint, 0 errors), `check:fmt`, and full `vitest` (607 passed) all green.

Note: not yet verified on the test server (it was offline at PR time); will deploy + functionally verify before merge.