### PR TITLE
fix(deps): bump msgpack to 1.2.1 (GHSA-6v7p-g79w-8964) via signalrcore --no-deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,11 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ffmpeg
 
       - name: Install Python dependencies
-        run: pip install -r requirements.txt
+        run: |
+          pip install -r requirements.txt
+          # signalrcore over-pins msgpack==1.1.2 (GHSA-6v7p-g79w-8964); install it
+          # with --no-deps so our msgpack==1.2.1 from requirements.txt wins.
+          pip install --no-deps signalrcore==1.0.2
 
       - name: Install dev dependencies
         run: pip install -r dev-requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ COPY requirements.txt postgres-requirements.txt ./
 # Use pip cache mount to avoid re-downloading packages across builds
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install --prefix=/install --ignore-installed "setuptools>=82.0.1" \
-    && pip install --prefix=/install -r requirements.txt -r postgres-requirements.txt
+    && pip install --prefix=/install -r requirements.txt -r postgres-requirements.txt \
+    && pip install --prefix=/install --no-deps signalrcore==1.0.2
 
 # =============================================================================
 # Stage 2: Build ALASS CLI

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ cd bazarr
 
 # Install Python dependencies
 pip install -r requirements.txt
+# signalrcore over-pins the vulnerable msgpack==1.1.2, so install it with
+# --no-deps (its only runtime dep is msgpack, pinned to 1.2.1 above)
+pip install --no-deps signalrcore==1.0.2
 
 # Build the frontend
 cd frontend && npm ci && npm run build && cd ..

--- a/bazarr/app/requirements.py
+++ b/bazarr/app/requirements.py
@@ -138,7 +138,7 @@ RUNTIME_REQUIREMENTS = {
     "json_tricks": ("json_tricks", "==3.17.3"),
     "knowit": ("knowit", "==0.5.11"),
     "lxml": ("lxml", ">=6.1.0"),
-    "msgpack": ("msgpack", "==1.1.2"),
+    "msgpack": ("msgpack", "==1.2.1"),  # signalrcore over-pins ==1.1.2; we install signalrcore --no-deps
     "numpy": ("numpy", ">=2.0.0,<2.4.0"),
     "PIL": ("Pillow", ">=12.2.0"),
     "plexapi": ("plexapi", ">=4.16.1"),
@@ -298,8 +298,29 @@ def install_requirements(missing_modules=None):
     if not is_virtualenv():
         pip_command.insert(4, "--user")
 
+    # signalrcore is kept out of requirements.txt because its metadata hard-pins
+    # the vulnerable msgpack==1.1.2 (GHSA-6v7p-g79w-8964), which the resolver
+    # would force over our msgpack==1.2.1. Its only runtime dep is msgpack, so we
+    # install it with --no-deps. Version comes from RUNTIME_REQUIREMENTS so there
+    # is a single source of truth.
+    sc_dist, sc_spec = RUNTIME_REQUIREMENTS["signalrcore"]
+    signalrcore_command = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "-qq",
+        "--disable-pip-version-check",
+        "--no-deps",
+        f"{sc_dist}{sc_spec}",
+    ]
+    if not is_virtualenv():
+        signalrcore_command.insert(4, "--user")
+
     try:
         subprocess.check_output(pip_command, stderr=subprocess.STDOUT)
+        subprocess.check_output(signalrcore_command, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         logging.exception("BAZARR requirements.txt installation result: %s", e.stdout)
         os._exit(EXIT_REQUIREMENTS_ERROR)

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ itsdangerous==2.2.0
 json_tricks==3.17.3
 knowit==0.5.11
 lxml>=6.1.1  # XXE fix in iterparse / ETCompatXMLParser
-msgpack==1.1.2  # pinned by signalrcore==1.0.2 (its only allowed version); cannot bump to 1.2.1 without breaking signalrcore
+msgpack==1.2.1  # GHSA-6v7p-g79w-8964 fix. signalrcore 1.0.2 over-pins msgpack==1.1.2 in its metadata, so it is installed with --no-deps (see Dockerfile, .github/workflows/ci.yml, bazarr/app/requirements.py). Bazarr forces the JSON SignalR protocol, so msgpack's MessagePack path is never used, and 1.2.1 is runtime-compatible with signalrcore 1.0.2 (verified).
 numpy>=2.4.6,<2.5.0  # cap excludes entire 2.4.x line: it raised the x86-64 baseline to v2, crashing pre-2009 CPUs (SIGILL on import). 2.4.0 itself is also yanked for an unrelated BC bug.
 Pillow>=12.2.0 --only-binary=Pillow
 plexapi>=4.18.1
@@ -56,7 +56,11 @@ rarfile==4.2
 requests==2.34.2
 retry==0.9.2
 semver==3.0.4
-signalrcore==1.0.2
+# signalrcore==1.0.2 is installed with --no-deps (Dockerfile, ci.yml,
+# bazarr/app/requirements.py). Its metadata hard-pins the vulnerable
+# msgpack==1.1.2 (GHSA-6v7p-g79w-8964), but its only runtime dep is msgpack,
+# which we pin above at 1.2.1. Keeping it out of the normal resolve avoids the
+# ResolutionImpossible conflict and keeps Dependabot off the transitive pin.
 six==1.17.0
 sqlalchemy==2.0.51
 srt==3.5.3


### PR DESCRIPTION
## Problem
Dependabot flags **msgpack** (high, GHSA-6v7p-g79w-8964): vulnerable `<= 1.2.0`, fixed `1.2.1`. It was pinned at `1.1.2` because `signalrcore==1.0.2` (the latest signalrcore; no newer release exists) hard-pins `msgpack==1.1.2` in its metadata, and pip's resolver refuses `msgpack==1.2.1` alongside it (`ResolutionImpossible`).

## Why it's safe
- `signalrcore`'s **only** non-dev runtime dependency is `msgpack`.
- Bazarr **forces the JSON SignalR protocol** (`test_signalrcore_compat.py` asserts `protocol == "json"`), so msgpack's MessagePack deserialization path (where the advisory lives) is never exercised at runtime.
- Verified in a clean venv: `signalrcore==1.0.2` + `msgpack==1.2.1` import fine, both JSON and MessagePack protocols load, and the msgpack pack/unpack roundtrip works.

## Change
Pin `msgpack==1.2.1` in `requirements.txt` and install `signalrcore==1.0.2` with `--no-deps` (it loses nothing but the over-strict msgpack pin) in every install path:
- `requirements.txt` (msgpack bumped; signalrcore moved to a documented comment so the resolver and Dependabot don't see its transitive `==1.1.2`)
- `Dockerfile` (production image)
- `.github/workflows/ci.yml` (backend test env)
- `bazarr/app/requirements.py` (runtime auto-installer + version guard)
- `README.md` (manual install)

## Tests
`test_signalrcore_compat.py` + `test_dependency_loading.py` pass locally (27), ruff clean. Full backend matrix runs here on CI.