### PR TITLE
fix(providers): terminate the provider a config change replaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
             tests/bazarr/test_app_get_providers.py \
             tests/bazarr/test_retired_provider_config_compat.py \
             tests/bazarr/test_provider_hub.py \
+            tests/bazarr/test_provider_pool_config_reload.py \
             tests/bazarr/test_provider_hub_auto_install_optin.py \
             tests/bazarr/test_provider_hub_archive_select.py \
             tests/bazarr/test_provider_hub_worker_timeout.py \

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -110,21 +110,27 @@ class _ProviderConfigs(dict):
             registered_val.update(val)
 
             logger.debug("Config changed. Restarting provider: %s", key)
+
+            # Tear the old instance down before building its replacement.
+            # Dropping the reference releases nothing it owns, and a Provider
+            # Hub provider owns a worker process and the threads pumping its
+            # stdio, so a settings save that touched a config used to leak one
+            # for the life of the process. Order matters as much as the call
+            # does: EmbeddedSubtitles.terminate() removes a cache directory
+            # every instance of it shares, so tearing the old one down last
+            # would delete what the replacement had just created.
+            self._pool.retire_provider(key)
+
             try:
                 provider = provider_registry[key](**registered_val)  # type: ignore
                 provider.initialize()
             except Exception as error:
-                # The running provider stays: a replacement that could not
-                # start is no reason to lose the one that works.
+                # Nothing is installed. The pool initializes on next access, so
+                # a provider that is merely unreachable right now comes back on
+                # its own, with the new config rather than the one the user
+                # just changed away from.
                 self._pool.throttle_callback(key, error)
             else:
-                if key in self._pool.initialized_providers:
-                    # Terminate the instance being replaced. Dropping the
-                    # reference releases nothing it owns, and a Provider Hub
-                    # provider owns a worker process and the threads pumping
-                    # its stdio, so every settings save that touched a config
-                    # leaked one for the life of the process.
-                    del self._pool[key]
                 self._pool.initialized_providers[key] = provider
 
         if updated:
@@ -334,6 +340,24 @@ class SZProviderPool(ProviderPool):
             self.initialized_providers[name] = provider
 
         return self.initialized_providers[name]
+
+    def retire_provider(self, name):
+        """Terminate an initialized provider without throttling its name.
+
+        Teardown failures are logged rather than routed to throttle_callback:
+        that takes the provider out of the rotation for the throttle interval,
+        and the instance being discarded misbehaving on its way out is no
+        reason to do that to the one replacing it.
+        """
+        provider = self.initialized_providers.pop(name, None)
+        if provider is None:
+            return
+
+        try:
+            logger.info('Terminating provider %s', name)
+            provider.terminate()
+        except Exception:
+            logger.exception('Provider %r terminated unexpectedly', name)
 
     def __delitem__(self, name):
         if name not in self.initialized_providers:

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -114,8 +114,17 @@ class _ProviderConfigs(dict):
                 provider = provider_registry[key](**registered_val)  # type: ignore
                 provider.initialize()
             except Exception as error:
+                # The running provider stays: a replacement that could not
+                # start is no reason to lose the one that works.
                 self._pool.throttle_callback(key, error)
             else:
+                if key in self._pool.initialized_providers:
+                    # Terminate the instance being replaced. Dropping the
+                    # reference releases nothing it owns, and a Provider Hub
+                    # provider owns a worker process and the threads pumping
+                    # its stdio, so every settings save that touched a config
+                    # leaked one for the life of the process.
+                    del self._pool[key]
                 self._pool.initialized_providers[key] = provider
 
         if updated:

--- a/tests/bazarr/test_provider_pool_config_reload.py
+++ b/tests/bazarr/test_provider_pool_config_reload.py
@@ -8,6 +8,8 @@ one provider's config leaked a worker for the life of the process. Bazarr saves
 settings often enough that this accumulates.
 """
 
+import shutil
+
 import pytest
 
 from subliminal_patch.core import SZProviderPool
@@ -77,7 +79,11 @@ def test_an_unchanged_config_leaves_the_running_provider_alone(registered):
     assert pool["fake"] is first
 
 
-def test_a_failed_replacement_keeps_the_running_provider(registered, monkeypatch):
+def test_a_failed_replacement_leaves_nothing_installed_and_is_retried(registered, monkeypatch):
+    """The stale-config instance goes either way. Leaving it installed would
+    keep serving the configuration the user just changed, and the pool
+    re-initializes on next access, so a provider that is merely unreachable
+    right now recovers on its own with the new config."""
     pool, first = _pool_with_initialized_provider(registered)
 
     class _Broken(_FakeProvider):
@@ -91,5 +97,54 @@ def test_a_failed_replacement_keeps_the_running_provider(registered, monkeypatch
     pool.provider_configs.update({"fake": {"token": "new"}})
 
     assert throttled == ["fake"]
-    assert not first.terminated, "the working provider was torn down for a replacement that never started"
-    assert pool.initialized_providers["fake"] is first
+    assert first.terminated
+    assert "fake" not in pool.initialized_providers
+
+    monkeypatch.setitem(provider_registry.providers, "fake", _FakeProvider)
+    assert pool["fake"].config["token"] == "new"
+
+
+def test_the_replacement_is_built_after_the_old_one_is_torn_down(registered, tmp_path):
+    """Ordering, and it is not academic: EmbeddedSubtitles.terminate() rmtree's
+    a cache directory shared by every instance of it, and initialize() creates
+    that same directory. Tearing the old one down last therefore deletes what
+    the replacement just set up, and embedded extraction fails until something
+    reinitializes the provider."""
+    shared = tmp_path / "cache"
+
+    class _OwnsSharedState(_FakeProvider):
+        def initialize(self):
+            shared.mkdir(exist_ok=True)
+            super().initialize()
+
+        def terminate(self):
+            shutil.rmtree(shared, ignore_errors=True)
+            super().terminate()
+
+    provider_registry.providers["fake"] = _OwnsSharedState
+    pool = SZProviderPool(providers=["fake"], provider_configs={"fake": {"token": "old"}})
+    assert pool["fake"].initialized
+
+    pool.provider_configs.update({"fake": {"token": "new"}})
+
+    assert shared.is_dir(), "the replacement's shared state was destroyed by the teardown that followed it"
+
+
+def test_a_teardown_failure_does_not_throttle_the_healthy_replacement(registered, monkeypatch):
+    """throttle_callback takes the provider name out of the rotation for the
+    throttle interval. The instance being discarded misbehaving on the way out
+    is no reason to do that to the one that just started cleanly."""
+    class _BadTerminate(_FakeProvider):
+        def terminate(self):
+            raise RuntimeError("teardown blew up")
+
+    monkeypatch.setitem(provider_registry.providers, "fake", _BadTerminate)
+    pool = SZProviderPool(providers=["fake"], provider_configs={"fake": {"token": "old"}})
+    assert pool["fake"].initialized
+    throttled = []
+    pool.throttle_callback = lambda name, error: throttled.append(name)
+
+    pool.provider_configs.update({"fake": {"token": "new"}})
+
+    assert throttled == []
+    assert pool.initialized_providers["fake"].config["token"] == "new"

--- a/tests/bazarr/test_provider_pool_config_reload.py
+++ b/tests/bazarr/test_provider_pool_config_reload.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+"""A config change replaces a provider instance. The old one must be terminated.
+
+Every provider holds something: a requests Session at minimum, and for a
+Provider Hub provider a worker subprocess plus the threads pumping its stdio.
+Dropping the reference releases none of that, so a settings save that touches
+one provider's config leaked a worker for the life of the process. Bazarr saves
+settings often enough that this accumulates.
+"""
+
+import pytest
+
+from subliminal_patch.core import SZProviderPool
+from subliminal_patch.extensions import provider_registry
+
+
+class _FakeProvider:
+    """Stands in for a provider that owns something worth releasing."""
+
+    instances = []
+
+    def __init__(self, **config):
+        self.config = config
+        self.initialized = False
+        self.terminated = False
+        _FakeProvider.instances.append(self)
+
+    def initialize(self):
+        self.initialized = True
+
+    def terminate(self):
+        self.terminated = True
+
+
+@pytest.fixture
+def registered(monkeypatch):
+    _FakeProvider.instances = []
+    monkeypatch.setitem(provider_registry.providers, "fake", _FakeProvider)
+    yield _FakeProvider
+
+
+def _pool_with_initialized_provider(registered):
+    pool = SZProviderPool(providers=["fake"], provider_configs={"fake": {"token": "old"}})
+    first = pool["fake"]
+    assert first.initialized
+    return pool, first
+
+
+def test_a_config_change_terminates_the_provider_it_replaces(registered):
+    pool, first = _pool_with_initialized_provider(registered)
+
+    pool.provider_configs.update({"fake": {"token": "new"}})
+
+    assert first.terminated, (
+        "the replaced provider was dropped without terminate(); a Provider Hub "
+        "provider would leave its worker process and stdio threads behind"
+    )
+    assert pool["fake"] is not first
+    assert pool["fake"].config["token"] == "new"
+
+
+def test_a_provider_that_was_never_initialized_is_not_terminated(registered):
+    pool = SZProviderPool(providers=["fake"], provider_configs={"fake": {"token": "old"}})
+
+    pool.provider_configs.update({"fake": {"token": "new"}})
+
+    # Nothing was running, so nothing should have been built just to tear down.
+    assert [p for p in registered.instances if p.terminated] == []
+
+
+def test_an_unchanged_config_leaves_the_running_provider_alone(registered):
+    pool, first = _pool_with_initialized_provider(registered)
+
+    pool.provider_configs.update({"fake": {"token": "old"}})
+
+    assert not first.terminated
+    assert pool["fake"] is first
+
+
+def test_a_failed_replacement_keeps_the_running_provider(registered, monkeypatch):
+    pool, first = _pool_with_initialized_provider(registered)
+
+    class _Broken(_FakeProvider):
+        def initialize(self):
+            raise RuntimeError("no")
+
+    monkeypatch.setitem(provider_registry.providers, "fake", _Broken)
+    throttled = []
+    pool.throttle_callback = lambda name, error: throttled.append(name)
+
+    pool.provider_configs.update({"fake": {"token": "new"}})
+
+    assert throttled == ["fake"]
+    assert not first.terminated, "the working provider was torn down for a replacement that never started"
+    assert pool.initialized_providers["fake"] is first


### PR DESCRIPTION
## What

`_ProviderConfigs.update()` rebuilds a provider when its config changes and installs the new instance over the old one in `initialized_providers`. The old instance is never terminated, so nothing it owns is released.

For most providers that is a `requests.Session`. For a Provider Hub provider it is a worker subprocess plus the two threads pumping its stdio, and those survive for the life of the process. Bazarr rebuilds provider configs on every settings save that touches them, so the count only goes up.

## Fix

Terminate through the pool's existing `__delitem__`, which already handles a provider that times out or raises on teardown and routes it to the throttle callback. A replacement that fails to initialize still leaves the running provider in place, unchanged from before.

## Tests

`tests/bazarr/test_provider_pool_config_reload.py`, enumerated in CI:

- a config change terminates the instance it replaces (this is the one that was failing)
- a provider that was never initialized is not built just to be torn down
- an unchanged config leaves the running provider alone
- a replacement that fails to start does not cost the working provider

Full backend suite green locally, ruff clean.