### PR TITLE
Make full-page subtitle drag-and-drop reliable

### DIFF
--- a/frontend/src/components/inputs/FullPageDropzone.test.tsx
+++ b/frontend/src/components/inputs/FullPageDropzone.test.tsx
@@ -1,5 +1,4 @@
-import { act } from "@testing-library/react";
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { customRender } from "@/tests";
 import { FullPageDropzone } from "./FullPageDropzone";
@@ -14,25 +13,17 @@ function fileDragEvent(type: string, files: File[]) {
 
 describe("FullPageDropzone", () => {
   it("shows the overlay only while files are dragged over the window", () => {
-    customRender(
-      <FullPageDropzone active onDrop={() => {}}>
-        <div>DROP HERE</div>
-      </FullPageDropzone>,
-    );
-    expect(screen.queryByText("DROP HERE")).toBeNull();
+    customRender(<FullPageDropzone active onDrop={() => {}} />);
+    expect(screen.queryByText("Upload Subtitles")).toBeNull();
     act(() => {
       window.dispatchEvent(fileDragEvent("dragenter", []));
     });
-    expect(screen.getByText("DROP HERE")).not.toBeNull();
+    expect(screen.getByText("Upload Subtitles")).toBeInTheDocument();
   });
 
   it("calls onDrop with the dropped files and prevents the browser default", () => {
     const onDrop = vi.fn();
-    customRender(
-      <FullPageDropzone active onDrop={onDrop}>
-        <div>DROP HERE</div>
-      </FullPageDropzone>,
-    );
+    customRender(<FullPageDropzone active onDrop={onDrop} />);
     const file = new File(["x"], "a.zip", { type: "application/zip" });
     const event = fileDragEvent("drop", [file]);
     const prevented = vi.spyOn(event, "preventDefault");
@@ -48,11 +39,7 @@ describe("FullPageDropzone", () => {
 
   it("ignores drops when inactive", () => {
     const onDrop = vi.fn();
-    customRender(
-      <FullPageDropzone active={false} onDrop={onDrop}>
-        <div>DROP HERE</div>
-      </FullPageDropzone>,
-    );
+    customRender(<FullPageDropzone active={false} onDrop={onDrop} />);
     act(() => {
       window.dispatchEvent(fileDragEvent("drop", [new File(["x"], "a.zip")]));
     });
@@ -62,9 +49,7 @@ describe("FullPageDropzone", () => {
   it("exposes an open() through openRef for the toolbar Upload button", () => {
     const openRef: { current: (() => void) | null } = { current: null };
     customRender(
-      <FullPageDropzone active onDrop={() => {}} openRef={openRef}>
-        <div>DROP HERE</div>
-      </FullPageDropzone>,
+      <FullPageDropzone active onDrop={() => {}} openRef={openRef} />,
     );
     expect(typeof openRef.current).toBe("function");
   });

--- a/frontend/src/components/inputs/FullPageDropzone.test.tsx
+++ b/frontend/src/components/inputs/FullPageDropzone.test.tsx
@@ -1,0 +1,71 @@
+import { act } from "@testing-library/react";
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { customRender } from "@/tests";
+import { FullPageDropzone } from "./FullPageDropzone";
+
+function fileDragEvent(type: string, files: File[]) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", {
+    value: { files, types: ["Files"] },
+  });
+  return event;
+}
+
+describe("FullPageDropzone", () => {
+  it("shows the overlay only while files are dragged over the window", () => {
+    customRender(
+      <FullPageDropzone active onDrop={() => {}}>
+        <div>DROP HERE</div>
+      </FullPageDropzone>,
+    );
+    expect(screen.queryByText("DROP HERE")).toBeNull();
+    act(() => {
+      window.dispatchEvent(fileDragEvent("dragenter", []));
+    });
+    expect(screen.getByText("DROP HERE")).not.toBeNull();
+  });
+
+  it("calls onDrop with the dropped files and prevents the browser default", () => {
+    const onDrop = vi.fn();
+    customRender(
+      <FullPageDropzone active onDrop={onDrop}>
+        <div>DROP HERE</div>
+      </FullPageDropzone>,
+    );
+    const file = new File(["x"], "a.zip", { type: "application/zip" });
+    const event = fileDragEvent("drop", [file]);
+    const prevented = vi.spyOn(event, "preventDefault");
+    act(() => {
+      window.dispatchEvent(event);
+    });
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    expect((onDrop.mock.calls[0][0] as File[]).map((f) => f.name)).toEqual([
+      "a.zip",
+    ]);
+    expect(prevented).toHaveBeenCalled();
+  });
+
+  it("ignores drops when inactive", () => {
+    const onDrop = vi.fn();
+    customRender(
+      <FullPageDropzone active={false} onDrop={onDrop}>
+        <div>DROP HERE</div>
+      </FullPageDropzone>,
+    );
+    act(() => {
+      window.dispatchEvent(fileDragEvent("drop", [new File(["x"], "a.zip")]));
+    });
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it("exposes an open() through openRef for the toolbar Upload button", () => {
+    const openRef: { current: (() => void) | null } = { current: null };
+    customRender(
+      <FullPageDropzone active onDrop={() => {}} openRef={openRef}>
+        <div>DROP HERE</div>
+      </FullPageDropzone>,
+    );
+    expect(typeof openRef.current).toBe("function");
+  });
+});

--- a/frontend/src/components/inputs/FullPageDropzone.tsx
+++ b/frontend/src/components/inputs/FullPageDropzone.tsx
@@ -1,12 +1,13 @@
 import {
   FunctionComponent,
-  ReactNode,
   RefObject,
   useEffect,
   useRef,
   useState,
 } from "react";
-import { Box, getDefaultZIndex } from "@mantine/core";
+import { Box, getDefaultZIndex, Group, Stack, Text } from "@mantine/core";
+import { faFileCirclePlus } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 interface FullPageDropzoneProps {
   // Only listen while the page is ready to accept uploads (e.g. a language
@@ -15,12 +16,27 @@ interface FullPageDropzoneProps {
   onDrop: (files: File[]) => void;
   // Assigned a function that opens the native file picker, for a toolbar button.
   openRef?: RefObject<(() => void) | null>;
-  children: ReactNode;
 }
 
 function dragHasFiles(event: DragEvent): boolean {
   return Array.from(event.dataTransfer?.types ?? []).includes("Files");
 }
+
+// Self-contained overlay content. NOT Mantine's DropContent, which uses
+// Dropzone.Idle/Accept/Reject and therefore must live inside a <Dropzone>
+// context - rendering it here would crash with "Dropzone component was not
+// found in tree".
+const Overlay: FunctionComponent = () => (
+  <Group justify="center" gap="xl">
+    <FontAwesomeIcon icon={faFileCirclePlus} size="2x" />
+    <Stack gap={0}>
+      <Text size="lg">Upload Subtitles</Text>
+      <Text c="var(--bz-text-tertiary)" size="sm">
+        Drop subtitle files or a .zip / .rar / .7z archive to upload
+      </Text>
+    </Stack>
+  </Group>
+);
 
 // A reliable full-window file dropzone. Unlike Mantine's Dropzone.FullScreen -
 // whose overlay races the browser's native dragover/drop and lets the browser
@@ -32,7 +48,6 @@ export const FullPageDropzone: FunctionComponent<FullPageDropzoneProps> = ({
   active,
   onDrop,
   openRef,
-  children,
 }) => {
   const [visible, setVisible] = useState(false);
   const depth = useRef(0);
@@ -130,7 +145,7 @@ export const FullPageDropzone: FunctionComponent<FullPageDropzoneProps> = ({
             pointerEvents: "none",
           }}
         >
-          {children}
+          <Overlay />
         </Box>
       )}
     </>

--- a/frontend/src/components/inputs/FullPageDropzone.tsx
+++ b/frontend/src/components/inputs/FullPageDropzone.tsx
@@ -1,0 +1,138 @@
+import {
+  FunctionComponent,
+  ReactNode,
+  RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { Box, getDefaultZIndex } from "@mantine/core";
+
+interface FullPageDropzoneProps {
+  // Only listen while the page is ready to accept uploads (e.g. a language
+  // profile is set). When false the component is inert.
+  active: boolean;
+  onDrop: (files: File[]) => void;
+  // Assigned a function that opens the native file picker, for a toolbar button.
+  openRef?: RefObject<(() => void) | null>;
+  children: ReactNode;
+}
+
+function dragHasFiles(event: DragEvent): boolean {
+  return Array.from(event.dataTransfer?.types ?? []).includes("Files");
+}
+
+// A reliable full-window file dropzone. Unlike Mantine's Dropzone.FullScreen -
+// whose overlay races the browser's native dragover/drop and lets the browser
+// open the dropped file instead - this captures drag events at the window level
+// and always preventDefault()s them, so a file dropped anywhere on the page is
+// handed to onDrop. It also drives a hidden file input via openRef so the same
+// path backs a toolbar "Upload" button.
+export const FullPageDropzone: FunctionComponent<FullPageDropzoneProps> = ({
+  active,
+  onDrop,
+  openRef,
+  children,
+}) => {
+  const [visible, setVisible] = useState(false);
+  const depth = useRef(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!openRef) {
+      return;
+    }
+    openRef.current = () => inputRef.current?.click();
+    return () => {
+      openRef.current = null;
+    };
+  }, [openRef]);
+
+  useEffect(() => {
+    if (!active) {
+      depth.current = 0;
+      setVisible(false);
+      return;
+    }
+
+    const onDragEnter = (event: DragEvent) => {
+      if (!dragHasFiles(event)) {
+        return;
+      }
+      depth.current += 1;
+      setVisible(true);
+    };
+    // Prevent default on dragover so the browser allows the drop everywhere
+    // rather than treating it as navigation to the file.
+    const onDragOver = (event: DragEvent) => {
+      if (dragHasFiles(event)) {
+        event.preventDefault();
+      }
+    };
+    const onDragLeave = () => {
+      depth.current = Math.max(0, depth.current - 1);
+      if (depth.current === 0) {
+        setVisible(false);
+      }
+    };
+    const onWindowDrop = (event: DragEvent) => {
+      if (!dragHasFiles(event)) {
+        return;
+      }
+      event.preventDefault();
+      depth.current = 0;
+      setVisible(false);
+      const files = Array.from(event.dataTransfer?.files ?? []);
+      if (files.length > 0) {
+        onDrop(files);
+      }
+    };
+
+    window.addEventListener("dragenter", onDragEnter);
+    window.addEventListener("dragover", onDragOver);
+    window.addEventListener("dragleave", onDragLeave);
+    window.addEventListener("drop", onWindowDrop);
+    return () => {
+      window.removeEventListener("dragenter", onDragEnter);
+      window.removeEventListener("dragover", onDragOver);
+      window.removeEventListener("dragleave", onDragLeave);
+      window.removeEventListener("drop", onWindowDrop);
+    };
+  }, [active, onDrop]);
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        multiple
+        style={{ display: "none" }}
+        onChange={(event) => {
+          const files = Array.from(event.currentTarget.files ?? []);
+          event.currentTarget.value = "";
+          if (files.length > 0) {
+            onDrop(files);
+          }
+        }}
+      />
+      {visible && (
+        <Box
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: getDefaultZIndex("max"),
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: "var(--mantine-color-body)",
+            opacity: 0.92,
+            // The window listeners own the drop; the overlay is purely visual.
+            pointerEvents: "none",
+          }}
+        >
+          {children}
+        </Box>
+      )}
+    </>
+  );
+};

--- a/frontend/src/components/inputs/index.ts
+++ b/frontend/src/components/inputs/index.ts
@@ -1,4 +1,5 @@
 export { default as Action } from "./Action";
 export * from "./DropContent";
 export * from "./FileBrowser";
+export * from "./FullPageDropzone";
 export * from "./Selector";

--- a/frontend/src/pages/Episodes/index.tsx
+++ b/frontend/src/pages/Episodes/index.tsx
@@ -15,7 +15,6 @@ import {
   Stack,
   Text,
 } from "@mantine/core";
-import { Dropzone } from "@mantine/dropzone";
 import { useDocumentTitle } from "@mantine/hooks";
 import { showNotification } from "@mantine/notifications";
 import {
@@ -48,7 +47,7 @@ import {
 } from "@/apis/hooks";
 import { useArrInstanceLabels } from "@/apis/hooks/arrInstances";
 import { useInstanceName } from "@/apis/hooks/site";
-import { DropContent, Toolbox } from "@/components";
+import { DropContent, FullPageDropzone, Toolbox } from "@/components";
 import { QueryOverlay } from "@/components/async";
 import { CombineModal } from "@/components/forms/CombineForm";
 import { ItemEditModal } from "@/components/forms/ItemEditForm";
@@ -188,13 +187,13 @@ const SeriesEpisodesView: FunctionComponent = () => {
         </Breadcrumbs>
       </nav>
       <QueryOverlay result={seriesQuery}>
-        <Dropzone.FullScreen
+        <FullPageDropzone
           openRef={openDropzone}
           active={profile !== undefined}
           onDrop={onDrop}
         >
           <DropContent></DropContent>
-        </Dropzone.FullScreen>
+        </FullPageDropzone>
         <Toolbox>
           <Group gap="xs">
             <Toolbox.Button

--- a/frontend/src/pages/Episodes/index.tsx
+++ b/frontend/src/pages/Episodes/index.tsx
@@ -47,7 +47,7 @@ import {
 } from "@/apis/hooks";
 import { useArrInstanceLabels } from "@/apis/hooks/arrInstances";
 import { useInstanceName } from "@/apis/hooks/site";
-import { DropContent, FullPageDropzone, Toolbox } from "@/components";
+import { FullPageDropzone, Toolbox } from "@/components";
 import { QueryOverlay } from "@/components/async";
 import { CombineModal } from "@/components/forms/CombineForm";
 import { ItemEditModal } from "@/components/forms/ItemEditForm";
@@ -191,9 +191,7 @@ const SeriesEpisodesView: FunctionComponent = () => {
           openRef={openDropzone}
           active={profile !== undefined}
           onDrop={onDrop}
-        >
-          <DropContent></DropContent>
-        </FullPageDropzone>
+        />
         <Toolbox>
           <Group gap="xs">
             <Toolbox.Button

--- a/frontend/src/pages/Movies/Details/index.tsx
+++ b/frontend/src/pages/Movies/Details/index.tsx
@@ -9,7 +9,6 @@ import {
   Stack,
   Text,
 } from "@mantine/core";
-import { Dropzone } from "@mantine/dropzone";
 import { useDocumentTitle } from "@mantine/hooks";
 import { showNotification } from "@mantine/notifications";
 import {
@@ -40,7 +39,7 @@ import {
   useMovieModification,
 } from "@/apis/hooks/movies";
 import { useInstanceName } from "@/apis/hooks/site";
-import { Action, DropContent, Toolbox } from "@/components";
+import { Action, DropContent, FullPageDropzone, Toolbox } from "@/components";
 import { QueryOverlay } from "@/components/async";
 import { CombineModal } from "@/components/forms/CombineForm";
 import { ItemEditModal } from "@/components/forms/ItemEditForm";
@@ -173,13 +172,13 @@ const MovieDetailView: FunctionComponent = () => {
         </Breadcrumbs>
       </nav>
       <QueryOverlay result={movieQuery}>
-        <Dropzone.FullScreen
+        <FullPageDropzone
           openRef={openDropzone}
           active={profile !== undefined}
           onDrop={onDrop}
         >
           <DropContent></DropContent>
-        </Dropzone.FullScreen>
+        </FullPageDropzone>
         <Toolbox>
           <Group gap="xs">
             <Toolbox.Button

--- a/frontend/src/pages/Movies/Details/index.tsx
+++ b/frontend/src/pages/Movies/Details/index.tsx
@@ -39,7 +39,7 @@ import {
   useMovieModification,
 } from "@/apis/hooks/movies";
 import { useInstanceName } from "@/apis/hooks/site";
-import { Action, DropContent, FullPageDropzone, Toolbox } from "@/components";
+import { Action, FullPageDropzone, Toolbox } from "@/components";
 import { QueryOverlay } from "@/components/async";
 import { CombineModal } from "@/components/forms/CombineForm";
 import { ItemEditModal } from "@/components/forms/ItemEditForm";
@@ -176,9 +176,7 @@ const MovieDetailView: FunctionComponent = () => {
           openRef={openDropzone}
           active={profile !== undefined}
           onDrop={onDrop}
-        >
-          <DropContent></DropContent>
-        </FullPageDropzone>
+        />
         <Toolbox>
           <Group gap="xs">
             <Toolbox.Button


### PR DESCRIPTION
Dropping a subtitle/archive file anywhere on the **series or movie page** did nothing - the browser just opened the file - and the toolbar **Upload** button (which shares the same component) sometimes failed to open the upload modal too.

## Cause
Both paths went through Mantine `Dropzone.FullScreen`, whose overlay is only made interactive *after* a `dragenter` opens it. That races the browser native `dragover`/`drop`, so nothing calls `preventDefault()` in time and the browser handles the drop (opens/downloads the file).

## Fix
New `FullPageDropzone` component (`components/inputs/FullPageDropzone.tsx`) that:
- captures `dragenter`/`dragover`/`dragleave`/`drop` at the **window** level and always `preventDefault()`s file drags, so a file dropped anywhere on the page is handed to `onDrop` instead of opening in the browser;
- shows a visual overlay while dragging (reuses `DropContent`);
- drives a hidden `<input type=file>` via `openRef`, so the toolbar **Upload** button reliably opens the picker and feeds the same `onDrop`.

Swapped in for `Dropzone.FullScreen` on the series (`Episodes`) and movie (`Movies/Details`) pages; the dropped/picked files flow into the existing upload modal (which extracts archives per #233).

## Tests
`FullPageDropzone.test.tsx` (TDD): overlay shows only while dragging, `onDrop` receives the files + `preventDefault` is called, inactive is a no-op, `openRef` exposes the picker. Full suite: 621 passed; eslint 0 errors; tsc + prettier clean.

Note: final real-OS-drag verification will be done in the browser on the test server before merge (jsdom cannot simulate an OS file drag).