### PR TITLE
fix(upload): decide episode ownership by owning series, not list membership

### DIFF
--- a/frontend/src/components/forms/SeriesUploadForm.tsx
+++ b/frontend/src/components/forms/SeriesUploadForm.tsx
@@ -66,7 +66,7 @@ type SubtitleValidateResult = {
 
 const validator = (
   file: SubtitleFile,
-  episodes: Item.Episode[],
+  seriesLocalId: number,
 ): SubtitleValidateResult => {
   if (file.language === null) {
     return {
@@ -78,7 +78,7 @@ const validator = (
       state: "error",
       messages: "Episode is not selected",
     };
-  } else if (!episodeBelongsToSeries(file.episode, episodes)) {
+  } else if (!episodeBelongsToSeries(file.episode, seriesLocalId)) {
     return {
       state: "error",
       messages: "Episode does not belong to this series",
@@ -118,8 +118,7 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
   // drift from the local id for anything added after the local-id cutover, so
   // reading by the upstream id can return another series' episodes.
   const episodes = useEpisodesBySeriesId(series.id);
-  // Stable list for row validation, so a row cannot keep an episode that the
-  // opened series does not own.
+  // Stable reference for the auto-match effect's dependency array.
   const episodeList = useMemo(() => episodes.data ?? [], [episodes.data]);
   const episodeOptions = useSelectorOptions(
     episodes.data ?? [],
@@ -149,9 +148,9 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
         hi: defaultLanguage?.hi ?? false,
         episode: null,
       };
-      return { ...row, validateResult: validator(row, episodeList) };
+      return { ...row, validateResult: validator(row, series.id) };
     },
-    [defaultLanguage, episodeList],
+    [defaultLanguage, series.id],
   );
 
   const [processing, setProcessing] = useState(false);
@@ -224,7 +223,7 @@ const SeriesUploadForm: FunctionComponent<Props> = ({
     form.setValues((values) => {
       const newFiles = fn(values.files ?? []);
       newFiles.forEach((v) => {
-        v.validateResult = validator(v, episodeList);
+        v.validateResult = validator(v, series.id);
       });
       return { ...values, files: newFiles };
     });

--- a/frontend/src/components/forms/__tests__/SeriesUploadForm.test.tsx
+++ b/frontend/src/components/forms/__tests__/SeriesUploadForm.test.tsx
@@ -100,6 +100,13 @@ function makeSeries(): Item.Series {
   } as unknown as Item.Series;
 }
 
+/** The row status cell renders a FontAwesome icon; "xmark" is the error state. */
+function errorIcons() {
+  return screen
+    .queryAllByRole("img", { hidden: true })
+    .filter((el) => el.getAttribute("data-icon") === "xmark");
+}
+
 function makeFile() {
   return new File(["1\n00:00:01,000 --> 00:00:02,000\nhi\n"], "S01E01.srt", {
     type: "application/x-subrip",
@@ -211,5 +218,47 @@ describe("SeriesUploadForm episode resolution", () => {
     // submission only rejects an unset episode, so a wrong one uploads silently.
     expect(screen.queryByDisplayValue(/Ralphie/)).not.toBeInTheDocument();
     expect(screen.queryByDisplayValue(/Pizza Boy/)).not.toBeInTheDocument();
+  });
+
+  it("flags a row whose episode is owned by a different series", async () => {
+    await setupHooks();
+
+    // Simulate the identifier regression this guard exists for: the form
+    // fetches the WRONG series' episodes. The auto-matcher then selects from
+    // that wrong list, so a membership check would pass. Ownership is decided
+    // against the opened series' own id, so this must still be rejected.
+    const { useEpisodesBySeriesId } = await import("@/apis/hooks");
+    vi.mocked(useEpisodesBySeriesId).mockImplementation(
+      () =>
+        ({
+          data: ROOM_104_EPISODES,
+        }) as unknown as ReturnType<typeof useEpisodesBySeriesId>,
+    );
+
+    customRender(
+      <SeriesUploadForm series={makeSeries()} files={[makeFile()]} />,
+    );
+
+    // The wrong-series episode is auto-selected, exactly as it would be after a
+    // regression, and the row is marked invalid rather than silently uploaded.
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("(1x1) Ralphie")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(errorIcons()).toHaveLength(1);
+    });
+  });
+
+  it("does not flag a row whose episode is owned by the opened series", async () => {
+    await setupHooks();
+
+    customRender(
+      <SeriesUploadForm series={makeSeries()} files={[makeFile()]} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("(1x1) First Sight")).toBeInTheDocument();
+    });
+    expect(errorIcons()).toHaveLength(0);
   });
 });

--- a/frontend/src/components/forms/uploadHelpers.test.ts
+++ b/frontend/src/components/forms/uploadHelpers.test.ts
@@ -10,6 +10,18 @@ const ep = (season: number, episode: number, id: number) =>
   ({ season, episode, sonarrEpisodeId: id }) as unknown as Item.Episode;
 const info = (filename: string, season: number, episode: number) =>
   ({ filename, season, episode }) as SubtitleInfo;
+const epOf = (
+  seriesLocalId: number,
+  season: number,
+  episode: number,
+  id: number,
+) =>
+  ({
+    series_id: seriesLocalId,
+    season,
+    episode,
+    sonarrEpisodeId: id,
+  }) as unknown as Item.Episode;
 
 describe("matchEpisode", () => {
   const episodes = [ep(1, 1, 11), ep(1, 2, 12)];
@@ -70,23 +82,39 @@ describe("shouldAutoCloseUpload", () => {
 });
 
 describe("episodeBelongsToSeries", () => {
-  const episodes = [ep(1, 1, 11), ep(1, 2, 12)];
+  // An episode carries the local id of the series that owns it, so ownership is
+  // decided against the opened series rather than against the list the form
+  // happened to fetch. Checking membership of that list cannot catch the bug
+  // this guard exists for: if the wrong list is fetched, the matcher picks from
+  // the wrong list and the episode is a member of it.
+  const owned = epOf(560, 1, 1, 11);
+  const foreign = epOf(559, 1, 1, 99);
 
-  it("accepts an episode present in the series' episode list", () => {
-    expect(episodeBelongsToSeries(episodes[0], episodes)).toBe(true);
+  it("accepts an episode owned by the opened series", () => {
+    expect(episodeBelongsToSeries(owned, 560)).toBe(true);
   });
 
-  it("rejects an episode from a different series", () => {
-    // Same season and episode numbers, different upstream episode id: this is
-    // exactly the shape a wrong-series lookup produces.
-    expect(episodeBelongsToSeries(ep(1, 1, 99), episodes)).toBe(false);
+  it("rejects an episode owned by a different series", () => {
+    expect(episodeBelongsToSeries(foreign, 560)).toBe(false);
   });
 
-  it("rejects any episode when the series has no episodes loaded", () => {
-    expect(episodeBelongsToSeries(episodes[0], [])).toBe(false);
+  it("rejects an episode from another series that shares season and episode numbers", () => {
+    // The exact shape a wrong-series lookup produces: same S01E01, different owner.
+    expect(foreign.season).toBe(owned.season);
+    expect(foreign.episode).toBe(owned.episode);
+    expect(episodeBelongsToSeries(foreign, 560)).toBe(false);
   });
 
   it("treats a null episode as not belonging", () => {
-    expect(episodeBelongsToSeries(null, episodes)).toBe(false);
+    expect(episodeBelongsToSeries(null, 560)).toBe(false);
+  });
+
+  it("rejects when the episode carries no owning series id", () => {
+    const orphan = {
+      season: 1,
+      episode: 1,
+      sonarrEpisodeId: 11,
+    } as Item.Episode;
+    expect(episodeBelongsToSeries(orphan, 560)).toBe(false);
   });
 });

--- a/frontend/src/components/forms/uploadHelpers.ts
+++ b/frontend/src/components/forms/uploadHelpers.ts
@@ -43,20 +43,23 @@ export function shouldAutoCloseUpload(
   return ready && !processing && fileCount <= 0;
 }
 
-// True when the chosen episode is one the opened series actually owns.
+// True when the chosen episode is owned by the opened series.
 //
-// Defence in depth. While the episode list is fetched with the correct series
-// identifier this can never be false, but an identifier regression previously
-// let another series' episode be auto-selected and uploaded with no warning,
-// because submission only ever rejected an unset episode. Comparing on the
-// upstream episode id rather than season/episode numbers matters: two series
-// both have a season 1 episode 1.
+// Compared against the series' own local id, NOT against the fetched episode
+// list. Membership of that list cannot catch the bug this guard exists for: if
+// a regression makes the form fetch the wrong series' episodes, the matcher
+// selects from that wrong list, so the episode is a member of it and a
+// membership check passes while the subtitle goes to the wrong show.
+//
+// The episode payload carries `series_id`, the local id of its owning series,
+// so this holds even when the fetched list is wrong. An episode with no owning
+// id is rejected rather than assumed to belong.
 export function episodeBelongsToSeries(
   episode: Item.Episode | null,
-  episodes: Item.Episode[],
+  seriesLocalId: number,
 ): boolean {
   if (episode === null) {
     return false;
   }
-  return episodes.some((v) => v.sonarrEpisodeId === episode.sonarrEpisodeId);
+  return episode.series_id === seriesLocalId;
 }


### PR DESCRIPTION
Follow-up to https://github.com/LavX/bazarr/pull/316. Found by an adversarial review of that change before release.

## The guard did not guard

PR #316 added `episodeBelongsToSeries` as defence in depth, checking whether the chosen episode was a member of the episode list the form had fetched. That check cannot catch the bug it was added for.

If a regression makes the form fetch the wrong series' episodes, the auto-matcher selects from that wrong list. So the episode **is** a member of it. The guard passes, the row shows a green check, and the subtitle is written into the wrong show exactly as before. The guard and the matcher read the same source, so they always agree.

The commit message on #316 claimed it would surface a future identifier regression as a blocked submission. That was wrong, and worth correcting before it is repeated in release notes.

## The fix

Decide ownership against the opened series' own local id rather than against the fetched list. The episode payload carries `series_id`, the local id of its owning series, so the check holds even when the fetched list is wrong. An episode carrying no owning id is rejected rather than assumed to belong.

## The wiring test that was missing

#316 shipped with the guard's wiring untested, on the reasoning that the state it guards was unreachable through the UI. That reasoning was itself a symptom of the flaw: with a membership check the state genuinely was unreachable, because guard and matcher shared a source.

With ownership decided independently, it is reachable and now tested. The new case renders with a deliberately wrong episode list, lets the auto-matcher select from it, and asserts the row is marked invalid.

That test was verified to fail against a permissive guard, so it is known to catch the regression rather than merely passing.

## Verification

- Full frontend suite: 89 files, 840 passed, 2 skipped
- `check:ts` clean, `check:fmt` clean
- eslint: 0 errors
