### PR TITLE
ci: drop the exclusion for a test file that no longer exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,8 @@ jobs:
             tests/subliminal_patch/test_score.py \
             tests/subliminal_patch/test_subdl_anime_mode.py \
             tests/subliminal_patch/test_subtitle.py \
+            tests/subliminal_patch/test_http.py \
+            tests/subliminal_patch/test_legendasdivx.py \
             tests/subliminal_patch/test_utils.py \
             -v --tb=short
 

--- a/tests/bazarr/test_ci_guard_list.py
+++ b/tests/bazarr/test_ci_guard_list.py
@@ -235,12 +235,6 @@ EXCLUDED = {
         "en and pl. Two of the four that pass do so vacuously, one asserting "
         "only isinstance(subs, list) and one looping over a list that is empty."
     ),
-    "tests/subliminal_patch/test_hosszupuska.py": (
-        "hosszupuskasub.com is dead, so the provider is being retired. Until "
-        "that lands: replays recorded HTTP, touches no network, and both cases "
-        "fail because the recorded page now yields adf.ly-wrapped links while "
-        "the assertions expect bare download URLs."
-    ),
     "tests/subliminal_patch/test_napiprojekt.py": (
         "replays recorded HTTP and touches no network, but subliminal 2.6.0 "
         "moved server_url to https while the cassettes were recorded against "


### PR DESCRIPTION
Development is currently red on the CI guard.

`tests/subliminal_patch/test_hosszupuska.py` was deleted when the dead providers were retired, but the guard's `EXCLUDED` dict still names it, and the guard requires every excluded path to be a real file:

```
AssertionError: EXCLUDED names files that no longer exist; remove them:
    tests/subliminal_patch/test_hosszupuska.py
```

Neither pull request could see this alone: one deleted the file, the other listed it, and because they touched different files git merged them without a conflict. That is precisely the case the guard exists to catch, and it caught it on the first build after both landed.

The other guard failure on development, `test_http.py` and `test_legendasdivx.py` not being enumerated, is fixed by #328, which adds both to the workflow. Merging that one and this one together returns development to green.