### PR TITLE
fix(cache): stop keying series invalidations on the upstream id

### DIFF
--- a/frontend/src/apis/hooks/__tests__/seriesInvalidations.test.tsx
+++ b/frontend/src/apis/hooks/__tests__/seriesInvalidations.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Tests for mutation hooks that must refresh the series views afterwards.
+ *
+ * Series queries are cached under the canonical LOCAL series id (see
+ * SeriesIdType), while these mutations receive the upstream Sonarr id, because
+ * the endpoints they call are keyed on it. Several hooks invalidated
+ * [Series, <upstream id>], which therefore never matched: at best a no-op, at
+ * worst an accidental refetch of whichever series happens to own that number as
+ * its local id.
+ *
+ * These assert the observable contract of each hook: after it succeeds, the
+ * series views are invalidated, and no key built from the upstream id is used.
+ * Follows the pattern established in subtitleInvalidations.test.tsx.
+ */
+
+import { PropsWithChildren } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useEpisodeAddBlacklist } from "@/apis/hooks/episodes";
+import { useEpisodeSubtitleModification } from "@/apis/hooks/subtitles";
+import { QueryKeys } from "@/apis/queries/keys";
+
+vi.mock("@/apis/raw", () => ({
+  default: {
+    episodes: {
+      addBlacklist: vi.fn().mockResolvedValue(undefined),
+      downloadSubtitles: vi.fn().mockResolvedValue(undefined),
+      deleteSubtitles: vi.fn().mockResolvedValue(undefined),
+      uploadSubtitles: vi.fn().mockResolvedValue(undefined),
+    },
+  },
+}));
+
+/** The upstream id used by every fixture. If a key is built from it, that key
+ * cannot match a series cache entry, which is keyed on the local id. */
+const UPSTREAM_SERIES_ID = 559;
+
+function makeClientAndWrapper() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { networkMode: "offlineFirst" },
+    },
+  });
+
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+
+  const spy = vi.spyOn(client, "invalidateQueries");
+
+  return { client, wrapper, spy };
+}
+
+function capturedKeys(spy: ReturnType<typeof vi.spyOn>) {
+  return spy.mock.calls.map((call: unknown[]) => {
+    const arg = call[0] as { queryKey?: unknown[] } | undefined;
+    return arg?.queryKey ?? [];
+  });
+}
+
+describe("useEpisodeAddBlacklist", () => {
+  let spy: ReturnType<typeof vi.spyOn>;
+  let wrapper: ReturnType<typeof makeClientAndWrapper>["wrapper"];
+
+  beforeEach(() => {
+    ({ spy, wrapper } = makeClientAndWrapper());
+  });
+
+  it("refreshes the series views, so a blacklisted subtitle disappears without a manual reload", async () => {
+    const { result } = renderHook(() => useEpisodeAddBlacklist(), { wrapper });
+
+    result.current.mutate({
+      seriesId: UPSTREAM_SERIES_ID,
+      episodeId: 12,
+      form: {
+        provider: "x",
+        subs_id: "y",
+        language: "en",
+        subtitles_path: "/p",
+      },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = capturedKeys(spy);
+    // The blacklist list itself.
+    expect(keys).toContainEqual([
+      QueryKeys.Series,
+      QueryKeys.Episodes,
+      QueryKeys.Blacklist,
+    ]);
+    // And the series views. Without this the detail page kept showing the
+    // subtitle until something else happened to refresh it.
+    expect(keys).toContainEqual([QueryKeys.Series]);
+  });
+
+  it("does not build a key from the upstream series id", async () => {
+    const { result } = renderHook(() => useEpisodeAddBlacklist(), { wrapper });
+
+    result.current.mutate({
+      seriesId: UPSTREAM_SERIES_ID,
+      episodeId: 12,
+      form: {
+        provider: "x",
+        subs_id: "y",
+        language: "en",
+        subtitles_path: "/p",
+      },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(capturedKeys(spy)).not.toContainEqual([
+      QueryKeys.Series,
+      UPSTREAM_SERIES_ID,
+    ]);
+  });
+});
+
+describe("useEpisodeSubtitleModification", () => {
+  let spy: ReturnType<typeof vi.spyOn>;
+  let wrapper: ReturnType<typeof makeClientAndWrapper>["wrapper"];
+
+  beforeEach(() => {
+    ({ spy, wrapper } = makeClientAndWrapper());
+  });
+
+  it("download refreshes the series views without an upstream-keyed invalidation", async () => {
+    const { result } = renderHook(() => useEpisodeSubtitleModification(), {
+      wrapper,
+    });
+
+    result.current.download.mutate({
+      seriesId: UPSTREAM_SERIES_ID,
+      episodeId: 12,
+      form: { language: "en", forced: false, hi: false },
+    });
+
+    await waitFor(() => expect(result.current.download.isSuccess).toBe(true));
+
+    const keys = capturedKeys(spy);
+    expect(keys).toContainEqual([QueryKeys.Series]);
+    expect(keys).not.toContainEqual([QueryKeys.Series, UPSTREAM_SERIES_ID]);
+  });
+
+  it("remove refreshes the series views without an upstream-keyed invalidation", async () => {
+    const { result } = renderHook(() => useEpisodeSubtitleModification(), {
+      wrapper,
+    });
+
+    result.current.remove.mutate({
+      seriesId: UPSTREAM_SERIES_ID,
+      episodeId: 12,
+      form: { language: "en", forced: false, hi: false, path: "/p" },
+    });
+
+    await waitFor(() => expect(result.current.remove.isSuccess).toBe(true));
+
+    const keys = capturedKeys(spy);
+    expect(keys).toContainEqual([QueryKeys.Series]);
+    expect(keys).not.toContainEqual([QueryKeys.Series, UPSTREAM_SERIES_ID]);
+  });
+});

--- a/frontend/src/apis/hooks/__tests__/seriesInvalidations.test.tsx
+++ b/frontend/src/apis/hooks/__tests__/seriesInvalidations.test.tsx
@@ -18,6 +18,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useEpisodeAddBlacklist } from "@/apis/hooks/episodes";
+import { useMovieAddBlacklist } from "@/apis/hooks/movies";
 import { useEpisodeSubtitleModification } from "@/apis/hooks/subtitles";
 import { QueryKeys } from "@/apis/queries/keys";
 
@@ -29,12 +30,16 @@ vi.mock("@/apis/raw", () => ({
       deleteSubtitles: vi.fn().mockResolvedValue(undefined),
       uploadSubtitles: vi.fn().mockResolvedValue(undefined),
     },
+    movies: {
+      addBlacklist: vi.fn().mockResolvedValue(undefined),
+    },
   },
 }));
 
 /** The upstream id used by every fixture. If a key is built from it, that key
  * cannot match a series cache entry, which is keyed on the local id. */
 const UPSTREAM_SERIES_ID = 559;
+const UPSTREAM_MOVIE_ID = 77;
 
 function makeClientAndWrapper() {
   const client = new QueryClient({
@@ -161,5 +166,57 @@ describe("useEpisodeSubtitleModification", () => {
     const keys = capturedKeys(spy);
     expect(keys).toContainEqual([QueryKeys.Series]);
     expect(keys).not.toContainEqual([QueryKeys.Series, UPSTREAM_SERIES_ID]);
+  });
+});
+
+describe("useMovieAddBlacklist", () => {
+  let spy: ReturnType<typeof vi.spyOn>;
+  let wrapper: ReturnType<typeof makeClientAndWrapper>["wrapper"];
+
+  beforeEach(() => {
+    ({ spy, wrapper } = makeClientAndWrapper());
+  });
+
+  it("refreshes the movie views, so a blacklisted subtitle disappears without a manual reload", async () => {
+    const { result } = renderHook(() => useMovieAddBlacklist(), { wrapper });
+
+    result.current.mutate({
+      id: UPSTREAM_MOVIE_ID,
+      form: {
+        provider: "x",
+        subs_id: "y",
+        language: "en",
+        subtitles_path: "/p",
+      },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = capturedKeys(spy);
+    expect(keys).toContainEqual([QueryKeys.Movies, QueryKeys.Blacklist]);
+    // Movies are cached under the local id. Without a prefix invalidation the
+    // detail page kept showing the subtitle, exactly as the episode hook did.
+    expect(keys).toContainEqual([QueryKeys.Movies]);
+  });
+
+  it("does not build a key from the upstream movie id", async () => {
+    const { result } = renderHook(() => useMovieAddBlacklist(), { wrapper });
+
+    result.current.mutate({
+      id: UPSTREAM_MOVIE_ID,
+      form: {
+        provider: "x",
+        subs_id: "y",
+        language: "en",
+        subtitles_path: "/p",
+      },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(capturedKeys(spy)).not.toContainEqual([
+      QueryKeys.Movies,
+      UPSTREAM_MOVIE_ID,
+    ]);
   });
 });

--- a/frontend/src/apis/hooks/episodes.ts
+++ b/frontend/src/apis/hooks/episodes.ts
@@ -69,13 +69,18 @@ export function useEpisodeAddBlacklist() {
       return api.episodes.addBlacklist(seriesId, episodeId, form);
     },
 
-    onSuccess: (_, { seriesId }) => {
+    onSuccess: () => {
       void client.invalidateQueries({
         queryKey: [QueryKeys.Series, QueryKeys.Episodes, QueryKeys.Blacklist],
       });
 
+      // Prefix, not [Series, seriesId]. Series queries are cached under the
+      // canonical LOCAL id while seriesId here is the upstream one, so the old
+      // key matched nothing and the series detail kept showing a blacklisted
+      // subtitle until something else happened to refresh it. Unlike the
+      // sibling hooks there is no other broad invalidation here to cover it.
       void client.invalidateQueries({
-        queryKey: [QueryKeys.Series, seriesId],
+        queryKey: [QueryKeys.Series],
       });
     },
   });

--- a/frontend/src/apis/hooks/movies.ts
+++ b/frontend/src/apis/hooks/movies.ts
@@ -116,13 +116,17 @@ export function useMovieAddBlacklist() {
       return api.movies.addBlacklist(id, form);
     },
 
-    onSuccess: (_, { id }) => {
+    onSuccess: () => {
       void client.invalidateQueries({
         queryKey: [QueryKeys.Movies, QueryKeys.Blacklist],
       });
 
+      // Prefix, not [Movies, id]. Movies are cached under the canonical LOCAL
+      // id while callers pass the upstream radarrId, so the old key matched
+      // nothing and the detail page kept showing a blacklisted subtitle. Unlike
+      // the sibling movie hooks there is no other broad invalidation here.
       void client.invalidateQueries({
-        queryKey: [QueryKeys.Movies, id],
+        queryKey: [QueryKeys.Movies],
       });
     },
   });

--- a/frontend/src/apis/hooks/providers.ts
+++ b/frontend/src/apis/hooks/providers.ts
@@ -89,10 +89,10 @@ export function useDownloadEpisodeSubtitles() {
         param.arrInstanceId,
       ),
 
-    onSuccess: (_, param) => {
-      client.invalidateQueries({
-        queryKey: [QueryKeys.Series, param.seriesId],
-      });
+    onSuccess: () => {
+      // Invalidate by prefix. Series queries are cached under the canonical
+      // LOCAL series id, while seriesId here is the upstream one, so a key
+      // built from it never matched a series cache entry.
       client.invalidateQueries({
         queryKey: [QueryKeys.Series],
       });

--- a/frontend/src/apis/hooks/subtitles.ts
+++ b/frontend/src/apis/hooks/subtitles.ts
@@ -63,10 +63,10 @@ export function useEpisodeSubtitleModification() {
         param.arrInstanceId,
       ),
 
-    onSuccess: (_, param) => {
-      client.invalidateQueries({
-        queryKey: [QueryKeys.Series, param.seriesId],
-      });
+    onSuccess: () => {
+      // Invalidate by prefix. Series queries are cached under the canonical
+      // LOCAL series id, while seriesId here is the upstream one, so a key
+      // built from it never matched a series cache entry.
       client.invalidateQueries({
         queryKey: [QueryKeys.Series],
       });
@@ -84,10 +84,10 @@ export function useEpisodeSubtitleModification() {
         param.arrInstanceId,
       ),
 
-    onSuccess: (_, param) => {
-      client.invalidateQueries({
-        queryKey: [QueryKeys.Series, param.seriesId],
-      });
+    onSuccess: () => {
+      // Invalidate by prefix. Series queries are cached under the canonical
+      // LOCAL series id, while seriesId here is the upstream one, so a key
+      // built from it never matched a series cache entry.
       client.invalidateQueries({
         queryKey: [QueryKeys.Series],
       });

--- a/frontend/src/apis/hooks/subtitles.ts
+++ b/frontend/src/apis/hooks/subtitles.ts
@@ -18,9 +18,12 @@ export function useSubtitleAction() {
       // TODO: Query less
       const { type, id } = param.form;
       if (type === "episode") {
-        // id is the sonarrEpisodeId here, not a series id. Invalidate the
-        // individual episode cache and the Series root so the episode list,
-        // wanted, blacklist and episode history all refresh.
+        // id is the sonarrEpisodeId, the upstream id. Keep it: the ref-track
+        // query is keyed [Episodes, sonarrEpisodeId, Subtitles, ...], so this
+        // prefix-matches and refreshes it, and those queries are active exactly
+        // when this mutation fires. It does NOT reach the [Episodes, localId]
+        // entries primed by cacheEpisodes, which are read directly rather than
+        // through a query, so nothing there needs invalidating.
         client.invalidateQueries({
           queryKey: [QueryKeys.Episodes, id],
         });


### PR DESCRIPTION
Series queries are cached under the canonical **local** series id, while these mutations receive the **upstream** Sonarr id, because the endpoints they call are keyed on it. Several hooks invalidated `[Series, <upstream id>]`, which therefore never matched a series cache entry: at best a no-op, at worst an accidental refetch of whichever series happens to own that number as its local id.

Found while reviewing the upload id-scoping fix, which removed one instance of the same pattern.

## Two of them were real bugs

**Blacklisting an episode subtitle** had no broad invalidation beside it, only the blacklist list itself. So nothing refreshed the series views, and a blacklisted subtitle kept showing on the detail page until some other event happened to refresh it. It now invalidates by prefix.

**Blacklisting a movie subtitle** is the exact twin, found by review after the first version of this PR. Same shape: an upstream-keyed invalidation, no broad call beside it, so the movie detail kept showing the subtitle. On a multi-instance install the upstream id could instead refetch whichever unrelated movie owns that number locally.

## The rest were redundant as well as wrong

Subtitle download, subtitle removal and provider-driven download each had the mis-keyed call sitting next to a prefix invalidation over all series queries, which already covered everything the targeted call was meant to. Removed.

## Tests

New `seriesInvalidations.test.tsx`, following the pattern already established in `subtitleInvalidations.test.tsx`: assert that after each mutation succeeds the series views are invalidated, and that no key is built from the upstream id. All four fail on the old code.

The fixtures deliberately use an upstream id that would collide with a real local id, so a key built from it is not merely useless but actively wrong.

## Deliberately not changed, and a correction

The subtitle action hook invalidates an episode key built from the upstream episode id, and it is kept.

An earlier version of this description called it inert. That was wrong, and the in-code comment has been corrected too. The ref-track query is keyed `[Episodes, sonarrEpisodeId, Subtitles, ...]`, the same upstream id, so this call prefix-matches and refreshes it, and those queries are active precisely when the mutation fires. Removing it would have silently stopped ref tracks refreshing. Keeping it was the right call; the stated reason was not.

Genuinely inert and left alone: the `[Episodes, localId]` entries primed by the cache helper are read directly rather than through a query, so invalidation cannot affect them.

## Verification

- Full frontend suite: 843 passed, 2 skipped
- `check:ts` clean, `check:fmt` clean, eslint 0 errors

