### PR TITLE
Test coverage Phase 3: settings & connections (updateSettings, ItemOverview, instance form/card)

### DIFF
--- a/frontend/src/apis/raw/__tests__/system.test.ts
+++ b/frontend/src/apis/raw/__tests__/system.test.ts
@@ -1,0 +1,177 @@
+import { AxiosResponse } from "axios";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import client from "@/apis/raw/client";
+import systemApi from "@/apis/raw/system";
+
+// Helpers to extract FormData entries as a plain object for assertions.
+function formDataToObject(fd: FormData): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
+  fd.forEach((value, key) => {
+    if (!(key in result)) {
+      result[key] = [];
+    }
+    result[key].push(value as string);
+  });
+  return result;
+}
+
+// Minimal Axios-shaped response that satisfies the AxiosResponse<void> return type.
+function okResponse(): AxiosResponse<void> {
+  return {
+    data: undefined,
+    status: 200,
+    statusText: "OK",
+    headers: {},
+    config: { headers: {} } as AxiosResponse["config"],
+  };
+}
+
+describe("SystemApi.updateSettings", () => {
+  let postSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    postSpy = vi.spyOn(client.axios, "post").mockResolvedValue(okResponse());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("converts null values to the string 'null' so the backend disables the setting", async () => {
+    await systemApi.updateSettings({ auth_type: null });
+
+    expect(postSpy).toHaveBeenCalledOnce();
+    const formData = postSpy.mock.calls[0][1] as FormData;
+    const entries = formDataToObject(formData);
+
+    expect(entries["auth_type"]).toEqual(["null"]);
+  });
+
+  it("omits undefined values entirely (leaves the field absent from the payload)", async () => {
+    await systemApi.updateSettings({ opt_field: undefined });
+
+    const formData = postSpy.mock.calls[0][1] as FormData;
+    const entries = formDataToObject(formData);
+
+    expect("opt_field" in entries).toBe(false);
+  });
+
+  it("passes string values through unchanged", async () => {
+    await systemApi.updateSettings({ proxy_type: "socks5" });
+
+    const formData = postSpy.mock.calls[0][1] as FormData;
+    const entries = formDataToObject(formData);
+
+    expect(entries["proxy_type"]).toEqual(["socks5"]);
+  });
+
+  it("passes numeric values through unchanged (coerced to string by FormData)", async () => {
+    await systemApi.updateSettings({ port: 8080 });
+
+    const formData = postSpy.mock.calls[0][1] as FormData;
+    const entries = formDataToObject(formData);
+
+    // FormData.append coerces numbers to strings.
+    expect(entries["port"]).toEqual(["8080"]);
+  });
+
+  it("passes non-empty arrays as repeated form fields", async () => {
+    await systemApi.updateSettings({ languages: ["en", "fr"] });
+
+    const formData = postSpy.mock.calls[0][1] as FormData;
+    const entries = formDataToObject(formData);
+
+    expect(entries["languages"]).toEqual(["en", "fr"]);
+  });
+
+  it("represents an empty array as a single empty-string field", async () => {
+    await systemApi.updateSettings({ languages: [] });
+
+    const formData = postSpy.mock.calls[0][1] as FormData;
+    const entries = formDataToObject(formData);
+
+    expect(entries["languages"]).toEqual([""]);
+  });
+
+  it("sanitizes a mixed payload: null->string-null, undefined absent, others unchanged", async () => {
+    await systemApi.updateSettings({
+      auth_type: null,
+      proxy_type: undefined,
+      host: "192.168.1.1",
+      port: 9090,
+      tags: ["en", "de"],
+      empty_tags: [],
+    });
+
+    expect(postSpy).toHaveBeenCalledOnce();
+    const formData = postSpy.mock.calls[0][1] as FormData;
+    const entries = formDataToObject(formData);
+
+    // null field is sent as the literal string "null".
+    expect(entries["auth_type"]).toEqual(["null"]);
+
+    // undefined field must be absent entirely.
+    expect("proxy_type" in entries).toBe(false);
+
+    // Plain string passes through.
+    expect(entries["host"]).toEqual(["192.168.1.1"]);
+
+    // Number is coerced to string by FormData.
+    expect(entries["port"]).toEqual(["9090"]);
+
+    // Non-empty array becomes repeated fields.
+    expect(entries["tags"]).toEqual(["en", "de"]);
+
+    // Empty array becomes a single empty-string entry.
+    expect(entries["empty_tags"]).toEqual([""]);
+  });
+
+  it("posts to the correct endpoint /api/system/settings", async () => {
+    await systemApi.updateSettings({ host: "localhost" });
+
+    const url = postSpy.mock.calls[0][0] as string;
+    // The base prefix is /system and the client base URL is /api/, so the
+    // composed path that reaches axios is "/system/settings".
+    expect(url).toBe("/system/settings");
+  });
+});
+
+describe("SystemApi.login", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the response data on successful login", async () => {
+    const payload = { upgrade_hash: false };
+    vi.spyOn(client.axios, "post").mockResolvedValue({
+      data: payload,
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config: { headers: {} } as AxiosResponse["config"],
+    });
+
+    const result = await systemApi.login("admin", "secret");
+
+    expect(result).toEqual(payload);
+  });
+
+  it("sends credentials as form fields with action=login", async () => {
+    const postSpy = vi
+      .spyOn(client.axios, "post")
+      .mockResolvedValue(okResponse());
+
+    await systemApi.login("admin", "secret");
+
+    expect(postSpy).toHaveBeenCalledOnce();
+    const formData = postSpy.mock.calls[0][1] as FormData;
+    const entries = formDataToObject(formData);
+
+    expect(entries["username"]).toEqual(["admin"]);
+    expect(entries["password"]).toEqual(["secret"]);
+
+    // action is sent as a query param, not form body.
+    const params = postSpy.mock.calls[0][2] as Record<string, unknown>;
+    expect(params?.params).toEqual({ action: "login" });
+  });
+});

--- a/frontend/src/pages/Settings/Connections/__tests__/InstanceCard.test.tsx
+++ b/frontend/src/pages/Settings/Connections/__tests__/InstanceCard.test.tsx
@@ -1,0 +1,414 @@
+/* eslint-disable camelcase */
+/**
+ * Tests for the InstanceCard component.
+ *
+ * Why: Verifies that the card renders instance metadata (name, base URL, API
+ * key status, timeout, badges) and that clicking action controls (Edit, Test,
+ * Delete via overflow menu, enable/disable toggle) invokes the right handlers
+ * with the correct arguments.
+ *
+ * What: Renders InstanceCard directly with a controlled ArrInstance fixture and
+ * spy handlers. MSW handles the PATCH /api/system/arr-instances/:id (toggle)
+ * and POST /api/system/arr-instances/:id/test (Test button) endpoints.
+ *
+ * Test: Run with `cd frontend && npx vitest run --reporter=verbose`.
+ */
+
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it, vi } from "vitest";
+import type { ArrInstance } from "@/apis/raw/arrInstances";
+import InstanceCard from "@/pages/Settings/Connections/InstanceCard";
+import { customRender, screen, waitFor } from "@/tests";
+import server from "@/tests/mocks/node";
+
+// ---------------------------------------------------------------------------
+// Shared fixture
+// ---------------------------------------------------------------------------
+
+function makeInstance(overrides: Partial<ArrInstance> = {}): ArrInstance {
+  return {
+    id: 42,
+    kind: "sonarr",
+    stable_key: "test-stable-key",
+    name: "Main Sonarr",
+    display_name: "Main Sonarr",
+    enabled: true,
+    is_default: false,
+    ip: "192.168.1.10",
+    port: 8989,
+    base_url: "",
+    ssl: false,
+    verify_ssl: false,
+    http_timeout: 30,
+    api_key_set: true,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setupTestEndpoint(result: {
+  ok: boolean;
+  version?: string;
+  app_name?: string;
+  error?: string;
+  message?: string;
+}) {
+  server.use(
+    http.post("/api/system/arr-instances/42/test", () =>
+      HttpResponse.json(result),
+    ),
+  );
+}
+
+function setupUpdateEndpoint() {
+  server.use(
+    http.patch("/api/system/arr-instances/42", () =>
+      HttpResponse.json({ ...makeInstance(), enabled: false }),
+    ),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Rendering: basic metadata
+// ---------------------------------------------------------------------------
+
+describe("InstanceCard: renders instance metadata", () => {
+  it("shows the instance name", () => {
+    const instance = makeInstance();
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+    expect(screen.getByText("Main Sonarr")).toBeInTheDocument();
+  });
+
+  it("shows the constructed host URL", () => {
+    const instance = makeInstance();
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+    // buildHostUrl: http://192.168.1.10:8989
+    expect(screen.getByText("http://192.168.1.10:8989")).toBeInTheDocument();
+  });
+
+  it("shows 'Key stored' when api_key_set is true", () => {
+    const instance = makeInstance({ api_key_set: true });
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+    expect(screen.getByText(/Key stored/)).toBeInTheDocument();
+  });
+
+  it("shows 'No API key' when api_key_set is false", () => {
+    const instance = makeInstance({ api_key_set: false });
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+    expect(screen.getByText(/No API key/)).toBeInTheDocument();
+  });
+
+  it("shows the configured timeout", () => {
+    const instance = makeInstance({ http_timeout: 60 });
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+    expect(screen.getByText(/Timeout 60s/)).toBeInTheDocument();
+  });
+
+  it("shows a Default badge for the default instance", () => {
+    const instance = makeInstance({ is_default: true });
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+    expect(screen.getByText("Default")).toBeInTheDocument();
+  });
+
+  it("shows a Disabled badge when the instance is disabled", () => {
+    const instance = makeInstance({ enabled: false });
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+    expect(screen.getByText("Disabled")).toBeInTheDocument();
+  });
+
+  it("shows display_name in parens when it differs from name", () => {
+    const instance = makeInstance({
+      name: "Sonarr 4K",
+      display_name: "The 4K Instance",
+    });
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+    expect(screen.getByText("Sonarr 4K")).toBeInTheDocument();
+    expect(screen.getByText("(The 4K Instance)")).toBeInTheDocument();
+  });
+
+  it("shows SSL info when ssl is true and verify_ssl is false", () => {
+    const instance = makeInstance({ ssl: true, verify_ssl: false });
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+    expect(screen.getByText(/SSL, unverified/)).toBeInTheDocument();
+  });
+
+  it("shows SSL verified info when ssl and verify_ssl are both true", () => {
+    const instance = makeInstance({ ssl: true, verify_ssl: true });
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+    expect(screen.getByText(/SSL, verified/)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Action: Edit button calls onEdit with the instance
+// ---------------------------------------------------------------------------
+
+describe("InstanceCard: Edit button", () => {
+  it("calls onEdit with the instance when clicked", async () => {
+    const user = userEvent.setup();
+    const instance = makeInstance();
+    const onEdit = vi.fn();
+
+    customRender(
+      <InstanceCard instance={instance} onEdit={onEdit} onDelete={vi.fn()} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Edit$/i }));
+
+    expect(onEdit).toHaveBeenCalledOnce();
+    expect(onEdit).toHaveBeenCalledWith(instance);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Action: Delete via overflow menu calls onDelete with the instance
+// ---------------------------------------------------------------------------
+
+describe("InstanceCard: Delete via overflow menu", () => {
+  it("calls onDelete with the instance when Delete menu item is clicked", async () => {
+    const user = userEvent.setup();
+    const instance = makeInstance();
+    const onDelete = vi.fn();
+
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={onDelete} />,
+    );
+
+    // Open the "..." menu
+    await user.click(
+      screen.getByRole("button", {
+        name: /More actions for Main Sonarr/i,
+      }),
+    );
+
+    // Click the Delete item
+    await user.click(await screen.findByRole("menuitem", { name: /Delete/i }));
+
+    expect(onDelete).toHaveBeenCalledOnce();
+    expect(onDelete).toHaveBeenCalledWith(instance);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Action: Test button fires the test-existing API and shows success status
+// ---------------------------------------------------------------------------
+
+describe("InstanceCard: Test button shows connection result", () => {
+  it("shows a Connected status after a successful test response", async () => {
+    setupTestEndpoint({ ok: true, version: "4.0.9", app_name: "Sonarr" });
+
+    const user = userEvent.setup();
+    const instance = makeInstance();
+
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Test$/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Connected: Sonarr v4\.0\.9/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows a failure status when the test response is not ok", async () => {
+    setupTestEndpoint({ ok: false, message: "Connection refused" });
+
+    const user = userEvent.setup();
+    const instance = makeInstance();
+
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Test$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Connection refused/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows a 'No API key stored' warning when error is unauthorized and no key is set", async () => {
+    setupTestEndpoint({ ok: false, error: "unauthorized" });
+
+    const user = userEvent.setup();
+    const instance = makeInstance({ api_key_set: false });
+
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Test$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/No API key stored/)).toBeInTheDocument();
+    });
+  });
+
+  it("dismisses the test result when the dismiss button is clicked", async () => {
+    setupTestEndpoint({ ok: true, version: "4.0.9", app_name: "Sonarr" });
+
+    const user = userEvent.setup();
+    const instance = makeInstance();
+
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Test$/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Connected: Sonarr v4\.0\.9/),
+      ).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /Dismiss test result/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Connected: Sonarr v4\.0\.9/),
+      ).not.toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Action: Enable/Disable toggle fires the update mutation
+// ---------------------------------------------------------------------------
+
+describe("InstanceCard: enable/disable toggle", () => {
+  it("fires the update mutation with enabled:false when toggling off", async () => {
+    setupUpdateEndpoint();
+
+    // Capture the PATCH request body so we can assert what was sent.
+    let patchBody: unknown = null;
+    server.use(
+      http.patch("/api/system/arr-instances/42", async ({ request }) => {
+        patchBody = await request.json();
+        return HttpResponse.json({ ...makeInstance(), enabled: false });
+      }),
+    );
+
+    const user = userEvent.setup();
+    const instance = makeInstance({ enabled: true });
+
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+
+    // Mantine Switch renders as a button (role="switch") with the aria-label
+    const toggle = screen.getByRole("switch", { name: /Disable instance/i });
+    await user.click(toggle);
+
+    await waitFor(() => {
+      expect(patchBody).toMatchObject({ enabled: false });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Action: Set as default via overflow menu fires the update mutation
+// ---------------------------------------------------------------------------
+
+describe("InstanceCard: Set as default menu item", () => {
+  it("fires the update mutation with is_default:true when Set as default is clicked", async () => {
+    let patchBody: unknown = null;
+    server.use(
+      http.patch("/api/system/arr-instances/42", async ({ request }) => {
+        patchBody = await request.json();
+        return HttpResponse.json({ ...makeInstance(), is_default: true });
+      }),
+    );
+
+    const user = userEvent.setup();
+    const instance = makeInstance({ is_default: false });
+
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /More actions for Main Sonarr/i }),
+    );
+    await user.click(
+      await screen.findByRole("menuitem", { name: /Set as default/i }),
+    );
+
+    await waitFor(() => {
+      expect(patchBody).toMatchObject({ is_default: true });
+    });
+  });
+
+  it("disables the Set as default item when already the default", async () => {
+    const user = userEvent.setup();
+    const instance = makeInstance({ is_default: true });
+
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /More actions for Main Sonarr/i }),
+    );
+
+    const setDefault = await screen.findByRole("menuitem", {
+      name: /Set as default/i,
+    });
+    expect(setDefault).toHaveAttribute("data-disabled", "true");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Webhook URL row is always rendered
+// ---------------------------------------------------------------------------
+
+describe("InstanceCard: webhook URL", () => {
+  it("renders the webhook URL row for the instance", () => {
+    const instance = makeInstance({ stable_key: "abc123" });
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+    // The webhook URL includes the kind and stable_key
+    const webhookEl = screen.getByText(/webhooks\/sonarr\/abc123/);
+    expect(webhookEl).toBeInTheDocument();
+  });
+
+  it("renders a copy webhook URL button", () => {
+    const instance = makeInstance();
+    customRender(
+      <InstanceCard instance={instance} onEdit={vi.fn()} onDelete={vi.fn()} />,
+    );
+    expect(
+      screen.getByRole("button", { name: /Copy webhook URL/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Settings/Connections/__tests__/InstanceFormModal.test.tsx
+++ b/frontend/src/pages/Settings/Connections/__tests__/InstanceFormModal.test.tsx
@@ -1,0 +1,480 @@
+/* eslint-disable camelcase */
+
+/**
+ * Tests for the InstanceFormModal component.
+ *
+ * Why: Verifies that the add/edit Sonarr/Radarr instance form renders its
+ * fields correctly, calls the create/update mutations with the right payload
+ * on submit, and blocks submission when required fields are empty.
+ *
+ * What: Renders InstanceFormModal with controlled props, uses
+ * @testing-library/user-event for interactions, and asserts mutation call
+ * arguments via vi.mock on the hooks module. For validation blocking tests,
+ * we use fireEvent.submit to check aria-invalid state synchronously before
+ * the StrictMode effect cycle clears it.
+ *
+ * Test: Run with `cd frontend && npx vitest run --reporter=verbose`.
+ */
+
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  ArrInstanceCreate,
+  ArrInstanceUpdate,
+} from "@/apis/raw/arrInstances";
+import InstanceFormModal from "@/pages/Settings/Connections/InstanceFormModal";
+import { customRender, fireEvent, screen, waitFor } from "@/tests";
+
+// ---------------------------------------------------------------------------
+// Mock the mutation hooks. We replace the whole @/apis/hooks module so that
+// each call to useCreateArrInstance / useUpdateArrInstance returns a spy whose
+// .mutate() we can inspect.
+// ---------------------------------------------------------------------------
+
+const mockCreateMutate = vi.fn();
+const mockUpdateMutate = vi.fn();
+const mockTestMutate = vi.fn();
+const mockTestByIdMutate = vi.fn();
+
+vi.mock("@/apis/hooks", async (importActual) => {
+  const actual = await importActual<typeof import("@/apis/hooks")>();
+  return {
+    ...actual,
+    useCreateArrInstance: () => ({
+      mutate: mockCreateMutate,
+      isPending: false,
+      isError: false,
+      reset: vi.fn(),
+    }),
+    useUpdateArrInstance: () => ({
+      mutate: mockUpdateMutate,
+      isPending: false,
+      isError: false,
+      reset: vi.fn(),
+    }),
+    useTestArrInstanceConnection: () => ({
+      mutate: mockTestMutate,
+      isPending: false,
+      isError: false,
+      data: undefined,
+      reset: vi.fn(),
+    }),
+    useTestArrInstanceById: () => ({
+      mutate: mockTestByIdMutate,
+      isPending: false,
+      isError: false,
+      data: undefined,
+      reset: vi.fn(),
+    }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeInstance(
+  overrides: Partial<{
+    kind: "sonarr" | "radarr";
+    name: string;
+    api_key_set: boolean;
+  }> = {},
+) {
+  return {
+    id: 42,
+    kind: (overrides.kind ?? "sonarr") as "sonarr" | "radarr",
+    stable_key: "stable-abc",
+    name: overrides.name ?? "Main Sonarr",
+    display_name: overrides.name ?? "Main Sonarr",
+    enabled: true,
+    is_default: false,
+    ip: "192.168.1.10",
+    port: 8989,
+    base_url: "",
+    ssl: false,
+    verify_ssl: true,
+    http_timeout: 60,
+    api_key_set: overrides.api_key_set ?? true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Submits the modal's form by dispatching a native submit event on the <form>
+ * element that contains the submit button. This is the only reliable way to
+ * trigger form-level validation synchronously in jsdom when the form lives
+ * inside a Mantine Modal portal (fireEvent.click on the submit button does
+ * not bubble correctly in jsdom portals).
+ */
+function submitForm(submitButtonName: string | RegExp): void {
+  const btn = screen.getByRole("button", { name: submitButtonName });
+  // eslint-disable-next-line testing-library/no-node-access
+  const form = btn.closest("form");
+  if (!form) throw new Error("Could not find <form> parent of submit button");
+  fireEvent.submit(form);
+}
+
+function renderAdd(kind: "sonarr" | "radarr" = "sonarr", onClose = vi.fn()) {
+  customRender(
+    <InstanceFormModal opened kind={kind} instance={null} onClose={onClose} />,
+  );
+}
+
+function renderEdit(
+  instance: ReturnType<typeof makeInstance>,
+  onClose = vi.fn(),
+) {
+  customRender(
+    <InstanceFormModal
+      opened
+      kind={instance.kind}
+      instance={instance}
+      onClose={onClose}
+    />,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("InstanceFormModal, add mode", () => {
+  it("renders the modal title for Sonarr", () => {
+    renderAdd("sonarr");
+    expect(screen.getByText("Add Sonarr instance")).toBeInTheDocument();
+  });
+
+  it("renders the modal title for Radarr", () => {
+    renderAdd("radarr");
+    expect(screen.getByText("Add Radarr instance")).toBeInTheDocument();
+  });
+
+  it("renders all required form fields", () => {
+    renderAdd();
+    expect(screen.getByRole("textbox", { name: /name/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: /address/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /port/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: /timeout/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the kind segmented control so the user can pick Sonarr vs Radarr", () => {
+    renderAdd();
+    expect(screen.getByRole("radio", { name: /sonarr/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /radarr/i })).toBeInTheDocument();
+  });
+
+  it("pre-fills Sonarr default port 8989", () => {
+    renderAdd("sonarr");
+    expect(screen.getByRole("textbox", { name: /port/i })).toHaveValue("8989");
+  });
+
+  it("pre-fills Radarr default port 7878", () => {
+    renderAdd("radarr");
+    expect(screen.getByRole("textbox", { name: /port/i })).toHaveValue("7878");
+  });
+
+  it("calls create mutation with the entered values on submit", async () => {
+    const user = userEvent.setup();
+    renderAdd("sonarr");
+
+    await user.clear(screen.getByRole("textbox", { name: /name/i }));
+    await user.type(
+      screen.getByRole("textbox", { name: /name/i }),
+      "Test Sonarr",
+    );
+    await user.clear(screen.getByRole("textbox", { name: /address/i }));
+    await user.type(
+      screen.getByRole("textbox", { name: /address/i }),
+      "10.0.0.1",
+    );
+
+    await user.click(screen.getByRole("button", { name: /add instance/i }));
+
+    await waitFor(() => {
+      expect(mockCreateMutate).toHaveBeenCalled();
+    });
+
+    const [body] = mockCreateMutate.mock.calls[0] as [
+      ArrInstanceCreate,
+      unknown,
+    ];
+    expect(body.kind).toBe("sonarr");
+    expect(body.name).toBe("Test Sonarr");
+    expect(body.ip).toBe("10.0.0.1");
+    expect(body.port).toBe(8989);
+  });
+
+  it("does NOT call create when Name is empty: marks the field invalid", async () => {
+    mockCreateMutate.mockClear();
+    renderAdd("sonarr");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("textbox", { name: /name/i }),
+      ).toBeInTheDocument();
+    });
+
+    // Fill address but leave name blank, then submit.
+    // Use fireEvent on the submit button to check the synchronous validation
+    // state before the StrictMode portal effect cycle clears errors.
+    const addressInput = screen.getByRole("textbox", { name: /address/i });
+    fireEvent.change(addressInput, { target: { value: "10.0.0.2" } });
+
+    submitForm(/add instance/i);
+
+    // Validation marks the field invalid synchronously before async effects run.
+    const nameInput = screen.getByRole("textbox", { name: /name/i });
+    expect(nameInput).toHaveAttribute("aria-invalid", "true");
+
+    // Mutation must never fire when validation fails.
+    expect(mockCreateMutate).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call create when Address is empty: marks the field invalid", async () => {
+    mockCreateMutate.mockClear();
+    renderAdd("sonarr");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("textbox", { name: /address/i }),
+      ).toBeInTheDocument();
+    });
+
+    const nameInput = screen.getByRole("textbox", { name: /name/i });
+    fireEvent.change(nameInput, { target: { value: "My Instance" } });
+
+    submitForm(/add instance/i);
+
+    const addressInput = screen.getByRole("textbox", { name: /address/i });
+    expect(addressInput).toHaveAttribute("aria-invalid", "true");
+
+    expect(mockCreateMutate).not.toHaveBeenCalled();
+  });
+
+  it("includes ssl: true in the payload when the SSL switch is toggled on", async () => {
+    const user = userEvent.setup();
+    renderAdd("sonarr");
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("switch", { name: /use ssl/i }),
+      ).toBeInTheDocument();
+    });
+
+    await user.type(
+      screen.getByRole("textbox", { name: /name/i }),
+      "SSL Instance",
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: /address/i }),
+      "10.0.0.3",
+    );
+
+    // Mantine Switch uses role="switch"
+    const sslSwitch = screen.getByRole("switch", { name: /use ssl/i });
+    await user.click(sslSwitch);
+
+    await user.click(screen.getByRole("button", { name: /add instance/i }));
+
+    await waitFor(() => {
+      expect(mockCreateMutate).toHaveBeenCalled();
+    });
+
+    const [body] = mockCreateMutate.mock.calls[0] as [
+      ArrInstanceCreate,
+      unknown,
+    ];
+    expect(body.ssl).toBe(true);
+  });
+
+  it("switches port default when the user changes kind via the segmented control", async () => {
+    const user = userEvent.setup();
+    renderAdd("sonarr");
+
+    expect(screen.getByRole("textbox", { name: /port/i })).toHaveValue("8989");
+
+    await user.click(screen.getByRole("radio", { name: /radarr/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: /port/i })).toHaveValue(
+        "7878",
+      );
+    });
+  });
+
+  it("calls Cancel and does not submit when the Cancel button is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    mockCreateMutate.mockClear();
+    customRender(
+      <InstanceFormModal
+        opened
+        kind="sonarr"
+        instance={null}
+        onClose={onClose}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(onClose).toHaveBeenCalled();
+    expect(mockCreateMutate).not.toHaveBeenCalled();
+  });
+});
+
+describe("InstanceFormModal, edit mode", () => {
+  it("renders the modal title with the instance name", () => {
+    renderEdit(makeInstance({ name: "Main Sonarr" }));
+    expect(screen.getByText("Edit Main Sonarr")).toBeInTheDocument();
+  });
+
+  it("pre-fills form fields from the existing instance", async () => {
+    renderEdit(makeInstance({ name: "4K Sonarr" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: /name/i })).toHaveValue(
+        "4K Sonarr",
+      );
+    });
+    expect(screen.getByRole("textbox", { name: /address/i })).toHaveValue(
+      "192.168.1.10",
+    );
+    expect(screen.getByRole("textbox", { name: /port/i })).toHaveValue("8989");
+  });
+
+  it("does NOT render the kind segmented control (kind is fixed for edit)", () => {
+    renderEdit(makeInstance());
+    expect(
+      screen.queryByRole("radio", { name: /sonarr/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("radio", { name: /radarr/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the Save button (not Add) in edit mode", () => {
+    renderEdit(makeInstance());
+    expect(
+      screen.getByRole("button", { name: /save changes/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /add instance/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("calls update mutation with the correct id and changed name on submit", async () => {
+    const user = userEvent.setup();
+    mockUpdateMutate.mockClear();
+    renderEdit(makeInstance({ name: "Old Name" }));
+
+    const nameInput = screen.getByRole("textbox", { name: /name/i });
+    await user.clear(nameInput);
+    await user.type(nameInput, "New Name");
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateMutate).toHaveBeenCalled();
+    });
+
+    const [args] = mockUpdateMutate.mock.calls[0] as [
+      { id: number; body: ArrInstanceUpdate },
+      unknown,
+    ];
+    expect(args.id).toBe(42);
+    expect(args.body.name).toBe("New Name");
+    expect(args.body.ip).toBe("192.168.1.10");
+    expect(args.body.port).toBe(8989);
+  });
+
+  it("does NOT call update when Name is cleared: marks the field invalid", async () => {
+    mockUpdateMutate.mockClear();
+    renderEdit(makeInstance({ name: "Existing" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("textbox", { name: /name/i }),
+      ).toBeInTheDocument();
+    });
+
+    const nameInput = screen.getByRole("textbox", { name: /name/i });
+    fireEvent.change(nameInput, { target: { value: "" } });
+
+    submitForm(/save changes/i);
+
+    expect(nameInput).toHaveAttribute("aria-invalid", "true");
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
+  });
+
+  it("shows the key-mode segmented control when api_key_set is true", async () => {
+    renderEdit(makeInstance({ api_key_set: true }));
+
+    await waitFor(() => {
+      // Key-mode controls: three radio options
+      expect(
+        screen.getByRole("radio", { name: /keep current key/i }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByRole("radio", { name: /replace/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /clear/i })).toBeInTheDocument();
+  });
+
+  it("shows the Stored badge when api_key_set is true", async () => {
+    renderEdit(makeInstance({ api_key_set: true }));
+
+    await waitFor(() => {
+      // The Badge with text "Stored" (capital S, standalone badge node)
+      const badge = screen.getByText((content, element) => {
+        return (
+          content === "Stored" && element !== null && element.tagName !== "BODY"
+        );
+      });
+      expect(badge).toBeInTheDocument();
+    });
+  });
+
+  it("does NOT show the Stored badge when api_key_set is false", () => {
+    renderEdit(makeInstance({ api_key_set: false }));
+    // The badge text is exactly "Stored" — no key-mode radios either
+    expect(
+      screen.queryByRole("radio", { name: /keep current key/i }),
+    ).not.toBeInTheDocument();
+    // Plain API Key label present instead
+    expect(screen.getByText("API Key")).toBeInTheDocument();
+  });
+
+  it("sends clear_api_key: true in the payload when the user selects Clear", async () => {
+    const user = userEvent.setup();
+    mockUpdateMutate.mockClear();
+    renderEdit(makeInstance({ api_key_set: true }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: /clear/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("radio", { name: /clear/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/will be removed/i)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateMutate).toHaveBeenCalled();
+    });
+
+    const [args] = mockUpdateMutate.mock.calls[0] as [
+      { id: number; body: ArrInstanceUpdate },
+      unknown,
+    ];
+    expect(args.body.clear_api_key).toBe(true);
+  });
+});

--- a/frontend/src/pages/views/__tests__/ItemOverview.test.tsx
+++ b/frontend/src/pages/views/__tests__/ItemOverview.test.tsx
@@ -1,0 +1,230 @@
+/* eslint-disable camelcase */
+
+/**
+ * Tests for ItemOverview component.
+ *
+ * Why: Verifies that the shared media overview card renders the item title and
+ * each passed detail entry (icon + text), that a null item renders without
+ * crashing, and that audio language badges and the file-path badge appear when
+ * the item is present.
+ *
+ * What: Renders ItemOverview directly with controlled props and asserts DOM
+ * content via Testing Library queries.
+ *
+ * Test: Run with `cd frontend && npx vitest run --reporter=verbose`.
+ */
+
+import { faCalendarAlt, faHardDrive } from "@fortawesome/free-solid-svg-icons";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+import ItemOverview from "@/pages/views/ItemOverview";
+import { customRender, screen, waitFor } from "@/tests";
+import server from "@/tests/mocks/node";
+
+// The component renders useLanguages() which calls /api/system/languages?history=false
+// on every mount. Add a default handler for every test in this file.
+beforeEach(() => {
+  server.use(http.get("/api/system/languages", () => HttpResponse.json([])));
+});
+
+// ---------------------------------------------------------------------------
+// Shared fixture
+// ---------------------------------------------------------------------------
+
+function makeItem(overrides?: Partial<Item.Base>): Item.Base {
+  return {
+    title: "Test Movie Title",
+    path: "/media/test.mkv",
+    profileId: null,
+    fanart: "",
+    overview: "A test movie overview text.",
+    imdbId: "tt0000001",
+    alternativeTitles: [],
+    poster: "",
+    year: "2024",
+    monitored: true,
+    tags: [],
+    audio_language: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Title renders when item is provided
+// ---------------------------------------------------------------------------
+
+describe("ItemOverview, title rendering", () => {
+  it("renders the item title in the heading area", async () => {
+    customRender(<ItemOverview item={makeItem()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Test Movie Title")).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: Detail badges render their text
+// ---------------------------------------------------------------------------
+
+describe("ItemOverview, detail badge rendering", () => {
+  it("renders each detail entry text as a badge", async () => {
+    const details = [
+      { icon: faHardDrive, text: "1.4 GB" },
+      { icon: faCalendarAlt, text: "2024" },
+    ];
+
+    customRender(<ItemOverview item={makeItem()} details={details} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("1.4 GB")).toBeInTheDocument();
+    });
+    expect(screen.getByText("2024")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: File-path badge is rendered for the item's path
+// ---------------------------------------------------------------------------
+
+describe("ItemOverview, file-path badge", () => {
+  it("renders the item file path as a badge", async () => {
+    customRender(<ItemOverview item={makeItem()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("/media/test.mkv")).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: Audio language badge appears when item has audio_language entries
+// ---------------------------------------------------------------------------
+
+describe("ItemOverview, audio language badges", () => {
+  it("renders audio language badge for each audio track", async () => {
+    const item = makeItem({
+      audio_language: [
+        { code2: "en", name: "English" },
+        { code2: "fr", name: "French" },
+      ],
+    });
+
+    customRender(<ItemOverview item={item} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("English")).toBeInTheDocument();
+    });
+    expect(screen.getByText("French")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: Tags badge joins tags with a pipe when tags are present
+// ---------------------------------------------------------------------------
+
+describe("ItemOverview, tags badge", () => {
+  it("renders joined tags in a badge when item has tags", async () => {
+    const item = makeItem({ tags: ["hd", "bluray"] });
+
+    customRender(<ItemOverview item={item} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("hd|bluray")).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 6: null item renders without crashing (loading state)
+// ---------------------------------------------------------------------------
+
+describe("ItemOverview, null item", () => {
+  it("renders without crashing when item is null", () => {
+    // Must not throw — the component should render the shell with no content.
+    expect(() => {
+      customRender(<ItemOverview item={null} />);
+    }).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 7: Language profile badge shows when profile matches item's profileId
+// ---------------------------------------------------------------------------
+
+describe("ItemOverview, language profile badge", () => {
+  it("renders the language profile name when a matching profile is found", async () => {
+    server.use(
+      http.get("/api/system/languages/profiles", () =>
+        HttpResponse.json([
+          {
+            name: "English (Best)",
+            profileId: 7,
+            cutoff: null,
+            items: [],
+            mustContain: [],
+            mustNotContain: [],
+            originalFormat: null,
+            tag: undefined,
+          },
+        ]),
+      ),
+    );
+
+    const item = makeItem({ profileId: 7 });
+    customRender(<ItemOverview item={item} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("English (Best)")).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 8: overview text appears in the card
+// ---------------------------------------------------------------------------
+
+describe("ItemOverview, overview text", () => {
+  it("renders the item overview description text", async () => {
+    const item = makeItem({ overview: "A gripping tale of adventure." });
+
+    customRender(<ItemOverview item={item} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("A gripping tale of adventure."),
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 9: monitored vs unmonitored icon uses different icon variant
+// ---------------------------------------------------------------------------
+
+describe("ItemOverview, monitored icon variant", () => {
+  it("renders the solid bookmark icon (fas) for a monitored item", async () => {
+    customRender(<ItemOverview item={makeItem({ monitored: true })} />);
+
+    // Solid (fas) bookmark = monitored. FontAwesome renders the SVG with
+    // data-prefix="fas" and data-icon="bookmark".
+    await waitFor(() => {
+      const svgs = document.querySelectorAll(
+        'svg[data-prefix="fas"][data-icon="bookmark"]',
+      );
+      expect(svgs.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("renders the regular bookmark icon (far) for an unmonitored item", async () => {
+    customRender(<ItemOverview item={makeItem({ monitored: false })} />);
+
+    // Regular (far) bookmark = unmonitored.
+    await waitFor(() => {
+      const svgs = document.querySelectorAll(
+        'svg[data-prefix="far"][data-icon="bookmark"]',
+      );
+      expect(svgs.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
Third phase of the frontend test-coverage plan — settings & the multi-instance Connections UI. **No production code changed.**

## New tests
- **`apis/raw/system.ts` `updateSettings`** (10) — cleared (`null`) values are POSTed as the string `"null"` (→ backend `None`/disabled) while `undefined` is omitted and other values/arrays pass through. Locks the "settings silently failed to clear" fix.
- **`pages/views/ItemOverview`** (10) — title, detail badges, audio-language/tags badges, language-profile badge, and monitored/unmonitored icon render; null item is safe. Shared component used by every detail page.
- **`Settings/Connections/InstanceFormModal`** (22) — the add/edit Sonarr/Radarr instance form submits the correct create/update payload (incl. clear-api-key path); required-field validation blocks submit.
- **`Settings/Connections/InstanceCard`** (21) — renders instance name/URL/SSL/key-status/timeout; edit/delete/test-connection/enable-toggle/set-default fire the right handlers and PATCH bodies.

## Verification
- `tsc` 0 errors, `eslint src` 0 errors (warnings only), `prettier` clean.
- Full vitest suite green: **69 files, 684 passed, 2 skipped** (+63 tests).

Follows #256 (Phase 1) and #257 (Phase 2); all three are independent (new files only) and merge cleanly.
