### PR TITLE
Fix/legendasdivx brotli login

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ LABEL org.opencontainers.image.title="Bazarr+" \
       org.opencontainers.image.licenses="GPL-3.0"
 
 # Install runtime dependencies. RAR archives from subtitle providers are
-# extracted via p7zip's 7z binary, so no non-free repo or unrar package needed.
+# extracted via unar (from Debian main) or unrar.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
@@ -84,6 +84,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libpq5 \
     mediainfo \
     p7zip-full \
+    unar \
     bash \
     gosu \
     curl \

--- a/bazarr/init.py
+++ b/bazarr/init.py
@@ -195,11 +195,11 @@ def init_binaries():
     # that already have them on PATH; they are no longer in binaries.json, so
     # get_binary never attempts a (read-only, failing) self-download for them.
     try:
-        exe = get_binary("7z")
-        rarfile.UNRAR_TOOL = None
+        exe = get_binary("unrar")
+        rarfile.UNRAR_TOOL = exe
         rarfile.UNAR_TOOL = None
-        rarfile.SEVENZIP_TOOL = exe
-        rarfile.tool_setup(unrar=False, unar=False, bsdtar=False, sevenzip=True, force=True)
+        rarfile.SEVENZIP_TOOL = None
+        rarfile.tool_setup(unrar=True, unar=False, bsdtar=False, sevenzip=False, force=True)
     except (BinaryNotFound, rarfile.RarCannotExec):
         try:
             exe = get_binary("unar")
@@ -209,22 +209,22 @@ def init_binaries():
             rarfile.tool_setup(unrar=False, unar=True, bsdtar=False, sevenzip=False, force=True)
         except (BinaryNotFound, rarfile.RarCannotExec):
             try:
-                exe = get_binary("unrar")
-                rarfile.UNRAR_TOOL = exe
+                exe = get_binary("7z")
+                rarfile.UNRAR_TOOL = None
                 rarfile.UNAR_TOOL = None
-                rarfile.SEVENZIP_TOOL = None
-                rarfile.tool_setup(unrar=True, unar=False, bsdtar=False, sevenzip=False, force=True)
+                rarfile.SEVENZIP_TOOL = exe
+                rarfile.tool_setup(unrar=False, unar=False, bsdtar=False, sevenzip=True, force=True)
             except (BinaryNotFound, rarfile.RarCannotExec):
-                logging.exception("BAZARR requires a rar archive extraction utility (7z, unar, or unrar) and none could be found.")
+                logging.exception("BAZARR requires a rar archive extraction utility (unrar, unar, or 7z) and none could be found.")
                 raise BinaryNotFound
             else:
-                logging.debug("Using UnRAR from: %s", exe)
+                logging.debug("Using 7zip from: %s", exe)
                 return exe
         else:
             logging.debug("Using unar from: %s", exe)
             return exe
     else:
-        logging.debug("Using 7zip from: %s", exe)
+        logging.debug("Using UnRAR from: %s", exe)
         return exe
 
 

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -311,7 +311,13 @@ class SZProviderPool(ProviderPool):
 
     def __getitem__(self, name):
         if name not in self.providers:
-            raise KeyError
+            if name in provider_registry:
+                if isinstance(self.providers, set):
+                    self.providers.add(name)
+                else:
+                    self.providers.append(name)
+            else:
+                raise KeyError(name)
         if name not in self.initialized_providers:
             logger.info('Initializing provider %s', name)
             provider = provider_registry[name](**self.provider_configs.get(name, {}))

--- a/custom_libs/subliminal_patch/http.py
+++ b/custom_libs/subliminal_patch/http.py
@@ -12,8 +12,6 @@ import requests
 import six.moves.xmlrpc_client
 import dns.resolver
 import ipaddress
-import re
-from six import PY3
 
 from requests import exceptions
 from urllib3.util import connection
@@ -21,21 +19,15 @@ from retry.api import retry_call
 from .exceptions import APIThrottled
 from dogpile.cache.api import NO_VALUE
 from subliminal.cache import region
-from subliminal_patch.pitcher import pitchers
 from cloudscraper import CloudScraper
 import six
 
-try:
-    import brotli
-except:
-    pass
 
 try:
     from six.moves.urllib.parse import urlparse
 except ImportError:
     from urllib.parse import urlparse
 
-from subzero.lib.io import get_viable_encoding
 
 logger = logging.getLogger(__name__)
 pem_file = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", certifi.where()))
@@ -75,77 +67,6 @@ class CFSession(CloudScraper):
         super(CFSession, self).__init__(*args, **kwargs)
         self.debug = os.environ.get("CF_DEBUG", False)
 
-    def _request(self, method, url, *args, **kwargs):
-        ourSuper = super(CloudScraper, self)
-        resp = ourSuper.request(method, url, *args, **kwargs)
-
-        if resp.headers.get('Content-Encoding') == 'br':
-            if self.allow_brotli and resp._content:
-                resp._content = brotli.decompress(resp.content)
-            else:
-                logging.warning('Brotli content detected, But option is disabled, we will not continue.')
-                return resp
-
-        # Debug request
-        if self.debug:
-            self.debugRequest(resp)
-
-        # Check if Cloudflare anti-bot is on
-        try:
-            if self.is_Challenge_Request(resp):
-                if resp.request.method != 'GET':
-                    # Work around if the initial request is not a GET,
-                    # Supersede with a GET then re-request the original METHOD.
-                    CloudScraper.request(self, 'GET', resp.url)
-                    resp = ourSuper.request(method, url, *args, **kwargs)
-                else:
-                    # Solve Challenge
-                    resp = self.sendChallengeResponse(resp, **kwargs)
-
-        except ValueError as e:
-            if PY3:
-                error = str(e)
-            else:
-                error = e.message
-            if error == "Captcha":
-                parsed_url = urlparse(url)
-                domain = parsed_url.netloc
-                # solve the captcha
-                site_key = re.search(r'data-sitekey="(.+?)"', resp.text).group(1)
-                challenge_s = re.search(r'type="hidden" name="s" value="(.+?)"', resp.text).group(1)
-                challenge_ray = re.search(r'data-ray="(.+?)"', resp.text).group(1)
-                if not all([site_key, challenge_s, challenge_ray]):
-                    raise Exception("cf: Captcha site-key not found!")
-
-                pitcher = pitchers.get_pitcher()("cf: %s" % domain, resp.request.url, site_key,
-                                                 user_agent=self.headers["User-Agent"],
-                                                 cookies=self.cookies.get_dict(),
-                                                 is_invisible=True)
-
-                parsed_url = urlparse(resp.url)
-                logger.info("cf: %s: Solving captcha", domain)
-                result = pitcher.throw()
-                if not result:
-                    raise Exception("cf: Couldn't solve captcha!")
-
-                submit_url = '{}://{}/cdn-cgi/l/chk_captcha'.format(parsed_url.scheme, domain)
-                method = resp.request.method
-
-                cloudflare_kwargs = {
-                    'allow_redirects': False,
-                    'headers': {'Referer': resp.url},
-                    'params': OrderedDict(
-                        [
-                            ('s', challenge_s),
-                            ('g-recaptcha-response', result)
-                        ]
-                    )
-                }
-
-                return CloudScraper.request(self, method, submit_url, **cloudflare_kwargs)
-
-        return resp
-
     def request(self, method, url, *args, **kwargs):
         parsed_url = urlparse(url)
         domain = parsed_url.netloc
@@ -162,7 +83,7 @@ class CFSession(CloudScraper):
 
                 self.headers = hdrs
 
-        ret = self._request(method, url, *args, **kwargs)
+        ret = super(CFSession, self).request(method, url, *args, **kwargs)
 
         try:
             cf_data = self.get_cf_live_tokens(domain)

--- a/custom_libs/subliminal_patch/providers/legendasdivx.py
+++ b/custom_libs/subliminal_patch/providers/legendasdivx.py
@@ -29,6 +29,63 @@ from dogpile.cache.api import NO_VALUE
 
 logger = logging.getLogger(__name__)
 
+def clean_release_line(text):
+    # Separate glued keywords like versãoThe or releaseThe
+    text = re.sub(r"(vers[aã]o|release|filme)([A-Z0-9])", r"\1 \2", text, flags=re.I)
+    # Strip common Portuguese subtitle upload prefixes
+    prefix_pattern = (
+        r"^(legendas?\s*(anteriormente\s*)?(enviadas?\s*(por|pelo)?\s*[\w\d_]+\s*)?"
+        r"|sincronizadas?|ressincronizadas?|sinc|sync|traduzidas?|ripadas?|ajustad[ao]s?|ajustei\s*(a\s*)?sincronia)?"
+        r"\s*(de\s*raiz\s*)?(para\s*(a|o|as|os)?\s*)?(vers[aã]o|release[s]?|filme|nomes?)?\s*[:\-–]?\s*"
+    )
+    return re.sub(prefix_pattern, "", text, flags=re.I).strip().strip("*").strip("`").strip()
+
+
+def extract_release_info(title, year, desc):
+    default_name = f"{title} ({year})" if year and title else (title or "")
+    if not desc or desc.strip().lower() in (
+        "não há descrição disponível",
+        "nao ha descricao disponivel",
+        "n/a",
+        "none",
+        "",
+    ):
+        return default_name
+
+    lines = [line.strip().strip("*").strip("`") for line in desc.splitlines() if line.strip()]
+    candidates = []
+    release_re = re.compile(
+        r"(2160p|1080p|720p|480p|4k|bluray|blu-ray|bdrip|brrip|web-dl|webdl|web-rip|webrip|web|dvdrip|dvd|hdtv|x264|x265|hevc|h\.264|h\.265|xvid|divx|remastered|proper|internal|repack)",
+        re.I,
+    )
+
+    for line in lines:
+        cleaned = clean_release_line(line)
+        if release_re.search(cleaned):
+            match = re.search(
+                r"([\w\.\-_]+(?:2160p|1080p|720p|480p|4k|bluray|blu-ray|bdrip|brrip|web-dl|webdl|dvdrip|dvd|x264|x265|hevc|xvid|divx)[\w\.\-_]*)",
+                cleaned,
+                re.I,
+            )
+            if match and len(match.group(1)) > 10:
+                candidates.append(match.group(1).strip("."))
+            else:
+                candidates.append(cleaned)
+        elif title and title.lower() in cleaned.lower() and len(cleaned) > len(title):
+            candidates.append(cleaned)
+
+    if candidates:
+        return candidates[0]
+
+    first_meaningful = [
+        candidate for candidate in lines
+        if len(candidate) > 3 and not candidate.lower().startswith(("cumps", "enjoy", "obrigado", "avisem", "não se", "duração:", "duracao:"))
+    ]
+    if first_meaningful and len(first_meaningful[0]) <= 80:
+        return f"{default_name} - {first_meaningful[0]}" if default_name else first_meaningful[0]
+
+    return default_name
+
 
 class LegendasdivxSubtitle(Subtitle):
     """Legendasdivx Subtitle."""
@@ -39,15 +96,16 @@ class LegendasdivxSubtitle(Subtitle):
         self.page_link = data['link']
         self.hits = data['hits']
         self.exact_match = data['exact_match']
+        self.title = data.get('title', '')
+        self.year = data.get('year')
         self.description = data['description']
         self.video = video
         self.sub_frame_rate = data['frame_rate']
         self.uploader = data['uploader']
         self.wrong_fps = False
         self.skip_wrong_fps = skip_wrong_fps
-        self.release_info = self.description
+        self.release_info = data.get('release_info') or self.description
         self.matches = set()
-
     @property
     def id(self):
         try:
@@ -77,53 +135,49 @@ class LegendasdivxSubtitle(Subtitle):
 
         description = sanitize(self.description)
 
-        video_filename = video.name
-        video_filename = os.path.basename(video_filename)
-        video_filename, _ = os.path.splitext(video_filename)
-        video_filename = sanitize_release_group(video_filename)
+        # Match title
+        if video.title:
+            for movie_name in [video.title] + getattr(video, 'alternative_titles', []):
+                if sanitize(movie_name) == sanitize(self.title) or sanitize(movie_name) in description:
+                    self.matches.update(['title'])
 
-        if sanitize(video_filename) in description:
-            self.matches.update(['title'])
-            # relying people won' use just S01E01 for the file name
-            if isinstance(video, Episode):
-                self.matches.update(['series'])
-                self.matches.update(['season'])
-                self.matches.update(['episode'])
-
-        # can match both movies and series
-        if video.year and '{:04d}'.format(video.year) in description:
-            self.matches.update(['year'])
+        # Match year
+        if video.year:
+            if self.year and video.year == self.year:
+                self.matches.update(['year'])
+            elif '{:04d}'.format(video.year) in description:
+                self.matches.update(['year'])
 
         type_ = "movie" if isinstance(video, Movie) else "episode"
-        # match movie title (include alternative movie names)
-        if type_ == "movie":
-            if video.title:
-                for movie_name in [video.title] + video.alternative_titles:
-                    if sanitize(movie_name) in description:
-                        self.matches.update(['title'])
 
+        if isinstance(video, Movie):
+            if video.imdb_id:
+                self.matches.update(['imdb_id'])
         else:
-            if video.title and sanitize(video.title) in description:
-                self.matches.update(['title'])
             if video.series:
-                for series_name in [video.series] + video.alternative_series:
-                    if sanitize(series_name) in description:
+                for series_name in [video.series] + getattr(video, 'alternative_series', []):
+                    if sanitize(series_name) == sanitize(self.title) or sanitize(series_name) in description:
                         self.matches.update(['series'])
+            if video.series_imdb_id:
+                self.matches.update(['series', 'series_imdb_id', 'season', 'episode'])
             if video.season and 's{:02d}'.format(video.season) in description:
                 self.matches.update(['season'])
             if video.episode and 'e{:02d}'.format(video.episode) in description:
                 self.matches.update(['episode'])
-            # All the search is already based on the series_imdb_id when present in the video and controlled via the
-            # the legendasdivx backend it, so if there is a result, it matches, either inside of a pack or a specific
-            # series and episode, so we can assume the season and episode matches.
-            if video.series_imdb_id:
-                self.matches.update(['series', 'series_imdb_id', 'season', 'episode'])
 
-        # release_group
-        if video.release_group and sanitize_release_group(video.release_group) in sanitize_release_group(description):
+        # release_group matching
+        if video.release_group and sanitize_release_group(video.release_group) in sanitize_release_group(self.description):
             self.matches.update(['release_group'])
 
-        self.matches |= guess_matches(video, guessit(description, {"type": type_}))
+        # Guess matches from release_info
+        if self.release_info:
+            self.matches |= guess_matches(video, guessit(self.release_info, {"type": type_}))
+
+        # Also guess matches across description candidate lines
+        for line in self.description.splitlines():
+            cleaned_line = clean_release_line(line)
+            if len(cleaned_line) > 5 and cleaned_line != self.release_info:
+                self.matches |= guess_matches(video, guessit(cleaned_line, {"type": type_}))
 
         return self.matches
 
@@ -265,9 +319,24 @@ class LegendasdivxProvider(Provider):
                 logger.debug("Legendasdivx.pt :: Couldn't find download link. Trying next...")
                 continue
 
-            # get subtitle uploader
+            # get title and year from sub_header
+            title = ''
+            year = None
             sub_header = _subbox.find("div", {"class": "sub_header"})
-            uploader = sub_header.find("a").text if sub_header else 'anonymous'
+            if sub_header:
+                title_elem = sub_header.find("b")
+                if title_elem:
+                    title = title_elem.get_text().strip()
+                header_text = sub_header.get_text()
+                year_match = re.search(r'\((\d{4})\)', header_text)
+                if year_match:
+                    try:
+                        year = int(year_match.group(1))
+                    except ValueError:
+                        pass
+
+            uploader = sub_header.find("a").text if sub_header and sub_header.find("a") else 'anonymous'
+            release_info = extract_release_info(title, year, description)
 
             exact_match = False
             if video.name.lower() in description.lower():
@@ -278,6 +347,9 @@ class LegendasdivxProvider(Provider):
                     'hits': hits,
                     'uploader': uploader,
                     'frame_rate': frame_rate,
+                    'title': title,
+                    'year': year,
+                    'release_info': release_info,
                     'description': description
                     }
             subtitles.append(

--- a/custom_libs/subliminal_patch/providers/legendasdivx.py
+++ b/custom_libs/subliminal_patch/providers/legendasdivx.py
@@ -581,45 +581,69 @@ class LegendasdivxProvider(Provider):
     def _get_subtitle_from_archive(self, archive, subtitle):
         # some files have a non subtitle with .txt extension
         _tmp = list(SUBTITLE_EXTENSIONS)
-        _tmp.remove('.txt')
+        if '.txt' in _tmp:
+            _tmp.remove('.txt')
         _subtitle_extensions = tuple(_tmp)
-        _max_score = 0
+        _max_score = -1
+        _max_name = None
         _scores = get_scores(subtitle.video)
 
+        candidate_files = []
         for name in archive.namelist():
-            # discard hidden files
-            if os.path.split(name)[-1].startswith('.'):
+            # discard hidden files and directories
+            if os.path.split(name)[-1].startswith('.') or name.endswith('/'):
                 continue
 
             # discard non-subtitle files
             if not name.lower().endswith(_subtitle_extensions):
                 continue
 
+            candidate_files.append(name)
+
+        if not candidate_files:
+            logger.error("Legendasdivx.pt :: No subtitle file found in archive")
+            return None
+
+        # If archive contains only 1 subtitle file, return it directly
+        if len(candidate_files) == 1:
+            logger.debug("Legendasdivx.pt :: Only 1 subtitle in archive, returning: %s", candidate_files[0])
+            return archive.read(candidate_files[0])
+
+        for name in candidate_files:
             _guess = guessit(name)
             if isinstance(subtitle.video, Episode):
-                if all(key in _guess for key in ('season', 'episode')):
-                    logger.debug("Legendasdivx.pt :: guessing %s", name)
-                    logger.debug("Legendasdivx.pt :: subtitle S%sE%s video S%sE%s", _guess['season'], _guess['episode'],
-                                 subtitle.video.season, subtitle.video.episode)
+                ep = _guess.get('episode')
+                season = _guess.get('season')
 
-                    if subtitle.video.episode != _guess['episode'] or subtitle.video.season != _guess['season']:
-                        logger.debug('Legendasdivx.pt :: subtitle does not match video, skipping')
+                # Check episode number
+                if ep is not None:
+                    if isinstance(ep, list):
+                        if subtitle.video.episode not in ep:
+                            continue
+                    elif ep != subtitle.video.episode:
                         continue
-                else:
-                    logger.debug('Legendasdivx.pt :: no "season" and/or "episode" on "_guess" , skipping')
-                    continue
+
+                # Check season number if present in filename
+                if season is not None:
+                    if isinstance(season, list):
+                        if subtitle.video.season not in season:
+                            continue
+                    elif season != subtitle.video.season:
+                        continue
+
             matches = set()
             matches |= guess_matches(subtitle.video, _guess)
-            logger.debug('Legendasdivx.pt :: sub matches: %s', matches)
             _score = sum((_scores.get(match, 0) for match in matches))
+            if isinstance(subtitle.video, Episode) and _guess.get('episode') == subtitle.video.episode:
+                _score += 10
+
             if _score > _max_score:
                 _max_name = name
                 _max_score = _score
-                logger.debug("Legendasdivx.pt :: new max: %s %s", name, _score)
+                logger.debug("Legendasdivx.pt :: candidate %s scored %s", name, _score)
 
-        if _max_score > 0:
-            logger.debug("Legendasdivx.pt :: returning from archive: %s scored %s", _max_name, _max_score)
+        if _max_name:
+            logger.debug("Legendasdivx.pt :: returning from archive: %s (score %s)", _max_name, _max_score)
             return archive.read(_max_name)
 
-        logger.error("Legendasdivx.pt :: No subtitle found on compressed file. Max score was 0")
-        return None
+        return archive.read(candidate_files[0])

--- a/custom_libs/subliminal_patch/providers/legendasdivx.py
+++ b/custom_libs/subliminal_patch/providers/legendasdivx.py
@@ -34,9 +34,9 @@ def clean_release_line(text):
     text = re.sub(r"(vers[aã]o|release|filme)([A-Z0-9])", r"\1 \2", text, flags=re.I)
     # Strip common Portuguese subtitle upload prefixes
     prefix_pattern = (
-        r"^(legendas?\s*(anteriormente\s*)?(enviadas?\s*(por|pelo)?\s*[\w\d_]+\s*)?"
-        r"|sincronizadas?|ressincronizadas?|sinc|sync|traduzidas?|ripadas?|ajustad[ao]s?|ajustei\s*(a\s*)?sincronia)?"
-        r"\s*(de\s*raiz\s*)?(para\s*(a|o|as|os)?\s*)?(vers[aã]o|release[s]?|filme|nomes?)?\s*[:\-–]?\s*"
+        r"^(legendas?\s*(anteriormente\s*)?(enviadas?\s*(por|pelo|do)?\s*[\w\d_]+\s*)?"
+        r"|sincronizadas?|ressincronizadas?|sinc|sync|traduzidas?|ripadas?\s*(por\s*mim)?|ajustad[ao]s?|ajustei\s*(a\s*)?sincronia)?"
+        r"\s*(do\s*dvd\.?|de\s*raiz\s*)?(para\s*(a|o|as|os)?\s*)?(vers[aã]o|release[s]?|filme|nomes?)?\s*[:\-–]?\s*"
     )
     return re.sub(prefix_pattern, "", text, flags=re.I).strip().strip("*").strip("`").strip()
 
@@ -58,9 +58,15 @@ def extract_release_info(title, year, desc):
         r"(2160p|1080p|720p|480p|4k|bluray|blu-ray|bdrip|brrip|web-dl|webdl|web-rip|webrip|web|dvdrip|dvd|hdtv|x264|x265|hevc|h\.264|h\.265|xvid|divx|remastered|proper|internal|repack)",
         re.I,
     )
+    conversational_re = re.compile(
+        r"^(legenda[s]?|ripada[s]?|enviada[s]?|postada[s]?|corrigido[s]?|feita[s]?|fiz\s|peguei\s|são\s|sao\s|não\s|nao\s|avisem|cumps|enjoy|obrigado|duração|duracao)",
+        re.I,
+    )
 
     for line in lines:
         cleaned = clean_release_line(line)
+        if not cleaned:
+            continue
         if release_re.search(cleaned):
             match = re.search(
                 r"([\w\.\-_]+(?:2160p|1080p|720p|480p|4k|bluray|blu-ray|bdrip|brrip|web-dl|webdl|dvdrip|dvd|x264|x265|hevc|xvid|divx)[\w\.\-_]*)",
@@ -69,20 +75,22 @@ def extract_release_info(title, year, desc):
             )
             if match and len(match.group(1)) > 10:
                 candidates.append(match.group(1).strip("."))
-            else:
+            elif not conversational_re.search(cleaned) and len(cleaned) > 5:
                 candidates.append(cleaned)
-        elif title and title.lower() in cleaned.lower() and len(cleaned) > len(title):
+        elif title and title.lower() in cleaned.lower() and len(cleaned) > len(title) and not conversational_re.search(cleaned):
             candidates.append(cleaned)
 
     if candidates:
-        return candidates[0]
+        def candidate_quality(cand):
+            score = len(cand)
+            if title and title.lower() in cand.lower():
+                score += 100
+            if "." in cand or "-" in cand:
+                score += 50
+            return score
 
-    first_meaningful = [
-        candidate for candidate in lines
-        if len(candidate) > 3 and not candidate.lower().startswith(("cumps", "enjoy", "obrigado", "avisem", "não se", "duração:", "duracao:"))
-    ]
-    if first_meaningful and len(first_meaningful[0]) <= 80:
-        return f"{default_name} - {first_meaningful[0]}" if default_name else first_meaningful[0]
+        best = max(candidates, key=candidate_quality)
+        return best
 
     return default_name
 

--- a/custom_libs/subliminal_patch/providers/legendasdivx.py
+++ b/custom_libs/subliminal_patch/providers/legendasdivx.py
@@ -399,6 +399,8 @@ class LegendasdivxProvider(Provider):
                             else:
                                 if searches_count >= self.SAFE_SEARCH_LIMIT:
                                     searchLimitReached = True
+            except (AuthenticationError, ConfigurationError, IPAddressBlocked, TooManyRequests, SearchLimitReached):
+                raise
             except HTTPError as e:
                 if "bloqueado" in res.text.lower():
                     logger.error("LegendasDivx.pt :: Your IP is blocked on this server.")
@@ -455,6 +457,8 @@ class LegendasdivxProvider(Provider):
             sleep(1)
             res = self.session.get(subtitle.page_link)
             res.raise_for_status()
+        except (AuthenticationError, ConfigurationError, IPAddressBlocked, TooManyRequests, DownloadLimitExceeded):
+            raise
         except HTTPError as e:
             if "bloqueado" in res.text.lower():
                 logger.error("LegendasDivx.pt :: Your IP is blocked on this server.")

--- a/custom_libs/subliminal_patch/providers/legendasdivx.py
+++ b/custom_libs/subliminal_patch/providers/legendasdivx.py
@@ -4,6 +4,9 @@ import io
 import os
 import re
 import zipfile
+import tempfile
+import subprocess
+import shutil
 from time import sleep
 from urllib.parse import quote
 from urllib.parse import parse_qs
@@ -555,13 +558,15 @@ class LegendasdivxProvider(Provider):
             raise DownloadLimitExceeded("Legendasdivx.pt :: Daily download limit reached!")
 
         archive = self._get_archive(res.content)
-        # extract the subtitle
         if archive:
-            subtitle_content = self._get_subtitle_from_archive(archive, subtitle)
-            if subtitle_content:
-                subtitle.content = fix_line_ending(subtitle_content)
-                subtitle.normalize()
-                return subtitle
+            subtitle_content = self._get_subtitle_from_archive(archive, res.content, subtitle)
+        else:
+            subtitle_content = self._extract_via_cli(res.content)
+
+        if subtitle_content:
+            subtitle.content = fix_line_ending(subtitle_content)
+            subtitle.normalize()
+            return subtitle
         return
 
     def _get_archive(self, content):
@@ -578,7 +583,60 @@ class LegendasdivxProvider(Provider):
             return None
         return archive
 
-    def _get_subtitle_from_archive(self, archive, subtitle):
+    def _read_from_archive(self, archive, content, target_name):
+        try:
+            return archive.read(target_name)
+        except Exception as e:
+            logger.warning("Legendasdivx.pt :: Direct archive.read failed (%s), attempting CLI extraction fallback", e)
+            return self._extract_via_cli(content, target_name)
+
+    def _extract_via_cli(self, content, target_name=None):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            tmparc = os.path.join(tmpdir, "archive.rar")
+            with open(tmparc, "wb") as f:
+                f.write(content)
+
+            extracted = False
+            for tool, cmd in [
+                ("unar", ["unar", "-o", tmpdir, "-f", tmparc]),
+                ("7z", ["7z", "x", "-y", f"-o{tmpdir}", tmparc]),
+                ("unrar", ["unrar", "x", "-y", tmparc, tmpdir]),
+            ]:
+                if shutil.which(tool):
+                    p = subprocess.run(cmd, capture_output=True)
+                    if p.returncode == 0:
+                        extracted = True
+                        break
+
+            if extracted:
+                _tmp = list(SUBTITLE_EXTENSIONS)
+                if ".txt" in _tmp:
+                    _tmp.remove(".txt")
+                _subtitle_extensions = tuple(_tmp)
+
+                target_base = os.path.split(target_name)[-1].lower() if target_name else None
+                found_files = []
+                for root, _, files in os.walk(tmpdir):
+                    for f in files:
+                        if f != "archive.rar" and f.lower().endswith(_subtitle_extensions):
+                            full_path = os.path.join(root, f)
+                            if target_base and f.lower() == target_base:
+                                with open(full_path, "rb") as sf:
+                                    return sf.read()
+                            found_files.append(full_path)
+
+                if found_files:
+                    with open(found_files[0], "rb") as sf:
+                        return sf.read()
+        except Exception as err:
+            logger.error("Legendasdivx.pt :: CLI extraction fallback failed: %s", err)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        return None
+
+    def _get_subtitle_from_archive(self, archive, content, subtitle):
         # some files have a non subtitle with .txt extension
         _tmp = list(SUBTITLE_EXTENSIONS)
         if '.txt' in _tmp:
@@ -602,12 +660,12 @@ class LegendasdivxProvider(Provider):
 
         if not candidate_files:
             logger.error("Legendasdivx.pt :: No subtitle file found in archive")
-            return None
+            return self._extract_via_cli(content)
 
         # If archive contains only 1 subtitle file, return it directly
         if len(candidate_files) == 1:
             logger.debug("Legendasdivx.pt :: Only 1 subtitle in archive, returning: %s", candidate_files[0])
-            return archive.read(candidate_files[0])
+            return self._read_from_archive(archive, content, candidate_files[0])
 
         for name in candidate_files:
             _guess = guessit(name)
@@ -644,6 +702,6 @@ class LegendasdivxProvider(Provider):
 
         if _max_name:
             logger.debug("Legendasdivx.pt :: returning from archive: %s (score %s)", _max_name, _max_score)
-            return archive.read(_max_name)
+            return self._read_from_archive(archive, content, _max_name)
 
-        return archive.read(candidate_files[0])
+        return self._read_from_archive(archive, content, candidate_files[0])

--- a/custom_libs/subliminal_patch/providers/legendasdivx.py
+++ b/custom_libs/subliminal_patch/providers/legendasdivx.py
@@ -180,7 +180,7 @@ class LegendasdivxProvider(Provider):
             res.raise_for_status()
             bsoup = ParserBeautifulSoup(res.content, ['lxml'])
 
-            _allinputs = bsoup.findAll('input')
+            _allinputs = bsoup.find_all('input')
             data = {}
             # necessary to set 'sid' for POST request
             for field in _allinputs:
@@ -193,17 +193,24 @@ class LegendasdivxProvider(Provider):
             res = self.session.post(self.loginpage, data)
             res.raise_for_status()
             # make sure we're logged in
-            logger.debug('Legendasdivx.pt :: Logged in successfully: PHPSESSID: %s',
-                         self.session.cookies.get_dict()['PHPSESSID'])
+            uid = self.session.cookies.get('phpbb3_2z8zs_u')
+            session_id = self.session.cookies.get('PHPSESSID') or self.session.cookies.get('phpbb3_2z8zs_sid')
+            if uid == '1' or not session_id:
+                logger.error("Legendasdivx.pt :: Couldn't get session ID, check your credentials")
+                raise AuthenticationError("Legendasdivx.pt :: Couldn't get session ID, check your credentials")
+
+            logger.debug('Legendasdivx.pt :: Logged in successfully: session: %s', session_id)
             cj = self.session.cookies.copy()
             store_cks = ("PHPSESSID", "phpbb3_2z8zs_sid", "phpbb3_2z8zs_k", "phpbb3_2z8zs_u", "lang")
-            for cn in iter(self.session.cookies.keys()):
+            for cn in list(self.session.cookies.keys()):
                 if cn not in store_cks:
                     del cj[cn]
             # store session cookies on cache
             logger.debug("Legendasdivx.pt :: Storing legendasdivx session cookies: %r", cj)
             region.set("legendasdivx_cookies2", cj)
 
+        except (AuthenticationError, ConfigurationError, IPAddressBlocked, TooManyRequests):
+            raise
         except KeyError:
             logger.error("Legendasdivx.pt :: Couldn't get session ID, check your credentials")
             raise AuthenticationError("Legendasdivx.pt :: Couldn't get session ID, check your credentials")
@@ -220,17 +227,16 @@ class LegendasdivxProvider(Provider):
         except Exception as e:
             logger.error("LegendasDivx.pt :: Uncaught error: %r", e)
             raise ServiceUnavailable("LegendasDivx.pt :: Uncaught error: %r", e)
-
     def _process_page(self, video, bsoup):
 
         subtitles = []
 
-        _allsubs = bsoup.findAll("div", {"class": "sub_box"})
+        _allsubs = bsoup.find_all("div", {"class": "sub_box"})
 
         for _subbox in _allsubs:
 
             hits = 0
-            for th in _subbox.findAll("th"):
+            for th in _subbox.find_all("th"):
                 if th.text == 'Hits:':
                     hits = int(th.find_next("td").text)
                 if th.text == 'Idioma:':

--- a/tests/subliminal_patch/test_http.py
+++ b/tests/subliminal_patch/test_http.py
@@ -1,0 +1,39 @@
+import brotli
+from subliminal.cache import region
+from subliminal_patch.http import CFSession, RetryingCFSession
+
+
+def test_cf_session_brotli_response(requests_mock):
+    region.configure("dogpile.cache.memory", replace_existing_backend=True)
+    raw_html = b"<!DOCTYPE html><html><body>Test LegendasDivx Content</body></html>"
+    compressed_html = brotli.compress(raw_html)
+
+    requests_mock.get(
+        "https://www.legendasdivx.pt/forum/ucp.php?mode=login",
+        content=compressed_html,
+        headers={"Content-Encoding": "br"},
+    )
+
+    session = CFSession()
+    resp = session.get("https://www.legendasdivx.pt/forum/ucp.php?mode=login")
+    assert resp.status_code == 200
+    assert resp.content == raw_html
+    assert "Test LegendasDivx" in resp.text
+
+
+def test_retrying_cf_session_brotli_response(requests_mock):
+    region.configure("dogpile.cache.memory", replace_existing_backend=True)
+    raw_html = b"<!DOCTYPE html><html><body>Test RetryingCFSession Brotli</body></html>"
+    compressed_html = brotli.compress(raw_html)
+
+    requests_mock.get(
+        "https://www.legendasdivx.pt/forum/ucp.php?mode=login",
+        content=compressed_html,
+        headers={"Content-Encoding": "br"},
+    )
+
+    session = RetryingCFSession()
+    resp = session.get("https://www.legendasdivx.pt/forum/ucp.php?mode=login")
+    assert resp.status_code == 200
+    assert resp.content == raw_html
+    assert "Test RetryingCFSession" in resp.text

--- a/tests/subliminal_patch/test_legendasdivx.py
+++ b/tests/subliminal_patch/test_legendasdivx.py
@@ -1,9 +1,10 @@
 import brotli
+from guessit import guessit
 import pytest
 from subliminal.cache import region
 from subliminal.exceptions import AuthenticationError, ConfigurationError
 from subliminal.video import Movie
-from subliminal_patch.providers.legendasdivx import LegendasdivxProvider, LegendasdivxSubtitle
+from subliminal_patch.providers.legendasdivx import LegendasdivxProvider, LegendasdivxSubtitle, extract_release_info
 from subzero.language import Language
 
 
@@ -27,6 +28,9 @@ SEARCH_PAGE_HTML = b"""<!DOCTYPE html>
 <body>
 <div class="pager_bar">(1 encontradas)</div>
 <div class="sub_box">
+    <div class="sub_header">
+        <b>The Matrix</b> (1999) - Enviada por: <a href="profile.php?u=100">UploaderName</a>
+    </div>
     <table>
         <tr>
             <th>Idioma:</th>
@@ -37,10 +41,7 @@ SEARCH_PAGE_HTML = b"""<!DOCTYPE html>
             <td>23.976</td>
         </tr>
     </table>
-    <td class="td_desc brd_up">The Matrix 1999 1080p BluRay x264-SPARKS</td>
-    <div class="sub_header">
-        <a href="profile.php?mode=viewprofile&u=100">UploaderName</a>
-    </div>
+    <td class="td_desc brd_up">Sincronizadas para a release: The.Matrix.1999.1080p.BluRay.x264-SPARKS</td>
     <div class="sub_footer">
         <a class="sub_download" href="?name=Downloads&d_op=getit&lid=12345">Download</a>
     </div>
@@ -53,6 +54,20 @@ SEARCH_PAGE_HTML = b"""<!DOCTYPE html>
 def configure_cache():
     region.configure("dogpile.cache.memory", replace_existing_backend=True)
     region.delete("legendasdivx_cookies2")
+
+
+def test_extract_release_info():
+    # 1. Strip sync/upload prefixes and keep clean release
+    desc1 = "Legendas anteriormente enviadas pelo cristiano170, ressincronizadas por mim para a(s) release(s):\n\n**The.Truman.Show.1998.720p.BluRay.x264-SEPTiC**"
+    assert extract_release_info("The Truman Show", 1998, desc1) == "The.Truman.Show.1998.720p.BluRay.x264-SEPTiC"
+
+    # 2. Handle empty or 'Não há descrição disponível'
+    desc2 = "Não há descrição disponível"
+    assert extract_release_info("The Truman Show", 1998, desc2) == "The Truman Show (1998)"
+
+    # 3. Handle version label prefix
+    desc3 = "Sincronizadas para a versão: The.Truman.Show.1998.DVDRip.XviD.AC3-DEViSE"
+    assert extract_release_info("The Truman Show", 1998, desc3) == "The.Truman.Show.1998.DVDRip.XviD.AC3-DEViSE"
 
 
 def test_legendasdivx_config_error():
@@ -75,24 +90,10 @@ def test_legendasdivx_login_failure(requests_mock):
         headers={"Content-Encoding": "br"},
     )
 
-    provider = LegendasdivxProvider("wronguser", "wrongpass")
-    # Simulate failed authentication cookie
-    def set_failed_cookie(r, **kw):
-        provider.session.cookies.set("phpbb3_2z8zs_u", "1")
-
-    provider.initialize = lambda: (setattr(provider, "session", provider.session if hasattr(provider, "session") else None), LegendasdivxProvider.initialize(provider))
-    # Hook into session creation
     orig_init = LegendasdivxProvider.initialize
 
-    def wrapped_init(self):
-        orig_init(self)
-
-    # Directly run initialize with response hook
     with pytest.raises(AuthenticationError):
         provider = LegendasdivxProvider("wronguser", "wrongpass")
-        # Run initialize
-        provider.session = provider.__class__.__dict__["initialize"]
-        # Or simply call provider.initialize() where response returns no valid session
         orig_init(provider)
 
 
@@ -113,8 +114,6 @@ def test_legendasdivx_login_success(requests_mock):
     )
 
     provider = LegendasdivxProvider("gooduser", "goodpass")
-    # Initialize will create session and login
-    # We patch session creation to attach response hook that sets cookies
     orig_login = provider.login
 
     def login_with_cookies():
@@ -148,13 +147,10 @@ def test_legendasdivx_query_movie(requests_mock):
         headers={"Content-Encoding": "br"},
     )
 
-    movie = Movie(
-        name="The.Matrix.1999.1080p.mkv",
-        title="The Matrix",
-        year=1999,
-        imdb_id="tt0133093",
-        fps=23.976,
-    )
+    filename = "The.Matrix.1999.1080p.BluRay.x264-SPARKS.mkv"
+    movie = Movie.fromguess(filename, guessit(filename))
+    movie.imdb_id = "tt0133093"
+    movie.fps = 23.976
 
     provider = LegendasdivxProvider("gooduser", "goodpass", skip_wrong_fps=False)
     provider.initialize()
@@ -164,4 +160,13 @@ def test_legendasdivx_query_movie(requests_mock):
     sub = subtitles[0]
     assert isinstance(sub, LegendasdivxSubtitle)
     assert sub.hits == 42
-    assert "12345" in sub.id or "tt0133093" in sub.id
+    assert sub.title == "The Matrix"
+    assert sub.year == 1999
+    assert sub.release_info == "The.Matrix.1999.1080p.BluRay.x264-SPARKS"
+    matches = sub.get_matches(movie)
+    assert "title" in matches
+    assert "year" in matches
+    assert "imdb_id" in matches
+    assert "video_codec" in matches
+    assert "resolution" in matches
+    assert "release_group" in matches

--- a/tests/subliminal_patch/test_legendasdivx.py
+++ b/tests/subliminal_patch/test_legendasdivx.py
@@ -1,0 +1,167 @@
+import brotli
+import pytest
+from subliminal.cache import region
+from subliminal.exceptions import AuthenticationError, ConfigurationError
+from subliminal.video import Movie
+from subliminal_patch.providers.legendasdivx import LegendasdivxProvider, LegendasdivxSubtitle
+from subzero.language import Language
+
+
+LOGIN_PAGE_HTML = b"""<!DOCTYPE html>
+<html>
+<head><title>LegendasDivx - Painel de Controlo do Utilizador - Ligue-se</title></head>
+<body>
+<form method="post" action="./ucp.php?mode=login">
+    <input type="text" name="username" value="" />
+    <input type="password" name="password" />
+    <input type="hidden" name="sid" value="1890def6632a667396e33b8df3ac94ac" />
+    <input type="hidden" name="redirect" value="index.php" />
+    <input type="submit" name="login" value="Ligue-se" />
+</form>
+</body>
+</html>"""
+
+SEARCH_PAGE_HTML = b"""<!DOCTYPE html>
+<html>
+<head><title>LegendasDivx - Downloads</title></head>
+<body>
+<div class="pager_bar">(1 encontradas)</div>
+<div class="sub_box">
+    <table>
+        <tr>
+            <th>Idioma:</th>
+            <td><img src="images/flags/portugal.png" /></td>
+            <th>Hits:</th>
+            <td>42</td>
+            <th>Frame Rate:</th>
+            <td>23.976</td>
+        </tr>
+    </table>
+    <td class="td_desc brd_up">The Matrix 1999 1080p BluRay x264-SPARKS</td>
+    <div class="sub_header">
+        <a href="profile.php?mode=viewprofile&u=100">UploaderName</a>
+    </div>
+    <div class="sub_footer">
+        <a class="sub_download" href="?name=Downloads&d_op=getit&lid=12345">Download</a>
+    </div>
+</div>
+</body>
+</html>"""
+
+
+@pytest.fixture(autouse=True)
+def configure_cache():
+    region.configure("dogpile.cache.memory", replace_existing_backend=True)
+    region.delete("legendasdivx_cookies2")
+
+
+def test_legendasdivx_config_error():
+    with pytest.raises(ConfigurationError):
+        LegendasdivxProvider("user", None)
+    with pytest.raises(ConfigurationError):
+        LegendasdivxProvider(None, "pass")
+
+
+def test_legendasdivx_login_failure(requests_mock):
+    requests_mock.get(
+        "https://www.legendasdivx.pt/forum/ucp.php?mode=login",
+        content=brotli.compress(LOGIN_PAGE_HTML),
+        headers={"Content-Encoding": "br"},
+    )
+    # Login POST returns user id 1 (anonymous/guest in phpbb)
+    requests_mock.post(
+        "https://www.legendasdivx.pt/forum/ucp.php?mode=login",
+        content=brotli.compress(b"<html><body><div class='error'>Invalid password</div></body></html>"),
+        headers={"Content-Encoding": "br"},
+    )
+
+    provider = LegendasdivxProvider("wronguser", "wrongpass")
+    # Simulate failed authentication cookie
+    def set_failed_cookie(r, **kw):
+        provider.session.cookies.set("phpbb3_2z8zs_u", "1")
+
+    provider.initialize = lambda: (setattr(provider, "session", provider.session if hasattr(provider, "session") else None), LegendasdivxProvider.initialize(provider))
+    # Hook into session creation
+    orig_init = LegendasdivxProvider.initialize
+
+    def wrapped_init(self):
+        orig_init(self)
+
+    # Directly run initialize with response hook
+    with pytest.raises(AuthenticationError):
+        provider = LegendasdivxProvider("wronguser", "wrongpass")
+        # Run initialize
+        provider.session = provider.__class__.__dict__["initialize"]
+        # Or simply call provider.initialize() where response returns no valid session
+        orig_init(provider)
+
+
+def test_legendasdivx_login_success(requests_mock):
+    requests_mock.get(
+        "https://www.legendasdivx.pt/forum/ucp.php?mode=login",
+        content=brotli.compress(LOGIN_PAGE_HTML),
+        headers={"Content-Encoding": "br"},
+    )
+
+    def set_success_cookies(request, context):
+        context.headers["Content-Encoding"] = "br"
+        return brotli.compress(b"<html><body>Logged in</body></html>")
+
+    requests_mock.post(
+        "https://www.legendasdivx.pt/forum/ucp.php?mode=login",
+        content=set_success_cookies,
+    )
+
+    provider = LegendasdivxProvider("gooduser", "goodpass")
+    # Initialize will create session and login
+    # We patch session creation to attach response hook that sets cookies
+    orig_login = provider.login
+
+    def login_with_cookies():
+        provider.session.cookies.set("phpbb3_2z8zs_u", "4242")
+        provider.session.cookies.set("phpbb3_2z8zs_sid", "abcdef1234567890")
+        provider.session.cookies.set("PHPSESSID", "sess4242")
+        provider.session.cookies.set("extra_junk", "discard_me")
+        orig_login()
+
+    provider.login = login_with_cookies
+    provider.initialize()
+
+    cached_cookies = region.get("legendasdivx_cookies2")
+    assert cached_cookies is not None
+    assert cached_cookies.get("phpbb3_2z8zs_u") == "4242"
+    assert cached_cookies.get("phpbb3_2z8zs_sid") == "abcdef1234567890"
+    assert "extra_junk" not in cached_cookies
+
+
+def test_legendasdivx_query_movie(requests_mock):
+    cached_cookies = {
+        "phpbb3_2z8zs_u": "4242",
+        "phpbb3_2z8zs_sid": "abcdef1234567890",
+        "PHPSESSID": "sess4242",
+    }
+    region.set("legendasdivx_cookies2", cached_cookies)
+
+    requests_mock.get(
+        "https://www.legendasdivx.pt/modules.php",
+        content=brotli.compress(SEARCH_PAGE_HTML),
+        headers={"Content-Encoding": "br"},
+    )
+
+    movie = Movie(
+        name="The.Matrix.1999.1080p.mkv",
+        title="The Matrix",
+        year=1999,
+        imdb_id="tt0133093",
+        fps=23.976,
+    )
+
+    provider = LegendasdivxProvider("gooduser", "goodpass", skip_wrong_fps=False)
+    provider.initialize()
+    subtitles = provider.query(movie, [Language("por")])
+
+    assert len(subtitles) == 1
+    sub = subtitles[0]
+    assert isinstance(sub, LegendasdivxSubtitle)
+    assert sub.hits == 42
+    assert "12345" in sub.id or "tt0133093" in sub.id


### PR DESCRIPTION
Comprehensive fixes and reliability improvements for the `LegendasDivx` (`legendasdivx`) subtitle provider, the shared `CFSession` HTTP transport layer, and RAR
archive extraction:

1. **Fixed Brotli Decompression in `CFSession` (`subliminal_patch/http.py`)**:
   - Modern `urllib3` (>= 1.25.1 and 2.x) and `requests` automatically decompress responses with `Content-Encoding: br`.
   - Removed an obsolete `_request` override in `CFSession` that performed manual Brotli re-decompression on already-decoded payload buffers, which was causing `brotli.error: brotli: decoder failed` across all requests.
   - Delegated request handling directly to `super().request()` with `self.decodeBrotli()` from `CloudScraper`.

2. **Fixed Authentication & Session Cookie Handling**:
   - Updated `LegendasdivxProvider.login()` to look for `phpbb3_2z8zs_sid` and verify user ID `phpbb3_2z8zs_u != '1'` (detecting guest vs authenticated session), avoiding `KeyError` exceptions when `PHPSESSID` is not explicitly set.
   - Preserved typed exceptions (`AuthenticationError`, `ConfigurationError`, `IPAddressBlocked`, `TooManyRequests`, `SearchLimitReached`, `DownloadLimitExceeded`) so they are not masked as generic `ServiceUnavailable`.

3. **Dynamic Provider Resolution in `SZProviderPool` (`subliminal_patch/core.py`)**:
   - Updated `SZProviderPool.__getitem__` so that when a subtitle download requests an unlisted or throttled provider dynamically, it registers and initializes the provider from `provider_registry` rather than throwing a bare `KeyError` loop.

4. **Improved Release Name Extraction & Match Scoring**:
   - Extracted movie/episode `title` and `year` directly from the box header (`sub_header`), guaranteeing `title`, `year`, and `imdb_id` matches.
   - Added smart release name extractor `extract_release_info()` to clean upload/sync commentary prefixes (`Sincronizadas para a versão:`, `Sync para a release:`, etc.) and rank specific release candidates above single-word tags (`DVDRIP`) or conversational text (`Ripada por mim...`).
   - Clean fallback to `"{title} ({year})"` when no description is available rather than displaying raw text `"Não há descrição disponível"`.
   - Updated deprecated BeautifulSoup `findAll()` calls to `find_all()`.

5. **Fixed Archive Extraction for Season Packs & Multi-Episode Files**:
   - Fixed `_get_subtitle_from_archive()` to support season pack archives with standalone episode filenames (e.g. `E01.srt`, `01.srt`) without requiring a redundant `'season'` key in the filename.
   - Fixed multi-episode filename matching (e.g. `1x01-02.srt` list match).
   - Added direct extraction fallback for single-subtitle archives.

6. **Fixed RAR Extraction in Docker & Prioritized `unar`/`unrar` (`Dockerfile`, `bazarr/init.py`)**:
   - Debian's `p7zip-full` package has the non-free unrar codec stripped out, causing `7z` to fail with `Cannot open the file as archive` on Solid RAR format archives.
   - Added **`unar`** (The Unarchiver) to `Dockerfile` runtime dependencies.
   - Updated **`bazarr/init.py`** to prioritize `unrar` and `unar` ahead of `7z` for all RAR archive operations.
   - Added CLI extraction fallback in `legendasdivx.py` for resilience.

---

## Testing

- Unit test suite in `tests/subliminal_patch/test_http.py` and `tests/subliminal_patch/test_legendasdivx.py` (7 passing tests).
- Verified live end-to-end against `legendasdivx.pt`:
  - Authentication and session maintenance
  - Movie searches (`The Matrix`, `The Truman Show`) with clean release names and 90%+ match scoring
  - TV episode searches (`Breaking Bad S01E01`, `The Good Place S01E01`, `The Good Place S01E07`, `FROM S01E04`)
  - Subtitle download and `.rar`/`.zip` extraction across individual releases, season packs (`E01.srt`), multi-episode files (`1x01-02.srt`), and Solid RAR format archives.
- Verified in live Docker Compose container environment.
