### PR TITLE
fix(gestdown): format release_info with show name and episode tag

### DIFF
--- a/custom_libs/subliminal_patch/providers/gestdown.py
+++ b/custom_libs/subliminal_patch/providers/gestdown.py
@@ -24,15 +24,31 @@ class GestdownSubtitle(Subtitle):
     hash_verifiable = False
     hearing_impaired_verifiable = True
 
-    def __init__(self, language, data: dict):
+    def __init__(self, language, data: dict, series=None, season=None, episode=None):
         super().__init__(language, hearing_impaired=data["hearingImpaired"])
         self.page_link = _BASE_URL + data["downloadUri"]
         self._id = data["subtitleId"]
-        self.releases = [v.strip() for v in data["version"].split(",")]
+        raw_releases = [v.strip() for v in data["version"].split(",") if v.strip()]
+        self.releases = []
+        for v in raw_releases:
+            if season is not None and episode is not None and not (
+                f"s{season:02d}" in v.lower()
+                or f"{season}x" in v.lower()
+                or (series and series.lower() in v.lower())
+            ):
+                clean_ver = v.replace(" ", ".")
+                clean_series = series.strip().replace(" ", ".") if series else ""
+                formatted = (
+                    f"{clean_series}.S{season:02d}E{episode:02d}.{clean_ver}"
+                    if clean_series
+                    else f"S{season:02d}E{episode:02d}.{clean_ver}"
+                )
+                self.releases.append(formatted)
+            else:
+                self.releases.append(v)
         self.qualities = data.get("qualities") or []
-        self.release_info = "\n".join(self.releases)
+        self.release_info = "\n".join(self.releases) if self.releases else data.get("version", "")
         self.matches = set()
-
     def get_matches(self, video):
         self.matches = {"title", "series", "season", "episode", "tvdb_id"}
 
@@ -92,12 +108,12 @@ class GestdownProvider(Provider):
     video_types = (Episode,)
 
     # fmt: off
-    languages = {Language('por', 'BR')} | {Language(l) for l in [
+    languages = {Language('por', 'BR')} | {Language(lang) for lang in [
         'ara', 'aze', 'ben', 'bos', 'bul', 'cat', 'ces', 'dan', 'deu', 'ell', 'eng', 'eus', 'fas', 'fin', 'fra', 'glg',
         'heb', 'hrv', 'hun', 'hye', 'ind', 'ita', 'jpn', 'kor', 'mkd', 'msa', 'nld', 'nor', 'pol', 'por', 'ron', 'rus',
         'slk', 'slv', 'spa', 'sqi', 'srp', 'swe', 'tha', 'tur', 'ukr', 'vie', 'zho'
-    ]} | {Language.fromietf(l) for l in ["sr-Latn", "sr-Cyrl"]}
-    languages.update(set(Language.rebuild(l, hi=True) for l in languages))
+    ]} | {Language.fromietf(lang) for lang in ["sr-Latn", "sr-Cyrl"]}
+    languages.update(set(Language.rebuild(lang, hi=True) for lang in languages))
     # fmt: on
 
     _converter = PatchedAddic7edConverter()
@@ -117,21 +133,31 @@ class GestdownProvider(Provider):
 
         # TODO: implement rate limiting
         response.raise_for_status()
-
-        matching_subtitles = response.json()["matchingSubtitles"]
+        resp_json = response.json()
+        matching_subtitles = resp_json.get("matchingSubtitles")
 
         if not matching_subtitles:
             logger.debug("No episodes found for '%s' language", language)
             return None
 
+        episode_info = resp_json.get("episode") or {}
+        series_name = episode_info.get("show") or getattr(video, "series", None)
+        season_num = episode_info.get("season") or getattr(video, "season", None)
+        episode_num = episode_info.get("number") or getattr(video, "episode", None)
+
         for subtitle_dict in matching_subtitles:
             if not subtitle_dict["completed"]:
                 continue
 
-            sub = GestdownSubtitle(language, subtitle_dict)
+            sub = GestdownSubtitle(
+                language,
+                subtitle_dict,
+                series=series_name,
+                season=season_num,
+                episode=episode_num,
+            )
             logger.debug("Found subtitle: %s", sub)
             yield sub
-
     def _search_show(self, video):
         try:
             response = self._session.get(

--- a/tests/subliminal_patch/test_gestdown.py
+++ b/tests/subliminal_patch/test_gestdown.py
@@ -15,8 +15,8 @@ def test_language_list_is_convertible():
 @pytest.mark.parametrize(
     "episode_key,language,expected_any_release_info",
     [
-        ("breaking_bad_s01e01", Language.fromietf("en"), "BluRayREWARD"),
-        ("better_call_saul_s06e04", Language.fromietf("fr"), "AMZN-NTb"),
+        ("breaking_bad_s01e01", Language.fromietf("en"), "Breaking.Bad.S01E01.BluRayREWARD"),
+        ("better_call_saul_s06e04", Language.fromietf("fr"), "Better.Call.Saul.S06E04.AMZN-NTb"),
     ],
 )
 def test_list_subtitles(episodes, episode_key, language, expected_any_release_info):
@@ -25,7 +25,6 @@ def test_list_subtitles(episodes, episode_key, language, expected_any_release_in
         assert any(
             subtitle.release_info == expected_any_release_info for subtitle in subtitles
         )
-
 
 def test_list_subtitles_hearing_impaired(episodes):
     with GestdownProvider() as provider:
@@ -87,6 +86,22 @@ def test_subtitle_multi_release_version():
     assert sub.release_info == "HDTV\nWEB"
 
 
+def test_subtitle_formatted_with_series_and_episode():
+    sub = GestdownSubtitle(
+        Language.fromietf("en"),
+        {
+            "subtitleId": "abc",
+            "version": "LOL, DVDRip ORPHEUS",
+            "hearingImpaired": False,
+            "downloadUri": "/download/abc",
+            "qualities": [],
+        },
+        series="Breaking Bad",
+        season=1,
+        episode=4,
+    )
+    assert sub.releases == ["Breaking.Bad.S01E04.LOL", "Breaking.Bad.S01E04.DVDRip.ORPHEUS"]
+    assert sub.release_info == "Breaking.Bad.S01E04.LOL\nBreaking.Bad.S01E04.DVDRip.ORPHEUS"
 def test_subtitle_get_matches_release_group(episodes):
     sub = GestdownSubtitle(
         Language.fromietf("en"),


### PR DESCRIPTION
Improves the display and match scoring of subtitles from the `Gestdown` (`gestdown`) provider (Addic7ed proxy):

- **Formatted Release Strings**:
  - The Gestdown API returns raw Addic7ed version tags (e.g., `LOL`, `DSR`, `DVDRip ORPHEUS`, `Bluray-CtrlHD`) in its `version` field without the series title or season/episode numbers.
  - `GestdownSubtitle` now formats these tags with the show name and season/episode identifier (e.g. `Breaking.Bad.S01E04.LOL`, `Breaking.Bad.S01E04.DVDRip.ORPHEUS`, `Breaking.Bad.S01E04.Bluray-CtrlHD`).
  - If a version string already contains the season/episode or series name, it is preserved without duplication.

- **Improved Subtitle Scoring**:
  - Having standard release names allows `guessit` and `update_matches()` to extract resolution, source, and release group accurately, improving score calculations in Bazarr.

---

## Testing

- Updated and added unit tests in `tests/subliminal_patch/test_gestdown.py` (13 passing tests).
- Verified live against `https://api.gestdown.info` for TV show searches and subtitle downloads.