### PR TITLE
test(connection-tester): authenticate the way the frontend does

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
         run: |
           pytest \
             tests/bazarr/test_pretty_date.py \
+            tests/bazarr/test_connection_tester.py \
             tests/bazarr/test_dependency_loading.py \
             tests/bazarr/test_signalrcore_compat.py \
             tests/bazarr/test_app_get_providers.py \

--- a/tests/bazarr/test_ci_guard_list.py
+++ b/tests/bazarr/test_ci_guard_list.py
@@ -261,18 +261,6 @@ EXCLUDED = {
     # Currently failing for reasons that are not network flakiness. Each needs a
     # fix, not an exemption; the reason names what is wrong so it cannot be
     # forgotten again.
-    "tests/bazarr/test_connection_tester.py": (
-        "stale harness, 14 failed and 28 passed. /test gained a second guard, "
-        "_require_proxy_api_key() at bazarr/app/ui.py:74, which aborts 401 "
-        "before any handler code runs unless the request carries the global API "
-        "key. The session-injection helper still gets past @check_login but not "
-        "past that, so the 14 test_proxy_service_* cases read a non-JSON 401 "
-        "body and die on it. Give the helper the API key, then remove this "
-        "entry. The other 28 cases pass deterministically and are this "
-        "repository's only coverage for _resolve_and_validate_constrained and "
-        "the DNS-rebinding pinning cases, so they are worth splitting out if "
-        "the helper is not fixed soon."
-    ),
     "tests/bazarr/test_database_sqlite_maintenance.py": (
         "one stale case out of six, test_configure_sqlite_connection_sets_wal_once. "
         "configure_sqlite_connection gained an isinstance(dbapi_connection, "

--- a/tests/bazarr/test_connection_tester.py
+++ b/tests/bazarr/test_connection_tester.py
@@ -150,10 +150,32 @@ def _build_app():
     return app
 
 
+TEST_API_KEY = "test-api-key"
+
+
+@pytest.fixture(autouse=True)
+def _configure_api_key(monkeypatch):
+    """Give the server a known API key for every test in this module."""
+    monkeypatch.setattr("app.config.settings.auth.apikey", TEST_API_KEY)
+
+
 def _login(client):
-    """Pre-populate the session so @check_login passes."""
+    """Authenticate the client the way the frontend does.
+
+    Two independent gates apply. @check_login covers settings.auth.type, and
+    the /test proxies additionally require the global API key regardless of
+    that setting, because they forward a server-side request to a user-supplied
+    host and must never be reachable unauthenticated.
+
+    The query string's `apikey` is the TARGET arr's key. Note that the gate
+    accepts an api key from either the header OR that query parameter, so a
+    query value that happens to equal Bazarr's own key WOULD satisfy it. That
+    dual use is a real gap, characterised below and tracked for a separate fix;
+    the harness deliberately authenticates by header, as the frontend does.
+    """
     with client.session_transaction() as sess:
         sess["logged_in"] = True
+    client.environ_base["HTTP_X_API_KEY"] = TEST_API_KEY
 
 
 def test_proxy_service_rejects_unknown_service(monkeypatch):
@@ -451,3 +473,60 @@ def test_proxy_service_pins_for_https_when_verify_disabled(monkeypatch):
         assert "203.0.113.42" in called_url
         assert called_headers.get("Host") == "sonarr.example.com"
         assert fake_get.call_args_list[0].kwargs["verify"] is False
+
+
+def test_proxy_service_rejects_an_unauthenticated_request(monkeypatch):
+    """The hardening itself, which had no coverage.
+
+    These endpoints forward a server-side request to a user-supplied host, so
+    they were an unauthenticated reconnaissance surface before the API key was
+    required. Without this test, a regression that dropped the requirement
+    would look identical to a passing suite.
+    """
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    app = _build_app()
+    client = app.test_client()
+    # Deliberately not authenticated: no X-API-KEY header.
+    r = client.get("/test/sonarr?url=http://127.0.0.1:8989&apikey=k")
+    assert r.status_code == 401
+
+
+def test_proxy_service_rejects_a_target_key_that_is_not_bazarrs(monkeypatch):
+    """A target arr key that differs from Bazarr's own does not authenticate.
+
+    Note what this does and does not prove. It passes because the VALUE differs,
+    not because query parameters are excluded from the gate. See the
+    characterisation test below for the case that is genuinely wrong.
+    """
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    app = _build_app()
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["logged_in"] = True
+    r = client.get("/test/sonarr?url=http://127.0.0.1:8989&apikey=some-arr-key")
+    assert r.status_code == 401
+
+
+def test_proxy_service_currently_accepts_the_api_key_from_the_query_string(monkeypatch):
+    """Characterises a known gap, so it cannot regress unnoticed and so the fix
+    has a test to flip.
+
+    The gate reads the key from the X-API-KEY header OR the `apikey` query
+    parameter. On these routes that same parameter is also the target arr's key,
+    which the endpoint forwards to the user-supplied host it probes. So a caller
+    who authenticates by putting Bazarr's key in the query string has that key
+    sent onward to an arbitrary address, and an operator who reuses one key for
+    Sonarr and Bazarr inverts the intended separation.
+
+    The fix is to accept the key from the header only on these two routes. When
+    that lands, this test should be inverted to assert a 401.
+    """
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    app = _build_app()
+    client = app.test_client()
+    # No session, no header: authenticated purely by the query string.
+    r = client.get(f"/test/sonarr?url=http://127.0.0.1:8989&apikey={TEST_API_KEY}")
+    assert r.status_code != 401, (
+        "if this now returns 401 the header-only fix has landed; invert this "
+        "test and delete this note"
+    )


### PR DESCRIPTION
> Stacked on https://github.com/LavX/bazarr/pull/317, because it removes an exclusion that PR adds. Merge that one first.

## Verdict: the endpoint is right, the harness was stale

All 14 tests in this file failed with the same `NoneType` error, because the endpoint answered 401 and the assertions ran against a non-JSON error page. The file had never been collected by CI, so nobody saw it.

The 401 is correct behaviour. These `/test` proxies forward a server-side request to a user-supplied host, which made them an unauthenticated reconnaissance surface, so they now require the global API key **regardless of `settings.auth.type`**. The harness only pre-populated the session, which satisfies the login decorator but not that second, independent gate.

## A correction, and a gap this uncovered

An earlier version of this description said the query string's `apikey` "cannot satisfy Bazarr's own gate". **That was wrong**, and review caught it.

The gate reads `headers.get('X-API-KEY') or args.get('apikey')`, so a query value equal to Bazarr's own key does authenticate. The earlier test passed because the fixture values differed, not because query parameters are excluded.

That dual use is a real problem, not just a test inaccuracy. On these routes the same `apikey` parameter is also the **target arr's** key, which the endpoint forwards to the user-supplied host it probes. So a caller authenticating the ordinary Bazarr way, with the key in the query string, has that key sent onward to an arbitrary address. An operator reusing one key for Sonarr and Bazarr also inverts the intended separation, and a secret in a URL reaches access logs.

The fix is to accept the key from the header only on these two routes. That is tracked separately rather than smuggled into a test-harness change. This PR characterises the current behaviour in a test so it cannot regress unnoticed, with a note telling whoever lands the fix to invert it.

## Coverage the hardening never had

Two new cases:

- an unauthenticated request is rejected
- the target's key is not accepted as authentication

Both were confirmed to fail when the API-key requirement is removed. Without them, a regression that dropped the requirement would have looked identical to a passing suite, which is exactly the situation this file was already in.

## Verification

44 tests pass. `ruff` clean. Re-enumerates the file in CI and drops its exclusion entry from the guard list.

