### PR TITLE
chore(deps): bump dynaconf 3.2.13 -> 3.3.2 (supersedes #284)

### DIFF
--- a/bazarr/app/requirements.py
+++ b/bazarr/app/requirements.py
@@ -114,7 +114,7 @@ RUNTIME_REQUIREMENTS = {
     "deep_translator": ("deep-translator", "==1.11.4"),
     "dns": ("dnspython", "==2.8.0"),
     "dogpile": ("dogpile.cache", "==1.5.0"),
-    "dynaconf": ("dynaconf", "==3.2.13"),
+    "dynaconf": ("dynaconf", "==3.3.2"),
     "emoji": ("emoji", "==2.15.0"),
     "enzyme": ("enzyme", "==0.5.2"),
     "fcache": ("fcache", "==0.6.0"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ deathbycaptcha-official==4.7.1
 deep-translator==1.11.4
 dnspython==2.8.0
 dogpile.cache==1.5.0
-dynaconf==3.2.13
+dynaconf==3.3.2
 emoji==2.15.0
 enzyme==0.5.2
 fcache==0.6.0

--- a/tests/bazarr/test_dependency_loading.py
+++ b/tests/bazarr/test_dependency_loading.py
@@ -234,7 +234,7 @@ def test_startup_requirements_probe_uses_security_patched_dependency_versions():
     requirements = (repo_root / "requirements.txt").read_text()
 
     expected_versions = {
-        "dynaconf": ("dynaconf", "==3.2.13"),
+        "dynaconf": ("dynaconf", "==3.3.2"),
         "urllib3": ("urllib3", "==2.7.0"),
     }
 


### PR DESCRIPTION
Supersedes LavX/bazarr#284.

Dependabot bumped only `requirements.txt` to `dynaconf==3.3.2`, which tripped the startup requirements probe and failed CI. The fork pins the security-probed dynaconf version in `bazarr/app/requirements.py` (`RUNTIME_REQUIREMENTS`), and `test_startup_requirements_probe_uses_security_patched_dependency_versions` asserts requirements.txt and the probe agree. This PR bumps all three in lockstep:

- `requirements.txt`: `dynaconf==3.3.2`
- `bazarr/app/requirements.py`: `RUNTIME_REQUIREMENTS["dynaconf"]` -> `==3.3.2`
- `tests/bazarr/test_dependency_loading.py`: expected pin -> `==3.3.2`

## Verification
- `tests/bazarr/test_dependency_loading.py` 23/23, arr suites 34/34, ruff clean
- dynaconf 3.3.2 runtime smoke: validators pass, settings load/set/write OK
- Deploy-verified on the test server: clean boot, requirements probe passes, `/api/system/settings` and `/api/system/status` return 200, zero tracebacks, and the scalar-config reconcile stays healthy (no regression to the multi-instance fix).
