### PR TITLE
Harden API/UI against SSRF and path traversal (security advisory)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
             tests/bazarr/test_sync_instance_overrides.py \
             tests/bazarr/test_subzero_keep_lyrics.py \
             tests/bazarr/test_archive_extraction.py \
+            tests/bazarr/test_security_guards.py \
             tests/bazarr/test_utilities_video_analyzer.py \
             tests/bazarr/test_embedded_subtitle_extraction.py \
             tests/subliminal_patch/test_subliminal_rebase.py \

--- a/bazarr/api/plex/oauth.py
+++ b/bazarr/api/plex/oauth.py
@@ -8,7 +8,7 @@ import requests
 import xml.etree.ElementTree as ET
 from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus, urlparse
 from flask import request
 from flask_restx import Resource, reqparse, abort
 import plexapi
@@ -33,6 +33,7 @@ def _validate_state_token(state: str, stored_state: str) -> bool:
     return _secrets.compare_digest(state, stored_state)
 from app.config import get_ssl_verify  # noqa: E402
 from app.config import settings, write_config  # noqa: E402
+from utilities.security_guards import is_trusted_plex_target  # noqa: E402
 from app.logger import logger  # noqa: E402
 from utilities.plex_utils import _get_library_locations  # noqa: E402
 from ..utils import authenticate  # noqa: E402
@@ -824,6 +825,27 @@ class PlexTestConnection(Resource):
     def post(self):
         args = self.post_request_parser.parse_args()
         uri = args.get('uri')
+
+        # SSRF / token-exfiltration guard (#GHSA): validate the destination
+        # BEFORE touching the token. The token must only be sent to the user's
+        # own Plex server or a Plex-owned domain, never to an arbitrary public
+        # host. Local/LAN/loopback targets stay allowed (the common case).
+        trusted_hosts = []
+        server_url = settings.plex.get('server_url') or ''
+        if server_url:
+            server_host = urlparse(
+                server_url if '://' in server_url else 'https://' + server_url
+            ).hostname
+            if server_host:
+                trusted_hosts.append(server_host)
+        plex_ip = settings.plex.get('ip') or ''
+        if plex_ip:
+            trusted_hosts.append(plex_ip)
+        if not is_trusted_plex_target(uri, trusted_hosts=trusted_hosts):
+            return {
+                'success': False,
+                'error': 'Refusing to send Plex credentials to an untrusted host'
+            }, 400
 
         decrypted_token = get_decrypted_token()
         if not decrypted_token:

--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -10,6 +10,7 @@ from app.database import TableShows, TableEpisodes, TableMovies, database, selec
 from arr_instances.resolution import scoped
 from languages.get_languages import alpha3_from_alpha2
 from utilities.path_mappings import path_mappings
+from utilities.security_guards import subtitle_path_within_area
 from utilities.video_analyzer import subtitles_sync_references
 from subtitles.tools.subsyncer import SubSyncer  # noqa: F401
 from subtitles.tools.subsync_engines import is_sync_engine_output
@@ -227,6 +228,7 @@ class Subtitles(Resource):
 
         language = args.get("language")
         subtitles_path = args.get("path") or ""
+        user_supplied_path = bool(subtitles_path.strip())
         media_type = args.get("type")
         id = args.get("id")
         arr_instance_id = args.get("arr_instance_id")
@@ -345,6 +347,19 @@ class Subtitles(Resource):
                 return "Movie not found", 404
 
             video_path = path_mappings.path_replace_movie(metadata.path)
+
+        # Path-traversal containment (#GHSA): a user-supplied subtitle path must
+        # stay where Bazarr stores subtitles for this video (alongside it / a
+        # subfolder under it / the configured absolute custom folder). The
+        # embedded-track branch sets a server-generated path (user_supplied_path
+        # is False) and is intentionally exempt.
+        if user_supplied_path and not subtitle_path_within_area(
+            subtitles_path,
+            video_path,
+            subfolder_mode=settings.general.subfolder,
+            custom_subfolder=settings.general.subfolder_custom,
+        ):
+            return "Subtitle path is outside the media library.", 403
 
         if action == "sync":
             try:

--- a/bazarr/api/subtitles/subtitles_contents.py
+++ b/bazarr/api/subtitles/subtitles_contents.py
@@ -5,6 +5,7 @@ import srt
 from flask_restx import Resource, Namespace, reqparse, fields, marshal
 
 from ..utils import authenticate
+from utilities.security_guards import is_subtitle_path_extension
 
 
 api_ns_subtitle_contents = Namespace('Subtitle Contents', description='Retrieve contents of subtitle file')
@@ -42,14 +43,25 @@ class SubtitleNameContents(Resource):
         args = self.get_request_parser.parse_args()
         path = args.get('subtitlePath')
 
+        # Only read recognised subtitle files; refuse arbitrary paths (config,
+        # keys, db) so this endpoint cannot become a file-disclosure primitive
+        # (#GHSA). Subtitle paths always carry a subtitle extension.
+        if not is_subtitle_path_extension(path):
+            return "Unsupported or missing subtitle path", 400
+
         results = []
 
-        # Load the SRT content
-        with open(path, "r", encoding="utf-8") as f:
-            file_content = f.read()
+        # Load the SRT content. Never surface file contents on failure: srt
+        # embeds the raw (mis-parsed) text in SRTParseError, so swallow it.
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                file_content = f.read()
+            parsed = list(srt.parse(file_content))
+        except (OSError, ValueError, srt.SRTParseError):
+            return "Unable to read subtitle file", 422
 
         # Map contents
-        for sub in srt.parse(file_content):
+        for sub in parsed:
 
             start_total_seconds = int(sub.start.total_seconds())
             end_total_seconds = int(sub.end.total_seconds())

--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -17,6 +17,7 @@ from sonarr.info import url_api_sonarr
 from radarr.info import url_api_radarr
 from utilities.helper import check_credentials
 from utilities.central import get_log_file_path
+from utilities.security_guards import api_key_matches
 
 from .config import settings, base_url, get_ssl_verify
 from .database import database, System
@@ -67,6 +68,16 @@ def check_login(actual_method):
                 return abort(401)
         return actual_method(*args, **kwargs)
     return wrapper
+
+
+def _require_proxy_api_key():
+    """The /test connection proxies forward a server-side request to a
+    user-supplied host (an SSRF surface). Require the global API key so they are
+    never reachable unauthenticated, independent of settings.auth.type (which is
+    None by default). The frontend already sends X-API-KEY on every request."""
+    provided = request.headers.get('X-API-KEY') or request.args.get('apikey')
+    if not api_key_matches(provided, settings.auth.apikey):
+        abort(401)
 
 
 @ui_bp.route('/', defaults={'path': ''})
@@ -197,11 +208,13 @@ def movies_images(url):
 @ui_bp.route('/system/backup/download/<path:filename>', methods=['GET'])
 @check_login
 def backup_download(filename):
-    fullpath = os.path.normpath(os.path.join(settings.backup.folder, filename))
-    if not fullpath.startswith(settings.backup.folder):
+    backup_folder = os.path.realpath(settings.backup.folder)
+    fullpath = os.path.realpath(os.path.join(backup_folder, filename))
+    # Trailing-separator containment so a sibling dir sharing the prefix
+    # (e.g. /config/backup-evil) cannot pass; realpath also defeats `..`/symlinks.
+    if fullpath != backup_folder and not fullpath.startswith(backup_folder + os.sep):
         return '', 404
-    else:
-        return send_file(fullpath, max_age=0, as_attachment=True)
+    return send_file(fullpath, max_age=0, as_attachment=True)
 
 
 @ui_bp.route('/api/swaggerui/static/<path:filename>', methods=['GET'])
@@ -400,6 +413,7 @@ def proxy_service(service):
 
     See LavX/bazarr#92 for the original report and rationale.
     """
+    _require_proxy_api_key()
     if service not in _TEST_SERVICES:
         return dict(status=False, error='unsupported service', code=0)
     config = _TEST_SERVICES[service]
@@ -511,6 +525,7 @@ def proxy_service(service):
 @ui_bp.route('/test/<protocol>/<path:url>', methods=['GET'])
 @check_login
 def proxy(protocol, url):
+    _require_proxy_api_key()
     if protocol.lower() not in ['http', 'https']:
         return dict(status=False, error='Unsupported protocol', code=0)
     url = f'{protocol}://{unquote(url)}'

--- a/bazarr/utilities/security_guards.py
+++ b/bazarr/utilities/security_guards.py
@@ -1,0 +1,122 @@
+# coding=utf-8
+"""Pure security-guard helpers shared by the API/UI hardening fixes.
+
+These functions hold the security *decisions* (and nothing else) so they can be
+unit-tested in isolation: no Flask, no DB, no network. The matching route
+handlers call them.
+
+Design note: Bazarr is overwhelmingly run on localhost / a private LAN, so these
+guards deliberately ALLOW loopback and RFC1918 targets. The goal is not to ban
+local traffic (that would break the common case) but to stop credentials/secrets
+from leaking to *arbitrary public* hosts and to keep request-controlled file
+paths inside their intended areas.
+"""
+import hmac
+import ipaddress
+import os
+import socket
+from urllib.parse import urlparse
+
+# Mirrors subliminal_patch.core.SUBTITLE_EXTENSIONS (kept local to avoid a heavy
+# import in this widely-imported, dependency-free module).
+SUBTITLE_FILE_EXTENSIONS = (
+    ".srt", ".sub", ".smi", ".txt", ".ssa", ".ass", ".mpl", ".vtt",
+)
+
+# Domains that Plex itself owns; sending a Plex token to these is expected
+# (covers plex.tv and the *.plex.direct TLS hostnames used for remote access).
+_PLEX_OWNED_SUFFIXES = (".plex.tv", ".plex.direct")
+
+
+def api_key_matches(provided, expected) -> bool:
+    """Constant-time check that ``provided`` equals the configured API key.
+
+    Returns False if either side is empty so an unset server key can never
+    authorize a request.
+    """
+    if not provided or not expected:
+        return False
+    return hmac.compare_digest(str(provided), str(expected))
+
+
+def is_trusted_plex_target(uri, trusted_hosts=()) -> bool:
+    """True if it is safe to send the Plex token to ``uri``.
+
+    Trusted = a Plex-owned domain (plex.tv / *.plex.direct), an explicitly
+    configured host (the user's own server), or any host that resolves only to
+    loopback / link-local / RFC1918 addresses (a home Plex). Any other public
+    destination is refused so the token cannot be exfiltrated.
+    """
+    if not uri:
+        return False
+
+    parsed = urlparse(uri if "://" in uri else "https://" + uri)
+    if parsed.scheme not in ("http", "https"):
+        return False
+
+    host = parsed.hostname
+    if not host:
+        return False
+    host = host.lower().rstrip(".")
+
+    if host == "plex.tv" or host.endswith(_PLEX_OWNED_SUFFIXES):
+        return True
+
+    if host in {h.lower() for h in trusted_hosts if h}:
+        return True
+
+    try:
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except ValueError:
+        return False
+
+    try:
+        infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except (socket.gaierror, UnicodeError, ValueError, OSError):
+        return False
+    if not infos:
+        return False
+
+    for info in infos:
+        try:
+            ip = ipaddress.ip_address(info[4][0])
+        except ValueError:
+            return False
+        # Any single public address makes the destination untrusted.
+        if not (ip.is_private or ip.is_loopback or ip.is_link_local):
+            return False
+    return True
+
+
+def subtitle_path_within_area(subtitle_path, video_path,
+                              subfolder_mode=None, custom_subfolder=None) -> bool:
+    """True if ``subtitle_path`` lives where Bazarr stores subtitles for
+    ``video_path``: alongside the video (or a subfolder under it), or under the
+    configured absolute custom subtitle folder. Symlinks / ``..`` are resolved
+    via realpath before the containment check.
+    """
+    if not subtitle_path or not video_path:
+        return False
+
+    real_sub = os.path.realpath(subtitle_path)
+    try:
+        video_dir = os.path.realpath(os.path.dirname(video_path))
+        if os.path.commonpath([video_dir, real_sub]) == video_dir:
+            return True
+        if subfolder_mode == "absolute" and custom_subfolder:
+            custom_dir = os.path.realpath(str(custom_subfolder).strip())
+            if custom_dir and os.path.commonpath([custom_dir, real_sub]) == custom_dir:
+                return True
+    except ValueError:
+        # commonpath raises across different Windows drives -> not contained.
+        return False
+    return False
+
+
+def is_subtitle_path_extension(path) -> bool:
+    """True if ``path`` ends with a recognised subtitle extension. Used to keep
+    the subtitle-contents reader from opening arbitrary files (config, keys, db).
+    """
+    if not path:
+        return False
+    return str(path).lower().endswith(SUBTITLE_FILE_EXTENSIONS)

--- a/tests/bazarr/test_security_guards.py
+++ b/tests/bazarr/test_security_guards.py
@@ -1,0 +1,154 @@
+# coding=utf-8
+"""Unit tests for the pure security-guard helpers used to harden the API/UI
+surface (SSRF + path traversal). These functions encode the security decisions;
+the route handlers just call them. Kept dependency-free so they run without
+booting Flask or the DB and never touch the network (numeric IPs only).
+"""
+import pytest
+
+from utilities.security_guards import (
+    api_key_matches,
+    is_subtitle_path_extension,
+    is_trusted_plex_target,
+    subtitle_path_within_area,
+)
+
+
+# --- api_key_matches (Finding 2: gate the /test proxy) -----------------------
+
+def test_api_key_matches_exact():
+    assert api_key_matches("abc123", "abc123") is True
+
+
+def test_api_key_matches_wrong():
+    assert api_key_matches("abc123", "different") is False
+
+
+@pytest.mark.parametrize("provided", ["", None])
+def test_api_key_matches_empty_provided(provided):
+    assert api_key_matches(provided, "abc123") is False
+
+
+def test_api_key_matches_empty_expected():
+    # An unset server key must never authorize a request.
+    assert api_key_matches("anything", "") is False
+    assert api_key_matches("", "") is False
+
+
+def test_api_key_matches_prefix_is_not_enough():
+    assert api_key_matches("abc", "abc123") is False
+
+
+# --- is_trusted_plex_target (Finding 1: don't leak the token) ----------------
+
+@pytest.mark.parametrize("uri", [
+    "http://127.0.0.1:32400",
+    "https://192.168.1.50:32400",
+    "http://10.5.5.5",
+    "http://172.16.0.9:32400",
+    "https://[::1]:32400",
+])
+def test_trusted_plex_local_targets(uri):
+    # The common case: home Plex on loopback / LAN must stay allowed.
+    assert is_trusted_plex_target(uri) is True
+
+
+@pytest.mark.parametrize("uri", [
+    "http://8.8.8.8",
+    "https://1.2.3.4:32400",
+])
+def test_untrusted_public_ip_rejected(uri):
+    # A public, non-Plex destination would exfiltrate the token -> reject.
+    assert is_trusted_plex_target(uri) is False
+
+
+@pytest.mark.parametrize("uri", [
+    "https://plex.tv",
+    "https://app.plex.tv",
+    "https://abc123.plex.direct:32400",
+])
+def test_plex_owned_domains_trusted(uri):
+    assert is_trusted_plex_target(uri) is True
+
+
+def test_configured_host_trusted_even_if_public():
+    # The user's own configured Plex server (possibly a public hostname) is fine.
+    assert is_trusted_plex_target(
+        "https://myplex.example.com:32400",
+        trusted_hosts=("myplex.example.com",),
+    ) is True
+
+
+def test_unknown_public_host_not_in_trustlist_rejected():
+    assert is_trusted_plex_target(
+        "https://evil.example.com",
+        trusted_hosts=("myplex.example.com",),
+    ) is False
+
+
+@pytest.mark.parametrize("uri", ["", "ftp://127.0.0.1", "file:///etc/passwd", "127.0.0.1:32400"])
+def test_trusted_plex_bad_scheme_or_empty(uri):
+    # bare host (no scheme) defaults to https and is allowed if local; the
+    # explicitly bad schemes and empty string must be rejected.
+    if uri == "127.0.0.1:32400":
+        assert is_trusted_plex_target(uri) is True
+    else:
+        assert is_trusted_plex_target(uri) is False
+
+
+# --- subtitle_path_within_area (Finding 3: contain PATCH /api/subtitles) ------
+
+VIDEO = "/media/movies/Film (2020)/Film.mkv"
+
+
+def test_subtitle_alongside_video_allowed():
+    assert subtitle_path_within_area(
+        "/media/movies/Film (2020)/Film.en.srt", VIDEO) is True
+
+
+def test_subtitle_in_subfolder_under_video_allowed():
+    assert subtitle_path_within_area(
+        "/media/movies/Film (2020)/subs/Film.en.srt", VIDEO) is True
+
+
+def test_subtitle_outside_video_dir_rejected():
+    assert subtitle_path_within_area("/config/config/config.yaml", VIDEO) is False
+
+
+def test_subtitle_traversal_escape_rejected():
+    assert subtitle_path_within_area(
+        "/media/movies/Film (2020)/../../../etc/passwd", VIDEO) is False
+
+
+def test_subtitle_absolute_custom_subfolder_allowed():
+    assert subtitle_path_within_area(
+        "/srt-store/Film.en.srt", VIDEO,
+        subfolder_mode="absolute", custom_subfolder="/srt-store") is True
+
+
+def test_subtitle_custom_subfolder_ignored_when_mode_not_absolute():
+    assert subtitle_path_within_area(
+        "/srt-store/Film.en.srt", VIDEO,
+        subfolder_mode="relative", custom_subfolder="/srt-store") is False
+
+
+@pytest.mark.parametrize("sub,video", [("", VIDEO), (VIDEO, ""), ("", "")])
+def test_subtitle_within_area_empty_inputs(sub, video):
+    assert subtitle_path_within_area(sub, video) is False
+
+
+# --- is_subtitle_path_extension (Finding 4: reject non-subtitle reads) --------
+
+@pytest.mark.parametrize("path", [
+    "/x/a.srt", "/x/a.ass", "/x/a.ssa", "/x/a.vtt", "/x/a.sub", "/x/a.SRT",
+])
+def test_subtitle_extensions_allowed(path):
+    assert is_subtitle_path_extension(path) is True
+
+
+@pytest.mark.parametrize("path", [
+    "/config/config.yaml", "/etc/passwd", "/x/id_rsa", "/x/bazarr.db",
+    "/x/a.srt.bak", "/x/noext", "",
+])
+def test_non_subtitle_extensions_rejected(path):
+    assert is_subtitle_path_extension(path) is False


### PR DESCRIPTION
## What

Hardens the API/UI surface against SSRF and path traversal found in an internal security audit. Tracked in the private advisory GHSA-w6f4-fvxw-4crf.

## Changes
- **Plex test-connection**: refuse sending the `X-Plex-Token` to untrusted public hosts; local/LAN, `plex.tv`/`*.plex.direct`, and the configured server stay allowed.
- **`/test` connection proxies**: require the API key (the UI already sends `X-API-KEY`), so they are not reachable unauthenticated on the default `auth.type=None` install. Local/LAN targets still allowed.
- **`PATCH /api/subtitles`**: containment-check the user-supplied subtitle path so mods/sync/translate cannot delete or overwrite files outside the media area.
- **`GET /api/subtitles/contents`**: restrict to subtitle extensions and stop echoing file contents on parse errors.
- **backup download**: trailing-separator + realpath containment.

## Design
Security decisions are isolated in `bazarr/utilities/security_guards.py` as pure functions with unit tests covering the bypass cases (`tests/bazarr/test_security_guards.py`, added to the CI guard list). Bazarr is overwhelmingly run on localhost / private LAN, so the guards deliberately allow loopback/RFC1918 and only block credential/secret leakage to arbitrary public hosts.

## Verification
- Full backend guard suite green locally (636 passed, 8 skipped), `ruff` clean.
- Built and deployed to the test server; live-verified each fix, and confirmed local Plex/Sonarr/Radarr connection testing and subtitle reading still work.