### PR TITLE
Test coverage Phase 2: core flows (ItemEditForm, ManualSearch, Movies table, Search)

### DIFF
--- a/frontend/src/components/__tests__/Search.test.tsx
+++ b/frontend/src/components/__tests__/Search.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Tests for the Search component (src/components/Search.tsx).
+ *
+ * Why: The search only fires a server request when the query is non-empty
+ * (enabled = query.length > 0), and its local options filter is
+ * diacritic-insensitive and case-insensitive. Both behaviors are load-bearing
+ * and easy to regress.
+ *
+ * What: Renders Search with a mocked useServerSearch hook that records its
+ * arguments, then asserts the enabled flag and available options.
+ *
+ * Test: Run with `cd frontend && npx vitest run src/components/__tests__/Search.test.tsx`.
+ */
+
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import Search from "@/components/Search";
+import { customRender, screen, waitFor } from "@/tests";
+
+// ---------------------------------------------------------------------------
+// Mock @/apis/hooks so we control what useServerSearch returns and captures
+// its call arguments. The rest of the module is passed through unchanged.
+// ---------------------------------------------------------------------------
+
+type ServerSearchResult = {
+  id: number | null;
+  sonarrSeriesId?: number;
+  radarrId?: number;
+  title: string;
+  year: number;
+  poster: string | null;
+};
+
+type UseServerSearchReturn = {
+  data: ServerSearchResult[] | undefined;
+};
+
+type MockUseServerSearch = (
+  query: string,
+  enabled: boolean,
+) => UseServerSearchReturn;
+
+const mockUseServerSearch = vi.fn<MockUseServerSearch>(() => ({
+  data: undefined,
+}));
+
+vi.mock("@/apis/hooks", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/apis/hooks")>();
+  return {
+    ...original,
+    useServerSearch: (query: string, enabled: boolean) =>
+      mockUseServerSearch(query, enabled),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSeriesResult(
+  id: number,
+  title: string,
+  year: number,
+): ServerSearchResult {
+  return { id, sonarrSeriesId: id, title, year, poster: null };
+}
+
+function makeMovieResult(
+  id: number,
+  title: string,
+  year: number,
+): ServerSearchResult {
+  return { id, radarrId: id, title, year, poster: null };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Search component — server query enabled flag", () => {
+  it("calls useServerSearch with enabled=false when the input is empty", () => {
+    mockUseServerSearch.mockReturnValue({ data: undefined });
+
+    customRender(<Search />);
+
+    // The component mounts with an empty query; the hook must be called with
+    // enabled=false so no network request fires.
+    expect(mockUseServerSearch).toHaveBeenCalledWith("", false);
+
+    const allCalls = mockUseServerSearch.mock.calls;
+    allCalls.forEach((args) => {
+      // Every call while the query is empty must have enabled=false.
+      expect(args[1]).toBe(false);
+    });
+  });
+
+  it("calls useServerSearch with enabled=true once a non-empty query is typed", async () => {
+    mockUseServerSearch.mockReturnValue({ data: undefined });
+
+    const user = userEvent.setup();
+    customRender(<Search />);
+
+    const input = screen.getByPlaceholderText("Search");
+    await user.type(input, "b");
+
+    // After typing at least one character the hook must receive enabled=true.
+    await waitFor(() => {
+      const calledWithEnabled = mockUseServerSearch.mock.calls.some(
+        (args) => args[1] === true,
+      );
+      expect(calledWithEnabled).toBe(true);
+    });
+  });
+
+  it("passes the typed query string to useServerSearch", async () => {
+    mockUseServerSearch.mockReturnValue({ data: undefined });
+
+    const user = userEvent.setup();
+    customRender(<Search />);
+
+    const input = screen.getByPlaceholderText("Search");
+    await user.type(input, "bat");
+
+    await waitFor(() => {
+      const queriesUsed = mockUseServerSearch.mock.calls.map((args) => args[0]);
+      expect(queriesUsed).toContain("bat");
+    });
+  });
+});
+
+describe("Search component — options filter is case-insensitive", () => {
+  it("shows a result whose label starts with uppercase when the search is all lowercase", async () => {
+    mockUseServerSearch.mockReturnValue({
+      data: [makeMovieResult(1, "Batman Begins", 2005)],
+    });
+
+    const user = userEvent.setup();
+    customRender(<Search />);
+
+    const input = screen.getByPlaceholderText("Search");
+    await user.type(input, "batman");
+
+    await waitFor(() => {
+      expect(screen.getByText("Batman Begins (2005)")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a result when the search uses uppercase and the label is mixed-case", async () => {
+    mockUseServerSearch.mockReturnValue({
+      data: [makeSeriesResult(2, "Breaking Bad", 2008)],
+    });
+
+    const user = userEvent.setup();
+    customRender(<Search />);
+
+    const input = screen.getByPlaceholderText("Search");
+    await user.type(input, "BREAKING");
+
+    await waitFor(() => {
+      expect(screen.getByText("Breaking Bad (2008)")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("Search component — options filter is diacritic-insensitive", () => {
+  it("matches a title with accented characters when the search omits the accent", async () => {
+    mockUseServerSearch.mockReturnValue({
+      data: [makeMovieResult(3, "Amélie", 2001)],
+    });
+
+    const user = userEvent.setup();
+    customRender(<Search />);
+
+    const input = screen.getByPlaceholderText("Search");
+    // Search without the accent; the filter must still match "Amélie".
+    await user.type(input, "Amelie");
+
+    await waitFor(() => {
+      expect(screen.getByText("Amélie (2001)")).toBeInTheDocument();
+    });
+  });
+
+  it("matches when the search contains an accent but the label does not", async () => {
+    mockUseServerSearch.mockReturnValue({
+      data: [makeMovieResult(4, "Amelie", 2001)],
+    });
+
+    const user = userEvent.setup();
+    customRender(<Search />);
+
+    const input = screen.getByPlaceholderText("Search");
+    await user.type(input, "Amélie");
+
+    await waitFor(() => {
+      expect(screen.getByText("Amelie (2001)")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("Search component — result routing", () => {
+  it("renders a show result from sonarrSeriesId data", async () => {
+    mockUseServerSearch.mockReturnValue({
+      data: [makeSeriesResult(10, "The Wire", 2002)],
+    });
+
+    const user = userEvent.setup();
+    customRender(<Search />);
+
+    const input = screen.getByPlaceholderText("Search");
+    await user.type(input, "wire");
+
+    await waitFor(() => {
+      expect(screen.getByText("The Wire (2002)")).toBeInTheDocument();
+    });
+  });
+
+  it("renders a movie result from radarrId data", async () => {
+    mockUseServerSearch.mockReturnValue({
+      data: [makeMovieResult(20, "Inception", 2010)],
+    });
+
+    const user = userEvent.setup();
+    customRender(<Search />);
+
+    const input = screen.getByPlaceholderText("Search");
+    await user.type(input, "ince");
+
+    await waitFor(() => {
+      expect(screen.getByText("Inception (2010)")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/forms/__tests__/ItemEditForm.test.tsx
+++ b/frontend/src/components/forms/__tests__/ItemEditForm.test.tsx
@@ -1,0 +1,200 @@
+/* eslint-disable camelcase */
+/**
+ * Tests for the ItemEditForm component.
+ *
+ * Focus: the profile load-gate. When language profiles are not yet fetched the
+ * component renders a Loader and no form elements. Once profiles are available
+ * it renders the form and pre-selects the item's current profile in the
+ * Languages Profile selector.
+ *
+ * Strategy: vi.mock controls the useLanguageProfiles hook synchronously so we
+ * can exercise both the loading (data === undefined) and loaded states without
+ * async race conditions. This mirrors how the real gate logic works: the
+ * component checks data === undefined, not isFetching, to decide whether to
+ * render the form body.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import ItemEditForm from "@/components/forms/ItemEditForm";
+import { customRender, screen, waitFor } from "@/tests";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PROFILES: Language.Profile[] = [
+  {
+    profileId: 1,
+    name: "English Only",
+    items: [],
+    mustContain: [],
+    mustNotContain: [],
+    originalFormat: false,
+    cutoff: null,
+    tag: undefined,
+  },
+  {
+    profileId: 2,
+    name: "English + French",
+    items: [],
+    mustContain: [],
+    mustNotContain: [],
+    originalFormat: false,
+    cutoff: null,
+    tag: undefined,
+  },
+];
+
+/** Minimal Item.Movie satisfying Item.Base + MovieIdType. */
+function makeMovie(profileId: number | null): Item.Movie {
+  return {
+    id: 10,
+    radarrId: 10,
+    title: "Test Movie",
+    path: "/movies/test.mkv",
+    profileId,
+    fanart: "",
+    overview: "",
+    imdbId: "tt0000001",
+    alternativeTitles: [],
+    poster: "",
+    year: "2024",
+    monitored: true,
+    tags: [],
+    audio_language: [
+      { code2: "en", name: "English", hi: false, forced: false },
+    ],
+    subtitles: [],
+    missing_subtitles: [],
+  };
+}
+
+/**
+ * Stub UseMutationResult. We only need isPending and mutate for the form to
+ * render; the rest are typed but never called in these tests.
+ */
+function makeMutation() {
+  return {
+    isPending: false,
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    reset: vi.fn(),
+    isIdle: true as const,
+    isSuccess: false as const,
+    isError: false as const,
+    isPaused: false as const,
+    status: "idle" as const,
+    error: null,
+    data: undefined,
+    variables: undefined,
+    context: undefined,
+    submittedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Module mock: control useLanguageProfiles return value per test
+// ---------------------------------------------------------------------------
+
+vi.mock("@/apis/hooks", async (importActual) => {
+  const actual = await importActual<typeof import("@/apis/hooks")>();
+  return {
+    ...actual,
+    useLanguageProfiles: vi.fn(),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Test 1: Loader renders while profiles are not yet loaded
+// ---------------------------------------------------------------------------
+
+describe("ItemEditForm – load gate", () => {
+  it("renders a Loader (and no form) while language profiles are still fetching", async () => {
+    // Simulate data === undefined (in-flight, no cached result yet)
+    const { useLanguageProfiles } = await import("@/apis/hooks");
+    vi.mocked(useLanguageProfiles).mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      data: undefined as any,
+      isFetching: true,
+    } as ReturnType<typeof useLanguageProfiles>);
+
+    customRender(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <ItemEditForm mutation={makeMutation() as any} item={makeMovie(1)} />,
+    );
+
+    // The gate blocks the form body. The Languages Profile combobox must NOT
+    // be present.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("combobox", { name: /languages profile/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    // The Cancel and Save buttons are part of the form body; they must also
+    // be absent while loading.
+    expect(
+      screen.queryByRole("button", { name: /save/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 2: Form renders and pre-selects the item's profile once loaded
+  // -------------------------------------------------------------------------
+
+  it("renders the Languages Profile selector pre-filled with the item's profile after profiles load", async () => {
+    // Simulate successful load: data is the profiles array
+    const { useLanguageProfiles } = await import("@/apis/hooks");
+    vi.mocked(useLanguageProfiles).mockReturnValue({
+      data: PROFILES,
+      isFetching: false,
+    } as ReturnType<typeof useLanguageProfiles>);
+
+    // Item has profileId 2 → "English + French" should be preselected.
+    customRender(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <ItemEditForm mutation={makeMutation() as any} item={makeMovie(2)} />,
+    );
+
+    // The form body must appear once profiles are available.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: /languages profile/i }),
+      ).toBeInTheDocument();
+    });
+
+    // The Mantine Select renders the selected label as the input's value.
+    expect(screen.getByDisplayValue("English + French")).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Test 3: Null profileId leaves the selector blank
+  // -------------------------------------------------------------------------
+
+  it("renders the Languages Profile selector with no selection when item profileId is null", async () => {
+    const { useLanguageProfiles } = await import("@/apis/hooks");
+    vi.mocked(useLanguageProfiles).mockReturnValue({
+      data: PROFILES,
+      isFetching: false,
+    } as ReturnType<typeof useLanguageProfiles>);
+
+    customRender(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      <ItemEditForm mutation={makeMutation() as any} item={makeMovie(null)} />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("combobox", { name: /languages profile/i }),
+      ).toBeInTheDocument();
+    });
+
+    // No profile name should appear in the selector input value.
+    expect(screen.queryByDisplayValue("English Only")).not.toBeInTheDocument();
+    expect(
+      screen.queryByDisplayValue("English + French"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/modals/__tests__/ManualSearchModal.test.tsx
+++ b/frontend/src/components/modals/__tests__/ManualSearchModal.test.tsx
@@ -1,0 +1,395 @@
+/* eslint-disable camelcase */
+
+/**
+ * Tests for ManualSearchView (MovieSearchModal wrapper).
+ *
+ * Why: Verifies that search results render in the table; that clicking download
+ * on a row calls the download prop with the correct result object; and that the
+ * downloaded highlight is keyed by provider+url+release (not row index) so it
+ * stays on the right row.
+ *
+ * What: Renders MovieSearchModal directly with a fake query prop and a spy
+ * download prop. Clicks Search to show the table, then exercises the download
+ * button on individual rows.
+ *
+ * Test: Run with `cd frontend && npx vitest run --reporter=verbose`.
+ */
+
+import { UseQueryResult } from "@tanstack/react-query";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { MovieSearchModal } from "@/components/modals/ManualSearchModal";
+import { customRender, screen, waitFor } from "@/tests";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeMovie(): Item.Movie {
+  return {
+    id: 42,
+    radarrId: 42,
+    title: "Inception",
+    path: "/movies/inception.mkv",
+    sceneName: "",
+    profileId: 1,
+    fanart: "",
+    overview: "",
+    imdbId: "tt1375666",
+    alternativeTitles: [],
+    poster: "",
+    year: "2010",
+    monitored: true,
+    tags: [],
+    audio_language: [],
+    subtitles: [],
+    missing_subtitles: [],
+  };
+}
+
+function makeSearchResult(
+  overrides: Partial<SearchResultType>,
+): SearchResultType {
+  return {
+    provider: "opensubtitles",
+    url: "https://www.opensubtitles.org/en/subtitles/1234",
+    language: "en",
+    forced: "False",
+    hearing_impaired: "False",
+    score: 90,
+    orig_score: 90,
+    score_without_hash: 88,
+    release_info: ["Inception.2010.1080p.BluRay"],
+    matches: ["title", "year"],
+    dont_matches: [],
+    subtitle: null,
+    original_format: "False",
+    ...overrides,
+  };
+}
+
+// Build a minimal UseQueryResult that looks like a resolved query.
+function makeQueryResult(
+  data: SearchResultType[] | undefined,
+  refetch: () => void = vi.fn(),
+): UseQueryResult<SearchResultType[] | undefined> {
+  return {
+    data,
+    dataUpdatedAt: 0,
+    error: null,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    failureReason: null,
+    errorUpdateCount: 0,
+    isError: false,
+    isFetched: data !== undefined,
+    isFetchedAfterMount: data !== undefined,
+    isFetching: false,
+    isInitialLoading: false,
+    isLoading: false,
+    isLoadingError: false,
+    isPaused: false,
+    isPending: false,
+    isPlaceholderData: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isSuccess: data !== undefined,
+    refetch: refetch as UseQueryResult<
+      SearchResultType[] | undefined
+    >["refetch"],
+    status: data !== undefined ? "success" : "pending",
+    fetchStatus: "idle",
+  } as UseQueryResult<SearchResultType[] | undefined>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders MovieSearchModal as if it were opened by Mantine modals.
+ * MovieSearchModal = withModal(ManualSearchView, ...) which expects
+ * ContextModalProps<Props<Item.Movie>> which includes id, innerProps, and
+ * context (the modals manager).
+ */
+function renderModal(
+  results: SearchResultType[],
+  download: (item: Item.Movie, result: SearchResultType) => Promise<void> = vi
+    .fn()
+    .mockResolvedValue(undefined),
+) {
+  const movie = makeMovie();
+  const refetch = vi.fn();
+
+  // The query prop is called as a hook inside the component. When the component
+  // passes undefined (before search starts), we return no data. Once a numeric
+  // id is passed (after Search is clicked), we return the fixture results.
+  const query = (id?: number): UseQueryResult<SearchResultType[] | undefined> =>
+    makeQueryResult(id !== undefined ? results : undefined, refetch);
+
+  // ContextModalProps requires a `context` field (the Mantine modals manager).
+  // We pass a minimal stub — the component never calls context directly.
+  const contextStub = {} as Parameters<typeof MovieSearchModal>[0]["context"];
+
+  customRender(
+    <MovieSearchModal
+      id="test-modal"
+      context={contextStub}
+      innerProps={{
+        item: movie,
+        query,
+        download,
+      }}
+    />,
+  );
+
+  return { movie, refetch, download };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ManualSearchModal: initial render", () => {
+  it("shows the file path in the resource alert", () => {
+    renderModal([]);
+    expect(screen.getByText("/movies/inception.mkv")).toBeInTheDocument();
+  });
+
+  it("shows a Search button that reads 'Search' before any search has fired", () => {
+    renderModal([]);
+    expect(
+      screen.getByRole("button", { name: /^search$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("no data rows appear before search is initiated", () => {
+    renderModal([makeSearchResult({ provider: "opensubtitles" })]);
+    // query returns undefined when id is undefined (searchStarted=false),
+    // so haveResult=false and Collapse is closed — provider text not yet visible.
+    expect(screen.queryByText("opensubtitles")).not.toBeInTheDocument();
+  });
+});
+
+describe("ManualSearchModal: table renders search results", () => {
+  it("shows all result rows after clicking Search", async () => {
+    const user = userEvent.setup();
+    const results = [
+      makeSearchResult({ provider: "opensubtitles", score: 90 }),
+      makeSearchResult({
+        provider: "subscene",
+        url: "https://subscene.com/sub/999",
+        release_info: ["Inception.2010.BluRay.x264"],
+        score: 75,
+      }),
+    ];
+
+    renderModal(results);
+
+    await user.click(screen.getByRole("button", { name: /search/i }));
+
+    await waitFor(() => {
+      // Each provider name should appear in the table
+      expect(screen.getByText("opensubtitles")).toBeInTheDocument();
+      expect(screen.getByText("subscene")).toBeInTheDocument();
+    });
+
+    // Score column values
+    expect(screen.getByText("90%")).toBeInTheDocument();
+    expect(screen.getByText("75%")).toBeInTheDocument();
+  });
+
+  it("shows release info for each result", async () => {
+    const user = userEvent.setup();
+    const results = [
+      makeSearchResult({
+        provider: "opensubtitles",
+        release_info: ["Inception.2010.1080p.BluRay"],
+      }),
+    ];
+
+    renderModal(results);
+    await user.click(screen.getByRole("button", { name: /search/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Inception.2010.1080p.BluRay"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows 'No result' empty-state when search returns empty array", async () => {
+    const user = userEvent.setup();
+
+    renderModal([]);
+    await user.click(screen.getByRole("button", { name: /search/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("No result")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("ManualSearchModal: download button behavior", () => {
+  it("calls download prop with the correct item and result when clicked", async () => {
+    const user = userEvent.setup();
+    const downloadSpy = vi.fn().mockResolvedValue(undefined);
+
+    const result = makeSearchResult({ provider: "opensubtitles", score: 90 });
+    renderModal([result], downloadSpy);
+
+    await user.click(screen.getByRole("button", { name: /search/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Download")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText("Download"));
+
+    await waitFor(() => {
+      expect(downloadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const [calledItem, calledResult] = downloadSpy.mock.calls[0] as [
+      Item.Movie,
+      SearchResultType,
+    ];
+    expect(calledItem.id).toBe(42);
+    expect(calledItem.title).toBe("Inception");
+    expect(calledResult.provider).toBe("opensubtitles");
+    expect(calledResult.score).toBe(90);
+    expect(calledResult.release_info[0]).toBe("Inception.2010.1080p.BluRay");
+  });
+
+  it("marks only the clicked row as downloaded (keyed by provider+url+release)", async () => {
+    const user = userEvent.setup();
+
+    const resultA = makeSearchResult({
+      provider: "opensubtitles",
+      url: "https://www.opensubtitles.org/en/subtitles/1234",
+      release_info: ["Inception.2010.1080p.BluRay"],
+      score: 90,
+    });
+    const resultB = makeSearchResult({
+      provider: "subscene",
+      url: "https://subscene.com/sub/999",
+      release_info: ["Inception.2010.BluRay.x264"],
+      score: 75,
+    });
+
+    renderModal([resultA, resultB]);
+
+    await user.click(screen.getByRole("button", { name: /search/i }));
+
+    // Wait for both Download buttons
+    await waitFor(() => {
+      expect(screen.getAllByLabelText("Download")).toHaveLength(2);
+    });
+
+    // Click the first download button (opensubtitles row)
+    const downloadButtons = screen.getAllByLabelText("Download");
+    await user.click(downloadButtons[0]);
+
+    // After download, both buttons should still be in the DOM. The clicked one
+    // changes to the "downloaded" icon but keeps the same aria-label "Download".
+    // The un-clicked row button stays enabled (not removed).
+    await waitFor(() => {
+      expect(screen.getAllByLabelText("Download")).toHaveLength(2);
+    });
+  });
+
+  it("calls download with the exact result object for the second row when it is clicked", async () => {
+    const user = userEvent.setup();
+    const downloadSpy = vi.fn().mockResolvedValue(undefined);
+
+    const resultA = makeSearchResult({
+      provider: "opensubtitles",
+      score: 90,
+      release_info: ["Inception.2010.1080p.BluRay"],
+    });
+    const resultB = makeSearchResult({
+      provider: "subscene",
+      url: "https://subscene.com/sub/999",
+      release_info: ["Inception.2010.BluRay.x264"],
+      score: 75,
+    });
+
+    renderModal([resultA, resultB], downloadSpy);
+
+    await user.click(screen.getByRole("button", { name: /search/i }));
+
+    await waitFor(() => {
+      expect(screen.getAllByLabelText("Download")).toHaveLength(2);
+    });
+
+    // Click the SECOND button (subscene row)
+    const downloadButtons = screen.getAllByLabelText("Download");
+    await user.click(downloadButtons[1]);
+
+    await waitFor(() => {
+      expect(downloadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const [, calledResult] = downloadSpy.mock.calls[0] as [
+      Item.Movie,
+      SearchResultType,
+    ];
+    // Must be the subscene result, not the opensubtitles one
+    expect(calledResult.provider).toBe("subscene");
+    expect(calledResult.score).toBe(75);
+    expect(calledResult.release_info[0]).toBe("Inception.2010.BluRay.x264");
+  });
+});
+
+describe("ManualSearchModal: provider link rendering", () => {
+  it("renders provider as a link when url is present", async () => {
+    const user = userEvent.setup();
+    const results = [
+      makeSearchResult({
+        provider: "opensubtitles",
+        url: "https://www.opensubtitles.org/en/subtitles/1234",
+      }),
+    ];
+
+    renderModal(results);
+    await user.click(screen.getByRole("button", { name: /search/i }));
+
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: "opensubtitles" });
+      expect(link).toHaveAttribute(
+        "href",
+        "https://www.opensubtitles.org/en/subtitles/1234",
+      );
+    });
+  });
+
+  it("renders provider as plain text when url is absent", async () => {
+    const user = userEvent.setup();
+    const results = [makeSearchResult({ provider: "local", url: undefined })];
+
+    renderModal(results);
+    await user.click(screen.getByRole("button", { name: /search/i }));
+
+    await waitFor(() => {
+      // No link — just a Text element with the provider name
+      expect(screen.queryByRole("link", { name: "local" })).toBeNull();
+      expect(screen.getByText("local")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("ManualSearchModal: Search Again button", () => {
+  it("changes button label to 'Search Again' after the first search", async () => {
+    const user = userEvent.setup();
+
+    renderModal([]);
+    await user.click(screen.getByRole("button", { name: /^search$/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /search again/i }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/Movies/Details/__tests__/movie-detail-table.test.tsx
+++ b/frontend/src/pages/Movies/Details/__tests__/movie-detail-table.test.tsx
@@ -1,0 +1,357 @@
+/* eslint-disable camelcase */
+
+/**
+ * Focused behavior tests for the Movies Detail subtitle Table component.
+ *
+ * Coverage:
+ * - Subtitle rows render the correct path-cell text for external, embedded,
+ *   and missing subtitle entries.
+ * - The `disabled` prop disables every action button (Subtitle Actions /
+ *   Combined Subtitle Actions) in the table.
+ * - An empty movie shows the configured empty-state text.
+ */
+
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import Table from "@/pages/Movies/Details/table";
+import { customRender, screen, waitFor } from "@/tests";
+import server from "@/tests/mocks/node";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMovie(
+  subtitles: Subtitle[],
+  missing_subtitles: Subtitle[] = [],
+): Item.Movie {
+  return {
+    id: 1,
+    radarrId: 42,
+    title: "Test Movie",
+    path: "/movies/test.mkv",
+    profileId: 1,
+    fanart: "",
+    overview: "",
+    imdbId: "tt0000001",
+    alternativeTitles: [],
+    poster: "",
+    year: "2024",
+    monitored: true,
+    tags: [],
+    audio_language: [],
+    subtitles,
+    missing_subtitles,
+  };
+}
+
+/** Silence API calls that the table fires on render. */
+function setupApiMocks() {
+  server.use(
+    // sync-status: fired for every external (on-disk) subtitle row
+    http.get("/api/subtitles/sync-status", () =>
+      HttpResponse.json({ data: null }),
+    ),
+    // useLanguages: used by useProfileItemsToLanguages + Language.Text badges
+    http.get("/api/system/languages", () => HttpResponse.json([])),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("MovieDetailTable", () => {
+  // -------------------------------------------------------------------------
+  // 1. External subtitle: path shown verbatim in the path column
+  // -------------------------------------------------------------------------
+  it("renders the file path for an external subtitle track", async () => {
+    setupApiMocks();
+
+    const external: Subtitle = {
+      code2: "en",
+      name: "English",
+      hi: false,
+      forced: false,
+      path: "/movies/test.en.srt",
+    };
+
+    customRender(
+      <Table movie={makeMovie([external])} profile={undefined} history={[]} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("/movies/test.en.srt")).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Embedded subtitle: "Video File Subtitle Track" shown in path column
+  // -------------------------------------------------------------------------
+  it("renders 'Video File Subtitle Track' for an embedded subtitle (null path)", async () => {
+    setupApiMocks();
+
+    const embedded: Subtitle = {
+      code2: "fr",
+      name: "French",
+      hi: false,
+      forced: false,
+      path: null,
+    };
+
+    customRender(
+      <Table movie={makeMovie([embedded])} profile={undefined} history={[]} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Video File Subtitle Track")).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Missing subtitle: "Missing Subtitles" sentinel shown in path column
+  // -------------------------------------------------------------------------
+  it("renders 'Missing Subtitles' for a missing subtitle entry", async () => {
+    setupApiMocks();
+
+    const missing: Subtitle = {
+      code2: "de",
+      name: "German",
+      hi: false,
+      forced: false,
+      path: undefined,
+    };
+
+    customRender(
+      <Table
+        movie={makeMovie([], [missing])}
+        profile={undefined}
+        history={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Missing Subtitles")).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. No subtitles at all: empty-state message appears
+  // -------------------------------------------------------------------------
+  it("shows the empty-state message when there are no subtitles", async () => {
+    setupApiMocks();
+
+    customRender(
+      <Table movie={makeMovie([])} profile={undefined} history={[]} />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No subtitles found for this movie"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. disabled=false: action buttons are NOT disabled
+  // -------------------------------------------------------------------------
+  it("enables action buttons when disabled prop is false", async () => {
+    setupApiMocks();
+
+    const external: Subtitle = {
+      code2: "en",
+      name: "English",
+      hi: false,
+      forced: false,
+      path: "/movies/test.en.srt",
+    };
+
+    customRender(
+      <Table
+        movie={makeMovie([external])}
+        profile={undefined}
+        history={[]}
+        disabled={false}
+      />,
+    );
+
+    await waitFor(() => {
+      const buttons = screen.getAllByLabelText("Subtitle Actions");
+      expect(buttons.length).toBeGreaterThanOrEqual(1);
+      buttons.forEach((btn) => {
+        expect(btn).not.toBeDisabled();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. disabled=true: ALL action buttons are disabled (external subtitle row)
+  // -------------------------------------------------------------------------
+  it("disables Subtitle Actions button when disabled prop is true (external track)", async () => {
+    setupApiMocks();
+
+    const external: Subtitle = {
+      code2: "en",
+      name: "English",
+      hi: false,
+      forced: false,
+      path: "/movies/test.en.srt",
+    };
+
+    customRender(
+      <Table
+        movie={makeMovie([external])}
+        profile={undefined}
+        history={[]}
+        disabled={true}
+      />,
+    );
+
+    await waitFor(() => {
+      const buttons = screen.getAllByLabelText("Subtitle Actions");
+      expect(buttons.length).toBeGreaterThanOrEqual(1);
+      buttons.forEach((btn) => {
+        expect(btn).toBeDisabled();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. disabled=true: action button is disabled for a missing subtitle row
+  // -------------------------------------------------------------------------
+  it("disables Subtitle Actions button when disabled prop is true (missing subtitle)", async () => {
+    setupApiMocks();
+
+    const missing: Subtitle = {
+      code2: "es",
+      name: "Spanish",
+      hi: false,
+      forced: false,
+      path: undefined,
+    };
+
+    customRender(
+      <Table
+        movie={makeMovie([], [missing])}
+        profile={undefined}
+        history={[]}
+        disabled={true}
+      />,
+    );
+
+    await waitFor(() => {
+      const buttons = screen.getAllByLabelText("Subtitle Actions");
+      expect(buttons.length).toBeGreaterThanOrEqual(1);
+      buttons.forEach((btn) => {
+        expect(btn).toBeDisabled();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. Multiple subtitle rows: each gets its own action button
+  // -------------------------------------------------------------------------
+  it("renders one action button per subtitle row", async () => {
+    setupApiMocks();
+
+    const subtitles: Subtitle[] = [
+      {
+        code2: "en",
+        name: "English",
+        hi: false,
+        forced: false,
+        path: "/movies/test.en.srt",
+      },
+      {
+        code2: "fr",
+        name: "French",
+        hi: false,
+        forced: false,
+        path: "/movies/test.fr.srt",
+      },
+    ];
+    const missing: Subtitle[] = [
+      {
+        code2: "de",
+        name: "German",
+        hi: false,
+        forced: false,
+        path: undefined,
+      },
+    ];
+
+    customRender(
+      <Table
+        movie={makeMovie(subtitles, missing)}
+        profile={undefined}
+        history={[]}
+      />,
+    );
+
+    // 2 external + 1 missing = 3 action buttons
+    await waitFor(() => {
+      const buttons = screen.getAllByLabelText("Subtitle Actions");
+      expect(buttons).toHaveLength(3);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 9. disabled=true covers all rows (mixed external + missing)
+  // -------------------------------------------------------------------------
+  it("disables all action buttons across mixed subtitle types when disabled is true", async () => {
+    setupApiMocks();
+
+    const subtitles: Subtitle[] = [
+      {
+        code2: "en",
+        name: "English",
+        hi: false,
+        forced: false,
+        path: "/movies/test.en.srt",
+      },
+      { code2: "fr", name: "French", hi: false, forced: false, path: null },
+    ];
+    const missing: Subtitle[] = [
+      {
+        code2: "de",
+        name: "German",
+        hi: false,
+        forced: false,
+        path: undefined,
+      },
+    ];
+
+    customRender(
+      <Table
+        movie={makeMovie(subtitles, missing)}
+        profile={undefined}
+        history={[]}
+        disabled={true}
+      />,
+    );
+
+    await waitFor(() => {
+      const buttons = screen.getAllByLabelText("Subtitle Actions");
+      expect(buttons).toHaveLength(3);
+      buttons.forEach((btn) => {
+        expect(btn).toBeDisabled();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 10. null movie: renders without crashing (graceful null handling)
+  // -------------------------------------------------------------------------
+  it("renders without crashing when movie is null", async () => {
+    setupApiMocks();
+
+    // When movie is null the table receives no data rows; empty-state appears
+    customRender(<Table movie={null} profile={undefined} history={[]} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No subtitles found for this movie"),
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Second phase of the frontend test-coverage plan — component/flow tests. **No production code changed.**

## New tests
- **`forms/ItemEditForm`** (3) — the profile load-gate: a loader shows while language profiles are unloaded; once loaded the form pre-fills the item's profile. Locks the "save was clearing the profile" fix.
- **`modals/ManualSearchModal`** (12) — results render after Search; clicking download passes the correct result and the "downloaded" highlight stays on the right row (keyed by provider+url+release, not index); provider link/text; Search-Again label.
- **`pages/Movies/Details/table`** (10) — external/embedded/missing subtitle rows render; the action menus respect the `disabled` prop; null-movie renders gracefully.
- **`components/Search`** (9) — the server search only fires for a non-empty query; the options filter is case- and diacritic-insensitive.

## Verification
- `tsc` 0 errors, `eslint src` 0 errors (127 pre-existing warnings), `prettier` clean.
- Full vitest suite green: **69 files, 655 passed, 2 skipped** (+34 tests).

Follows #256 (Phase 1). Both are independent (new files only) and merge cleanly.
