### PR TITLE
fix(arr): heal scalar config from default instance + refresh Discord invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://ghcr.io/lavx/bazarr"><img src="https://img.shields.io/badge/ghcr.io-lavx%2Fbazarr-blue?style=for-the-badge&logo=docker" alt="Docker"></a>
   <a href="https://github.com/LavX/bazarr/releases/latest"><img src="https://img.shields.io/github/v/release/LavX/bazarr?style=for-the-badge&label=RELEASE" alt="Latest Release"></a>
   <a href="https://github.com/LavX/bazarr/actions/workflows/build-docker.yml"><img src="https://img.shields.io/github/actions/workflow/status/LavX/bazarr/build-docker.yml?style=for-the-badge&label=DOCKER%20BUILD" alt="Docker Build"></a>
-  <a href="https://discord.gg/WSVzzaDg"><img src="https://img.shields.io/badge/Discord-Join%20Chat-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://discord.gg/fpp5JXmB8f"><img src="https://img.shields.io/badge/Discord-Join%20Chat-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
 <p align="center">

--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -822,6 +822,21 @@ def migrate_db(app):
         database.rollback()
         logging.exception("Multi-instance default backfill failed; continuing startup")
 
+    # Heal installs whose default instance was created directly via the API
+    # (onboarding wizard / Connections page) rather than backfilled from the
+    # scalar config: their scalar settings.<kind>.* never got populated, so the
+    # single-instance compat paths poll the default 127.0.0.1:8989 / :7878 and
+    # spam connection-refused errors (#276). Mirror the default instance back
+    # into the scalar config. Idempotent (write_config short-circuits when the
+    # config is unchanged, e.g. for backfilled installs) and guarded so a hiccup
+    # never blocks startup.
+    try:
+        from arr_instances.service import mirror_scalar_config_from_default
+        for _kind in ("sonarr", "radarr"):
+            mirror_scalar_config_from_default(database, _kind)
+    except Exception:
+        logging.exception("Scalar-config reconcile from default instances failed; continuing startup")
+
     optimize_sqlite_database(engine)
 
     # Refresh the cached migration revision now that pending migrations have run. init_db()

--- a/bazarr/arr_instances/service.py
+++ b/bazarr/arr_instances/service.py
@@ -34,6 +34,59 @@ def event_stream(*args, **kwargs):
     _event_stream(*args, **kwargs)
 
 
+def mirror_scalar_config_from_default(session, kind):
+    """Mirror the default instance's connection details into the scalar
+    ``settings.<kind>.*`` config so the single-instance compat paths target the
+    real server (#276).
+
+    Several legacy paths (the health-check rootfolder validation, the shared
+    ``get_<kind>_info`` version probe via ``url_<kind>()``, and the SignalR /
+    scheduler fall-back) read the scalar config whenever there is exactly ONE
+    instance of a kind, on the documented assumption that the scalar config
+    equals the default instance. That holds for installs upgraded via
+    ``backfill`` (which built the instance FROM the scalar config), but NOT for
+    instances created directly through the API (the onboarding wizard and the
+    Connections page), which never populated the scalar config. Those installs
+    then poll the default ``127.0.0.1:8989`` / ``:7878`` and spam
+    connection-refused errors even though the per-instance sync works fine.
+    Re-establish the invariant by copying the default instance back into the
+    scalar config after every create/update.
+
+    Best-effort and called only AFTER the row is committed, so a failure here
+    must never fail the CRUD request (the caller guards it).
+    """
+    if kind not in ("sonarr", "radarr"):
+        return
+    repo = ArrInstanceRepository(session)
+    default = repo.get_default(kind)
+    if default is None:
+        return
+    from app.config import settings, write_config
+    section = getattr(settings, kind)
+    before = (section.ip, section.port, section.base_url, bool(section.ssl),
+              bool(section.verify_ssl), int(section.http_timeout or 60), section.apikey)
+    section.ip = default.ip or "127.0.0.1"
+    if default.port:
+        section.port = int(default.port)
+    section.base_url = default.base_url or "/"
+    section.ssl = bool(default.ssl)
+    section.verify_ssl = bool(default.verify_ssl)
+    section.http_timeout = int(default.http_timeout or 60)
+    api_key = repo.get_decrypted_api_key(default.id)
+    if api_key is not None:
+        section.apikey = api_key
+    after = (section.ip, section.port, section.base_url, bool(section.ssl),
+             bool(section.verify_ssl), int(section.http_timeout or 60), section.apikey)
+    # Only persist when something actually changed: on the steady-state boot the
+    # scalar config already matches the default instance, and an unconditional
+    # write_config() would rewrite config.yaml on every startup for nothing.
+    if before != after:
+        logging.info(
+            "Mirrored default %s instance (%s:%s) into the scalar config (#276)",
+            kind, section.ip, section.port)
+        write_config()
+
+
 def refresh_runtime(kind, instance_id=None, removed=False):
     """Rebuild scheduler sync jobs and re-fan-out the affected kind's SignalR
     feed after an instance create/update/delete (#156).
@@ -65,6 +118,17 @@ def refresh_runtime(kind, instance_id=None, removed=False):
 
     if kind not in VALID_KINDS:
         return
+
+    # Keep the scalar settings.<kind>.* config mirroring the default instance so
+    # the single-instance compat paths (health check, get_<kind>_info version
+    # probe, scheduler/SignalR fall-back) target the real server, not the default
+    # 127.0.0.1:8989 / :7878 (#276). Best-effort, like the SignalR restart below.
+    try:
+        from app.database import database
+        mirror_scalar_config_from_default(database, kind)
+    except Exception:
+        logging.exception("Failed to mirror scalar config from default %s instance", kind)
+
     try:
         from app.scheduler import scheduler
 

--- a/frontend/src/pages/System/Status/index.tsx
+++ b/frontend/src/pages/System/Status/index.tsx
@@ -228,7 +228,7 @@ const SystemStatusView: FunctionComponent = () => {
             </Label>
           </Row>
           <Row title="Community">
-            <Label icon={faDiscord} link="https://discord.gg/WSVzzaDg">
+            <Label icon={faDiscord} link="https://discord.gg/fpp5JXmB8f">
               Bazarr+ on Discord
             </Label>
           </Row>

--- a/site/index.html
+++ b/site/index.html
@@ -168,7 +168,7 @@
     <a href="#roadmap-heading">Roadmap</a>
     <a href="guides/">Guides</a>
     <a href="https://github.com/LavX/bazarr" target="_blank" rel="noopener">GitHub</a>
-    <a href="https://discord.gg/WSVzzaDg" target="_blank" rel="noopener">Discord</a>
+    <a href="https://discord.gg/fpp5JXmB8f" target="_blank" rel="noopener">Discord</a>
   </div>
 </nav>
 
@@ -507,7 +507,7 @@
             <svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
           </button>
           <div class="faq-answer" id="faq-a6" role="region" aria-labelledby="faq-q6">
-            <div class="faq-answer-inner">Join our <a href="https://discord.gg/WSVzzaDg" target="_blank" rel="noopener">Discord server</a> for help and discussion, or open an issue on <a href="https://github.com/LavX/bazarr/issues" target="_blank" rel="noopener">GitHub</a>. The <a href="guides/">guides section</a> covers installation, AI translation setup, and migration in detail.</div>
+            <div class="faq-answer-inner">Join our <a href="https://discord.gg/fpp5JXmB8f" target="_blank" rel="noopener">Discord server</a> for help and discussion, or open an issue on <a href="https://github.com/LavX/bazarr/issues" target="_blank" rel="noopener">GitHub</a>. The <a href="guides/">guides section</a> covers installation, AI translation setup, and migration in detail.</div>
           </div>
         </div>
       </div>
@@ -562,7 +562,7 @@
         <li><a href="https://github.com/LavX/bazarr" target="_blank" rel="noopener">GitHub</a></li>
         <li><a href="https://github.com/LavX/bazarr/issues" target="_blank" rel="noopener">Issues</a></li>
         <li><a href="https://github.com/LavX/bazarr/wiki" target="_blank" rel="noopener">Wiki</a></li>
-        <li><a href="https://discord.gg/WSVzzaDg" target="_blank" rel="noopener">Discord</a></li>
+        <li><a href="https://discord.gg/fpp5JXmB8f" target="_blank" rel="noopener">Discord</a></li>
       </ul>
     </div>
   </div>

--- a/tests/bazarr/test_arr_instances_api.py
+++ b/tests/bazarr/test_arr_instances_api.py
@@ -131,6 +131,59 @@ def test_update_rejects_invalid_port(schema_session):
     assert status == 400
 
 
+# ---------------------------------- scalar config mirroring (#276 onboarding)
+
+def test_create_default_mirrors_connection_into_scalar_config(schema_session, monkeypatch):
+    """A default instance created via the API (onboarding wizard / Connections
+    page) must mirror its host/port/key into the scalar settings.<kind>.* config.
+
+    Without this the single-instance compat paths (health check, get_<kind>_info
+    version probe, scheduler/SignalR fall-back) keep targeting the default
+    127.0.0.1:8989 because the wizard never populated the scalar config, spamming
+    connection-refused errors even though the per-instance sync works (#276).
+    """
+    from app import config as app_config
+    from arr_instances import service
+
+    monkeypatch.setattr(app_config, "write_config", lambda: None)
+    settings = app_config.settings
+    original = (settings.sonarr.ip, settings.sonarr.port, settings.sonarr.apikey)
+    try:
+        created, status = service.create_instance(
+            schema_session,
+            {"kind": "sonarr", "name": "Main", "ip": "10.9.8.7", "port": 9999,
+             "api_key": "real-key", "is_default": True},
+        )
+        assert status == 201
+
+        # The mirror is a post-commit side effect the resource boundary triggers
+        # via refresh_runtime; exercise the kind-scoped helper directly.
+        service.mirror_scalar_config_from_default(schema_session, "sonarr")
+
+        assert settings.sonarr.ip == "10.9.8.7"
+        assert int(settings.sonarr.port) == 9999
+        assert settings.sonarr.apikey == "real-key"
+    finally:
+        settings.sonarr.ip, settings.sonarr.port, settings.sonarr.apikey = original
+
+
+def test_mirror_scalar_config_noop_without_default(schema_session, monkeypatch):
+    """No default instance -> the scalar config is left untouched (no crash)."""
+    from app import config as app_config
+    from arr_instances import service
+
+    wrote = []
+    monkeypatch.setattr(app_config, "write_config", lambda: wrote.append(True))
+    settings = app_config.settings
+    original_ip = settings.radarr.ip
+    try:
+        service.mirror_scalar_config_from_default(schema_session, "radarr")
+        assert settings.radarr.ip == original_ip
+        assert wrote == []  # nothing to mirror, no write
+    finally:
+        settings.radarr.ip = original_ip
+
+
 def test_test_connection_rejects_invalid_port():
     from arr_instances import service
 


### PR DESCRIPTION
Fixes two reported issues.

## `LavX/bazarr#276`: connection-refused spam after a fresh multi-instance onboarding

**Symptom:** a brand-new setup via the onboarding wizard configures Sonarr/Radarr correctly (the test passes, media syncs), yet the log fills with `Connection refused` retries against the **default** ports `8989`/`7878`, and the System page shows one app "down" while it actually works.

**Root cause:** the onboarding wizard (and the Connections page) create the arr instance directly via the API and flip `use_<kind>` on, but never populate the scalar `settings.<kind>.*` config. The single-instance compat paths (health-check rootfolder validation, the shared `get_<kind>_info` version probe via `url_<kind>()`, and the scheduler/SignalR fall-back) read the scalar config whenever there is exactly **one** instance, on the documented assumption that the scalar config equals the default instance. That holds for installs upgraded via `backfill` (which builds the instance *from* the scalar config) but **not** for instances created via the API, so those installs poll the default `127.0.0.1:8989` / `:7878`.

**Fix:** restore the invariant by mirroring the default instance's connection details back into the scalar config:
- after every instance create/update (`service.refresh_runtime`), and
- once at startup after backfill, to heal already-broken installs on upgrade (idempotent: `write_config` short-circuits when nothing changed).

**Verification (deployed to the test server):** forcing `scalar.sonarr.ip` back to the default and restarting self-heals it on the next boot:

```
Mirrored default sonarr instance (sonarr.lavx.local:8989) into the scalar config
```

Plus 2 new unit tests (TDD) and the existing arr_instances suite (34/34) pass; ruff clean.

## `LavX/bazarr#275`: Discord invite link

The previous invite had expired or been revoked. Swapped for a current never-expiring invite across the README badge, the System Status page link, and the marketing site.

> Note: the marketing-site link only goes live once `site/index.html` reaches `master` (Pages deploys from `site/`).
