### PR TITLE
fix(binaries): extract RAR via system 7z, stop self-downloading unrar

### DIFF
--- a/bazarr/init.py
+++ b/bazarr/init.py
@@ -189,37 +189,42 @@ if not hasattr(settings.general, 'provider_priorities') or not settings.general.
 
 
 def init_binaries():
+    # RAR archives are extracted with p7zip's 7z, matching the Dockerfile
+    # (installs p7zip-full; no unrar/unar package or self-download). 7z is tried
+    # first. unar/unrar remain only as a best-effort fallback for environments
+    # that already have them on PATH; they are no longer in binaries.json, so
+    # get_binary never attempts a (read-only, failing) self-download for them.
     try:
-        exe = get_binary("unar")
-        rarfile.UNAR_TOOL = exe
+        exe = get_binary("7z")
         rarfile.UNRAR_TOOL = None
-        rarfile.SEVENZIP_TOOL = None
-        rarfile.tool_setup(unrar=False, unar=True, bsdtar=False, sevenzip=False, force=True)
+        rarfile.UNAR_TOOL = None
+        rarfile.SEVENZIP_TOOL = exe
+        rarfile.tool_setup(unrar=False, unar=False, bsdtar=False, sevenzip=True, force=True)
     except (BinaryNotFound, rarfile.RarCannotExec):
         try:
-            exe = get_binary("unrar")
-            rarfile.UNRAR_TOOL = exe
-            rarfile.UNAR_TOOL = None
+            exe = get_binary("unar")
+            rarfile.UNAR_TOOL = exe
+            rarfile.UNRAR_TOOL = None
             rarfile.SEVENZIP_TOOL = None
-            rarfile.tool_setup(unrar=True, unar=False, bsdtar=False, sevenzip=False, force=True)
+            rarfile.tool_setup(unrar=False, unar=True, bsdtar=False, sevenzip=False, force=True)
         except (BinaryNotFound, rarfile.RarCannotExec):
             try:
-                exe = get_binary("7z")
-                rarfile.UNRAR_TOOL = None
+                exe = get_binary("unrar")
+                rarfile.UNRAR_TOOL = exe
                 rarfile.UNAR_TOOL = None
-                rarfile.SEVENZIP_TOOL = "7z"
-                rarfile.tool_setup(unrar=False, unar=False, bsdtar=False, sevenzip=True, force=True)
+                rarfile.SEVENZIP_TOOL = None
+                rarfile.tool_setup(unrar=True, unar=False, bsdtar=False, sevenzip=False, force=True)
             except (BinaryNotFound, rarfile.RarCannotExec):
-                logging.exception("BAZARR requires a rar archive extraction utilities (unrar, unar, 7zip) and it can't be found.")
+                logging.exception("BAZARR requires a rar archive extraction utility (7z, unar, or unrar) and none could be found.")
                 raise BinaryNotFound
             else:
-                logging.debug("Using 7zip from: %s", exe)
+                logging.debug("Using UnRAR from: %s", exe)
                 return exe
         else:
-            logging.debug("Using UnRAR from: %s", exe)
+            logging.debug("Using unar from: %s", exe)
             return exe
     else:
-        logging.debug("Using unar from: %s", exe)
+        logging.debug("Using 7zip from: %s", exe)
         return exe
 
 

--- a/bazarr/utilities/binaries.json
+++ b/bazarr/utilities/binaries.json
@@ -1,22 +1,6 @@
 [
   {
     "system": "Linux",
-    "machine": "aarch64",
-    "directory": "unrar",
-    "name": "unrar",
-    "checksum": "be7a08a75ffb1dcc5f8c6b16a75e822c",
-    "url": "https://github.com/LavX/bazarr-binaries/raw/master/bin/Linux/aarch64/unrar/unrar"
-  },
-  {
-    "system": "Linux",
-    "machine": "armv5tel",
-    "directory": "unrar",
-    "name": "unrar",
-    "checksum": "07a6371cc7db8493352739ce26b19ea1",
-    "url": "https://github.com/LavX/bazarr-binaries/raw/master/bin/Linux/armv5tel/unrar/unrar"
-  },
-  {
-    "system": "Linux",
     "machine": "i386",
     "directory": "ffmpeg",
     "name": "ffmpeg",
@@ -33,14 +17,6 @@
   },
   {
     "system": "Linux",
-    "machine": "i386",
-    "directory": "unrar",
-    "name": "unrar",
-    "checksum": "f03ae1d4abf871b95142a7248a6cfa3a",
-    "url": "https://github.com/LavX/bazarr-binaries/raw/master/bin/Linux/i386/unrar/unrar"
-  },
-  {
-    "system": "Linux",
     "machine": "x86_64",
     "directory": "ffmpeg",
     "name": "ffmpeg",
@@ -54,14 +30,6 @@
     "name": "ffprobe",
     "checksum": "29fdc34d9c7ad07c8f75e83d8fb5965b",
     "url": "https://github.com/LavX/bazarr-binaries/raw/master/bin/Linux/x86_64/ffmpeg/ffprobe"
-  },
-  {
-    "system": "Linux",
-    "machine": "x86_64",
-    "directory": "unrar",
-    "name": "unrar",
-    "checksum": "2a63e80d50c039e1fba01de7dcfa6432",
-    "url": "https://github.com/LavX/bazarr-binaries/raw/master/bin/Linux/x86_64/unrar/unrar"
   },
   {
     "system": "MacOSX",
@@ -81,14 +49,6 @@
   },
   {
     "system": "MacOSX",
-    "machine": "i386",
-    "directory": "unrar",
-    "name": "unrar",
-    "checksum": "47de1fed0a5d4f7bac4d8f7557926398",
-    "url": "https://github.com/LavX/bazarr-binaries/raw/master/bin/MacOSX/i386/unrar/unrar"
-  },
-  {
-    "system": "MacOSX",
     "machine": "x86_64",
     "directory": "ffmpeg",
     "name": "ffmpeg",
@@ -105,14 +65,6 @@
   },
   {
     "system": "MacOSX",
-    "machine": "x86_64",
-    "directory": "unrar",
-    "name": "unrar",
-    "checksum": "8d5b3d5d6be2c14b74b02767430ade9c",
-    "url": "https://github.com/LavX/bazarr-binaries/raw/master/bin/MacOSX/x86_64/unrar/unrar"
-  },
-  {
-    "system": "MacOSX",
     "machine": "arm64",
     "directory": "ffmpeg",
     "name": "ffmpeg",
@@ -126,14 +78,6 @@
     "name": "ffprobe",
     "checksum": "d81468cebd6630450d2f5a17720b4504",
     "url": "https://github.com/LavX/bazarr-binaries/raw/master/bin/MacOSX/x86_64/ffmpeg/ffprobe"
-  },
-  {
-    "system": "MacOSX",
-    "machine": "arm64",
-    "directory": "unrar",
-    "name": "unrar",
-    "checksum": "8d5b3d5d6be2c14b74b02767430ade9c",
-    "url": "https://github.com/LavX/bazarr-binaries/raw/master/bin/MacOSX/x86_64/unrar/unrar"
   },
   {
     "system": "Windows",
@@ -150,13 +94,5 @@
     "name": "ffprobe.exe",
     "checksum": "a0d88aa85624070a8ab65ed99c214bea",
     "url": "https://github.com/LavX/bazarr-binaries/raw/master/bin/Windows/i386/ffmpeg/ffprobe.exe"
-  },
-  {
-    "system": "Windows",
-    "machine": "i386",
-    "directory": "unrar",
-    "name": "unrar.exe",
-    "checksum": "4611a5b3f70a8d6c40776e0bfa3b3f36",
-    "url": "https://github.com/LavX/bazarr-binaries/raw/master/bin/Windows/i386/unrar/UnRAR.exe"
   }
 ]

--- a/tests/bazarr/test_dependency_loading.py
+++ b/tests/bazarr/test_dependency_loading.py
@@ -132,6 +132,24 @@ def test_msgpack_is_not_bundled_and_can_follow_signalrcore_dependency():
     assert not msgpack_path.is_relative_to(libs_dir)
 
 
+def test_binaries_json_does_not_self_download_rar_tools():
+    # RAR archives are extracted via p7zip's 7z (Dockerfile installs p7zip-full,
+    # no unrar/unar package). Listing unrar/unar here makes init_binaries try to
+    # download them into the read-only /app/bazarr/bin dir at startup
+    # (PermissionError) before falling back to 7z, so they must stay out.
+    import json
+
+    repo_root = Path(__file__).resolve().parents[2]
+    binaries = json.loads(
+        (repo_root / "bazarr" / "utilities" / "binaries.json").read_text()
+    )
+    names = {entry["name"].lower() for entry in binaries}
+
+    assert "unrar" not in names
+    assert "unrar.exe" not in names
+    assert "unar" not in names
+
+
 def test_third_party_libs_directory_is_not_part_of_runtime_or_tests():
     repo_root = Path(__file__).resolve().parents[2]
 


### PR DESCRIPTION
## Problem
On every startup the container logs a PermissionError:

```
ERROR (binaries:108) - BAZARR unable to download unrar to /app/bazarr/bin/Linux/x86_64/unrar ... PermissionError: [Errno 13] Permission denied: '/app/bazarr/bin/Linux'
```

The packaging was already moved to 7z (`1dd93850d`, `daaa5bf15`; the Dockerfile installs **p7zip-full** and says *"RAR archives ... extracted via p7zip's 7z binary, so no non-free repo or unrar package needed"*). But the **runtime** path was never updated: `init_binaries()` tried `get_binary("unar")` then `get_binary("unrar")` first, and since `unrar` is still listed in `binaries.json`, `get_binary` attempts a self-download into the read-only `/app/bazarr/bin` dir (fails) before finally falling back to 7z. (`binaries.py`/`init.py`/`binaries.json` were untouched since 2023.)

## Fix
- Remove the `unrar`/`unrar.exe` entries from `bazarr/utilities/binaries.json` (8 entries) so `get_binary` raises `BinaryNotFound` immediately, no `makedirs`/download.
- Reorder `init_binaries()` to try system **7z first** (matching the Dockerfile), keeping unar/unrar only as PATH-only fallbacks.
- Regression test: `binaries.json` must not list unrar/unar.

RAR extraction keeps working via 7z (as designed); the startup error is gone.

## Tests
`test_dependency_loading.py` green (23), ruff clean. Full backend matrix on CI.