### PR TITLE
Test coverage Phase 1: core logic modules (reducer, pagination, subtitle invalidations)

### DIFF
--- a/frontend/src/apis/hooks/__tests__/subtitleInvalidations.test.tsx
+++ b/frontend/src/apis/hooks/__tests__/subtitleInvalidations.test.tsx
@@ -1,0 +1,346 @@
+/**
+ * Tests for subtitle mutation hooks: verifies that onSuccess callbacks
+ * invalidate exactly the right query keys.
+ *
+ * Focused coverage:
+ *   - useSubtitleAction: episode path -> [Episodes, id] + [Series]
+ *   - useSubtitleAction: movie path -> [Movies, id] + [Movies, History]
+ *   - useBatchAction: -> [Series] + [Movies] + [System, History] + [Translator]
+ *     (NOT a bare [History] key)
+ *   - usePromoteSyncSubtitle: episode -> [Series] + [System, History] + content key
+ *   - usePromoteSyncSubtitle: movie  -> [Movies] + [System, History] + content key
+ */
+
+import { PropsWithChildren } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useBatchAction,
+  usePromoteSyncSubtitle,
+  useSubtitleAction,
+} from "@/apis/hooks/subtitles";
+import { QueryKeys } from "@/apis/queries/keys";
+
+// ---------------------------------------------------------------------------
+// Module mock: replace the raw API with lightweight stubs that resolve
+// immediately. We only care about the onSuccess side-effects here, so the
+// actual network call is irrelevant.
+// ---------------------------------------------------------------------------
+
+vi.mock("@/apis/raw", () => ({
+  default: {
+    subtitles: {
+      modify: vi.fn().mockResolvedValue(undefined),
+      batch: vi.fn().mockResolvedValue({ queued: 1, skipped: 0, errors: [] }),
+      promoteSyncOutput: vi.fn().mockResolvedValue({
+        sourceLanguage: "en",
+        targetLanguage: "fr",
+        targetPath: "/movies/1/subtitles/fr.srt",
+      }),
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Per-test QueryClient + wrapper so spy state never leaks between tests.
+// ---------------------------------------------------------------------------
+
+function makeClientAndWrapper() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { networkMode: "offlineFirst" },
+    },
+  });
+
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+
+  const spy = vi.spyOn(client, "invalidateQueries");
+
+  return { client, wrapper, spy };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: extract the queryKey arrays from all recorded spy calls.
+// ---------------------------------------------------------------------------
+
+function capturedKeys(spy: ReturnType<typeof vi.spyOn>) {
+  return spy.mock.calls.map((call: unknown[]) => {
+    // invalidateQueries is called as invalidateQueries({ queryKey: [...] })
+    const arg = call[0] as { queryKey?: unknown[] } | undefined;
+    return arg?.queryKey ?? [];
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useSubtitleAction
+// ---------------------------------------------------------------------------
+
+describe("useSubtitleAction – episode", () => {
+  let spy: ReturnType<typeof vi.spyOn>;
+  let wrapper: ReturnType<typeof makeClientAndWrapper>["wrapper"];
+
+  beforeEach(() => {
+    ({ spy, wrapper } = makeClientAndWrapper());
+  });
+
+  it("invalidates [Episodes, id] and [Series] but NOT [Movies]", async () => {
+    const { result } = renderHook(() => useSubtitleAction(), { wrapper });
+
+    result.current.mutate({
+      action: "translate",
+      form: {
+        id: 42,
+        type: "episode",
+        language: "fr",
+        path: "/series/1/ep01.en.srt",
+      },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = capturedKeys(spy);
+
+    // Must have invalidated the specific episode id
+    expect(keys).toContainEqual([QueryKeys.Episodes, 42]);
+
+    // Must have invalidated the Series root
+    expect(keys).toContainEqual([QueryKeys.Series]);
+
+    // Must NOT have touched Movies
+    const touchedMovies = keys.some(
+      (k: unknown[]) => Array.isArray(k) && k[0] === QueryKeys.Movies,
+    );
+    expect(touchedMovies).toBe(false);
+  });
+});
+
+describe("useSubtitleAction – movie", () => {
+  let spy: ReturnType<typeof vi.spyOn>;
+  let wrapper: ReturnType<typeof makeClientAndWrapper>["wrapper"];
+
+  beforeEach(() => {
+    ({ spy, wrapper } = makeClientAndWrapper());
+  });
+
+  it("invalidates [Movies, id] and [Movies, History] but NOT [Episodes] or [Series]", async () => {
+    const { result } = renderHook(() => useSubtitleAction(), { wrapper });
+
+    result.current.mutate({
+      action: "OCR_fixes",
+      form: {
+        id: 99,
+        type: "movie",
+        language: "en",
+        path: "/movies/film.en.srt",
+      },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = capturedKeys(spy);
+
+    // Must have invalidated the specific movie id
+    expect(keys).toContainEqual([QueryKeys.Movies, 99]);
+
+    // Must have invalidated [Movies, History] to refresh movie history page
+    expect(keys).toContainEqual([QueryKeys.Movies, QueryKeys.History]);
+
+    // Must NOT have touched Episodes or Series
+    const touchedEpisodes = keys.some(
+      (k: unknown[]) => Array.isArray(k) && k[0] === QueryKeys.Episodes,
+    );
+    const touchedSeries = keys.some(
+      (k: unknown[]) => Array.isArray(k) && k[0] === QueryKeys.Series,
+    );
+    expect(touchedEpisodes).toBe(false);
+    expect(touchedSeries).toBe(false);
+  });
+
+  it("uses [Movies, History] NOT [History] as the history invalidation key", async () => {
+    const { result } = renderHook(() => useSubtitleAction(), { wrapper });
+
+    result.current.mutate({
+      action: "common",
+      form: {
+        id: 7,
+        type: "movie",
+        language: "de",
+        path: "/movies/film.de.srt",
+      },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = capturedKeys(spy);
+
+    // The bare [History] key is never invalidated by useSubtitleAction
+    const usedBareHistory = keys.some(
+      (k: unknown[]) =>
+        Array.isArray(k) && k.length === 1 && k[0] === QueryKeys.History,
+    );
+    expect(usedBareHistory).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useBatchAction
+// ---------------------------------------------------------------------------
+
+describe("useBatchAction", () => {
+  let spy: ReturnType<typeof vi.spyOn>;
+  let wrapper: ReturnType<typeof makeClientAndWrapper>["wrapper"];
+
+  beforeEach(() => {
+    ({ spy, wrapper } = makeClientAndWrapper());
+  });
+
+  it("invalidates [Series], [Movies], [System, History], and [Translator]", async () => {
+    const { result } = renderHook(() => useBatchAction(), { wrapper });
+
+    result.current.mutate({
+      items: [
+        { type: "episode", sonarrSeriesId: 1, sonarrEpisodeId: 10 },
+        { type: "movie", radarrId: 5 },
+      ],
+      action: "sync",
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = capturedKeys(spy);
+
+    expect(keys).toContainEqual([QueryKeys.Series]);
+    expect(keys).toContainEqual([QueryKeys.Movies]);
+    expect(keys).toContainEqual([QueryKeys.System, QueryKeys.History]);
+    expect(keys).toContainEqual([QueryKeys.Translator]);
+  });
+
+  it("uses [System, History] NOT the bare [History] key", async () => {
+    const { result } = renderHook(() => useBatchAction(), { wrapper });
+
+    result.current.mutate({
+      items: [{ type: "movie", radarrId: 3 }],
+      action: "translate",
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = capturedKeys(spy);
+
+    // [System, History] must be present
+    expect(keys).toContainEqual([QueryKeys.System, QueryKeys.History]);
+
+    // The bare [History] key must NOT appear
+    const usedBareHistory = keys.some(
+      (k: unknown[]) =>
+        Array.isArray(k) && k.length === 1 && k[0] === QueryKeys.History,
+    );
+    expect(usedBareHistory).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// usePromoteSyncSubtitle
+// ---------------------------------------------------------------------------
+
+describe("usePromoteSyncSubtitle – episode", () => {
+  let spy: ReturnType<typeof vi.spyOn>;
+  let wrapper: ReturnType<typeof makeClientAndWrapper>["wrapper"];
+
+  beforeEach(() => {
+    ({ spy, wrapper } = makeClientAndWrapper());
+  });
+
+  it("invalidates [Series], [System, History], and the exact subtitle content key", async () => {
+    const { result } = renderHook(() => usePromoteSyncSubtitle(), { wrapper });
+
+    const params = {
+      mediaType: "episode",
+      mediaId: 55,
+      targetLanguage: "fr",
+      sourceLanguage: "en",
+      arrInstanceId: undefined as number | undefined,
+    };
+
+    result.current.mutate(params);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = capturedKeys(spy);
+
+    // Must invalidate the Series root (episode history lives here)
+    expect(keys).toContainEqual([QueryKeys.Series]);
+
+    // Must invalidate System history stats
+    expect(keys).toContainEqual([QueryKeys.System, QueryKeys.History]);
+
+    // Must invalidate the exact subtitle content cache entry
+    expect(keys).toContainEqual([
+      QueryKeys.Subtitles,
+      "content",
+      "episode",
+      55,
+      "fr",
+      undefined,
+    ]);
+
+    // Must NOT touch Movies
+    const touchedMovies = keys.some(
+      (k: unknown[]) => Array.isArray(k) && k[0] === QueryKeys.Movies,
+    );
+    expect(touchedMovies).toBe(false);
+  });
+});
+
+describe("usePromoteSyncSubtitle – movie", () => {
+  let spy: ReturnType<typeof vi.spyOn>;
+  let wrapper: ReturnType<typeof makeClientAndWrapper>["wrapper"];
+
+  beforeEach(() => {
+    ({ spy, wrapper } = makeClientAndWrapper());
+  });
+
+  it("invalidates [Movies], [System, History], and the exact subtitle content key", async () => {
+    const { result } = renderHook(() => usePromoteSyncSubtitle(), { wrapper });
+
+    const params = {
+      mediaType: "movie",
+      mediaId: 17,
+      targetLanguage: "es",
+      sourceLanguage: "en",
+      arrInstanceId: 2,
+    };
+
+    result.current.mutate(params);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = capturedKeys(spy);
+
+    // Must invalidate Movies root
+    expect(keys).toContainEqual([QueryKeys.Movies]);
+
+    // Must invalidate System history
+    expect(keys).toContainEqual([QueryKeys.System, QueryKeys.History]);
+
+    // Must invalidate the exact content key, including arrInstanceId
+    expect(keys).toContainEqual([
+      QueryKeys.Subtitles,
+      "content",
+      "movie",
+      17,
+      "es",
+      2,
+    ]);
+
+    // Must NOT touch Series
+    const touchedSeries = keys.some(
+      (k: unknown[]) => Array.isArray(k) && k[0] === QueryKeys.Series,
+    );
+    expect(touchedSeries).toBe(false);
+  });
+});

--- a/frontend/src/apis/queries/__tests__/usePaginationQuery.test.tsx
+++ b/frontend/src/apis/queries/__tests__/usePaginationQuery.test.tsx
@@ -1,0 +1,423 @@
+/* eslint-disable camelcase */
+import { PropsWithChildren } from "react";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { usePaginationQuery } from "@/apis/queries/hooks";
+import { QueryKeys } from "@/apis/queries/keys";
+import server from "@/tests/mocks/node";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeQueryFn(total: number, items: object[] = []): RangeQuery<object> {
+  return vi.fn().mockResolvedValue({ data: items, total });
+}
+
+/** Build a renderHook wrapper that provides QueryClient + MemoryRouter
+ *  at the given initial URL (e.g. "/?page=3"). */
+function buildWrapper(initialUrl = "/") {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: 0, networkMode: "offlineFirst" },
+    },
+  });
+
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[initialUrl]}>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+
+  return { qc, wrapper: Wrapper };
+}
+
+// ---------------------------------------------------------------------------
+// Setup: ensure /api/system/settings is always answered so usePageSize can
+// resolve the global page_size.
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  server.use(
+    http.get("/api/system/settings", () =>
+      HttpResponse.json({ general: { theme: "auto", page_size: 25 } }),
+    ),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("usePaginationQuery", () => {
+  describe("initial page clamping from URL ?page= param", () => {
+    it("starts at page index 0 when ?page= is absent", async () => {
+      const { wrapper } = buildWrapper("/");
+      const queryFn = makeQueryFn(100);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Movies], queryFn),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.paginationStatus.page).toBe(0));
+    });
+
+    it("starts at page index 0 when ?page=0 (zero-value, below 1-based min)", async () => {
+      const { wrapper } = buildWrapper("/?page=0");
+      const queryFn = makeQueryFn(100);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Movies], queryFn),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.paginationStatus.page).toBe(0));
+    });
+
+    it("starts at page index 0 when ?page=-5 (negative)", async () => {
+      const { wrapper } = buildWrapper("/?page=-5");
+      const queryFn = makeQueryFn(100);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Movies], queryFn),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.paginationStatus.page).toBe(0));
+    });
+
+    it("starts at page index 0 when ?page=NaN", async () => {
+      const { wrapper } = buildWrapper("/?page=NaN");
+      const queryFn = makeQueryFn(100);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Movies], queryFn),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.paginationStatus.page).toBe(0));
+    });
+
+    it("converts 1-based ?page=1 URL param to index 0", async () => {
+      const { wrapper } = buildWrapper("/?page=1");
+      const queryFn = makeQueryFn(100);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Movies], queryFn),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.paginationStatus.page).toBe(0));
+    });
+
+    it("converts 1-based ?page=3 URL param to index 2", async () => {
+      const { wrapper } = buildWrapper("/?page=3");
+      // Need enough total to have 3 pages at size 25
+      const queryFn = makeQueryFn(1000);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Movies], queryFn),
+        { wrapper },
+      );
+
+      await waitFor(() => expect(result.current.paginationStatus.page).toBe(2));
+    });
+  });
+
+  describe("setPageSize", () => {
+    it("overrides the page size and resets the page index to 0", async () => {
+      const { wrapper } = buildWrapper("/?page=3");
+      const queryFn = makeQueryFn(1000);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Movies], queryFn),
+        { wrapper },
+      );
+
+      // Initial page from URL: page=3 (1-based) -> index 2
+      await waitFor(() => expect(result.current.paginationStatus.page).toBe(2));
+
+      // Override the page size
+      result.current.controls.setPageSize(10);
+
+      await waitFor(() => {
+        expect(result.current.paginationStatus.pageSize).toBe(10);
+        expect(result.current.paginationStatus.page).toBe(0);
+      });
+    });
+
+    it("the overridden page size is reflected in pageCount", async () => {
+      const { wrapper } = buildWrapper("/");
+      // 100 total items
+      const queryFn = makeQueryFn(100);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Movies], queryFn),
+        { wrapper },
+      );
+
+      await waitFor(() => result.current.isSuccess);
+
+      // Default page_size=25 from settings: 100/25 = 4 pages
+      await waitFor(() =>
+        expect(result.current.paginationStatus.pageCount).toBe(4),
+      );
+
+      // Switch to page size 10: 100/10 = 10 pages
+      result.current.controls.setPageSize(10);
+
+      await waitFor(() =>
+        expect(result.current.paginationStatus.pageCount).toBe(10),
+      );
+    });
+
+    it("resets to page 0 even when currently on a later page", async () => {
+      const { wrapper } = buildWrapper("/");
+      const queryFn = makeQueryFn(200);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Movies], queryFn),
+        { wrapper },
+      );
+
+      // Wait until pageCount is known (8 pages for 200 items / 25)
+      await waitFor(() =>
+        expect(result.current.paginationStatus.pageCount).toBe(8),
+      );
+
+      // Navigate to page 3 (index 3 is valid: 0-7)
+      result.current.controls.gotoPage(3);
+      await waitFor(() => expect(result.current.paginationStatus.page).toBe(3));
+
+      // setPageSize must reset to 0
+      result.current.controls.setPageSize(5);
+      await waitFor(() => {
+        expect(result.current.paginationStatus.page).toBe(0);
+        expect(result.current.paginationStatus.pageSize).toBe(5);
+      });
+    });
+  });
+
+  describe("pageCount derivation", () => {
+    it("computes pageCount from total and active pageSize", async () => {
+      const { wrapper } = buildWrapper("/");
+      // 75 items with default page_size=25 -> 3 pages
+      const queryFn = makeQueryFn(75);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Movies], queryFn),
+        { wrapper },
+      );
+
+      await waitFor(() => result.current.isSuccess);
+      await waitFor(() =>
+        expect(result.current.paginationStatus.pageCount).toBe(3),
+      );
+    });
+
+    it("rounds up fractional pageCount (ceil)", async () => {
+      const { wrapper } = buildWrapper("/");
+      // 26 items / 25 per page = 1.04 -> rounds up to 2
+      const queryFn = makeQueryFn(26);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Movies], queryFn),
+        { wrapper },
+      );
+
+      await waitFor(() => result.current.isSuccess);
+      await waitFor(() =>
+        expect(result.current.paginationStatus.pageCount).toBe(2),
+      );
+    });
+
+    it("reports pageCount=0 when total is 0", async () => {
+      const { wrapper } = buildWrapper("/");
+      const queryFn = makeQueryFn(0);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Movies], queryFn),
+        { wrapper },
+      );
+
+      await waitFor(() => result.current.isSuccess);
+      await waitFor(() =>
+        expect(result.current.paginationStatus.pageCount).toBe(0),
+      );
+    });
+
+    it("uses the overridden pageSize when computing pageCount", async () => {
+      const { wrapper } = buildWrapper("/");
+      // 100 items, override to size 20 -> 5 pages
+      const queryFn = makeQueryFn(100);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Movies], queryFn),
+        { wrapper },
+      );
+
+      await waitFor(() => result.current.isSuccess);
+
+      result.current.controls.setPageSize(20);
+
+      await waitFor(() =>
+        expect(result.current.paginationStatus.pageCount).toBe(5),
+      );
+    });
+  });
+
+  describe("query key shape", () => {
+    it("includes QueryKeys.Range in the query key when not fetchAll", async () => {
+      const { qc, wrapper } = buildWrapper("/");
+      const queryFn = makeQueryFn(10);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Wanted], queryFn, false, false),
+        { wrapper },
+      );
+
+      await waitFor(() => result.current.isSuccess);
+
+      const queries = qc.getQueryCache().findAll({
+        queryKey: [QueryKeys.Wanted, QueryKeys.Range],
+        exact: false,
+      });
+      expect(queries.length).toBeGreaterThan(0);
+      const key = queries[0].queryKey as unknown[];
+      expect(key).toContain(QueryKeys.Range);
+    });
+
+    it("uses { all: true } in the query key when fetchAll=true", async () => {
+      const { qc, wrapper } = buildWrapper("/");
+      const queryFn = makeQueryFn(10);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.History], queryFn, false, true),
+        { wrapper },
+      );
+
+      await waitFor(() => result.current.isSuccess);
+
+      const queries = qc.getQueryCache().findAll({
+        queryKey: [QueryKeys.History, QueryKeys.Range],
+        exact: false,
+      });
+      expect(queries.length).toBeGreaterThan(0);
+      const key = queries[0].queryKey as unknown[];
+      // Last element should be { all: true }
+      expect(key[key.length - 1]).toEqual({ all: true });
+    });
+
+    it("includes start and size in the query key for paginated mode", async () => {
+      const { qc, wrapper } = buildWrapper("/");
+      const queryFn = makeQueryFn(10);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Wanted], queryFn, false, false),
+        { wrapper },
+      );
+
+      await waitFor(() => result.current.isSuccess);
+
+      const queries = qc.getQueryCache().findAll({
+        queryKey: [QueryKeys.Wanted, QueryKeys.Range],
+        exact: false,
+      });
+      expect(queries.length).toBeGreaterThan(0);
+      const key = queries[0].queryKey as unknown[];
+      // Should have a { start, size } object somewhere in the key
+      const rangeArg = key.find(
+        (part) =>
+          typeof part === "object" &&
+          part !== null &&
+          "start" in (part as object),
+      ) as { start: number; size: number } | undefined;
+      expect(rangeArg).toBeDefined();
+      expect(rangeArg?.start).toBe(0);
+    });
+  });
+
+  describe("fetchAll mode", () => {
+    it("passes start=0 and length=-1 to queryFn when fetchAll=true", async () => {
+      const { wrapper } = buildWrapper("/");
+      const queryFn = makeQueryFn(10);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Logs], queryFn, false, true),
+        { wrapper },
+      );
+
+      await waitFor(() => result.current.isSuccess);
+
+      expect(queryFn).toHaveBeenCalledWith({ start: 0, length: -1 });
+    });
+
+    it("exposes fetchAll=true in paginationStatus", async () => {
+      const { wrapper } = buildWrapper("/");
+      const queryFn = makeQueryFn(5);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Logs], queryFn, false, true),
+        { wrapper },
+      );
+
+      await waitFor(() => result.current.isSuccess);
+      expect(result.current.paginationStatus.fetchAll).toBe(true);
+    });
+
+    it("exposes fetchAll=false in paginationStatus when not in fetchAll mode", async () => {
+      const { wrapper } = buildWrapper("/");
+      const queryFn = makeQueryFn(5);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Logs], queryFn, false, false),
+        { wrapper },
+      );
+
+      await waitFor(() => result.current.isSuccess);
+      expect(result.current.paginationStatus.fetchAll).toBe(false);
+    });
+  });
+
+  describe("gotoPage control", () => {
+    it("advances the page index when target is in bounds", async () => {
+      const { wrapper } = buildWrapper("/");
+      // 100 items / 25 per page = 4 pages (indices 0-3)
+      const queryFn = makeQueryFn(100);
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Episodes], queryFn),
+        { wrapper },
+      );
+
+      // Wait until pageCount is established so gotoPage's bounds check passes
+      await waitFor(() =>
+        expect(result.current.paginationStatus.pageCount).toBe(4),
+      );
+
+      result.current.controls.gotoPage(2);
+      await waitFor(() => expect(result.current.paginationStatus.page).toBe(2));
+    });
+
+    it("ignores gotoPage when index is out of bounds (>= pageCount)", async () => {
+      const { wrapper } = buildWrapper("/");
+      const queryFn = makeQueryFn(25); // exactly 1 page at size 25
+
+      const { result } = renderHook(
+        () => usePaginationQuery([QueryKeys.Episodes], queryFn),
+        { wrapper },
+      );
+
+      await waitFor(() => result.current.isSuccess);
+      // pageCount=1, so index 1 is out of bounds
+      result.current.controls.gotoPage(1);
+
+      // page should remain 0
+      await waitFor(() => expect(result.current.paginationStatus.page).toBe(0));
+    });
+  });
+});

--- a/frontend/src/modules/socketio/__tests__/reducer.test.ts
+++ b/frontend/src/modules/socketio/__tests__/reducer.test.ts
@@ -1,0 +1,480 @@
+/**
+ * Behavior tests for createDefaultReducer().
+ *
+ * Covers every reducer key: verifies that socket events trigger the correct
+ * queryClient.invalidateQueries calls (with exact query keys) and that the
+ * "progress" reducer shows / updates / hides Mantine notifications correctly.
+ *
+ * The "episode" reducer (local-id cache lookup + series fallback) is already
+ * exercised by the sibling reducer.test.ts; here we focus on the gaps:
+ * progress notifications, inline jobs cache mutation, all "any" key reducers,
+ * connect/disconnect lifecycle, and the "message" notification path.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryKeys } from "@/apis/queries/keys";
+
+// ---------------------------------------------------------------------------
+// Hoist mocks so vi.mock factories can reference them
+// ---------------------------------------------------------------------------
+
+const queryClientMock = vi.hoisted(() => ({
+  getQueryData: vi.fn(),
+  invalidateQueries: vi.fn(),
+  setQueryData: vi.fn(),
+}));
+
+const showNotificationMock = vi.hoisted(() => vi.fn());
+const updateNotificationMock = vi.hoisted(() => vi.fn());
+const hideNotificationMock = vi.hoisted(() => vi.fn());
+const setOnlineStatusMock = vi.hoisted(() => vi.fn());
+const logMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/apis/queries", () => ({ default: queryClientMock }));
+
+vi.mock("@/apis/raw", () => ({
+  default: {
+    system: {
+      jobs: vi.fn().mockResolvedValue([]),
+    },
+  },
+}));
+
+vi.mock("@mantine/notifications", () => ({
+  showNotification: showNotificationMock,
+  updateNotification: updateNotificationMock,
+  hideNotification: hideNotificationMock,
+}));
+
+// Use the REAL notification module so we can assert on the exact shape it
+// produces (the progress reducer calls notification.progress.* directly).
+vi.mock("@/modules/task", async (importOriginal) => {
+  const real = await importOriginal<typeof import("@/modules/task")>();
+  return { ...real };
+});
+
+vi.mock("@/utilities/console", () => ({ LOG: logMock }));
+
+vi.mock("@/utilities/event", () => ({ setOnlineStatus: setOnlineStatusMock }));
+
+import { createDefaultReducer } from "@/modules/socketio/reducer";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Return the reducer for the given socket event key. */
+function get(key: string) {
+  const r = createDefaultReducer().find((item) => item.key === key);
+  if (r === undefined) throw new Error(`reducer for key "${key}" not found`);
+  return r;
+}
+
+/** Invoke the reducer's "any" handler. */
+function any(key: string) {
+  get(key).any?.();
+}
+
+/** Invoke the reducer's "update" handler. */
+function update<T>(key: string, payload: T[]) {
+  (get(key).update as ((p: T[]) => void) | undefined)?.(payload);
+}
+
+/** Invoke the reducer's "delete" handler. */
+function del<T>(key: string, payload: T[]) {
+  (get(key).delete as ((p: T[]) => void) | undefined)?.(payload);
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---- Lifecycle (connect / disconnect / connect_error) ---------------------
+
+describe("lifecycle reducers", () => {
+  it("sets online status to true on connect", () => {
+    any("connect");
+    expect(setOnlineStatusMock).toHaveBeenCalledWith(true);
+  });
+
+  it("sets online status to false on disconnect", () => {
+    any("disconnect");
+    expect(setOnlineStatusMock).toHaveBeenCalledWith(false);
+  });
+
+  it("sets online status to false on connect_error", () => {
+    any("connect_error");
+    expect(setOnlineStatusMock).toHaveBeenCalledWith(false);
+  });
+});
+
+// ---- message reducer ------------------------------------------------------
+
+describe("message reducer", () => {
+  it("calls showNotification once per incoming message", () => {
+    update("message", ["Download complete", "Subtitle synced"]);
+    expect(showNotificationMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows a notification with the message text", () => {
+    update("message", ["Hello"]);
+    const [args] = showNotificationMock.mock.calls;
+    expect(args[0]).toMatchObject({ message: "Hello" });
+  });
+});
+
+// ---- progress reducer -----------------------------------------------------
+
+describe("progress reducer", () => {
+  const item = (
+    overrides: Partial<{
+      id: string;
+      header: string;
+      name: string;
+      value: number;
+      count: number;
+    }> = {},
+  ) => ({
+    id: "prog-1",
+    header: "Downloading",
+    name: "sub.srt",
+    value: 1,
+    count: 5,
+    ...overrides,
+  });
+
+  it("always calls showNotification (pending) before updateNotification", () => {
+    update("progress", [item()]);
+
+    expect(showNotificationMock).toHaveBeenCalledTimes(1);
+    expect(updateNotificationMock).toHaveBeenCalledTimes(1);
+
+    // showNotification must come before updateNotification
+    const showOrder = showNotificationMock.mock.invocationCallOrder[0];
+    const updateOrder = updateNotificationMock.mock.invocationCallOrder[0];
+    expect(showOrder).toBeLessThan(updateOrder);
+  });
+
+  it("showNotification receives a pending notification with the correct id and header", () => {
+    update("progress", [item({ id: "x1", header: "Syncing" })]);
+
+    expect(showNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "x1", title: "Syncing", loading: true }),
+    );
+  });
+
+  it("calls updateNotification with an in-progress payload when value < count", () => {
+    update("progress", [item({ value: 2, count: 10 })]);
+
+    expect(updateNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "prog-1",
+        loading: true,
+        autoClose: false,
+        message: expect.stringContaining("2/10"),
+      }),
+    );
+  });
+
+  it("calls updateNotification with a completion payload when value === count", () => {
+    update("progress", [item({ value: 5, count: 5, header: "Done" })]);
+
+    expect(updateNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "prog-1",
+        message: "All Tasks Completed",
+        color: "green",
+      }),
+    );
+  });
+
+  it("calls updateNotification with a completion payload when value > count", () => {
+    update("progress", [item({ value: 6, count: 5 })]);
+
+    expect(updateNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "All Tasks Completed" }),
+    );
+  });
+
+  it("handles multiple items in one event, calling show+update for each", () => {
+    update("progress", [
+      item({ id: "a", value: 1, count: 3 }),
+      item({ id: "b", value: 3, count: 3 }),
+    ]);
+
+    expect(showNotificationMock).toHaveBeenCalledTimes(2);
+    expect(updateNotificationMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("delete: calls hideNotification for each id (inside setTimeout)", () => {
+    vi.useFakeTimers();
+
+    del("progress", ["prog-1", "prog-2"]);
+
+    // Not yet called — it's behind a setTimeout
+    expect(hideNotificationMock).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+
+    expect(hideNotificationMock).toHaveBeenCalledWith("prog-1");
+    expect(hideNotificationMock).toHaveBeenCalledWith("prog-2");
+
+    vi.useRealTimers();
+  });
+
+  it("progress pending notification has loading: true and no autoClose", () => {
+    update("progress", [item()]);
+    const pendingCall = showNotificationMock.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(pendingCall.loading).toBe(true);
+    // Pending notifications should not auto-close
+    expect(pendingCall.autoClose).toBeUndefined();
+  });
+});
+
+// ---- series reducer -------------------------------------------------------
+
+describe("series reducer", () => {
+  it("update: invalidates each series by id and the series list", () => {
+    update("series", [10, 20]);
+
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKeys.Series, 10],
+    });
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKeys.Series, 20],
+    });
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKeys.Series],
+    });
+  });
+
+  it("delete: invalidates each series by id and the series list", () => {
+    del("series", [99]);
+
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKeys.Series, 99],
+    });
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKeys.Series],
+    });
+  });
+});
+
+// ---- movie reducer --------------------------------------------------------
+
+describe("movie reducer", () => {
+  it("update: invalidates each movie by id and the movies list", () => {
+    update("movie", [5, 6]);
+
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKeys.Movies, 5],
+    });
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKeys.Movies, 6],
+    });
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKeys.Movies],
+    });
+  });
+
+  it("delete: invalidates each movie by id and the movies list", () => {
+    del("movie", [77]);
+
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKeys.Movies, 77],
+    });
+    expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKeys.Movies],
+    });
+  });
+});
+
+// ---- episode-wanted / movie-wanted ----------------------------------------
+
+describe("episode-wanted reducer", () => {
+  it.each(["update", "delete"] as const)(
+    "%s invalidates [Series, Wanted]",
+    (event) => {
+      if (event === "update") update("episode-wanted", []);
+      else del("episode-wanted", []);
+
+      expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: [QueryKeys.Series, QueryKeys.Wanted],
+      });
+    },
+  );
+});
+
+describe("movie-wanted reducer", () => {
+  it.each(["update", "delete"] as const)(
+    "%s invalidates [Movies, Wanted]",
+    (event) => {
+      if (event === "update") update("movie-wanted", []);
+      else del("movie-wanted", []);
+
+      expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: [QueryKeys.Movies, QueryKeys.Wanted],
+      });
+    },
+  );
+});
+
+// ---- "any" key reducers ---------------------------------------------------
+
+describe("any-event reducers", () => {
+  it.each([
+    ["settings", [QueryKeys.System]],
+    ["languages", [QueryKeys.System, QueryKeys.Languages]],
+    ["badges", [QueryKeys.System, QueryKeys.Badges]],
+    ["backup", [QueryKeys.System, QueryKeys.Backups]],
+    ["movie-history", [QueryKeys.Movies, QueryKeys.History]],
+    ["movie-blacklist", [QueryKeys.Movies, QueryKeys.Blacklist]],
+    [
+      "episode-history",
+      [QueryKeys.Series, QueryKeys.Episodes, QueryKeys.History],
+    ],
+    [
+      "episode-blacklist",
+      [QueryKeys.Series, QueryKeys.Episodes, QueryKeys.Blacklist],
+    ],
+    ["reset-episode-wanted", [QueryKeys.Series, QueryKeys.Wanted]],
+    ["reset-movie-wanted", [QueryKeys.Movies, QueryKeys.Wanted]],
+    ["task", [QueryKeys.System, QueryKeys.Tasks]],
+  ] as const)(
+    '"%s" any event invalidates queryKey %j',
+    (key, expectedQueryKey) => {
+      any(key as string);
+
+      expect(queryClientMock.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: expectedQueryKey,
+      });
+    },
+  );
+});
+
+// ---- jobs reducer (inline cache path) ------------------------------------
+
+describe("jobs reducer (inline progress_value path)", () => {
+  const jobsKey = [QueryKeys.System, QueryKeys.Jobs];
+
+  it("inserts a new job into an empty cache when progress_value is present", () => {
+    queryClientMock.getQueryData.mockReturnValue([]);
+
+    update("jobs", [
+      /* eslint-disable camelcase */
+      {
+        job_id: 1,
+        progress_value: 0,
+        progress_max: 100,
+        progress_message: "Starting",
+        status: "running",
+      },
+      /* eslint-enable camelcase */
+    ]);
+
+    expect(queryClientMock.setQueryData).toHaveBeenCalledWith(
+      jobsKey,
+      expect.arrayContaining([
+        expect.objectContaining({
+          // eslint-disable-next-line camelcase
+          job_id: 1,
+          // eslint-disable-next-line camelcase
+          progress_value: 0,
+          status: "running",
+        }),
+      ]),
+    );
+  });
+
+  it("updates an existing job in the cache by job_id", () => {
+    queryClientMock.getQueryData.mockReturnValue([
+      /* eslint-disable camelcase */
+      {
+        job_id: 42,
+        progress_value: 10,
+        progress_max: 100,
+        progress_message: "Old",
+        status: "running",
+      },
+      /* eslint-enable camelcase */
+    ]);
+
+    update("jobs", [
+      /* eslint-disable camelcase */
+      {
+        job_id: 42,
+        progress_value: 50,
+        progress_max: 100,
+        progress_message: "Halfway",
+        status: "running",
+      },
+      /* eslint-enable camelcase */
+    ]);
+
+    const calls = queryClientMock.setQueryData.mock.calls as [
+      unknown,
+      unknown[],
+    ][];
+    const [, result] = calls[0];
+
+    const updated = (result as Record<string, unknown>[]).find(
+      (j) => j.job_id === 42,
+    );
+    expect(updated).toBeDefined();
+
+    expect(updated!.progress_value).toBe(50);
+
+    expect(updated!.progress_message).toBe("Halfway");
+  });
+
+  it("trims the cache to 100 entries when it exceeds 100 jobs", () => {
+    /* eslint-disable camelcase */
+    const existing = Array.from({ length: 100 }, (_, i) => ({
+      job_id: i,
+      progress_value: 0,
+      status: "done",
+    }));
+    /* eslint-enable camelcase */
+    queryClientMock.getQueryData.mockReturnValue(existing);
+
+    update("jobs", [
+      /* eslint-disable camelcase */
+      {
+        job_id: 200,
+        progress_value: 1,
+        progress_max: 10,
+        progress_message: "New",
+        status: "running",
+      },
+      /* eslint-enable camelcase */
+    ]);
+
+    const calls2 = queryClientMock.setQueryData.mock.calls as [
+      unknown,
+      unknown[],
+    ][];
+    const [, result] = calls2[0];
+    expect((result as unknown[]).length).toBe(100);
+  });
+
+  it("does not call setQueryData when progress_value is null (API fetch path)", () => {
+    update("jobs", [
+      /* eslint-disable camelcase */
+      {
+        job_id: 99,
+        progress_value: null,
+        progress_message: "Done",
+        status: "finished",
+      },
+      /* eslint-enable camelcase */
+    ]);
+
+    expect(queryClientMock.setQueryData).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
First phase of the frontend test-coverage plan, focused on high-ROI pure-logic modules. **No production code changed** — behaviour tests only.

## New tests
- **`modules/socketio/reducer.ts`** (36) — each socket event maps to the correct `queryClient.invalidateQueries` keys; the progress-notification reducer (show/update/hide); the jobs inline-cache path (insert/update/100-entry trim/null-progress skip).
- **`apis/queries/hooks.ts` `usePaginationQuery`** (21) — page clamp for missing/0/negative/NaN `?page=`; `setPageSize` override + reset to page 0; page-count derivation; `fetchAll` query args.
- **`apis/hooks/subtitles.ts`** (7) — `useSubtitleAction` / `useBatchAction` / `usePromoteSyncSubtitle` invalidate the correct query keys (episode → `[Episodes,id]`+`[Series]`; movie → `[Movies,id]`+`[Movies,History]`; batch → `[System,History]`).

These lock several behaviours that were bug sources in the recent frontend audit (query-key invalidation, pagination clamp).

## Verification
- `tsc` 0 errors, `eslint src` 0 errors (127 pre-existing warnings), `prettier` clean.
- Full vitest suite green: **68 files, 685 passed, 2 skipped** (+64 tests).
