### PR TITLE
fix(provider-hub): make plugin timeouts govern the worker deadline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
             tests/bazarr/test_provider_hub.py \
             tests/bazarr/test_provider_hub_auto_install_optin.py \
             tests/bazarr/test_provider_hub_archive_select.py \
+            tests/bazarr/test_provider_hub_worker_timeout.py \
             tests/bazarr/test_arr_instances_schema.py \
             tests/bazarr/test_arr_ownership_columns.py \
             tests/bazarr/test_arr_instance_repository.py \

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -160,6 +160,8 @@ validators = [
     Validator('general.chmod_enabled', must_exist=True, default=False, is_type_of=bool),
     Validator('general.enable_strm_support', must_exist=True, default=False, is_type_of=bool),
     Validator('general.provider_hub_auto_install', must_exist=True, default=False, is_type_of=bool),
+    Validator('general.provider_hub_worker_timeout', must_exist=True, default=120, is_type_of=int,
+              gte=30, lte=86400),
     Validator('general.chmod', must_exist=True, default='0640', is_type_of=str),
     Validator('general.subfolder', must_exist=True, default='current', is_type_of=str),
     Validator('general.subfolder_custom', must_exist=True, default='', is_type_of=str),

--- a/bazarr/provider_hub/registry.py
+++ b/bazarr/provider_hub/registry.py
@@ -24,7 +24,9 @@ from .worker import ProviderWorkerClient, WorkerError, worker_command
 logger = logging.getLogger(__name__)
 
 _REGISTERED_PROVIDER_HUB_IDS: set[str] = set()
-_MAX_WORKER_REQUEST_TIMEOUT = 3600.0
+_MAX_WORKER_REQUEST_TIMEOUT = 86400.0
+_HOST_TIMEOUT_MARGIN_SECONDS = 30.0
+_DEFAULT_GLOBAL_WORKER_TIMEOUT = 120.0
 
 
 def _coerce_timeout(value):
@@ -37,14 +39,30 @@ def _coerce_timeout(value):
     return timeout
 
 
+def _global_worker_timeout():
+    """Backstop host-side worker deadline from settings, with a defensive fallback.
+
+    Runs host-side, so app.config is importable. Falls back to the built-in
+    default if settings are unavailable or the value is missing/invalid."""
+    try:
+        from app.config import settings
+        value = _coerce_timeout(getattr(settings.general, "provider_hub_worker_timeout", None))
+    except Exception:
+        return _DEFAULT_GLOBAL_WORKER_TIMEOUT
+    return value or _DEFAULT_GLOBAL_WORKER_TIMEOUT
+
+
 class HubProxyProvider(Provider):
     provider_name = "providerhub"
     languages = set()
     video_types = (Episode, Movie)
     subtitle_class = None
 
-    def __init__(self, timeout=30, worker_client=None, **config):
-        self.timeout = _coerce_timeout(timeout) or 30.0
+    def __init__(self, timeout=None, worker_client=None, **config):
+        # An explicit per-instance timeout override is optional; when absent the
+        # global default backstop (see _request_timeout) applies instead of a
+        # hardcoded value.
+        self.timeout = _coerce_timeout(timeout)
         self.worker_client = worker_client or getattr(self.__class__, "worker_client", None)
         self.config = config
 
@@ -79,12 +97,37 @@ class HubProxyProvider(Provider):
         raise WorkerError("Provider Hub worker is not configured")
 
     def _request_timeout(self):
-        timeout = self.timeout
+        # The host deadline must never fire before the worker's own per-operation
+        # timeout, or a long transcription is killed regardless of the user's
+        # settings (issue: WhisperAI and 30 second worker timeout). Derive the
+        # deadline from every timeout the plugin config declares. A margin is
+        # added on top so a single-operation worker reaches its own timeout and
+        # returns a clean error before the host read-wall kills the subprocess.
+        # (A multi-phase worker, e.g. whisper's extract-then-transcribe, can
+        # still exceed the host wall; each phase is bounded by the worker's own
+        # per-phase timeout, so this is an accepted limitation, not a hard-kill
+        # regression of the 30s bug.) The plugin-declared value is clamped to the
+        # maximum BEFORE the margin is added so the margin survives at the cap,
+        # then floored by the global default backstop.
+        declared = []
+        explicit = _coerce_timeout(self.timeout)
+        if explicit is not None:
+            declared.append(explicit)
         for key in ("worker_timeout", "timeout_seconds", "timeout"):
-            configured = _coerce_timeout(self.config.get(key))
-            if configured is not None:
-                timeout = max(timeout, configured)
-        return min(timeout, _MAX_WORKER_REQUEST_TIMEOUT)
+            value = _coerce_timeout(self.config.get(key))
+            if value is not None:
+                declared.append(value)
+        for key, raw in self.config.items():
+            if key.endswith("_timeout_seconds"):
+                value = _coerce_timeout(raw)
+                if value is not None:
+                    declared.append(value)
+
+        global_default = _global_worker_timeout()
+        if not declared:
+            return global_default
+        base = min(max(declared), _MAX_WORKER_REQUEST_TIMEOUT)
+        return max(base + _HOST_TIMEOUT_MARGIN_SECONDS, global_default)
 
     def list_subtitles(self, video, languages):
         timeout = self._request_timeout()

--- a/frontend/src/pages/Settings/General/index.tsx
+++ b/frontend/src/pages/Settings/General/index.tsx
@@ -263,6 +263,19 @@ const SettingsGeneralView: FunctionComponent = () => {
           Installing or replacing providers manually from the Provider Hub
           Marketplace always works regardless of this setting.
         </Message>
+        <Number
+          label="Default worker timeout (seconds)"
+          settingKey="settings-general-provider_hub_worker_timeout"
+          min={30}
+          max={86400}
+          step={30}
+        ></Number>
+        <Message>
+          Fallback time limit for a Provider Hub plugin to answer a search or
+          download before Bazarr gives up. Plugins that define their own
+          timeouts (for example WhisperAI's transcription timeout) override
+          this. Default 120 seconds.
+        </Message>
       </Section>
       <Section header="Proxy">
         <Selector

--- a/frontend/src/pages/Settings/General/index.tsx
+++ b/frontend/src/pages/Settings/General/index.tsx
@@ -271,10 +271,10 @@ const SettingsGeneralView: FunctionComponent = () => {
           step={30}
         ></Number>
         <Message>
-          Fallback time limit for a Provider Hub plugin to answer a search or
-          download before Bazarr gives up. Plugins that define their own
-          timeouts (for example WhisperAI's transcription timeout) override
-          this. Default 120 seconds.
+          Minimum time a Provider Hub plugin is given to answer a search or
+          download before Bazarr gives up. Plugins that declare a longer timeout
+          (for example WhisperAI's transcription timeout) raise the deadline
+          above this value. Default 120 seconds.
         </Message>
       </Section>
       <Section header="Proxy">

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -2345,10 +2345,15 @@ def test_bundle_tree_verification_rejects_bundle_hash_mismatch(tmp_path):
         verify_bundle_tree(manifest, tmp_path)
 
 
-def test_hub_proxy_provider_search_and_download_uses_worker_payload():
+def test_hub_proxy_provider_search_and_download_uses_worker_payload(monkeypatch):
+    from provider_hub import registry as registry_module
     from provider_hub.manifest import validate_manifest
     from provider_hub.registry import _make_provider_class
     from provider_hub.protocol import language_to_payload
+
+    # Pin the global default so the timeout assertion below is a concrete value
+    # (an explicit timeout=9 is below the 120s floor -> raised to 120).
+    monkeypatch.setattr(registry_module, "_global_worker_timeout", lambda: 120.0)
 
     class FakeWorker:
         def __init__(self):
@@ -2412,7 +2417,9 @@ def test_hub_proxy_provider_search_and_download_uses_worker_payload():
     provider.download_subtitle(subtitles[0])
     assert subtitles[0].content == b"hello"
     assert worker.requests[0][0] == "search"
-    assert worker.requests[0][2] == 9
+    # The worker request carries the host-side deadline from _request_timeout();
+    # an explicit timeout (9) below the global default floor is raised to 120.
+    assert worker.requests[0][2] == 120.0
     assert worker.requests[0][1]["config"] == provider_config
     assert worker.requests[1][0] == "download"
     assert worker.requests[1][1]["config"] == provider_config
@@ -2482,8 +2489,10 @@ def test_hub_proxy_uses_configured_worker_timeout_for_long_downloads():
 
     provider.download_subtitle(subtitle)
 
-    assert worker.requests[0] == ("search", 600)
-    assert worker.requests[1] == ("download", 600)
+    # 600s configured + 30s host margin so the worker's own timeout fires first.
+    assert provider._request_timeout() == 630.0
+    assert worker.requests[0] == ("search", 630.0)
+    assert worker.requests[1] == ("download", 630.0)
 
 
 def test_hub_proxy_download_invokes_select_archive_member():

--- a/tests/bazarr/test_provider_hub_worker_timeout.py
+++ b/tests/bazarr/test_provider_hub_worker_timeout.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+
+import pytest
+
+import provider_hub.registry as registry
+from provider_hub.registry import HubProxyProvider
+
+
+WHISPER_CONFIG = {
+    "endpoint": "http://127.0.0.1:9000",
+    "ffmpeg_path": "ffmpeg",
+    "pass_video_name": False,
+    "response_timeout_seconds": 600,
+    "transcription_timeout_seconds": 3600,
+}
+
+
+def _pin_global(monkeypatch, value):
+    monkeypatch.setattr(registry, "_global_worker_timeout", lambda: float(value))
+
+
+def test_worker_timeout_validator_default():
+    from app.config import settings
+
+    assert int(settings.general.provider_hub_worker_timeout) == 120
+
+
+def test_declared_transcription_timeout_drives_deadline(monkeypatch):
+    _pin_global(monkeypatch, 120)
+    provider = HubProxyProvider(**WHISPER_CONFIG)
+    # 3600 declared + 30 margin, floored by 120, under the 86400 cap.
+    assert provider._request_timeout() == 3630.0
+
+
+def test_no_declared_timeout_uses_global_default(monkeypatch):
+    _pin_global(monkeypatch, 120)
+    provider = HubProxyProvider(endpoint="http://x", api_key="secret")
+    assert provider._request_timeout() == 120.0
+
+
+def test_global_default_is_a_floor(monkeypatch):
+    _pin_global(monkeypatch, 5000)
+    provider = HubProxyProvider(**WHISPER_CONFIG)
+    # derived 3630 < global default 5000 -> floor wins.
+    assert provider._request_timeout() == 5000.0
+
+
+def test_declared_timeout_clamped_to_cap(monkeypatch):
+    _pin_global(monkeypatch, 120)
+    # A plugin timeout above the cap is clamped to _MAX_WORKER_REQUEST_TIMEOUT
+    # BEFORE the margin is added, so the margin survives (host wall outlives the
+    # worker's own timeout rather than racing it).
+    provider = HubProxyProvider(endpoint="http://x", transcription_timeout_seconds=90000)
+    assert provider._request_timeout() == registry._MAX_WORKER_REQUEST_TIMEOUT + 30.0
+
+
+def test_margin_preserved_at_the_cap(monkeypatch):
+    _pin_global(monkeypatch, 120)
+    # Exactly at the manifest maximum, the +30 host margin must not be swallowed
+    # by the cap (regression guard: host deadline > worker's own timeout).
+    provider = HubProxyProvider(endpoint="http://x", transcription_timeout_seconds=86400)
+    assert provider._request_timeout() == 86430.0
+
+
+def test_explicit_constructor_timeout_override(monkeypatch):
+    _pin_global(monkeypatch, 120)
+    # An explicit timeout= above the floor drives the deadline (this is the only
+    # path exercising the self.timeout contribution to `declared`).
+    provider = HubProxyProvider(endpoint="http://x", timeout=5000)
+    assert provider._request_timeout() == 5030.0
+
+
+def test_legacy_worker_timeout_key_still_honored(monkeypatch):
+    _pin_global(monkeypatch, 120)
+    provider = HubProxyProvider(endpoint="http://x", worker_timeout=900)
+    assert provider._request_timeout() == 930.0
+
+
+def test_legacy_and_suffix_keys_take_the_larger(monkeypatch):
+    _pin_global(monkeypatch, 120)
+    # Both timeout categories present with the legacy key larger, so a refactor
+    # that let the *_timeout_seconds loop overwrite (rather than extend) the
+    # declared list would drop to 630 and fail here.
+    provider = HubProxyProvider(
+        endpoint="http://x", worker_timeout=3600, transcription_timeout_seconds=600
+    )
+    assert provider._request_timeout() == 3630.0
+
+
+def test_registry_cap_covers_the_validator_maximum():
+    # The host cap must accommodate the largest value the setting/manifest allow
+    # (validator lte and whisper manifest maximum are both 86400); otherwise a
+    # user's configured timeout would be silently clipped below what they set.
+    assert registry._MAX_WORKER_REQUEST_TIMEOUT >= 86400
+
+
+def test_global_worker_timeout_reads_setting(monkeypatch):
+    monkeypatch.setattr(
+        "app.config.settings",
+        SimpleNamespace(general=SimpleNamespace(provider_hub_worker_timeout=500)),
+        raising=False,
+    )
+    assert registry._global_worker_timeout() == 500.0
+
+
+@pytest.mark.parametrize("bad_value", [None, 0, -5, "oops"])
+def test_global_worker_timeout_falls_back(monkeypatch, bad_value):
+    # Missing, zero, negative, and non-numeric all fall back to the default via
+    # _coerce_timeout; the docstring promises this for "missing/invalid".
+    general = SimpleNamespace() if bad_value is None else SimpleNamespace(
+        provider_hub_worker_timeout=bad_value
+    )
+    monkeypatch.setattr(
+        "app.config.settings",
+        SimpleNamespace(general=general),
+        raising=False,
+    )
+    assert registry._global_worker_timeout() == 120.0

--- a/tests/bazarr/test_provider_hub_worker_timeout.py
+++ b/tests/bazarr/test_provider_hub_worker_timeout.py
@@ -49,8 +49,9 @@ def test_global_default_is_a_floor(monkeypatch):
 def test_declared_timeout_clamped_to_cap(monkeypatch):
     _pin_global(monkeypatch, 120)
     # A plugin timeout above the cap is clamped to _MAX_WORKER_REQUEST_TIMEOUT
-    # BEFORE the margin is added, so the margin survives (host wall outlives the
-    # worker's own timeout rather than racing it).
+    # before the margin is added, so the host wall is cap + margin. Defensive
+    # only: the setting validator and plugin manifests already bound configured
+    # values to the cap, so a value this high should not reach here in practice.
     provider = HubProxyProvider(endpoint="http://x", transcription_timeout_seconds=90000)
     assert provider._request_timeout() == registry._MAX_WORKER_REQUEST_TIMEOUT + 30.0
 


### PR DESCRIPTION
## Problem

Reported in **"WhisperAI and 30 second worker timeout"** (https://github.com/LavX/bazarr/issues/288): a self-hosted WhisperAI provider always times out at ~30s no matter what response/transcription timeouts the user sets.

Root cause: WhisperAI is a migrated built-in, so it runs inside a **Provider Hub worker subprocess**. The host-side deadline in `HubProxyProvider._request_timeout()` defaulted to a hardcoded **30s** and only recognized the config keys `worker_timeout` / `timeout_seconds` / `timeout`. WhisperAI's hub config declares `response_timeout_seconds` / `transcription_timeout_seconds`, none of which matched, so the deadline stayed at 30s and the host killed the worker mid-transcription. The user's timeouts only bounded the `urllib` calls *inside* the worker; the host guillotined the subprocess first.

## Fix

`_request_timeout()` now derives the host deadline from every timeout the plugin config declares (any `*_timeout_seconds` key, the legacy keys, and an explicit constructor override):

- Clamp the plugin-declared value to the max **before** adding a 30s margin, so the worker's own timeout surfaces a clean error before the host read-wall kills it.
- Floor the result by a new global default and cap it at 86400s (raised from 3600 so a long transcription is not silently re-clipped).
- New setting `general.provider_hub_worker_timeout` (default **120s**, 30..86400) is the backstop for plugins that declare no timeouts of their own, and is exposed in **Settings > General > Provider Hub**.

For the reporter's config (transcription 3600 / response 600) the host deadline becomes 3630s instead of 30s.

## Verification

- 15 unit tests covering derivation, floor, margin, cap, legacy keys, and the settings fallback (added to the CI guard-list).
- Deployed to the test server: a whisper-shaped config computes a **3630s** deadline in the live runtime (was 30s), and the new setting is exposed via the API.
- End to end through the real `ProviderWorkerClient` / `worker.py` deadline machinery against a real Whisper ASR service:
  - old 30s deadline: `WorkerError after 30.0s: worker exceeded 30.0s deadline`
  - new 630s deadline: a real 95s transcription **completes** (`OK after 96.1s`)

## Notes

- No changes to the catalog WhisperAI plugin: its in-worker timeouts were already correct. This is purely host-side Hub infrastructure.
- `local CI green`: ruff, provider-hub + config backend tests, and frontend `check:ts` / `eslint` / `prettier` / `build:ci`.
