### PR TITLE
release: Bazarr+ v2.5.1 (Murmuration)

### DIFF
--- a/frontend/src/data/whatsNew.ts
+++ b/frontend/src/data/whatsNew.ts
@@ -28,9 +28,27 @@ export interface WhatsNewSlide {
  * cutting a release. Kept as an explicit token so the wizard never has to parse the
  * fork's `version + YYMMDD` runtime string.
  */
-export const latestWhatsNewVersion = "2.5.0";
+export const latestWhatsNewVersion = "2.5.1";
 
 export const whatsNew: Record<string, WhatsNewSlide[]> = {
+  "2.5.1": [
+    {
+      title: "Cleaner multi-server first-run",
+      body: "A fresh setup no longer spams connection-refused errors at the default 8989/7878 ports while your real Sonarr/Radarr work. Existing setups self-heal automatically on this upgrade, no action needed.",
+      icon: faServer,
+      cta: { label: "Open Connections", to: "/settings/connections" },
+    },
+    {
+      title: "Reverse-proxy subpath fixed",
+      body: "Running Bazarr+ behind a reverse proxy on a subpath (base_url, e.g. /bazarr) no longer shows a blank page. Static assets now load correctly under the configured prefix.",
+      icon: faTowerBroadcast,
+    },
+    {
+      title: "Dependency & security maintenance",
+      body: "A round of dependency and security updates across the stack (dynaconf, pillow, apscheduler, numpy, alembic, cloudscraper and more), with no known vulnerabilities outstanding.",
+      icon: faShieldHalved,
+    },
+  ],
   "2.5.0": [
     {
       title: "Multiple Sonarr/Radarr instances",

--- a/package_info
+++ b/package_info
@@ -1,7 +1,7 @@
 # Bazarr+ Package Information
 
 # Package version identifier (shown in System Status)
-packageversion=Bazarr+ v2.5.0
+packageversion=Bazarr+ v2.5.1
 
 # Package author (shown in System Status)
 packageauthor=LavX

--- a/site/index.html
+++ b/site/index.html
@@ -37,7 +37,7 @@
     "url": "https://lavx.github.io/bazarr/",
     "image": "https://lavx.github.io/bazarr/screenshots/og-image.png",
     "downloadUrl": "https://github.com/LavX/bazarr",
-    "softwareVersion": "2.5.0",
+    "softwareVersion": "2.5.1",
     "author": {
       "@type": "Person",
       "name": "LavX",
@@ -523,6 +523,7 @@
       <ul class="roadmap-list">
         <li><strong>v2.4.0 &ldquo;Prism&rdquo;</strong> (released): the Distribution Hub multi-tenant subtitle API, Provider Hub built-in replacement with startup auto-install, combined bilingual and trilingual subtitles, embedded-track scoring, and host-side archive extraction.</li>
         <li><strong>v2.5.0 &ldquo;Murmuration&rdquo;</strong> (released): <a href="https://github.com/LavX/bazarr/issues/156" target="_blank" rel="noopener">multiple Radarr and Sonarr instances</a> managed as one flock, per-instance subtitle settings, compressed-archive uploads with drag-and-drop, and an SSRF / path-traversal security pass.</li>
+        <li><strong>v2.5.1 &ldquo;Murmuration&rdquo;</strong> (released): a stability patch for the multi-instance rollout. Fresh-setup connection-refused noise is fixed and self-heals on upgrade, reverse-proxy subpath asset loading works again, plus a full round of dependency and security maintenance.</li>
         <li><strong>v2.6.0</strong>: universal providers and federation. Point Bazarr+ at any OpenSubtitles.com-compatible endpoint, including another Bazarr+ instance, and daisy-chain instances together over a loop-safe federation protocol.</li>
         <li><strong>v3.0.0 &ldquo;Subnet&rdquo;</strong>: peer-to-peer subtitle federation, a self-organizing mesh of Bazarr+ instances.</li>
       </ul>


### PR DESCRIPTION
Version bump + in-app What's New + site update for the v2.5.1 stability patch.

- `package_info`: Bazarr+ v2.5.1
- `whatsNew.ts`: 2.5.1 entry (onboarding self-heal, reverse-proxy subpath, dependency/security maintenance) + `latestWhatsNewVersion` bumped
- `site/index.html`: softwareVersion 2.5.1 + roadmap entry

Deploy-verified on the test server: `/api/system/status` reports 2.5.1, clean boot, settings API 200, What's New slide present in the bundle.

Full release notes go on the GitHub Release when `development` is cut to `master`.