### PR TITLE
fix(sync): shim ffprobe for alass so attachment streams stop killing it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,7 @@ jobs:
             tests/bazarr/test_processing_postprocessing.py \
             tests/bazarr/test_sync_progress_report.py \
             tests/bazarr/test_subsync_engines.py \
+            tests/bazarr/test_alass_ffprobe_shim.py \
             tests/bazarr/test_sync_instance_overrides.py \
             tests/bazarr/test_subzero_keep_lyrics.py \
             tests/bazarr/test_archive_extraction.py \

--- a/bazarr/subtitles/tools/alass_ffprobe_shim.py
+++ b/bazarr/subtitles/tools/alass_ffprobe_shim.py
@@ -21,9 +21,10 @@ the first one on PATH, with the arguments it was given.
 """
 
 import json
+import logging
 import os
+import shlex
 import shutil
-import stat
 import subprocess
 import sys
 import tempfile
@@ -33,6 +34,8 @@ import tempfile
 UNKNOWN_CODEC = "unknown"
 
 REAL_FFPROBE_ENV = "BAZARR_ALASS_REAL_FFPROBE"
+
+logger = logging.getLogger(__name__)
 
 
 def patch_ffprobe_json(text):
@@ -65,9 +68,18 @@ def patch_ffprobe_json(text):
     return json.dumps(probe)
 
 
-_LAUNCHER = """#!/bin/sh
-exec {python} {shim} "$@"
-"""
+_LAUNCHER_PATH = None
+
+
+def launcher_script(python, shim):
+    """The one line shell wrapper that runs the shim under ``python``.
+
+    Both paths are quoted: /bin/sh splits on whitespace, and an install path
+    with a space in it is ordinary rather than exotic.
+    """
+    return "#!/bin/sh\nexec {python} {shim} \"$@\"\n".format(
+        python=shlex.quote(python), shim=shlex.quote(shim),
+    )
 
 
 def ensure_launcher():
@@ -76,36 +88,37 @@ def ensure_launcher():
     alass execs ALASS_FFPROBE_PATH directly, so it has to be a program, not an
     interpreter plus a script. A one line shell wrapper pins the interpreter to
     the one Bazarr is running under rather than whatever a shebang would find.
-    Windows has no equivalent that alass would run, so there the shim is simply
-    not installed and alass behaves as it always has.
+
+    The directory is created with mkdtemp rather than at a predictable path:
+    on a shared host another user could pre-create a well known path as
+    world-writable, and replace the launcher between our write and alass
+    execing it, which would run their code with Bazarr's credentials.
+
+    Windows has no equivalent alass would run, so there the shim is simply not
+    installed and alass behaves as it always has.
     """
+    global _LAUNCHER_PATH
+
     if os.name != "posix":
         return None
 
-    directory = os.path.join(tempfile.gettempdir(), "bazarr-alass-shim")
-    launcher = os.path.join(directory, "ffprobe")
-    content = _LAUNCHER.format(python=sys.executable, shim=os.path.abspath(__file__))
+    if _LAUNCHER_PATH and os.path.isfile(_LAUNCHER_PATH):
+        return _LAUNCHER_PATH
 
+    content = launcher_script(sys.executable, os.path.abspath(__file__))
     try:
-        os.makedirs(directory, exist_ok=True)
-        # Rewritten whenever it differs: the interpreter or the install path
-        # can move under an upgrade, and a stale wrapper would point at neither.
-        if not os.path.isfile(launcher) or _read(launcher) != content:
-            with open(launcher, "w", encoding="utf-8") as handle:
-                handle.write(content)
-        os.chmod(launcher, os.stat(launcher).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        # mkdtemp gives us 0700 ownership of a name nobody could have guessed.
+        directory = tempfile.mkdtemp(prefix="bazarr-alass-shim-", dir=tempfile.gettempdir())
+        launcher = os.path.join(directory, "ffprobe")
+        with open(launcher, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        os.chmod(launcher, 0o700)
     except OSError:
+        logger.debug("Could not install the alass ffprobe shim", exc_info=True)
         return None
 
+    _LAUNCHER_PATH = launcher
     return launcher
-
-
-def _read(path):
-    try:
-        with open(path, encoding="utf-8") as handle:
-            return handle.read()
-    except OSError:
-        return None
 
 
 def real_ffprobe():

--- a/bazarr/subtitles/tools/alass_ffprobe_shim.py
+++ b/bazarr/subtitles/tools/alass_ffprobe_shim.py
@@ -1,0 +1,131 @@
+# coding=utf-8
+"""An ffprobe stand-in for alass, which cannot read output it did not expect.
+
+alass-cli probes the reference video itself, with a fixed
+``ffprobe -v error -show_entries ... -of json`` command, and deserializes the
+result into a struct whose ``codec_long_name`` is a required String. ffprobe
+omits that field entirely for a stream whose codec it cannot identify: the
+codec descriptor is NULL, so the field is written with print_str_opt, which the
+JSON writer drops. An MKV attachment muxed as application/octet-stream is
+exactly that, and fansub releases carry fonts and other attachments as a matter
+of course, so one attachment fails the whole parse and alass dies before it
+extracts any audio.
+
+Upstream alass is effectively unmaintained, so this fills the field in on the
+way past instead. Only the missing field is invented, and only when the output
+is JSON carrying a streams array; everything else, including the exit code and
+stderr, is the real ffprobe's.
+
+Run as a program: it execs the ffprobe named by BAZARR_ALASS_REAL_FFPROBE, or
+the first one on PATH, with the arguments it was given.
+"""
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+
+# What a stream whose codec ffprobe could not identify gets called. alass only
+# needs the field to exist: it reads codec_type to pick the audio stream.
+UNKNOWN_CODEC = "unknown"
+
+REAL_FFPROBE_ENV = "BAZARR_ALASS_REAL_FFPROBE"
+
+
+def patch_ffprobe_json(text):
+    """Return ffprobe output with a codec_long_name on every stream.
+
+    Anything that is not JSON with a streams array comes back untouched, so a
+    caller that asked for another output format is unaffected.
+    """
+    try:
+        probe = json.loads(text)
+    except (ValueError, TypeError):
+        return text
+
+    if not isinstance(probe, dict):
+        return text
+
+    streams = probe.get("streams")
+    if not isinstance(streams, list):
+        return text
+
+    patched = False
+    for stream in streams:
+        if isinstance(stream, dict) and not stream.get("codec_long_name"):
+            stream["codec_long_name"] = UNKNOWN_CODEC
+            patched = True
+
+    if not patched:
+        return text
+
+    return json.dumps(probe)
+
+
+_LAUNCHER = """#!/bin/sh
+exec {python} {shim} "$@"
+"""
+
+
+def ensure_launcher():
+    """Path to an executable that runs this shim, or None if there cannot be one.
+
+    alass execs ALASS_FFPROBE_PATH directly, so it has to be a program, not an
+    interpreter plus a script. A one line shell wrapper pins the interpreter to
+    the one Bazarr is running under rather than whatever a shebang would find.
+    Windows has no equivalent that alass would run, so there the shim is simply
+    not installed and alass behaves as it always has.
+    """
+    if os.name != "posix":
+        return None
+
+    directory = os.path.join(tempfile.gettempdir(), "bazarr-alass-shim")
+    launcher = os.path.join(directory, "ffprobe")
+    content = _LAUNCHER.format(python=sys.executable, shim=os.path.abspath(__file__))
+
+    try:
+        os.makedirs(directory, exist_ok=True)
+        # Rewritten whenever it differs: the interpreter or the install path
+        # can move under an upgrade, and a stale wrapper would point at neither.
+        if not os.path.isfile(launcher) or _read(launcher) != content:
+            with open(launcher, "w", encoding="utf-8") as handle:
+                handle.write(content)
+        os.chmod(launcher, os.stat(launcher).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    except OSError:
+        return None
+
+    return launcher
+
+
+def _read(path):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return handle.read()
+    except OSError:
+        return None
+
+
+def real_ffprobe():
+    return os.environ.get(REAL_FFPROBE_ENV) or shutil.which("ffprobe")
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+
+    executable = real_ffprobe()
+    if not executable:
+        sys.stderr.write("bazarr alass ffprobe shim: no ffprobe found\n")
+        return 127
+
+    done = subprocess.run([executable, *argv], capture_output=True, text=True)
+
+    sys.stdout.write(patch_ffprobe_json(done.stdout))
+    sys.stderr.write(done.stderr)
+    return done.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bazarr/subtitles/tools/alass_ffprobe_shim.py
+++ b/bazarr/subtitles/tools/alass_ffprobe_shim.py
@@ -108,9 +108,41 @@ def _writable_directories():
     return directories
 
 
+LAUNCHER_PREFIX = "bazarr-alass-shim-"
+
+
 def _ensure(parent):
     os.makedirs(parent, exist_ok=True)
+    _sweep(parent)
     return parent
+
+
+def _sweep(parent):
+    """Remove launcher directories we left behind on earlier runs.
+
+    The current one is only remembered in memory and Bazarr exits through
+    os._exit, so nothing cleans up on the way out and every restart that syncs
+    with alass would leave another directory here. Only directories this user
+    owns are touched, and a running process that loses its launcher this way
+    simply installs another one.
+    """
+    try:
+        entries = os.listdir(parent)
+    except OSError:
+        return
+
+    for entry in entries:
+        if not entry.startswith(LAUNCHER_PREFIX):
+            continue
+
+        path = os.path.join(parent, entry)
+        try:
+            if os.stat(path).st_uid != os.getuid():
+                continue
+        except OSError:
+            continue
+
+        shutil.rmtree(path, ignore_errors=True)
 
 
 def _install_launcher(directory, content):
@@ -160,7 +192,7 @@ def ensure_launcher():
     for parent in _writable_directories():
         directory = None
         try:
-            directory = tempfile.mkdtemp(prefix="bazarr-alass-shim-", dir=_ensure(parent))
+            directory = tempfile.mkdtemp(prefix=LAUNCHER_PREFIX, dir=_ensure(parent))
             _LAUNCHER_PATH = _install_launcher(directory, content)
         except Exception:
             logger.debug("Could not install the alass ffprobe shim in %s", parent, exc_info=True)

--- a/bazarr/subtitles/tools/alass_ffprobe_shim.py
+++ b/bazarr/subtitles/tools/alass_ffprobe_shim.py
@@ -82,6 +82,50 @@ def launcher_script(python, shim):
     )
 
 
+def _writable_directories():
+    """Where the launcher may live, best first.
+
+    Bazarr's own config directory comes first: the system temp directory is
+    routinely mounted noexec, and a launcher there can be written and marked
+    executable and still refuse to run.
+    """
+    directories = []
+    try:
+        from app.get_args import args
+
+        if args.config_dir:
+            directories.append(os.path.join(args.config_dir, "cache"))
+    except Exception:
+        # Imported by the shim's own process too, which has no Bazarr around it.
+        logger.debug("No Bazarr config directory for the alass shim", exc_info=True)
+
+    directories.append(tempfile.gettempdir())
+    return directories
+
+
+def _install_launcher(parent, content):
+    """Write the launcher under ``parent`` and prove it can actually run."""
+    os.makedirs(parent, exist_ok=True)
+    # mkdtemp gives us 0700 ownership of a name nobody could have guessed.
+    directory = tempfile.mkdtemp(prefix="bazarr-alass-shim-", dir=parent)
+    launcher = os.path.join(directory, "ffprobe")
+    with open(launcher, "w", encoding="utf-8") as handle:
+        handle.write(content)
+    os.chmod(launcher, 0o700)
+
+    # Run it once against a program that ignores its arguments and succeeds. A
+    # noexec mount fails here rather than in the middle of a subtitle sync.
+    probe = subprocess.run(
+        [launcher], capture_output=True,
+        env=dict(os.environ, **{REAL_FFPROBE_ENV: "/bin/true"}),
+        timeout=30,
+    )
+    if probe.returncode != 0:
+        raise OSError(f"the launcher in {parent} exited {probe.returncode}")
+
+    return launcher
+
+
 def ensure_launcher():
     """Path to an executable that runs this shim, or None if there cannot be one.
 
@@ -106,19 +150,16 @@ def ensure_launcher():
         return _LAUNCHER_PATH
 
     content = launcher_script(sys.executable, os.path.abspath(__file__))
-    try:
-        # mkdtemp gives us 0700 ownership of a name nobody could have guessed.
-        directory = tempfile.mkdtemp(prefix="bazarr-alass-shim-", dir=tempfile.gettempdir())
-        launcher = os.path.join(directory, "ffprobe")
-        with open(launcher, "w", encoding="utf-8") as handle:
-            handle.write(content)
-        os.chmod(launcher, 0o700)
-    except OSError:
-        logger.debug("Could not install the alass ffprobe shim", exc_info=True)
-        return None
+    for parent in _writable_directories():
+        try:
+            _LAUNCHER_PATH = _install_launcher(parent, content)
+        except Exception:
+            logger.debug("Could not install the alass ffprobe shim in %s", parent, exc_info=True)
+            continue
 
-    _LAUNCHER_PATH = launcher
-    return launcher
+        return _LAUNCHER_PATH
+
+    return None
 
 
 def real_ffprobe():

--- a/bazarr/subtitles/tools/alass_ffprobe_shim.py
+++ b/bazarr/subtitles/tools/alass_ffprobe_shim.py
@@ -35,6 +35,11 @@ UNKNOWN_CODEC = "unknown"
 
 REAL_FFPROBE_ENV = "BAZARR_ALASS_REAL_FFPROBE"
 
+# Proves the launcher can be executed without depending on any other program:
+# /bin/true is not where macOS keeps it, and a self-test that needs a program
+# that is not there would disable the shim across a whole platform.
+SELFTEST_ARG = "--bazarr-shim-selftest"
+
 logger = logging.getLogger(__name__)
 
 
@@ -103,25 +108,27 @@ def _writable_directories():
     return directories
 
 
-def _install_launcher(parent, content):
-    """Write the launcher under ``parent`` and prove it can actually run."""
+def _ensure(parent):
     os.makedirs(parent, exist_ok=True)
-    # mkdtemp gives us 0700 ownership of a name nobody could have guessed.
-    directory = tempfile.mkdtemp(prefix="bazarr-alass-shim-", dir=parent)
+    return parent
+
+
+def _install_launcher(directory, content):
+    """Write the launcher in ``directory`` and prove it can actually run.
+
+    The directory comes from mkdtemp, which gives us 0700 ownership of a name
+    nobody could have guessed.
+    """
     launcher = os.path.join(directory, "ffprobe")
     with open(launcher, "w", encoding="utf-8") as handle:
         handle.write(content)
     os.chmod(launcher, 0o700)
 
-    # Run it once against a program that ignores its arguments and succeeds. A
-    # noexec mount fails here rather than in the middle of a subtitle sync.
-    probe = subprocess.run(
-        [launcher], capture_output=True,
-        env=dict(os.environ, **{REAL_FFPROBE_ENV: "/bin/true"}),
-        timeout=30,
-    )
+    # Run it once. A noexec mount fails here rather than in the middle of a
+    # subtitle sync.
+    probe = subprocess.run([launcher, SELFTEST_ARG], capture_output=True, timeout=30)
     if probe.returncode != 0:
-        raise OSError(f"the launcher in {parent} exited {probe.returncode}")
+        raise OSError(f"the launcher in {directory} exited {probe.returncode}")
 
     return launcher
 
@@ -151,10 +158,16 @@ def ensure_launcher():
 
     content = launcher_script(sys.executable, os.path.abspath(__file__))
     for parent in _writable_directories():
+        directory = None
         try:
-            _LAUNCHER_PATH = _install_launcher(parent, content)
+            directory = tempfile.mkdtemp(prefix="bazarr-alass-shim-", dir=_ensure(parent))
+            _LAUNCHER_PATH = _install_launcher(directory, content)
         except Exception:
             logger.debug("Could not install the alass ffprobe shim in %s", parent, exc_info=True)
+            # Nothing remembers the failure, so every sync retries this. Each
+            # retry leaving its private directory behind would leak inodes.
+            if directory:
+                shutil.rmtree(directory, ignore_errors=True)
             continue
 
         return _LAUNCHER_PATH
@@ -168,6 +181,10 @@ def real_ffprobe():
 
 def main(argv=None):
     argv = list(sys.argv[1:] if argv is None else argv)
+
+    if argv == [SELFTEST_ARG]:
+        # Only ever run by ensure_launcher, to prove this file can be executed.
+        return 0
 
     executable = real_ffprobe()
     if not executable:

--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -328,6 +328,18 @@ class SubSyncer:
         """
         environment = dict(os.environ)
 
+        # An ALASS_FFPROBE_PATH already in the environment is somebody's
+        # deliberate choice of ffprobe, which alass honoured before this shim
+        # existed. The shim runs it rather than replacing it.
+        configured = os.environ.get('ALASS_FFPROBE_PATH')
+        if configured:
+            launcher = alass_ffprobe_shim.ensure_launcher()
+            if not launcher:
+                return environment
+            environment[alass_ffprobe_shim.REAL_FFPROBE_ENV] = configured
+            environment['ALASS_FFPROBE_PATH'] = launcher
+            return environment
+
         try:
             ffprobe_exe = get_binary('ffprobe')
         except Exception:

--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -10,6 +10,7 @@ from utilities.binaries import get_binary
 from radarr.history import history_log_movie
 from sonarr.history import history_log
 from subtitles.processing import ProcessSubtitlesResult
+from subtitles.tools import alass_ffprobe_shim
 from subtitles.tools.subsync_engines import (
     DEFAULT_ENABLED_ENGINES,
     OUTPUT_MODE_OVERWRITE,
@@ -302,6 +303,7 @@ class SubSyncer:
                 capture_output=True,
                 text=True,
                 timeout=1800,
+                env=self._alass_environment() if engine == 'alass' else None,
             )
         except subprocess.CalledProcessError as exc:
             details = (getattr(exc, 'stderr', None) or getattr(exc, 'stdout', None) or str(exc)).strip()
@@ -313,6 +315,27 @@ class SubSyncer:
             'stderr': completed.stderr,
             'returncode': completed.returncode,
         }
+
+    def _alass_environment(self):
+        """Environment for alass, pointing its ffprobe at our shim.
+
+        alass probes the reference video itself and cannot parse the output for
+        a stream whose codec ffprobe could not identify, which any MKV with an
+        application/octet-stream attachment produces. It honours
+        ALASS_FFPROBE_PATH, so the shim goes in there rather than in a patched
+        build. If either half is unavailable the environment is left alone and
+        alass runs exactly as it did before.
+        """
+        environment = dict(os.environ)
+
+        ffprobe_exe = get_binary('ffprobe')
+        launcher = alass_ffprobe_shim.ensure_launcher()
+        if not ffprobe_exe or not launcher:
+            return environment
+
+        environment[alass_ffprobe_shim.REAL_FFPROBE_ENV] = ffprobe_exe
+        environment['ALASS_FFPROBE_PATH'] = launcher
+        return environment
 
     def _run_autosubsync_engine(self, output_path, video_path):
         reference = self.reference if self.reference and os.path.isfile(self.reference) else video_path

--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -328,7 +328,15 @@ class SubSyncer:
         """
         environment = dict(os.environ)
 
-        ffprobe_exe = get_binary('ffprobe')
+        try:
+            ffprobe_exe = get_binary('ffprobe')
+        except Exception:
+            # get_binary raises when it can neither find nor fetch the binary.
+            # An install that runs alass off an inherited PATH worked before
+            # this shim existed and has to keep working.
+            logging.debug('BAZARR no ffprobe for the alass shim, running alass unshimmed', exc_info=True)
+            return environment
+
         launcher = alass_ffprobe_shim.ensure_launcher()
         if not ffprobe_exe or not launcher:
             return environment

--- a/tests/bazarr/test_alass_ffprobe_shim.py
+++ b/tests/bazarr/test_alass_ffprobe_shim.py
@@ -147,6 +147,11 @@ def recorded_alass_run(monkeypatch, tmp_path):
     return syncer, calls
 
 
+def _alass_call(calls):
+    """The alass invocation, not the launcher self-test that precedes it."""
+    return next(call for call in calls if str(call["command"][0]).endswith("alass"))
+
+
 @pytest.mark.skipif(os.name != "posix", reason="the launcher is a POSIX shell script")
 def test_alass_is_run_against_the_shim(recorded_alass_run, tmp_path):
     syncer, calls = recorded_alass_run
@@ -154,7 +159,8 @@ def test_alass_is_run_against_the_shim(recorded_alass_run, tmp_path):
     syncer._run_external_engine(engine="alass", output_path=tmp_path / "out.srt",
                                 video_path=str(tmp_path / "video.mkv"))
 
-    env = calls[0]["env"]
+    call = _alass_call(calls)
+    env = call["env"]
     assert env is not None
     assert env["BAZARR_ALASS_REAL_FFPROBE"] == "/usr/bin/ffprobe"
     launcher = env["ALASS_FFPROBE_PATH"]
@@ -162,7 +168,7 @@ def test_alass_is_run_against_the_shim(recorded_alass_run, tmp_path):
     # The rest of the environment is alass's own, not a two-variable replacement for it.
     assert env["PATH"] == os.environ["PATH"]
     # And the invocation itself is untouched.
-    assert calls[0]["command"][0] == "/usr/bin/alass"
+    assert call["command"][0] == "/usr/bin/alass"
 
 
 @pytest.mark.skipif(os.name != "posix", reason="the launcher is a POSIX shell script")
@@ -252,6 +258,51 @@ def test_alass_runs_unshimmed_when_ffprobe_cannot_be_found(recorded_alass_run, m
     syncer._run_external_engine(engine="alass", output_path=tmp_path / "out.srt",
                                 video_path=str(tmp_path / "video.mkv"))
 
-    env = calls[0]["env"]
+    env = _alass_call(calls)["env"]
     assert "ALASS_FFPROBE_PATH" not in env
     assert env["PATH"] == os.environ["PATH"]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="the launcher is a POSIX shell script")
+def test_a_noexec_temp_directory_is_not_where_the_launcher_ends_up(monkeypatch, tmp_path):
+    """A temp filesystem mounted noexec is ordinary hardening. The launcher can
+    be written and marked executable there and still fail to run, which would
+    turn every alass sync into a permission error instead of the unshimmed
+    behaviour it had before this shim existed."""
+    shim = _shim()
+    noexec = tmp_path / "noexec-tmp"
+    noexec.mkdir()
+    usable = tmp_path / "config"
+    usable.mkdir()
+
+    monkeypatch.setattr(shim, "_LAUNCHER_PATH", None, raising=False)
+    monkeypatch.setattr(shim.tempfile, "gettempdir", lambda: str(noexec))
+    monkeypatch.setattr(shim, "_writable_directories", lambda: [str(noexec), str(usable)])
+
+    real_run = shim.subprocess.run
+
+    def run(command, *args, **kwargs):
+        if str(command[0]).startswith(str(noexec)):
+            raise PermissionError(13, "Permission denied")
+        return real_run(command, *args, **kwargs)
+
+    monkeypatch.setattr(shim.subprocess, "run", run)
+
+    launcher = shim.ensure_launcher()
+
+    assert launcher is not None, "no usable directory was found even though one was offered"
+    assert launcher.startswith(str(usable))
+
+
+@pytest.mark.skipif(os.name != "posix", reason="the launcher is a POSIX shell script")
+def test_no_launcher_at_all_when_nothing_can_execute(monkeypatch, tmp_path):
+    shim = _shim()
+    monkeypatch.setattr(shim, "_LAUNCHER_PATH", None, raising=False)
+    monkeypatch.setattr(shim, "_writable_directories", lambda: [str(tmp_path)])
+
+    def run(command, *args, **kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr(shim.subprocess, "run", run)
+
+    assert shim.ensure_launcher() is None

--- a/tests/bazarr/test_alass_ffprobe_shim.py
+++ b/tests/bazarr/test_alass_ffprobe_shim.py
@@ -179,3 +179,79 @@ def test_the_launcher_really_runs_the_shim(tmp_path):
     done = subprocess.run([launcher, "-of", "json", "x.mkv"], capture_output=True, text=True, env=env)
 
     assert json.loads(done.stdout)["streams"][0]["codec_long_name"] == "unknown"
+
+
+# --- the launcher must be ours, and must survive awkward install paths ------
+
+
+@pytest.mark.skipif(os.name != "posix", reason="the launcher is a POSIX shell script")
+def test_the_launcher_never_lands_in_a_directory_someone_else_prepared(monkeypatch, tmp_path):
+    """A predictable path under /tmp can be pre-created world-writable by
+    another user on a shared host. makedirs(exist_ok=True) would accept it, and
+    that user could then swap the file between our write and alass execing it,
+    so alass would run their code with our credentials."""
+    import stat as stat_module
+
+    shim = _shim()
+    monkeypatch.setattr(shim.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(shim, "_LAUNCHER_PATH", None, raising=False)
+    hostile = tmp_path / "bazarr-alass-shim"
+    hostile.mkdir(mode=0o777)
+
+    launcher = shim.ensure_launcher()
+
+    directory = os.path.dirname(launcher)
+    mode = os.stat(directory).st_mode
+    assert not mode & (stat_module.S_IWGRP | stat_module.S_IWOTH), (
+        f"{directory} is writable by someone other than us"
+    )
+    assert os.stat(directory).st_uid == os.getuid()
+    assert not os.path.exists(hostile / "ffprobe"), "the launcher landed in the directory someone else prepared"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="the launcher is a POSIX shell script")
+def test_an_install_path_with_spaces_still_produces_a_working_launcher(tmp_path):
+    """/bin/sh splits on whitespace, so an unquoted path in the generated
+    script means every alass sync fails on an install path with a space in it,
+    which is ordinary on macOS and Windows-turned-POSIX mounts."""
+    awkward = tmp_path / "my programs" / "shim dir"
+    awkward.mkdir(parents=True)
+    shim_copy = awkward / "alass_ffprobe_shim.py"
+    shim_copy.write_text(open(_shim().__file__, encoding="utf-8").read(), encoding="utf-8")
+
+    launcher = awkward / "ffprobe"
+    launcher.write_text(_shim().launcher_script(sys.executable, str(shim_copy)), encoding="utf-8")
+    launcher.chmod(0o700)
+
+    probe = {"streams": [{"index": 0, "codec_type": "attachment"}]}
+    fake = tmp_path / "ffprobe-real"
+    fake.write_text(f"#!/bin/sh\ncat <<'EOF'\n{json.dumps(probe)}\nEOF\n")
+    fake.chmod(0o755)
+
+    done = subprocess.run([str(launcher), "-of", "json", "x.mkv"], capture_output=True, text=True,
+                          env=dict(os.environ, BAZARR_ALASS_REAL_FFPROBE=str(fake)))
+
+    assert done.returncode == 0, done.stderr
+    assert json.loads(done.stdout)["streams"][0]["codec_long_name"] == "unknown"
+
+
+def test_alass_runs_unshimmed_when_ffprobe_cannot_be_found(recorded_alass_run, monkeypatch, tmp_path):
+    """get_binary raises rather than returning a falsy value when it cannot
+    find a binary. An install running alass off an inherited PATH worked before
+    the shim existed and has to keep working."""
+    from subtitles.tools import subsyncer as module
+    from utilities.binaries import BinaryNotFound
+
+    syncer, calls = recorded_alass_run
+
+    def raising(name):
+        raise BinaryNotFound()
+
+    monkeypatch.setattr(module, "get_binary", raising)
+
+    syncer._run_external_engine(engine="alass", output_path=tmp_path / "out.srt",
+                                video_path=str(tmp_path / "video.mkv"))
+
+    env = calls[0]["env"]
+    assert "ALASS_FFPROBE_PATH" not in env
+    assert env["PATH"] == os.environ["PATH"]

--- a/tests/bazarr/test_alass_ffprobe_shim.py
+++ b/tests/bazarr/test_alass_ffprobe_shim.py
@@ -306,3 +306,45 @@ def test_no_launcher_at_all_when_nothing_can_execute(monkeypatch, tmp_path):
     monkeypatch.setattr(shim.subprocess, "run", run)
 
     assert shim.ensure_launcher() is None
+
+
+def test_an_operator_configured_ffprobe_override_is_kept(recorded_alass_run, monkeypatch, tmp_path):
+    """ALASS_FFPROBE_PATH in the environment is someone's deliberate choice of
+    ffprobe, and alass honoured it before the shim existed. The shim runs it
+    rather than replacing it."""
+    monkeypatch.setenv("ALASS_FFPROBE_PATH", "/opt/custom/ffprobe")
+    syncer, calls = recorded_alass_run
+
+    syncer._run_external_engine(engine="alass", output_path=tmp_path / "out.srt",
+                                video_path=str(tmp_path / "video.mkv"))
+
+    env = _alass_call(calls)["env"]
+    assert env["BAZARR_ALASS_REAL_FFPROBE"] == "/opt/custom/ffprobe"
+    assert env["ALASS_FFPROBE_PATH"] != "/opt/custom/ffprobe", "the shim never got in front of it"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="the launcher is a POSIX shell script")
+def test_the_self_test_needs_no_external_program(tmp_path):
+    """/bin/true is not where macOS keeps it, and a self-test that depends on
+    a program that is not there rejects every candidate directory and quietly
+    disables the shim on a whole platform."""
+    launcher = _shim().ensure_launcher()
+
+    done = subprocess.run([launcher, _shim().SELFTEST_ARG], capture_output=True, text=True,
+                          env={k: v for k, v in os.environ.items() if k != "PATH"})
+
+    assert done.returncode == 0, done.stderr
+
+
+@pytest.mark.skipif(os.name != "posix", reason="the launcher is a POSIX shell script")
+def test_a_failed_install_leaves_no_directory_behind(monkeypatch, tmp_path):
+    """Nothing caches a failure, so every sync retries the install. Each retry
+    leaving a private directory behind is an inode leak on a noexec host."""
+    shim = _shim()
+    monkeypatch.setattr(shim, "_LAUNCHER_PATH", None, raising=False)
+    monkeypatch.setattr(shim, "_writable_directories", lambda: [str(tmp_path)])
+    monkeypatch.setattr(shim.subprocess, "run",
+                        lambda *a, **k: (_ for _ in ()).throw(PermissionError(13, "denied")))
+
+    assert shim.ensure_launcher() is None
+    assert list(tmp_path.iterdir()) == []

--- a/tests/bazarr/test_alass_ffprobe_shim.py
+++ b/tests/bazarr/test_alass_ffprobe_shim.py
@@ -308,6 +308,7 @@ def test_no_launcher_at_all_when_nothing_can_execute(monkeypatch, tmp_path):
     assert shim.ensure_launcher() is None
 
 
+@pytest.mark.skipif(os.name != "posix", reason="Windows installs no launcher, so the override is left untouched")
 def test_an_operator_configured_ffprobe_override_is_kept(recorded_alass_run, monkeypatch, tmp_path):
     """ALASS_FFPROBE_PATH in the environment is someone's deliberate choice of
     ffprobe, and alass honoured it before the shim existed. The shim runs it
@@ -348,3 +349,37 @@ def test_a_failed_install_leaves_no_directory_behind(monkeypatch, tmp_path):
 
     assert shim.ensure_launcher() is None
     assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.skipif(os.name != "posix", reason="the launcher is a POSIX shell script")
+def test_installing_reclaims_the_launcher_directories_we_left_behind(monkeypatch, tmp_path):
+    """The path lives in process memory and Bazarr exits with os._exit, so
+    nothing removes the directory on shutdown. Without a sweep, every restart
+    that syncs with alass leaves another one under config/cache forever."""
+    shim = _shim()
+    monkeypatch.setattr(shim, "_LAUNCHER_PATH", None, raising=False)
+    monkeypatch.setattr(shim, "_writable_directories", lambda: [str(tmp_path)])
+
+    installed = []
+    for _ in range(3):
+        # A fresh process each time: nothing carries over but the directory.
+        shim._LAUNCHER_PATH = None
+        installed.append(shim.ensure_launcher())
+
+    assert all(installed), "the launcher could not be installed at all"
+    remaining = [entry for entry in tmp_path.iterdir() if entry.is_dir()]
+    assert len(remaining) == 1, f"three installs left {len(remaining)} directories behind"
+    assert os.path.dirname(installed[-1]) == str(remaining[0])
+
+
+@pytest.mark.skipif(os.name != "posix", reason="the launcher is a POSIX shell script")
+def test_the_sweep_leaves_directories_that_are_not_ours_alone(monkeypatch, tmp_path):
+    shim = _shim()
+    monkeypatch.setattr(shim, "_LAUNCHER_PATH", None, raising=False)
+    monkeypatch.setattr(shim, "_writable_directories", lambda: [str(tmp_path)])
+    someone_else = tmp_path / "not-ours"
+    someone_else.mkdir()
+
+    shim.ensure_launcher()
+
+    assert someone_else.is_dir()

--- a/tests/bazarr/test_alass_ffprobe_shim.py
+++ b/tests/bazarr/test_alass_ffprobe_shim.py
@@ -1,0 +1,181 @@
+# coding=utf-8
+"""alass cannot read ffprobe output for a stream it cannot identify.
+
+alass-cli probes the reference video itself and deserializes the JSON into a
+struct whose codec_long_name is a required String. ffprobe omits that field
+entirely for a stream whose codec it cannot identify, which is what an MKV
+attachment muxed as application/octet-stream produces, and those are routine in
+fansub releases. One such stream fails the whole parse, so alass dies before
+extracting any audio and the user sees "alass is broken".
+
+The shim sits between alass and the real ffprobe and fills the field in.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+def _shim():
+    from subtitles.tools import alass_ffprobe_shim
+
+    return alass_ffprobe_shim
+
+
+def test_a_stream_without_codec_long_name_gets_one():
+    probe = {
+        "streams": [
+            {"index": 0, "codec_long_name": "AV1", "codec_type": "video", "duration": "1421.0"},
+            {"index": 1, "codec_long_name": "Opus", "codec_type": "audio", "channels": 2},
+            {"index": 2, "codec_type": "attachment"},
+        ],
+        "format": {"duration": "1421.0"},
+    }
+
+    patched = json.loads(_shim().patch_ffprobe_json(json.dumps(probe)))
+
+    assert [s.get("codec_long_name") for s in patched["streams"]] == ["AV1", "Opus", "unknown"]
+    assert patched["format"] == {"duration": "1421.0"}
+
+
+def test_streams_that_already_name_their_codec_are_untouched():
+    probe = {"streams": [{"index": 0, "codec_long_name": "TrueType font", "codec_type": "attachment"}]}
+
+    assert json.loads(_shim().patch_ffprobe_json(json.dumps(probe))) == probe
+
+
+def test_output_that_is_not_json_is_passed_through_verbatim():
+    text = "index=0\ncodec_type=video\n"
+
+    assert _shim().patch_ffprobe_json(text) == text
+
+
+def test_json_without_a_streams_array_is_passed_through():
+    text = json.dumps({"format": {"duration": "10.0"}})
+
+    assert json.loads(_shim().patch_ffprobe_json(text)) == {"format": {"duration": "10.0"}}
+
+
+def _run_shim(args, real_ffprobe):
+    env = dict(os.environ)
+    env["BAZARR_ALASS_REAL_FFPROBE"] = real_ffprobe
+    return subprocess.run(
+        [sys.executable, _shim().__file__, *args],
+        capture_output=True, text=True, env=env,
+    )
+
+
+def test_the_shim_reports_the_real_ffprobe_exit_code_and_stderr(tmp_path):
+    fake = tmp_path / "ffprobe"
+    fake.write_text("#!/bin/sh\necho 'boom' >&2\nexit 3\n")
+    fake.chmod(0o755)
+
+    done = _run_shim(["-of", "json", "-show_streams", "whatever.mkv"], str(fake))
+
+    assert done.returncode == 3
+    assert "boom" in done.stderr
+
+
+def test_the_shim_fills_the_field_when_ffprobe_is_run_for_json(tmp_path):
+    probe = {"streams": [{"index": 0, "codec_type": "attachment"}]}
+    fake = tmp_path / "ffprobe"
+    fake.write_text(f"#!/bin/sh\ncat <<'EOF'\n{json.dumps(probe)}\nEOF\n")
+    fake.chmod(0o755)
+
+    done = _run_shim(["-v", "error", "-of", "json", "file.mkv"], str(fake))
+
+    assert done.returncode == 0
+    assert json.loads(done.stdout)["streams"][0]["codec_long_name"] == "unknown"
+
+
+@pytest.mark.skipif(not shutil.which("ffmpeg") or not shutil.which("ffprobe"),
+                    reason="needs ffmpeg and ffprobe to build the reproduction file")
+def test_a_real_octet_stream_attachment_survives_the_shim(tmp_path):
+    """The end to end shape of the bug, built rather than committed as a fixture."""
+    attachment = tmp_path / "blob.bin"
+    attachment.write_bytes(b"\x00\x01\x02\x03")
+    mkv = tmp_path / "episode.mkv"
+    subprocess.run(
+        ["ffmpeg", "-v", "error", "-y",
+         "-f", "lavfi", "-i", "testsrc=duration=1:size=64x64:rate=5",
+         "-f", "lavfi", "-i", "sine=duration=1",
+         "-attach", str(attachment), "-metadata:s:t:0", "mimetype=application/octet-stream",
+         "-c:v", "libx264", "-c:a", "aac", str(mkv)],
+        check=True, capture_output=True,
+    )
+
+    args = ["-v", "error", "-show_entries",
+            "format=duration:stream=index,codec_long_name,channels,duration,codec_type",
+            "-of", "json", str(mkv)]
+    raw = subprocess.run(["ffprobe", *args], capture_output=True, text=True, check=True).stdout
+    assert any("codec_long_name" not in s for s in json.loads(raw)["streams"]), (
+        "this ffprobe build names every stream, so the reproduction is not reproducing"
+    )
+
+    done = _run_shim(args, shutil.which("ffprobe"))
+
+    assert done.returncode == 0
+    assert all(s.get("codec_long_name") for s in json.loads(done.stdout)["streams"])
+
+
+# --- wiring: only alass gets the shim ---------------------------------------
+
+
+@pytest.fixture
+def recorded_alass_run(monkeypatch, tmp_path):
+    """Run SubSyncer's external-engine path against a stub subprocess.run."""
+    from subtitles.tools import subsyncer as module
+
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append({"command": command, "env": kwargs.get("env")})
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.setattr(module.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(module, "get_binary", lambda name: f"/usr/bin/{name}")
+
+    syncer = module.SubSyncer()
+    syncer.srtin = str(tmp_path / "sub.srt")
+    syncer.reference = None
+
+    return syncer, calls
+
+
+@pytest.mark.skipif(os.name != "posix", reason="the launcher is a POSIX shell script")
+def test_alass_is_run_against_the_shim(recorded_alass_run, tmp_path):
+    syncer, calls = recorded_alass_run
+
+    syncer._run_external_engine(engine="alass", output_path=tmp_path / "out.srt",
+                                video_path=str(tmp_path / "video.mkv"))
+
+    env = calls[0]["env"]
+    assert env is not None
+    assert env["BAZARR_ALASS_REAL_FFPROBE"] == "/usr/bin/ffprobe"
+    launcher = env["ALASS_FFPROBE_PATH"]
+    assert os.access(launcher, os.X_OK), f"{launcher} is not executable, alass cannot run it"
+    # The rest of the environment is alass's own, not a two-variable replacement for it.
+    assert env["PATH"] == os.environ["PATH"]
+    # And the invocation itself is untouched.
+    assert calls[0]["command"][0] == "/usr/bin/alass"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="the launcher is a POSIX shell script")
+def test_the_launcher_really_runs_the_shim(tmp_path):
+    """Built as a script rather than asserted on its text: what matters is that
+    alass, which execs this path directly, gets patched output out of it."""
+    probe = {"streams": [{"index": 0, "codec_type": "attachment"}]}
+    fake = tmp_path / "ffprobe"
+    fake.write_text(f"#!/bin/sh\ncat <<'EOF'\n{json.dumps(probe)}\nEOF\n")
+    fake.chmod(0o755)
+
+    launcher = _shim().ensure_launcher()
+    env = dict(os.environ, BAZARR_ALASS_REAL_FFPROBE=str(fake))
+    done = subprocess.run([launcher, "-of", "json", "x.mkv"], capture_output=True, text=True, env=env)
+
+    assert json.loads(done.stdout)["streams"][0]["codec_long_name"] == "unknown"


### PR DESCRIPTION
## The failure

```
alass failed with exit code 1: error: processing video file '...' failed
caused by: failed to extract metadata ... using command 'ffprobe -v error -show_entries format=duration:stream=index,codec_long_name,channels,duration,codec_type -of json ...'
caused by: missing field codec_long_name at line 94 column 9
```

Three links, each verified:

1. alass-cli probes the reference video itself and deserializes the JSON into a struct whose `codec_long_name` is a required `String`.
2. ffprobe omits that field entirely for a stream whose codec it cannot identify: the codec descriptor is NULL, so the field is written with `print_str_opt`, which the JSON writer drops.
3. An MKV attachment muxed as `application/octet-stream` is exactly that. Fansub releases carry fonts and other attachments as a matter of course, which is why the reports are anime and why the error points at a late stream.

So one attachment fails the whole parse and alass dies before extracting any audio. To a user that reads as "alass is broken or not installed".

## The fix

alass honours `ALASS_FFPROBE_PATH`. `bazarr/subtitles/tools/alass_ffprobe_shim.py` execs the real ffprobe and fills in `codec_long_name` on any stream that lacks one, and `SubSyncer` points alass at it. Patching the Rust build instead would be Docker-only and fragile across alass versions.

Scope is deliberately narrow:

- only the alass subprocess gets the environment, and it is the process environment plus two variables, not a replacement for it
- output that is not JSON, or JSON without a `streams` array, is passed through verbatim
- the exit code and stderr are the real ffprobe's
- Windows gets no launcher and alass runs exactly as before
- if ffprobe or the launcher is unavailable, the environment is left alone

## Tests

`tests/bazarr/test_alass_ffprobe_shim.py`, enumerated in CI. Beyond the unit cases, one test builds the reproduction with ffmpeg rather than committing a fixture: it mixes an `application/octet-stream` attachment into an MKV, asserts the raw ffprobe output really is missing the field (so the test fails loudly if it ever stops reproducing), then asserts the shim's output has it on every stream. Another runs the launcher as a program, since alass execs that path directly.

Full backend suite green locally, ruff clean.

Still to do before release: verify against a real fansub MKV on the test server.