### PR TITLE
test(settings): fix flaky jellyfin render test (provide FormContext)

### DIFF
--- a/frontend/src/pages/Settings/settings.test.tsx
+++ b/frontend/src/pages/Settings/settings.test.tsx
@@ -1,14 +1,33 @@
+import { FunctionComponent } from "react";
+import { useForm } from "@mantine/form";
 import { http } from "msw";
 import { HttpResponse } from "msw";
 import server from "@/tests/mocks/node";
 import { renderTest, RenderTestCase } from "@/tests/render";
 import JellyfinSection from "./Jellyfin/JellyfinSection";
+import { FormContext, type FormValues } from "./utilities/FormValues";
 import SettingsGeneralView from "./General";
 import SettingsLanguagesView from "./Languages";
 import SettingsProvidersView from "./Providers";
 import SettingsSchedulerView from "./Scheduler";
 import SettingsSubtitlesView from "./Subtitles";
 import SettingsUIView from "./UI";
+
+// JellyfinSection normally renders inside the Connections page Layout, which
+// provides the settings FormContext. Rendered bare, its inputs call
+// useFormValues() with no context and throw (caught by the error boundary);
+// under React 19 concurrent rendering that surfaced as a flaky test failure.
+// Wrap it in a FormContext the way the app mounts it.
+const JellyfinWithForm: FunctionComponent = () => {
+  const form = useForm<FormValues>({
+    initialValues: { settings: {}, hooks: {} },
+  });
+  return (
+    <FormContext.Provider value={form}>
+      <JellyfinSection />
+    </FormContext.Provider>
+  );
+};
 
 const cases: RenderTestCase[] = [
   {
@@ -58,7 +77,7 @@ const cases: RenderTestCase[] = [
   // TODO: Test Radarr Page
   {
     name: "jellyfin page",
-    ui: JellyfinSection,
+    ui: JellyfinWithForm,
   },
   {
     name: "scheduler page",


### PR DESCRIPTION
## Problem
`settings.test.tsx > "jellyfin page should render"` intermittently failed CI with `useFormValues must be used within a FormContext` (caught by the router error boundary). It passed locally (4/4) and on parallel CI runs at the same commit, so it was a flake exposed by the React 19 upgrade's concurrent rendering.

## Root cause
The other settings cases render full Views (e.g. `SettingsGeneralView`) which include `<Layout>` → provides the settings `FormContext`. The jellyfin case rendered the bare `JellyfinSection`, whose inputs (`Check`, `useSettingValue`, ...) call `useFormValues()` and throw when there is no `FormContext`. The error was swallowed by the error boundary most of the time, but React 19 surfaced it as a failure intermittently.

## Fix
Wrap the jellyfin case in a `FormContext` provider (empty Mantine form) the way `JellyfinSection` actually mounts inside the Connections page Layout. It now renders for real (no error boundary) and deterministically. With an empty form, jellyfin is disabled so the library query stays gated — no new mocks needed.

## Verify
`settings.test.tsx` 4/4 stable locally; full coverage suite green (833), tsc/eslint/prettier clean.