### PR TITLE
fix(combine): resolve custom-lang tags like zh-TW as sources

### DIFF
--- a/bazarr/subtitles/tools/combine/rules.py
+++ b/bazarr/subtitles/tools/combine/rules.py
@@ -28,6 +28,9 @@ def resolve_source_paths(video_path, languages):
     language are present, prefers plain > hi > forced. Sync-engine outputs
     (.ffsubsync, .autosubsync, .alass) and combined outputs are never picked.
 
+    Custom-language filename tags (e.g. .zh-TW.srt → zt, .pt-BR.srt → pb) are
+    resolved through CustomLanguage, matching the external-subtitle indexer.
+
     Returns SourcePaths if every requested language has a matching file,
     None if any is missing.
 
@@ -80,6 +83,9 @@ def _extract_code_and_priority(base, path):
     <base>.<code>.hi.srt and <base>.<code>.sdh.srt and <base>.<code>.cc.srt
     (priority _HI), and <base>.<code>.forced.srt (priority _FORCED).
 
+    Also recognizes CustomLanguage filename tags such as .zh-TW / .pt-BR so
+    profiles that request zt / pb can combine those on-disk files.
+
     Returns None for combined outputs, sync-engine outputs, and anything that
     does not match a recognized single-language pattern.
     """
@@ -91,13 +97,25 @@ def _extract_code_and_priority(base, path):
     if len(parts) != 2 or parts[1] != "srt":
         return None
     middle = parts[0]
-    if "-" in middle:
-        # combined-X[-Y] markers always contain a hyphen.
+
+    # Combined outputs use ".combined-" (e.g. en.combined-hu). Do not treat
+    # every hyphen as combined — custom langs legitimately use tags like zh-TW.
+    if "combined-" in middle:
         return None
 
     segments = middle.split(".")
     if not segments:
         return None
+
+    # Sync-engine outputs are never combine sources, including custom-lang tags
+    # such as zh-TW.ffsubsync.srt.
+    if segments[-1].lower() in _SYNC_ENGINES:
+        return None
+
+    custom = _custom_language_match(filename, path)
+    if custom is not None:
+        return custom
+
     code = segments[0]
     if len(code) != 2 or not code.isalpha() or not code.islower():
         return None
@@ -117,4 +135,27 @@ def _extract_code_and_priority(base, path):
         return None
 
     # More than two segments: e.g. en.hi.ffsubsync.srt. Reject.
+    return None
+
+
+def _custom_language_match(filename, path):
+    """Map CustomLanguage filename tags to (code2, priority), or None."""
+    try:
+        from languages.custom_lang import CustomLanguage
+    except Exception:
+        return None
+
+    custom_code = CustomLanguage.found_external(filename, path)
+    if not custom_code:
+        return None
+
+    if ":" not in custom_code:
+        return custom_code, _PLAIN
+
+    code, modifier = custom_code.split(":", 1)
+    modifier = modifier.lower()
+    if modifier in ("hi", "sdh", "cc"):
+        return code, _HI
+    if modifier == "forced":
+        return code, _FORCED
     return None

--- a/tests/bazarr/test_combine_rules.py
+++ b/tests/bazarr/test_combine_rules.py
@@ -147,3 +147,65 @@ def test_skips_chained_modifier_sync_outputs(tmp_path):
         languages=["en", "hu"],
     )
     assert result is None
+
+
+def test_maps_zh_tw_filename_to_zt_code(tmp_path):
+    """Bazarr writes Traditional Chinese as .zh-TW.srt; profiles request zt."""
+    base = make_video_dir(tmp_path, [
+        "Movie.mkv",
+        "Movie.en.srt",
+        "Movie.zh-TW.srt",
+    ])
+    result = resolve_source_paths(
+        video_path=str(base / "Movie.mkv"),
+        languages=["zt", "en"],
+    )
+    assert result is not None
+    assert result.primary == str(base / "Movie.zh-TW.srt")
+    assert result.secondaries == [str(base / "Movie.en.srt")]
+
+
+def test_maps_lowercase_zh_tw_and_zht_aliases(tmp_path):
+    base = make_video_dir(tmp_path, [
+        "Movie.mkv",
+        "Movie.en.srt",
+        "Movie.zh-tw.srt",
+    ])
+    result = resolve_source_paths(
+        video_path=str(base / "Movie.mkv"),
+        languages=["zt", "en"],
+    )
+    assert result is not None
+    assert result.primary == str(base / "Movie.zh-tw.srt")
+
+
+def test_maps_pt_br_filename_to_pb_code(tmp_path):
+    """Same hyphen-tag bug class as zh-TW (Brazilian Portuguese)."""
+    base = make_video_dir(tmp_path, [
+        "Movie.mkv",
+        "Movie.en.srt",
+        "Movie.pt-BR.srt",
+    ])
+    result = resolve_source_paths(
+        video_path=str(base / "Movie.mkv"),
+        languages=["pb", "en"],
+    )
+    assert result is not None
+    assert result.primary == str(base / "Movie.pt-BR.srt")
+    assert result.secondaries == [str(base / "Movie.en.srt")]
+
+
+def test_still_skips_combined_when_custom_lang_present(tmp_path):
+    base = make_video_dir(tmp_path, [
+        "Movie.mkv",
+        "Movie.en.srt",
+        "Movie.zh-TW.srt",
+        "Movie.zt.combined-en.srt",
+        "Movie.en.combined-zt.srt",
+    ])
+    result = resolve_source_paths(
+        video_path=str(base / "Movie.mkv"),
+        languages=["zt", "en"],
+    )
+    assert result.primary == str(base / "Movie.zh-TW.srt")
+    assert result.secondaries == [str(base / "Movie.en.srt")]


### PR DESCRIPTION
## Summary
- Combined-subtitle source lookup rejected hyphenated and non-2-letter filename tags (e.g. `.zh-TW.srt`, `.pt-BR.srt`, `.es-MX.srt`), so language profiles using `zt` / `pb` / `ea` could not find the on-disk files Bazarr actually writes.
- Resolve those tags through `CustomLanguage` (same path as the external subtitle indexer) and only treat `combined-` markers as combined outputs.
- Also covers other custom-lang aliases (`zht`, `cht`, `pob`, `es-la`, etc.) that previously failed the strict 2-letter parser.

## Test plan
- [x] Added unit tests in `tests/bazarr/test_combine_rules.py` for `.zh-TW`, `.zh-tw`, `.pt-BR`, and combined-output skip behavior
- [x] Verified locally that `_extract_code_and_priority` maps `Movie.zh-TW.srt` → `zt` and still rejects `en.combined-zt`
- [x] Hotpatched running Bazarr+ and confirmed combine for a movie with `.zh-TW.srt` + `.en.srt` returns `status: built` (`.zt.combined-en.srt`)
- [X] `pytest tests/bazarr/test_combine_rules.py` in CI

Made with [Cursor](https://cursor.com)