### PR TITLE
fix(upload): resolve series upload episodes by local id

### DIFF
--- a/frontend/src/apis/hooks/subtitles.ts
+++ b/frontend/src/apis/hooks/subtitles.ts
@@ -105,10 +105,11 @@ export function useEpisodeSubtitleModification() {
         param.arrInstanceId,
       ),
 
-    onSuccess: (_, { seriesId }) => {
-      client.invalidateQueries({
-        queryKey: [QueryKeys.Series, seriesId],
-      });
+    onSuccess: () => {
+      // Invalidate by prefix. A previous targeted invalidation keyed on the
+      // upstream seriesId never matched, because series queries are cached
+      // under the LOCAL id; it was redundant as well as wrong, since this
+      // prefix already covers every series query.
       client.invalidateQueries({
         queryKey: [QueryKeys.Series],
       });

--- a/frontend/src/components/forms/SeriesUploadForm.tsx
+++ b/frontend/src/components/forms/SeriesUploadForm.tsx
@@ -33,7 +33,10 @@ import {
 } from "@/apis/hooks";
 import api from "@/apis/raw";
 import { subtitlesTypeOptions } from "@/components/forms/uploadFormSelectorTypes";
-import { matchEpisode } from "@/components/forms/uploadHelpers";
+import {
+  episodeBelongsToSeries,
+  matchEpisode,
+} from "@/components/forms/uploadHelpers";
 import { Action, DropContent, Selector } from "@/components/inputs";
 import SimpleTable from "@/components/tables/SimpleTable";
 import TextPopover from "@/components/TextPopover";
@@ -61,7 +64,10 @@ type SubtitleValidateResult = {
   messages?: string;
 };
 
-const validator = (file: SubtitleFile): SubtitleValidateResult => {
+const validator = (
+  file: SubtitleFile,
+  episodes: Item.Episode[],
+): SubtitleValidateResult => {
   if (file.language === null) {
     return {
       state: "error",
@@ -71,6 +77,11 @@ const validator = (file: SubtitleFile): SubtitleValidateResult => {
     return {
       state: "error",
       messages: "Episode is not selected",
+    };
+  } else if (!episodeBelongsToSeries(file.episode, episodes)) {
+    return {
+      state: "error",
+      messages: "Episode does not belong to this series",
     };
   } else {
     const { subtitles } = file.episode;
@@ -102,7 +113,14 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
   onComplete,
 }) => {
   const modals = useModals();
-  const episodes = useEpisodesBySeriesId(series.sonarrSeriesId);
+  // Resolve episodes by the canonical local id, not the upstream sonarrSeriesId
+  // (see SeriesIdType): upstream ids are not unique across arr instances and
+  // drift from the local id for anything added after the local-id cutover, so
+  // reading by the upstream id can return another series' episodes.
+  const episodes = useEpisodesBySeriesId(series.id);
+  // Stable list for row validation, so a row cannot keep an episode that the
+  // opened series does not own.
+  const episodeList = useMemo(() => episodes.data ?? [], [episodes.data]);
   const episodeOptions = useSelectorOptions(
     episodes.data ?? [],
     (v) => `(${v.season}x${v.episode}) ${v.title}`,
@@ -131,9 +149,9 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
         hi: defaultLanguage?.hi ?? false,
         episode: null,
       };
-      return { ...row, validateResult: validator(row) };
+      return { ...row, validateResult: validator(row, episodeList) };
     },
-    [defaultLanguage],
+    [defaultLanguage, episodeList],
   );
 
   const [processing, setProcessing] = useState(false);
@@ -206,7 +224,7 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
     form.setValues((values) => {
       const newFiles = fn(values.files ?? []);
       newFiles.forEach((v) => {
-        v.validateResult = validator(v);
+        v.validateResult = validator(v, episodeList);
       });
       return { ...values, files: newFiles };
     });
@@ -226,7 +244,6 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
   useEffect(() => {
     if (infos.data !== undefined) {
       const infoList = infos.data;
-      const episodeList = episodes.data ?? [];
       action.update((item) => {
         if (item.episode) {
           return item;
@@ -235,7 +252,7 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
         return matched ? { ...item, episode: matched } : item;
       });
     }
-  }, [action, episodes.data, infos.data]);
+  }, [action, episodeList, infos.data]);
 
   const ValidateResultCell = ({
     validateResult,

--- a/frontend/src/components/forms/__tests__/SeriesUploadForm.test.tsx
+++ b/frontend/src/components/forms/__tests__/SeriesUploadForm.test.tsx
@@ -1,0 +1,215 @@
+/* eslint-disable camelcase */
+/**
+ * Tests for the SeriesUploadForm component.
+ *
+ * Focus: which series' episodes the upload modal offers.
+ *
+ * A series row carries two identifiers: the canonical local `id` and the
+ * upstream `sonarrSeriesId`, which is no longer globally unique (see
+ * SeriesIdType in types/api.d.ts). The episodes endpoint used by this form is
+ * keyed on the LOCAL id. Passing the upstream id resolves either to nothing or,
+ * worse, to a different series' episodes, which the filename auto-matcher will
+ * then happily select from.
+ *
+ * Strategy: vi.mock replaces useEpisodesBySeriesId with a fake backed by a map
+ * keyed on the local series id, so the component's own argument decides which
+ * episodes come back. Assertions are on the episodes the user is offered, not on
+ * how the hook was called, so a refactor that keeps the behaviour correct stays
+ * green.
+ *
+ * Fixture values are taken from a real installation where the two identifiers
+ * had drifted: "Room 104" holds local id 559, while "Love me now" holds local id
+ * 560 and upstream id 559. Reading "Love me now" by its upstream id therefore
+ * lands on "Room 104".
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import SeriesUploadForm from "@/components/forms/SeriesUploadForm";
+import { customRender, screen, waitFor } from "@/tests";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeEpisode(
+  localId: number,
+  seriesLocalId: number,
+  sonarrEpisodeId: number,
+  season: number,
+  episode: number,
+  title: string,
+): Item.Episode {
+  return {
+    id: localId,
+    series_id: seriesLocalId,
+    sonarrSeriesId: 0,
+    sonarrEpisodeId,
+    season,
+    episode,
+    title,
+    path: `/tv/${title}.mkv`,
+    monitored: true,
+    subtitles: [],
+    missing_subtitles: [],
+    sceneName: null,
+    audio_language: [],
+  } as unknown as Item.Episode;
+}
+
+/** "Room 104" episodes. Local series id 559. */
+const ROOM_104_EPISODES = [
+  makeEpisode(9001, 559, 79001, 1, 1, "Ralphie"),
+  makeEpisode(9002, 559, 79002, 1, 2, "Pizza Boy"),
+];
+
+/** "Love me now" episodes. Local series id 560, upstream id 559. */
+const LOVE_ME_NOW_EPISODES = [
+  makeEpisode(9101, 560, 79101, 1, 1, "First Sight"),
+  makeEpisode(9102, 560, 79102, 1, 2, "Second Chance"),
+];
+
+const EPISODES_BY_LOCAL_SERIES_ID: Record<number, Item.Episode[]> = {
+  559: ROOM_104_EPISODES,
+  560: LOVE_ME_NOW_EPISODES,
+};
+
+/** "Love me now": local id and upstream id deliberately differ. */
+function makeSeries(): Item.Series {
+  return {
+    id: 560,
+    sonarrSeriesId: 559,
+    arr_instance_id: 1,
+    title: "Love me now",
+    path: "/tv/Love me now",
+    profileId: 1,
+    fanart: "",
+    overview: "",
+    imdbId: "tt0000002",
+    alternativeTitles: [],
+    poster: "",
+    year: "2023",
+    episodeFileCount: 2,
+    episodeMissingCount: 0,
+    ended: false,
+    lastAired: "2023-01-01",
+    seriesType: "standard",
+    tvdbId: 1234,
+    monitored: true,
+    tags: [],
+    audio_language: [],
+  } as unknown as Item.Series;
+}
+
+function makeFile() {
+  return new File(["1\n00:00:01,000 --> 00:00:02,000\nhi\n"], "S01E01.srt", {
+    type: "application/x-subrip",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/apis/hooks", async (importActual) => {
+  const actual = await importActual<typeof import("@/apis/hooks")>();
+  return {
+    ...actual,
+    useEpisodesBySeriesId: vi.fn(),
+    useEpisodeSubtitleModification: vi.fn(),
+    useSubtitleInfos: vi.fn(),
+  };
+});
+
+vi.mock("@/utilities/languages", async (importActual) => {
+  const actual = await importActual<typeof import("@/utilities/languages")>();
+  return {
+    ...actual,
+    useLanguageProfileBy: vi.fn(),
+    useProfileItemsToLanguages: vi.fn(),
+  };
+});
+
+async function setupHooks() {
+  const {
+    useEpisodesBySeriesId,
+    useEpisodeSubtitleModification,
+    useSubtitleInfos,
+  } = await import("@/apis/hooks");
+  const { useLanguageProfileBy, useProfileItemsToLanguages } =
+    await import("@/utilities/languages");
+
+  // The fake resolves episodes by LOCAL series id. Whatever the component
+  // passes is what it gets back, so a wrong identifier surfaces as wrong
+  // episodes rather than as a failed assertion on a call argument.
+  vi.mocked(useEpisodesBySeriesId).mockImplementation(
+    (id: number) =>
+      ({
+        data: EPISODES_BY_LOCAL_SERIES_ID[id] ?? [],
+      }) as unknown as ReturnType<typeof useEpisodesBySeriesId>,
+  );
+
+  vi.mocked(useEpisodeSubtitleModification).mockReturnValue({
+    upload: { mutateAsync: vi.fn(), isPending: false },
+  } as unknown as ReturnType<typeof useEpisodeSubtitleModification>);
+
+  // The uploaded file is recognised as season 1, episode 1. This is what drives
+  // the auto-matcher, and the auto-matcher is the dangerous path: it selects an
+  // episode from whatever list the form fetched, and submission only rejects an
+  // unset episode, never one belonging to another series.
+  vi.mocked(useSubtitleInfos).mockReturnValue({
+    data: [{ filename: "S01E01.srt", season: 1, episode: 1 }],
+  } as unknown as ReturnType<typeof useSubtitleInfos>);
+
+  vi.mocked(useLanguageProfileBy).mockReturnValue({
+    profileId: 1,
+    name: "English",
+    items: [],
+    mustContain: [],
+    mustNotContain: [],
+    originalFormat: false,
+    cutoff: null,
+    tag: undefined,
+  } as unknown as Language.Profile);
+
+  vi.mocked(useProfileItemsToLanguages).mockReturnValue([
+    { code2: "en", name: "English", forced: false, hi: false },
+  ] as Language.Info[]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SeriesUploadForm episode resolution", () => {
+  it("offers episodes of the opened series when its local and upstream ids differ", async () => {
+    await setupHooks();
+
+    customRender(
+      <SeriesUploadForm series={makeSeries()} files={[makeFile()]} />,
+    );
+
+    // The auto-matcher resolves S01E01 against the fetched episode list, so the
+    // selected episode is the observable proof of which series was fetched.
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("(1x1) First Sight")).toBeInTheDocument();
+    });
+  });
+
+  it("does not offer another series' episodes", async () => {
+    await setupHooks();
+
+    customRender(
+      <SeriesUploadForm series={makeSeries()} files={[makeFile()]} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("(1x1) First Sight")).toBeInTheDocument();
+    });
+
+    // "Room 104" owns local id 559, which is "Love me now"'s upstream id. Its
+    // episodes must never be offered here, and must never be auto-selected:
+    // submission only rejects an unset episode, so a wrong one uploads silently.
+    expect(screen.queryByDisplayValue(/Ralphie/)).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue(/Pizza Boy/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/forms/uploadHelpers.test.ts
+++ b/frontend/src/components/forms/uploadHelpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   assignEpisodes,
+  episodeBelongsToSeries,
   matchEpisode,
   shouldAutoCloseUpload,
 } from "./uploadHelpers";
@@ -65,5 +66,27 @@ describe("shouldAutoCloseUpload", () => {
 
   it("does not close while rows remain", () => {
     expect(shouldAutoCloseUpload(true, false, 2)).toBe(false);
+  });
+});
+
+describe("episodeBelongsToSeries", () => {
+  const episodes = [ep(1, 1, 11), ep(1, 2, 12)];
+
+  it("accepts an episode present in the series' episode list", () => {
+    expect(episodeBelongsToSeries(episodes[0], episodes)).toBe(true);
+  });
+
+  it("rejects an episode from a different series", () => {
+    // Same season and episode numbers, different upstream episode id: this is
+    // exactly the shape a wrong-series lookup produces.
+    expect(episodeBelongsToSeries(ep(1, 1, 99), episodes)).toBe(false);
+  });
+
+  it("rejects any episode when the series has no episodes loaded", () => {
+    expect(episodeBelongsToSeries(episodes[0], [])).toBe(false);
+  });
+
+  it("treats a null episode as not belonging", () => {
+    expect(episodeBelongsToSeries(null, episodes)).toBe(false);
   });
 });

--- a/frontend/src/components/forms/uploadHelpers.ts
+++ b/frontend/src/components/forms/uploadHelpers.ts
@@ -42,3 +42,21 @@ export function shouldAutoCloseUpload(
 ): boolean {
   return ready && !processing && fileCount <= 0;
 }
+
+// True when the chosen episode is one the opened series actually owns.
+//
+// Defence in depth. While the episode list is fetched with the correct series
+// identifier this can never be false, but an identifier regression previously
+// let another series' episode be auto-selected and uploaded with no warning,
+// because submission only ever rejected an unset episode. Comparing on the
+// upstream episode id rather than season/episode numbers matters: two series
+// both have a season 1 episode 1.
+export function episodeBelongsToSeries(
+  episode: Item.Episode | null,
+  episodes: Item.Episode[],
+): boolean {
+  if (episode === null) {
+    return false;
+  }
+  return episodes.some((v) => v.sonarrEpisodeId === episode.sonarrEpisodeId);
+}


### PR DESCRIPTION
Fixes https://github.com/LavX/bazarr/issues/312

Fixes the series subtitle upload modal offering the wrong show's episodes, or none at all.

## The bug

The upload modal fetched its episode list with `series.sonarrSeriesId`, but the episodes API client documents that parameter as the canonical **local** series id, and the Episodes page already passes the local id to the same hook. This call site was missed during the local-id cutover.

The two identifiers diverge routinely: the Sonarr sync parser sets `sonarrSeriesId` but never a local `id`, so the database autoincrements it. Only rows that existed at migration time have them aligned. On a fresh install against an established Sonarr, whose ids have gaps from deletions, nearly every show diverges.

## Why it matters more than the report suggests

The same wrong list feeds the filename auto-matcher, and validation only rejected an *unset* episode. So a wrong-series episode could be auto-selected and the subtitle written into another show's folder with no warning anywhere. Users who reported "I can't upload" hit the empty-dropdown case, which is the safe failure.

## Verified against a live library

The episodes endpoint on a real install, before the fix:

| Show | local id | upstream id | modal fetched | got |
| --- | --- | --- | --- | --- |
| Room 104 | 559 | 1 | `series_id=1` | nothing, empty dropdown |
| Love me now | 560 | 559 | `series_id=559` | **Room 104's episodes** |
| House of the Dragon | 561 | 560 | `series_id=560` | nothing, empty dropdown |
| MobLand | 562 | 561 | `series_id=561` | **House of the Dragon's episodes** |

After the fix each resolves to its own episodes. Deployed to a test server and confirmed, including that the served bundle contained the change rather than a cached layer.

## Also in this change

- `episodeBelongsToSeries` guards each row, so a future identifier regression surfaces as a blocked submission instead of a silent misfile.
- Removes a subtitle-upload cache invalidation keyed on the upstream id. Series queries are cached under the local id, so it never matched; the prefix invalidation beside it already covered every series query, making the mis-keyed call redundant as well as wrong.

## Tests

- New `SeriesUploadForm` tests assert the episodes actually offered, using a fixture where the two ids collide the way they do in production. They fail on the old code by auto-selecting `(1x1) Ralphie` from the wrong show.
- New `episodeBelongsToSeries` unit tests, including the case that matters: same season and episode numbers, different upstream episode id.
- Full frontend suite green: 89 files, 837 passed, 2 skipped.

## Note for review

The ownership guard's *wiring* has no behavioural test. Once the id is correct, the state it guards is unreachable through the UI, so a test would have to reach into implementation. The helper itself is unit-tested and the existing component tests cover the non-regression.
