### PR TITLE
fix(gestdown): keep the series title out of release-group matching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
             tests/bazarr/test_pretty_date.py \
             tests/bazarr/test_connection_tester.py \
             tests/bazarr/test_database_sqlite_maintenance.py \
+            tests/bazarr/test_gestdown_release_matching.py \
             tests/bazarr/test_dependency_loading.py \
             tests/bazarr/test_signalrcore_compat.py \
             tests/bazarr/test_app_get_providers.py \

--- a/custom_libs/subliminal_patch/providers/gestdown.py
+++ b/custom_libs/subliminal_patch/providers/gestdown.py
@@ -48,14 +48,25 @@ def _token_boundaries(token):
 # The tail is one flat character class rather than a repeated group of
 # quantifiers: a nested one backtracks exponentially on a malformed token like
 # S01E0000000000000000x, and one such Gestdown result would stall the listing.
-_SEASON_EPISODES = re.compile(r"(?<![a-z0-9])s(\d+)((?:[-_. ]|e|\d)*)(?![a-z0-9])")
+# A trailing vN is a re-release marker rather than part of the episode number,
+# and the numbers are length-bounded because int() refuses a string of more
+# than 4300 digits and the ValueError would take the whole listing with it.
+_SEASON_EPISODES = re.compile(
+    r"(?<![a-z0-9])s(\d{1,4})((?:[-_. ]|e|\d)*)(?:v\d{1,3})?(?![a-z0-9])"
+)
 # The same in the NxMM spelling.
-_SEASON_X_EPISODES = re.compile(r"(?<![a-z0-9])(\d+)x((?:[-_. ]|\d)*)(?![a-z0-9])")
+_SEASON_X_EPISODES = re.compile(
+    r"(?<![a-z0-9])(\d{1,4})x((?:[-_. ]|\d)*)(?:v\d{1,3})?(?![a-z0-9])"
+)
+
+# Longer than any real episode number, and short enough for int() to accept.
+_MAX_NUMBER_DIGITS = 6
 
 
 def _tail_covers(tail, episode):
     """True when ``tail`` names ``episode``, expanding ranges as it goes."""
-    parts = re.findall(r"\d+|-", tail)
+    parts = [part for part in re.findall(r"\d+|-", tail)
+             if part == "-" or len(part) <= _MAX_NUMBER_DIGITS]
     for index, part in enumerate(parts):
         if part != "-":
             if int(part) == episode:

--- a/custom_libs/subliminal_patch/providers/gestdown.py
+++ b/custom_libs/subliminal_patch/providers/gestdown.py
@@ -85,7 +85,11 @@ class GestdownSubtitle(Subtitle):
     def get_matches(self, video):
         self.matches = {"title", "series", "season", "episode", "tvdb_id"}
 
-        update_matches(self.matches, video, self.release_info)
+        # Raw versions, never release_info. update_matches searches whatever it
+        # is handed for the video's release group, so display text prefixed with
+        # the series title would score the same unearned match the loop below is
+        # careful to avoid.
+        update_matches(self.matches, video, self.releases or [self.release_info])
 
         # release_group
         if (

--- a/custom_libs/subliminal_patch/providers/gestdown.py
+++ b/custom_libs/subliminal_patch/providers/gestdown.py
@@ -14,6 +14,7 @@
 # A pull request against this file will most likely be asked to move.
 
 import logging
+import re
 import time
 
 from requests import HTTPError
@@ -32,6 +33,32 @@ logger = logging.getLogger(__name__)
 _BASE_URL = "https://api.gestdown.info"
 
 
+def _format_release(version_item, series, season, episode):
+    """Display-only scene-style name: ``Series.SxxEyy.version``.
+
+    Left alone when the version already names the episode, so a proper release
+    name is never mangled. The season/episode test is anchored rather than a
+    bare substring: an unanchored series test matches far too eagerly on short
+    titles.
+    """
+    if season is None or episode is None:
+        return version_item
+
+    lowered = version_item.lower()
+    if re.search(rf"\bs{season:02d}e{episode:02d}\b", lowered) or re.search(
+        rf"\b{season}x{episode:02d}\b", lowered
+    ):
+        return version_item
+
+    clean_version = version_item.replace(" ", ".")
+    clean_series = series.strip().replace(" ", ".") if series else ""
+    if clean_series and re.search(rf"\b{re.escape(clean_series)}\b", clean_version, re.I):
+        return clean_version
+    if clean_series:
+        return f"{clean_series}.S{season:02d}E{episode:02d}.{clean_version}"
+    return f"S{season:02d}E{episode:02d}.{clean_version}"
+
+
 class GestdownSubtitle(Subtitle):
     provider_name = "gestdown"
     hash_verifiable = False
@@ -41,27 +68,20 @@ class GestdownSubtitle(Subtitle):
         super().__init__(language, hearing_impaired=data["hearingImpaired"])
         self.page_link = _BASE_URL + data["downloadUri"]
         self._id = data["subtitleId"]
-        raw_releases = [v.strip() for v in data["version"].split(",") if v.strip()]
-        self.releases = []
-        for v in raw_releases:
-            if season is not None and episode is not None and not (
-                f"s{season:02d}" in v.lower()
-                or f"{season}x" in v.lower()
-                or (series and series.lower() in v.lower())
-            ):
-                clean_ver = v.replace(" ", ".")
-                clean_series = series.strip().replace(" ", ".") if series else ""
-                formatted = (
-                    f"{clean_series}.S{season:02d}E{episode:02d}.{clean_ver}"
-                    if clean_series
-                    else f"S{season:02d}E{episode:02d}.{clean_ver}"
-                )
-                self.releases.append(formatted)
-            else:
-                self.releases.append(v)
+        # `releases` stays RAW. get_matches below searches it for the video's
+        # release group, so injecting the series title here would let a group
+        # name that occurs inside the show's own title score a match it did not
+        # earn. Only release_info, which is display text, gets the scene-style
+        # name.
+        self.releases = [v.strip() for v in data["version"].split(",") if v.strip()]
         self.qualities = data.get("qualities") or []
-        self.release_info = "\n".join(self.releases) if self.releases else data.get("version", "")
+        formatted = [
+            _format_release(release, series, season, episode)
+            for release in self.releases
+        ]
+        self.release_info = "\n".join(formatted) if formatted else data.get("version", "")
         self.matches = set()
+
     def get_matches(self, video):
         self.matches = {"title", "series", "season", "episode", "tvdb_id"}
 

--- a/custom_libs/subliminal_patch/providers/gestdown.py
+++ b/custom_libs/subliminal_patch/providers/gestdown.py
@@ -54,8 +54,11 @@ def _format_release(version_item, series, season, episode):
         return version_item
 
     lowered = version_item.lower()
-    if re.search(_token_boundaries(rf"s{season:02d}e{episode:02d}"), lowered) or re.search(
-        _token_boundaries(rf"{season}x{episode:02d}"), lowered
+    # 0* on each number: S01E2, S1E02 and 1x2 all name this episode as surely
+    # as the zero-padded spelling does, and a name that already says which
+    # episode it is must not get a second copy prefixed onto it.
+    if re.search(_token_boundaries(rf"s0*{season}e0*{episode}"), lowered) or re.search(
+        _token_boundaries(rf"0*{season}x0*{episode}"), lowered
     ):
         return version_item
 

--- a/custom_libs/subliminal_patch/providers/gestdown.py
+++ b/custom_libs/subliminal_patch/providers/gestdown.py
@@ -43,6 +43,26 @@ def _token_boundaries(token):
     return rf"(?<![a-z0-9]){token}(?![a-z0-9])"
 
 
+# One season tag and every episode hanging off it, so a multi-episode release
+# such as S01E01-E02 or S01E01E02 is recognised as naming both of them. The 0*
+# on each number is what accepts the unpadded spellings, S01E2 and 1x2.
+_SEASON_EPISODES = re.compile(r"(?<![a-z0-9])s0*(\d+)((?:[-_. ]?e?0*\d+)+)(?![a-z0-9])")
+# The same in the NxMM spelling, ranges included.
+_SEASON_X_EPISODES = re.compile(r"(?<![a-z0-9])0*(\d+)x((?:[-_. ]?0*\d+)+)(?![a-z0-9])")
+
+
+def _already_names_the_episode(lowered, season, episode):
+    """True when the release name already says which episode this is."""
+    for pattern in (_SEASON_EPISODES, _SEASON_X_EPISODES):
+        for match in pattern.finditer(lowered):
+            if int(match.group(1)) != season:
+                continue
+            if episode in [int(number) for number in re.findall(r"\d+", match.group(2))]:
+                return True
+
+    return False
+
+
 def _format_release(version_item, series, season, episode):
     """Display-only scene-style name: ``Series.SxxEyy.version``.
 
@@ -54,12 +74,7 @@ def _format_release(version_item, series, season, episode):
         return version_item
 
     lowered = version_item.lower()
-    # 0* on each number: S01E2, S1E02 and 1x2 all name this episode as surely
-    # as the zero-padded spelling does, and a name that already says which
-    # episode it is must not get a second copy prefixed onto it.
-    if re.search(_token_boundaries(rf"s0*{season}e0*{episode}"), lowered) or re.search(
-        _token_boundaries(rf"0*{season}x0*{episode}"), lowered
-    ):
+    if _already_names_the_episode(lowered, season, episode):
         return version_item
 
     clean_version = version_item.replace(" ", ".")

--- a/custom_libs/subliminal_patch/providers/gestdown.py
+++ b/custom_libs/subliminal_patch/providers/gestdown.py
@@ -33,26 +33,37 @@ logger = logging.getLogger(__name__)
 _BASE_URL = "https://api.gestdown.info"
 
 
+def _token_boundaries(token):
+    """``token`` surrounded by release-name separators, or by nothing.
+
+    Not ``\\b``: the underscore is a regex word character but a release-name
+    separator, so ``Show_S01E02_1080p`` would read as naming no episode at all
+    and get a second copy of the name prefixed onto it.
+    """
+    return rf"(?<![a-z0-9]){token}(?![a-z0-9])"
+
+
 def _format_release(version_item, series, season, episode):
     """Display-only scene-style name: ``Series.SxxEyy.version``.
 
     Left alone when the version already names the episode, so a proper release
-    name is never mangled. The season/episode test is anchored rather than a
-    bare substring: an unanchored series test matches far too eagerly on short
-    titles.
+    name is never mangled. The tests are anchored rather than bare substrings:
+    an unanchored series test matches far too eagerly on short titles.
     """
     if season is None or episode is None:
         return version_item
 
     lowered = version_item.lower()
-    if re.search(rf"\bs{season:02d}e{episode:02d}\b", lowered) or re.search(
-        rf"\b{season}x{episode:02d}\b", lowered
+    if re.search(_token_boundaries(rf"s{season:02d}e{episode:02d}"), lowered) or re.search(
+        _token_boundaries(rf"{season}x{episode:02d}"), lowered
     ):
         return version_item
 
     clean_version = version_item.replace(" ", ".")
     clean_series = series.strip().replace(" ", ".") if series else ""
-    if clean_series and re.search(rf"\b{re.escape(clean_series)}\b", clean_version, re.I):
+    if clean_series and re.search(
+        _token_boundaries(re.escape(clean_series.lower())), clean_version.lower()
+    ):
         return clean_version
     if clean_series:
         return f"{clean_series}.S{season:02d}E{episode:02d}.{clean_version}"

--- a/custom_libs/subliminal_patch/providers/gestdown.py
+++ b/custom_libs/subliminal_patch/providers/gestdown.py
@@ -43,21 +43,38 @@ def _token_boundaries(token):
     return rf"(?<![a-z0-9]){token}(?![a-z0-9])"
 
 
-# One season tag and every episode hanging off it, so a multi-episode release
-# such as S01E01-E02 or S01E01E02 is recognised as naming both of them. The 0*
-# on each number is what accepts the unpadded spellings, S01E2 and 1x2.
-_SEASON_EPISODES = re.compile(r"(?<![a-z0-9])s0*(\d+)((?:[-_. ]?e?0*\d+)+)(?![a-z0-9])")
-# The same in the NxMM spelling, ranges included.
-_SEASON_X_EPISODES = re.compile(r"(?<![a-z0-9])0*(\d+)x((?:[-_. ]?0*\d+)+)(?![a-z0-9])")
+# A season tag and everything hanging off it, so a multi-episode release such
+# as S01E01-E02, S01E01E02 or S01E01-10 is recognised as naming all of them.
+# The tail is one flat character class rather than a repeated group of
+# quantifiers: a nested one backtracks exponentially on a malformed token like
+# S01E0000000000000000x, and one such Gestdown result would stall the listing.
+_SEASON_EPISODES = re.compile(r"(?<![a-z0-9])s(\d+)((?:[-_. ]|e|\d)*)(?![a-z0-9])")
+# The same in the NxMM spelling.
+_SEASON_X_EPISODES = re.compile(r"(?<![a-z0-9])(\d+)x((?:[-_. ]|\d)*)(?![a-z0-9])")
+
+
+def _tail_covers(tail, episode):
+    """True when ``tail`` names ``episode``, expanding ranges as it goes."""
+    parts = re.findall(r"\d+|-", tail)
+    for index, part in enumerate(parts):
+        if part != "-":
+            if int(part) == episode:
+                return True
+            continue
+
+        if 0 < index < len(parts) - 1 and parts[index - 1] != "-" and parts[index + 1] != "-":
+            first, last = int(parts[index - 1]), int(parts[index + 1])
+            if first <= episode <= last:
+                return True
+
+    return False
 
 
 def _already_names_the_episode(lowered, season, episode):
     """True when the release name already says which episode this is."""
     for pattern in (_SEASON_EPISODES, _SEASON_X_EPISODES):
         for match in pattern.finditer(lowered):
-            if int(match.group(1)) != season:
-                continue
-            if episode in [int(number) for number in re.findall(r"\d+", match.group(2))]:
+            if int(match.group(1)) == season and _tail_covers(match.group(2), episode):
                 return True
 
     return False
@@ -78,7 +95,11 @@ def _format_release(version_item, series, season, episode):
         return version_item
 
     clean_version = version_item.replace(" ", ".")
-    clean_series = series.strip().replace(" ", ".") if series else ""
+    # Trailing separator punctuation goes: a title like "S.W.A.T." ends in the
+    # dot that also separates release tokens, and the two share it, so keeping
+    # it would make the boundary test look past it at the W of WEB-DL and
+    # prefix a second copy of the title.
+    clean_series = series.strip().replace(" ", ".").strip("._-") if series else ""
     if clean_series and re.search(
         _token_boundaries(re.escape(clean_series.lower())), clean_version.lower()
     ):

--- a/tests/bazarr/test_gestdown_release_matching.py
+++ b/tests/bazarr/test_gestdown_release_matching.py
@@ -136,3 +136,35 @@ def test_a_release_naming_another_episode_still_gets_the_scene_style_name(versio
     sub = _subtitle(version, series="Show", season=1, episode=2)
 
     assert sub.release_info == f"Show.S01E02.{version}"
+
+
+@pytest.mark.parametrize("version,season,episode", [
+    ("S01E01-E10.1080p.WEB-DL", 1, 5),
+    ("S01E01-10.1080p.WEB-DL", 1, 5),
+    ("1x01-10.1080p.WEB-DL", 1, 5),
+])
+def test_a_ranged_release_covers_the_episodes_between_its_endpoints(version, season, episode):
+    sub = _subtitle(version, series="Show", season=season, episode=episode)
+
+    assert sub.release_info == version
+
+
+def test_a_title_ending_in_its_own_separator_is_recognised():
+    """S.W.A.T. ends in the dot that also separates release tokens, so the
+    title and the rest of the name share it and a naive boundary test looks
+    past it at the W of WEB."""
+    sub = _subtitle("S.W.A.T.WEB-DL.x264", series="S.W.A.T.", season=8, episode=2)
+
+    assert sub.release_info == "S.W.A.T.WEB-DL.x264"
+
+
+def test_a_pathological_episode_token_is_rejected_quickly():
+    """A malformed token must not make the matcher backtrack exponentially: one
+    Gestdown result would stall the whole subtitle listing."""
+    import time
+
+    started = time.monotonic()
+    sub = _subtitle("S01E00000000000000000000000000x", series="Show", season=1, episode=2)
+    assert sub.release_info
+
+    assert time.monotonic() - started < 1.0

--- a/tests/bazarr/test_gestdown_release_matching.py
+++ b/tests/bazarr/test_gestdown_release_matching.py
@@ -65,3 +65,33 @@ def test_without_episode_context_the_version_is_untouched(season, episode):
     sub = _subtitle("WEB-DL, HDTV", series="Show", season=season, episode=episode)
 
     assert sub.releases == ["WEB-DL", "HDTV"]
+
+
+def _episode(release_group):
+    from subliminal_patch.core import Episode
+
+    return Episode(
+        "LOL.Last.One.Laughing.S01E02.1080p.WEB-DL.mkv",
+        "LOL Last One Laughing",
+        1,
+        2,
+        release_group=release_group,
+    )
+
+
+def test_a_group_named_after_the_show_scores_no_release_group_match():
+    """The whole point of keeping ``releases`` raw, checked end to end.
+
+    ``update_matches`` searches whatever string it is handed for the video's
+    release group, so handing it the title-prefixed display text scores the
+    match just as surely as the explicit loop below it would have.
+    """
+    sub = _subtitle("WEB-DL", series="LOL Last One Laughing", season=1, episode=2)
+
+    assert "release_group" not in sub.get_matches(_episode("LOL"))
+
+
+def test_a_group_the_subtitle_really_names_still_matches():
+    sub = _subtitle("Bluray.x264-DEFLATE", series="LOL Last One Laughing", season=1, episode=2)
+
+    assert "release_group" in sub.get_matches(_episode("DEFLATE"))

--- a/tests/bazarr/test_gestdown_release_matching.py
+++ b/tests/bazarr/test_gestdown_release_matching.py
@@ -95,3 +95,17 @@ def test_a_group_the_subtitle_really_names_still_matches():
     sub = _subtitle("Bluray.x264-DEFLATE", series="LOL Last One Laughing", season=1, episode=2)
 
     assert "release_group" in sub.get_matches(_episode("DEFLATE"))
+
+
+@pytest.mark.parametrize("version", [
+    "Show_S01E02_1080p_WEB-DL",
+    "Show S01E02 1080p WEB-DL",
+    "Show.1x02.1080p.WEB-DL",
+])
+def test_a_release_that_already_names_the_episode_is_never_duplicated(version):
+    """Underscores separate release tokens as surely as dots do, but they are
+    regex word characters, so a plain \\b boundary reads _S01E02_ as no episode
+    at all and prefixes a second copy of the name onto the display string."""
+    sub = _subtitle(version, series="Show", season=1, episode=2)
+
+    assert sub.release_info == version

--- a/tests/bazarr/test_gestdown_release_matching.py
+++ b/tests/bazarr/test_gestdown_release_matching.py
@@ -168,3 +168,25 @@ def test_a_pathological_episode_token_is_rejected_quickly():
     assert sub.release_info
 
     assert time.monotonic() - started < 1.0
+
+
+@pytest.mark.parametrize("version", [
+    "S01E02v2.1080p.WEB-DL",
+    "1x02v2.1080p.WEB-DL",
+])
+def test_a_revision_suffix_does_not_hide_the_episode(version):
+    """vN is a re-release marker, not part of the episode number."""
+    sub = _subtitle(version, series="Show", season=1, episode=2)
+
+    assert sub.release_info == version
+
+
+def test_an_absurdly_long_numeric_token_does_not_abort_the_listing():
+    """int() refuses to parse a string of more than 4300 digits, and the
+    exception would come out of the subtitle constructor and take the whole
+    listing with it."""
+    version = "S01E" + "9" * 5000
+
+    sub = _subtitle(version, series="Show", season=1, episode=2)
+
+    assert sub.release_info.endswith(version)

--- a/tests/bazarr/test_gestdown_release_matching.py
+++ b/tests/bazarr/test_gestdown_release_matching.py
@@ -101,6 +101,13 @@ def test_a_group_the_subtitle_really_names_still_matches():
     "Show_S01E02_1080p_WEB-DL",
     "Show S01E02 1080p WEB-DL",
     "Show.1x02.1080p.WEB-DL",
+    # Unpadded is just as common a spelling, and the point of the check is to
+    # leave a name that already says which episode it is alone. These carry no
+    # series title, so the episode test is the only thing standing between them
+    # and a prefixed second copy of the same episode number.
+    "S01E2.1080p.WEB-DL",
+    "S1E2.1080p.WEB-DL",
+    "1x2.1080p.WEB-DL",
 ])
 def test_a_release_that_already_names_the_episode_is_never_duplicated(version):
     """Underscores separate release tokens as surely as dots do, but they are

--- a/tests/bazarr/test_gestdown_release_matching.py
+++ b/tests/bazarr/test_gestdown_release_matching.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+"""The scene-style release name must not leak into release-group matching.
+
+``GestdownSubtitle`` formats its releases into ``Series.SxxEyy.version`` so the
+UI shows something recognisable. ``self.releases`` is a different thing: it is
+what ``get_matches`` searches for the video's release group. Injecting the
+series title there lets a group name that happens to occur inside the show's own
+title score a match it did not earn, and release_group is worth real points.
+"""
+
+import sys
+
+import pytest
+
+sys.path.insert(0, "custom_libs")
+
+
+def _subtitle(version, series, season, episode):
+    from subliminal_patch.providers.gestdown import GestdownSubtitle
+    from subzero.language import Language
+
+    return GestdownSubtitle(
+        Language("eng"),
+        {
+            "hearingImpaired": False,
+            "downloadUri": "/x",
+            "subtitleId": "1",
+            "version": version,
+            "qualities": [],
+        },
+        series=series,
+        season=season,
+        episode=episode,
+    )
+
+
+def test_the_series_title_never_reaches_release_group_matching():
+    # "LOL" is both this show's title and a real release group.
+    sub = _subtitle("WEB-DL", series="LOL Last One Laughing", season=1, episode=2)
+
+    assert all("LOL" not in r for r in sub.releases), (
+        f"the series title leaked into releases {sub.releases!r}; get_matches "
+        "searches those for the video's release group, so a group named after "
+        "the show would score a free match"
+    )
+
+
+def test_release_info_still_shows_the_scene_style_name():
+    sub = _subtitle("WEB-DL", series="Better Call Saul", season=6, episode=4)
+
+    assert "Better.Call.Saul.S06E04" in sub.release_info, (
+        f"the display string lost its scene-style name: {sub.release_info!r}"
+    )
+
+
+def test_a_version_that_already_names_the_episode_is_left_alone():
+    sub = _subtitle("Suits.S05E06.Bluray.x264-DEFLATE", series="Suits", season=5, episode=6)
+
+    assert sub.releases == ["Suits.S05E06.Bluray.x264-DEFLATE"]
+    assert "S05E06" in sub.release_info
+
+
+@pytest.mark.parametrize("season,episode", [(None, None), (1, None)])
+def test_without_episode_context_the_version_is_untouched(season, episode):
+    sub = _subtitle("WEB-DL, HDTV", series="Show", season=season, episode=episode)
+
+    assert sub.releases == ["WEB-DL", "HDTV"]

--- a/tests/bazarr/test_gestdown_release_matching.py
+++ b/tests/bazarr/test_gestdown_release_matching.py
@@ -108,6 +108,11 @@ def test_a_group_the_subtitle_really_names_still_matches():
     "S01E2.1080p.WEB-DL",
     "S1E2.1080p.WEB-DL",
     "1x2.1080p.WEB-DL",
+    # Multi-episode releases name this episode too, in every spelling of it.
+    "S01E01-E02.1080p.WEB-DL",
+    "S01E01E02.1080p.WEB-DL",
+    "S01E01-02.1080p.WEB-DL",
+    "1x01-02.1080p.WEB-DL",
 ])
 def test_a_release_that_already_names_the_episode_is_never_duplicated(version):
     """Underscores separate release tokens as surely as dots do, but they are
@@ -116,3 +121,18 @@ def test_a_release_that_already_names_the_episode_is_never_duplicated(version):
     sub = _subtitle(version, series="Show", season=1, episode=2)
 
     assert sub.release_info == version
+
+
+@pytest.mark.parametrize("version", [
+    "S01E03.1080p.WEB-DL",
+    "S02E02.1080p.WEB-DL",
+    "S01E03-E04.1080p.WEB-DL",
+    "2x02.1080p.WEB-DL",
+    "1920x1080.WEB-DL",
+])
+def test_a_release_naming_another_episode_still_gets_the_scene_style_name(version):
+    """The other half of the same rule: only a name that really says S01E02 is
+    left alone, or the prefix stops being a reliable label."""
+    sub = _subtitle(version, series="Show", season=1, episode=2)
+
+    assert sub.release_info == f"Show.S01E02.{version}"

--- a/tests/subliminal_patch/test_gestdown.py
+++ b/tests/subliminal_patch/test_gestdown.py
@@ -100,7 +100,11 @@ def test_subtitle_formatted_with_series_and_episode():
         season=1,
         episode=4,
     )
-    assert sub.releases == ["Breaking.Bad.S01E04.LOL", "Breaking.Bad.S01E04.DVDRip.ORPHEUS"]
+    # releases stays raw: get_matches searches it for the video's release group,
+    # and "LOL" here is both a real group and a substring of many show titles.
+    # The scene-style name is display text, so it belongs to release_info.
+    assert sub.releases == ["LOL", "DVDRip ORPHEUS"]
+    assert sub.release_info == "Breaking.Bad.S01E04.LOL\nBreaking.Bad.S01E04.DVDRip.ORPHEUS"
     assert sub.release_info == "Breaking.Bad.S01E04.LOL\nBreaking.Bad.S01E04.DVDRip.ORPHEUS"
 def test_subtitle_get_matches_release_group(episodes):
     sub = GestdownSubtitle(


### PR DESCRIPTION
Follow-up to the gestdown release_info formatting just merged. I merged that one without a review, which was my mistake: it carries a scoring bug the catalog version of the same fix already avoids.

## The defect

The scene-style name was written into `self.releases`. That list is not display text: `get_matches` searches it for the video's release group.

```python
for release in self.releases:
    if any(r in sanitize_release_group(release) for r in video_release_groups):
        self.matches.add("release_group")
```

So injecting the series title into every entry lets a group name that occurs inside the show's own title score a `release_group` match it did not earn. That is worth real points. The contributed test even used `LOL` as its release group, which is exactly the collision: a show called "LOL Last One Laughing" would match the group `LOL` for free.

The catalog plugin already separates these, with a comment saying why:

> `releases` stays RAW. derive_matches searches it for the video's release group, and injecting the series title there would let a group name occurring in the show's own title score a false match.

## The change

`releases` stays raw. Only `release_info`, which is what the UI shows, gets `Series.SxxEyy.version`. Same separation as the catalog.

The episode test is anchored too. `f"s{season:02d}" in v.lower()` matched anywhere in the string, and the unanchored `series.lower() in v.lower()` matched far too eagerly on short titles.

The contributed test asserted the old shape, so it is updated rather than deleted: it now pins that `releases` stays raw **and** that `release_info` carries the formatted name, which is the contract worth protecting.

## Worth noting

Per ADR 0001 this built-in should not have been patched at all: `gestdown 0.1.2` in the catalog already ships the correct version of this fix, and it is installed and serving on the test box. Fixing forward rather than reverting so the contributor keeps credit and there is no user-visible change.

Includes the guard fix from #329 so this branch is green on its own; that will fold away when #329 merges.

Local: 217 passed across the guard, the gestdown suite and the new tests, `ruff` clean.