### PR TITLE
fix(mass download): map a series episode with the series path mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,7 @@ jobs:
             tests/bazarr/test_arr_local_id_cutover_migration.py \
             tests/bazarr/test_jobs_queue_progress.py \
             tests/bazarr/test_processing_sync_substep.py \
+            tests/bazarr/test_mass_download_path_mapping.py \
             tests/bazarr/test_processing_postprocessing.py \
             tests/bazarr/test_sync_progress_report.py \
             tests/bazarr/test_subsync_engines.py \

--- a/bazarr/subtitles/mass_download/series.py
+++ b/bazarr/subtitles/mass_download/series.py
@@ -124,7 +124,7 @@ def episode_download_subtitles(no, job_id=None, job_sub_function=False, provider
         return
     elif episode.subtitles is None:
         # subtitles indexing for this episode is incomplete, we'll do it again
-        store_subtitles(episode.path, path_mappings.path_replace_movie(episode.path))
+        store_subtitles(episode.path, path_mappings.path_replace(episode.path))
         episode = database.execute(stmt).first()
     elif episode.missing_subtitles is None:
         # missing subtitles calculation for this episode is incomplete, we'll do it again

--- a/bazarr/subtitles/mass_download/series.py
+++ b/bazarr/subtitles/mass_download/series.py
@@ -32,12 +32,14 @@ def series_download_subtitles(no, job_id=None, job_sub_function=False, arr_insta
 
     series_row = database.execute(scoped(
         select(TableShows.path,
+               TableShows.arr_instance_id,
                TableShows.title)
         .where(TableShows.sonarrSeriesId == no),
         TableShows.arr_instance_id, arr_instance_id))\
         .first()
 
-    if series_row and not os.path.exists(path_mappings.path_replace(series_row.path)):
+    if series_row and not os.path.exists(
+            path_mappings.path_replace_instance(series_row.path, series_row.arr_instance_id, 'series')):
         raise OSError
 
     conditions = [(TableEpisodes.sonarrSeriesId == no),
@@ -98,6 +100,7 @@ def episode_download_subtitles(no, job_id=None, job_sub_function=False, provider
     conditions = [(TableEpisodes.sonarrEpisodeId == no)]
     conditions += get_exclusion_clause('series')
     stmt = scoped(select(TableEpisodes.path,
+                  TableEpisodes.arr_instance_id,
                   TableEpisodes.missing_subtitles,
                   TableEpisodes.monitored,
                   TableEpisodes.sonarrEpisodeId,
@@ -124,14 +127,15 @@ def episode_download_subtitles(no, job_id=None, job_sub_function=False, provider
         return
     elif episode.subtitles is None:
         # subtitles indexing for this episode is incomplete, we'll do it again
-        store_subtitles(episode.path, path_mappings.path_replace(episode.path))
+        store_subtitles(episode.path,
+                        path_mappings.path_replace_instance(episode.path, episode.arr_instance_id, 'series'))
         episode = database.execute(stmt).first()
     elif episode.missing_subtitles is None:
         # missing subtitles calculation for this episode is incomplete, we'll do it again
         list_missing_subtitles(epno=no, arr_instance_id=arr_instance_id)
         episode = database.execute(stmt).first()
 
-    episodePath = path_mappings.path_replace(episode.path)
+    episodePath = path_mappings.path_replace_instance(episode.path, episode.arr_instance_id, 'series')
 
     if not os.path.exists(episodePath):
         logging.debug(f"BAZARR episode file not found. Path mapping issue?: {episodePath}")  # noqa: G004
@@ -177,7 +181,9 @@ def episode_download_subtitles(no, job_id=None, job_sub_function=False, provider
                 if result:
                     if isinstance(result, tuple) and len(result):
                         result = result[0]
-                    store_subtitles(episode.path, path_mappings.path_replace(episode.path))
+                    store_subtitles(episode.path,
+                                    path_mappings.path_replace_instance(episode.path, episode.arr_instance_id,
+                                                                        'series'))
                     history_log(1, episode.sonarrSeriesId, episode.sonarrEpisodeId, result,
                                 arr_instance_id=arr_instance_id)
                     send_notifications(episode.sonarrSeriesId, episode.sonarrEpisodeId, result.message,
@@ -203,6 +209,7 @@ def episode_download_specific_subtitles(sonarr_series_id, sonarr_episode_id, lan
     episodeInfo = database.execute(
         scoped(
             select(TableEpisodes.id,
+                   TableEpisodes.arr_instance_id,
                    TableEpisodes.path,
                    TableEpisodes.sceneName,
                    TableEpisodes.audio_language,
@@ -219,7 +226,7 @@ def episode_download_specific_subtitles(sonarr_series_id, sonarr_episode_id, lan
     if not episodeInfo:
         return 'Episode not found', 404
 
-    episodePath = path_mappings.path_replace(episodeInfo.path)
+    episodePath = path_mappings.path_replace_instance(episodeInfo.path, episodeInfo.arr_instance_id, 'series')
 
     if not os.path.exists(episodePath):
         return 'Episode file not found. Path mapping issue?', 500

--- a/tests/bazarr/test_mass_download_path_mapping.py
+++ b/tests/bazarr/test_mass_download_path_mapping.py
@@ -1,11 +1,16 @@
 # coding=utf-8
-"""A series episode is mapped with the series path mapping, not the movie one.
+"""A series episode is mapped as a series, and by the instance that owns it.
 
 Bazarr keeps separate movie and series path mappings, and installs that store
 the two libraries on different mounts configure them differently. Re-indexing an
 episode through path_replace_movie() therefore hands store_subtitles a path that
 does not exist, and the episode's subtitles stay unindexed with nothing in the
 log to say why.
+
+A secondary Sonarr instance can carry its own path mappings on top of that, so
+the episode row's own arr_instance_id decides the mapping rather than the global
+one. path_replace_instance() falls back to the global mapping when the instance
+has none configured, which is every single-instance install.
 """
 
 import types
@@ -28,6 +33,7 @@ def episode_module(monkeypatch):
     from subtitles.mass_download import series as module
 
     unindexed = types.SimpleNamespace(
+        arr_instance_id=None,
         path="/tv/Show/Season 1/Show.S01E01.mkv",
         subtitles=None,
         missing_subtitles=None,
@@ -48,6 +54,15 @@ def episode_module(monkeypatch):
                         lambda path: path.replace("/tv/", "/mnt/series/"))
     monkeypatch.setattr(module.path_mappings, "path_replace_movie",
                         lambda path: path.replace("/tv/", "/mnt/movies/"))
+    monkeypatch.setattr(
+        module.path_mappings, "path_replace_instance",
+        # What the real helper does: the instance's own mapping when it has one,
+        # the global mapping for its media type otherwise.
+        lambda path, arr_instance_id, media_type: (
+            path.replace("/tv/", "/mnt/instance7/") if arr_instance_id == 7
+            else path.replace("/tv/", f"/mnt/{media_type}/")
+        ),
+    )
 
     return module, unindexed
 
@@ -63,3 +78,15 @@ def test_reindexing_an_episode_uses_the_series_path_mapping(episode_module, monk
         module.episode_download_subtitles(1, job_id=1, job_sub_function=True)
 
     assert indexed == [(unindexed.path, "/mnt/series/Show/Season 1/Show.S01E01.mkv")]
+
+
+def test_the_owning_instance_path_mapping_wins(episode_module, monkeypatch):
+    module, unindexed = episode_module
+    unindexed.arr_instance_id = 7
+    indexed = []
+    monkeypatch.setattr(module, "store_subtitles", lambda path, mapped: indexed.append((path, mapped)))
+
+    with pytest.raises(OSError):
+        module.episode_download_subtitles(1, job_id=1, job_sub_function=True)
+
+    assert indexed == [(unindexed.path, "/mnt/instance7/Show/Season 1/Show.S01E01.mkv")]

--- a/tests/bazarr/test_mass_download_path_mapping.py
+++ b/tests/bazarr/test_mass_download_path_mapping.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+"""A series episode is mapped with the series path mapping, not the movie one.
+
+Bazarr keeps separate movie and series path mappings, and installs that store
+the two libraries on different mounts configure them differently. Re-indexing an
+episode through path_replace_movie() therefore hands store_subtitles a path that
+does not exist, and the episode's subtitles stay unindexed with nothing in the
+log to say why.
+"""
+
+import types
+
+import pytest
+
+import app.database  # noqa: F401
+
+
+class _Result:
+    def __init__(self, row):
+        self._row = row
+
+    def first(self):
+        return self._row
+
+
+@pytest.fixture
+def episode_module(monkeypatch):
+    from subtitles.mass_download import series as module
+
+    unindexed = types.SimpleNamespace(
+        path="/tv/Show/Season 1/Show.S01E01.mkv",
+        subtitles=None,
+        missing_subtitles=None,
+        sonarrSeriesId=1,
+        audio_language="English",
+        seriesType="standard",
+        title="Show",
+        episodeTitle="One",
+        season=1,
+        episode=1,
+        profileId=1,
+        tags="[]",
+    )
+
+    monkeypatch.setattr(module.database, "execute", lambda *a, **k: _Result(unindexed))
+    monkeypatch.setattr(module.jobs_queue, "update_job_progress", lambda **k: None)
+    monkeypatch.setattr(module.path_mappings, "path_replace",
+                        lambda path: path.replace("/tv/", "/mnt/series/"))
+    monkeypatch.setattr(module.path_mappings, "path_replace_movie",
+                        lambda path: path.replace("/tv/", "/mnt/movies/"))
+
+    return module, unindexed
+
+
+def test_reindexing_an_episode_uses_the_series_path_mapping(episode_module, monkeypatch):
+    module, unindexed = episode_module
+    indexed = []
+    monkeypatch.setattr(module, "store_subtitles", lambda path, mapped: indexed.append((path, mapped)))
+
+    # The episode file is not on this machine, so the call stops right after the
+    # re-index. That is the whole region under test.
+    with pytest.raises(OSError):
+        module.episode_download_subtitles(1, job_id=1, job_sub_function=True)
+
+    assert indexed == [(unindexed.path, "/mnt/series/Show/Season 1/Show.S01E01.mkv")]


### PR DESCRIPTION
## What

`episode_download_subtitles()` re-indexes an episode whose subtitle indexing is incomplete, and mapped its path with `path_replace_movie()`. It is a series episode, so it needs `path_replace()`, which is what the same file already uses at every other call site.

With distinct movie and series path mappings configured, which is the normal shape when the two libraries sit on different mounts, `store_subtitles` was handed a path that does not exist. The episode stayed unindexed and nothing in the log said why.

## Tests

`tests/bazarr/test_mass_download_path_mapping.py`, enumerated in CI: the two mappings are stubbed to distinguishable outputs, and the test pins which one reaches `store_subtitles`. It failed with the movie mapping before the change.

Full backend suite green locally, ruff clean.