### PR TITLE
fix(hooks): clear the throttle timer on unmount

### DIFF
--- a/frontend/src/utilities/__tests__/hooks.throttle.test.tsx
+++ b/frontend/src/utilities/__tests__/hooks.throttle.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Regression test for a leaked timer in useThrottle.
+ *
+ * useDebouncedValue is built on useThrottle, which schedules a window.setTimeout
+ * and previously never cleared it. A component that unmounted before the delay
+ * elapsed left the timer scheduled, so the callback ran against a torn-down
+ * environment. In the test suite that surfaced as an unhandled
+ * "ReferenceError: window is not defined" attributed to whichever file happened
+ * to be running, turning CI red while every test file passed. In the app it is a
+ * state update on an unmounted component.
+ */
+
+import { useEffect } from "react";
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useThrottle } from "@/utilities/hooks";
+
+const DELAY = 500;
+
+function Caller({ onFire }: { onFire: () => void }) {
+  const throttled = useThrottle(onFire, DELAY);
+  useEffect(() => {
+    throttled();
+  }, [throttled]);
+  return null;
+}
+
+describe("useThrottle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not fire after the component unmounts", () => {
+    const onFire = vi.fn();
+    const { unmount } = render(<Caller onFire={onFire} />);
+
+    unmount();
+    vi.advanceTimersByTime(DELAY * 2);
+
+    expect(onFire).not.toHaveBeenCalled();
+  });
+
+  it("still fires while the component is mounted", () => {
+    const onFire = vi.fn();
+    render(<Caller onFire={onFire} />);
+
+    vi.advanceTimersByTime(DELAY * 2);
+
+    expect(onFire).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/utilities/hooks.ts
+++ b/frontend/src/utilities/hooks.ts
@@ -113,6 +113,21 @@ export function useThrottle<F extends GenericFunction>(fn: F, ms: number) {
 
   const timer = useRef<number>(undefined);
 
+  // Clear any pending timer on unmount. Without this the scheduled callback
+  // still fires after the component is gone: a state update on an unmounted
+  // component in the app, and in the test suite a callback running against a
+  // torn-down environment, which surfaces as an unhandled "window is not
+  // defined" attributed to whichever file happened to be running.
+  useEffect(
+    () => () => {
+      if (timer.current) {
+        clearTimeout(timer.current);
+        timer.current = undefined;
+      }
+    },
+    [],
+  );
+
   return useCallback(
     (...args: Parameters<F>) => {
       if (timer.current) {


### PR DESCRIPTION
The frontend CI job has been failing intermittently on pull requests that change **no frontend code at all**. This is why.

## What happens

`useThrottle` schedules a `window.setTimeout` and never clears it. A component that unmounts before the delay elapses leaves the timer scheduled, so the callback runs after the component is gone.

In the app that is a state update on an unmounted component. In CI it is worse: the callback fires after vitest tears down the jsdom environment and touches `window`, which vitest reports as an **unhandled error** and fails the job even though every test file passed.

A failing run looks like this, and the detail that matters is the passing count:

```
Test Files  89 passed (89)
ReferenceError: window is not defined
##[error]ReferenceError: window is not defined
```

The search box debounces by 500ms via `useDebouncedValue`, which is built on this hook, and its tests finish well inside that window. So the error is usually attributed to the search test file, but the leak belongs to the hook and any consumer can trigger it.

## Correction to an earlier diagnosis

This same failure appeared on a dependency-update pull request and I attributed it to that update, suggesting a re-run would classify it as stale or real. That was wrong. It has now appeared on a backend-only change, which rules out any particular pull request as the cause.

## The fix

Clear the pending timer on unmount.

## Tests

A regression test that unmounts before the delay elapses and asserts the callback never fires. It fails without the cleanup.

The positive case is included deliberately: without it, the fix could be satisfied by disabling the timer outright, and the debounce would silently stop working.

## Verification

- Targeted test: fails before, passes after
- Full suite run three times consecutively: 839 passed, 2 skipped, no unhandled errors
- `check:ts` clean, eslint 0 errors
