### PR TITLE
fix(security): take the connection-test API key from the header only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
         run: |
           pytest \
             tests/bazarr/test_pretty_date.py \
+            tests/bazarr/test_connection_tester.py \
             tests/bazarr/test_dependency_loading.py \
             tests/bazarr/test_signalrcore_compat.py \
             tests/bazarr/test_app_get_providers.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,7 @@ jobs:
             tests/bazarr/test_dependency_loading.py \
             tests/bazarr/test_signalrcore_compat.py \
             tests/bazarr/test_app_get_providers.py \
+            tests/bazarr/test_jellyfin_apikey_location.py \
             tests/bazarr/test_provider_hub.py \
             tests/bazarr/test_provider_hub_auto_install_optin.py \
             tests/bazarr/test_provider_hub_archive_select.py \

--- a/bazarr/api/jellyfin/endpoints.py
+++ b/bazarr/api/jellyfin/endpoints.py
@@ -25,7 +25,13 @@ def _parse_verify_ssl(raw):
 class JellyfinTestConnection(Resource):
     post_request_parser = reqparse.RequestParser()
     post_request_parser.add_argument('url', type=str, required=True, help='Jellyfin server URL')
-    post_request_parser.add_argument('apikey', type=str, required=True, help='Jellyfin API key')
+    # Body only. The flask_restx default location is ('json', 'values'), and
+    # 'values' covers the query string, so a key in the URL would override the
+    # body and land in browser history and access logs. This argument is the
+    # Jellyfin server's key, which this endpoint forwards to a caller-supplied
+    # host, so it must never travel in a URL.
+    post_request_parser.add_argument('apikey', type=str, required=True, help='Jellyfin API key',
+                                     location=('json', 'form'))
     post_request_parser.add_argument('verify_ssl', type=str, required=False,
                                      help='Override saved verify_ssl flag for this test (true/false)')
 
@@ -58,7 +64,8 @@ class JellyfinLibraries(Resource):
     # tunnel and out of long-lived logs.
     post_request_parser = reqparse.RequestParser()
     post_request_parser.add_argument('url', type=str, required=False, help='Jellyfin server URL')
-    post_request_parser.add_argument('apikey', type=str, required=False, help='Jellyfin API key')
+    post_request_parser.add_argument('apikey', type=str, required=False, help='Jellyfin API key',
+                                     location=('json', 'form'))
     post_request_parser.add_argument('verify_ssl', type=str, required=False,
                                      help='Override saved verify_ssl flag for this query (true/false)')
 

--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -75,9 +75,19 @@ def _require_proxy_api_key():
     """The /test connection proxies forward a server-side request to a
     user-supplied host (an SSRF surface). Require the global API key so they are
     never reachable unauthenticated, independent of settings.auth.type (which is
-    None by default). The frontend already sends X-API-KEY on every request."""
-    provided = request.headers.get('X-API-KEY') or request.args.get('apikey')
-    if not api_key_matches(provided, settings.auth.apikey):
+    None by default). The frontend already sends X-API-KEY on every request.
+
+    Header only, unlike the deprecated query-string fallback the rest of the API
+    still honours. On these routes `apikey` in the query string is the TARGET
+    arr's key, which the endpoint forwards to the host it probes. Accepting it
+    as Bazarr's credential too gave one parameter two meanings: a caller
+    authenticating that way had Bazarr's own key sent onward to an
+    attacker-choosable address, and an operator reusing one key for Sonarr and
+    Bazarr turned the target's key into a valid credential for this gate. A key
+    in a query string also lands in browser history, access logs and Referer
+    headers, which a header does not.
+    """
+    if not api_key_matches(request.headers.get('X-API-KEY'), settings.auth.apikey):
         abort(401)
 
 

--- a/tests/bazarr/test_connection_tester.py
+++ b/tests/bazarr/test_connection_tester.py
@@ -10,6 +10,9 @@ Covers:
 - proxy_service: service whitelist, missing url/apikey, end-to-end status
   probe with mocked requests.get, both legacy (/api/system/status) and
   v3 (/api/v3/system/status) paths attempted.
+- the API-key gate on both /test routes: header only, because the `apikey`
+  query parameter on these routes is the target arr's key and is forwarded to
+  the host being probed.
 """
 import socket
 from unittest.mock import patch, MagicMock
@@ -167,11 +170,10 @@ def _login(client):
     that setting, because they forward a server-side request to a user-supplied
     host and must never be reachable unauthenticated.
 
-    The query string's `apikey` is the TARGET arr's key. Note that the gate
-    accepts an api key from either the header OR that query parameter, so a
-    query value that happens to equal Bazarr's own key WOULD satisfy it. That
-    dual use is a real gap, characterised below and tracked for a separate fix;
-    the harness deliberately authenticates by header, as the frontend does.
+    The query string's `apikey` is the TARGET arr's key and nothing else: the
+    gate reads Bazarr's own key from the X-API-KEY header only, so a query
+    value can never satisfy it whatever it happens to contain. The harness
+    authenticates by header, as the frontend does.
     """
     with client.session_transaction() as sess:
         sess["logged_in"] = True
@@ -494,9 +496,10 @@ def test_proxy_service_rejects_an_unauthenticated_request(monkeypatch):
 def test_proxy_service_rejects_a_target_key_that_is_not_bazarrs(monkeypatch):
     """A target arr key that differs from Bazarr's own does not authenticate.
 
-    Note what this does and does not prove. It passes because the VALUE differs,
-    not because query parameters are excluded from the gate. See the
-    characterisation test below for the case that is genuinely wrong.
+    This holds for the weak reason (the value differs) and, since the gate went
+    header-only, for the real one as well: the query string is not an
+    authentication channel here at all. The test below pins that stronger
+    property by putting Bazarr's own key in the query.
     """
     monkeypatch.setattr("app.config.settings.auth.type", None)
     app = _build_app()
@@ -507,26 +510,104 @@ def test_proxy_service_rejects_a_target_key_that_is_not_bazarrs(monkeypatch):
     assert r.status_code == 401
 
 
-def test_proxy_service_currently_accepts_the_api_key_from_the_query_string(monkeypatch):
-    """Characterises a known gap, so it cannot regress unnoticed and so the fix
-    has a test to flip.
+def test_proxy_service_rejects_the_api_key_from_the_query_string(monkeypatch):
+    """The query string is not an authentication channel on these routes.
 
-    The gate reads the key from the X-API-KEY header OR the `apikey` query
-    parameter. On these routes that same parameter is also the target arr's key,
-    which the endpoint forwards to the user-supplied host it probes. So a caller
-    who authenticates by putting Bazarr's key in the query string has that key
-    sent onward to an arbitrary address, and an operator who reuses one key for
-    Sonarr and Bazarr inverts the intended separation.
-
-    The fix is to accept the key from the header only on these two routes. When
-    that lands, this test should be inverted to assert a 401.
+    `apikey` here means the TARGET arr's key, which the endpoint forwards to the
+    user-supplied host it probes. While the gate also accepted it as Bazarr's
+    own credential, one parameter carried two meanings: a caller authenticating
+    the way Bazarr's API is normally used had Bazarr's key sent onward to an
+    arbitrary address, and an operator reusing one key for Sonarr and Bazarr
+    turned the target's key into a valid credential for Bazarr's own gate.
     """
     monkeypatch.setattr("app.config.settings.auth.type", None)
     app = _build_app()
     client = app.test_client()
-    # No session, no header: authenticated purely by the query string.
+    # No session, no header: authenticating purely by the query string.
     r = client.get(f"/test/sonarr?url=http://127.0.0.1:8989&apikey={TEST_API_KEY}")
-    assert r.status_code != 401, (
-        "if this now returns 401 the header-only fix has landed; invert this "
-        "test and delete this note"
-    )
+    assert r.status_code == 401
+
+
+def test_proxy_service_rejects_the_query_string_key_even_with_a_session(monkeypatch):
+    """A logged-in session does not soften the gate.
+
+    @check_login and the API-key gate are independent. The proxies forward a
+    server-side request to a user-supplied host, so the key is required on top
+    of the session, and it still has to arrive in the header.
+    """
+    monkeypatch.setattr("app.config.settings.auth.type", "form")
+    app = _build_app()
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["logged_in"] = True
+    r = client.get(f"/test/sonarr?url=http://127.0.0.1:8989&apikey={TEST_API_KEY}")
+    assert r.status_code == 401
+
+
+def test_proxy_service_never_forwards_bazarrs_own_key(monkeypatch):
+    """Bazarr's key reaches the probed host through no path of its own.
+
+    Whisper-ASR has no API-key concept, so a correct request carries no
+    `apikey` at all. Nothing in the route may substitute the configured global
+    key for the missing one: the outbound request goes out with no credential.
+    """
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    monkeypatch.setattr(socket, "getaddrinfo",
+                        lambda *a, **kw: [_addr("127.0.0.1")])
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"version": "1.0"}
+    with patch("app.ui.requests.get", return_value=resp) as fake_get:
+        app = _build_app()
+        client = app.test_client()
+        _login(client)
+        r = client.get("/test/whisperai?url=http://127.0.0.1:9000")
+        assert r.get_json()["status"] is True
+        called = fake_get.call_args_list[0]
+        assert "X-Api-Key" not in called.kwargs["headers"]
+        assert TEST_API_KEY not in called.args[0]
+        assert TEST_API_KEY not in repr(called.kwargs)
+
+
+# === the legacy /test/<protocol>/<url> proxy ===
+#
+# Same gate, same query parameter, and it forwards request.args wholesale to
+# the probed host, so the dual use bit harder here.
+
+
+def test_legacy_proxy_rejects_the_api_key_from_the_query_string(monkeypatch):
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    app = _build_app()
+    client = app.test_client()
+    r = client.get(f"/test/http/127.0.0.1:8989/api?apikey={TEST_API_KEY}")
+    assert r.status_code == 401
+
+
+def test_legacy_proxy_rejects_an_unauthenticated_request(monkeypatch):
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    app = _build_app()
+    client = app.test_client()
+    r = client.get("/test/http/127.0.0.1:8989/api?apikey=some-arr-key")
+    assert r.status_code == 401
+
+
+def test_legacy_proxy_accepts_the_header_and_forwards_only_the_query(monkeypatch):
+    """The header authenticates, and what goes upstream is what the caller
+    typed: the query parameters, Bazarr's own key not among them.
+
+    This route uses the strict resolver, which refuses loopback, hence the
+    private-LAN address.
+    """
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    monkeypatch.setattr(socket, "getaddrinfo",
+                        lambda *a, **kw: [_addr("10.0.0.5")])
+    resp = MagicMock(status_code=200)
+    resp.json.return_value = {"version": "4.0.0.0"}
+    with patch("app.ui.requests.get", return_value=resp) as fake_get:
+        app = _build_app()
+        client = app.test_client()
+        _login(client)
+        r = client.get("/test/http/sonarr.lan:8989/api?apikey=some-arr-key")
+        assert r.get_json()["status"] is True
+        forwarded = fake_get.call_args_list[0].args[1]
+        assert forwarded["apikey"] == "some-arr-key"
+        assert TEST_API_KEY not in repr(fake_get.call_args_list[0])

--- a/tests/bazarr/test_connection_tester.py
+++ b/tests/bazarr/test_connection_tester.py
@@ -150,10 +150,32 @@ def _build_app():
     return app
 
 
+TEST_API_KEY = "test-api-key"
+
+
+@pytest.fixture(autouse=True)
+def _configure_api_key(monkeypatch):
+    """Give the server a known API key for every test in this module."""
+    monkeypatch.setattr("app.config.settings.auth.apikey", TEST_API_KEY)
+
+
 def _login(client):
-    """Pre-populate the session so @check_login passes."""
+    """Authenticate the client the way the frontend does.
+
+    Two independent gates apply. @check_login covers settings.auth.type, and
+    the /test proxies additionally require the global API key regardless of
+    that setting, because they forward a server-side request to a user-supplied
+    host and must never be reachable unauthenticated.
+
+    The query string's `apikey` is the TARGET arr's key. Note that the gate
+    accepts an api key from either the header OR that query parameter, so a
+    query value that happens to equal Bazarr's own key WOULD satisfy it. That
+    dual use is a real gap, characterised below and tracked for a separate fix;
+    the harness deliberately authenticates by header, as the frontend does.
+    """
     with client.session_transaction() as sess:
         sess["logged_in"] = True
+    client.environ_base["HTTP_X_API_KEY"] = TEST_API_KEY
 
 
 def test_proxy_service_rejects_unknown_service(monkeypatch):
@@ -451,3 +473,60 @@ def test_proxy_service_pins_for_https_when_verify_disabled(monkeypatch):
         assert "203.0.113.42" in called_url
         assert called_headers.get("Host") == "sonarr.example.com"
         assert fake_get.call_args_list[0].kwargs["verify"] is False
+
+
+def test_proxy_service_rejects_an_unauthenticated_request(monkeypatch):
+    """The hardening itself, which had no coverage.
+
+    These endpoints forward a server-side request to a user-supplied host, so
+    they were an unauthenticated reconnaissance surface before the API key was
+    required. Without this test, a regression that dropped the requirement
+    would look identical to a passing suite.
+    """
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    app = _build_app()
+    client = app.test_client()
+    # Deliberately not authenticated: no X-API-KEY header.
+    r = client.get("/test/sonarr?url=http://127.0.0.1:8989&apikey=k")
+    assert r.status_code == 401
+
+
+def test_proxy_service_rejects_a_target_key_that_is_not_bazarrs(monkeypatch):
+    """A target arr key that differs from Bazarr's own does not authenticate.
+
+    Note what this does and does not prove. It passes because the VALUE differs,
+    not because query parameters are excluded from the gate. See the
+    characterisation test below for the case that is genuinely wrong.
+    """
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    app = _build_app()
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["logged_in"] = True
+    r = client.get("/test/sonarr?url=http://127.0.0.1:8989&apikey=some-arr-key")
+    assert r.status_code == 401
+
+
+def test_proxy_service_currently_accepts_the_api_key_from_the_query_string(monkeypatch):
+    """Characterises a known gap, so it cannot regress unnoticed and so the fix
+    has a test to flip.
+
+    The gate reads the key from the X-API-KEY header OR the `apikey` query
+    parameter. On these routes that same parameter is also the target arr's key,
+    which the endpoint forwards to the user-supplied host it probes. So a caller
+    who authenticates by putting Bazarr's key in the query string has that key
+    sent onward to an arbitrary address, and an operator who reuses one key for
+    Sonarr and Bazarr inverts the intended separation.
+
+    The fix is to accept the key from the header only on these two routes. When
+    that lands, this test should be inverted to assert a 401.
+    """
+    monkeypatch.setattr("app.config.settings.auth.type", None)
+    app = _build_app()
+    client = app.test_client()
+    # No session, no header: authenticated purely by the query string.
+    r = client.get(f"/test/sonarr?url=http://127.0.0.1:8989&apikey={TEST_API_KEY}")
+    assert r.status_code != 401, (
+        "if this now returns 401 the header-only fix has landed; invert this "
+        "test and delete this note"
+    )

--- a/tests/bazarr/test_jellyfin_apikey_location.py
+++ b/tests/bazarr/test_jellyfin_apikey_location.py
@@ -1,0 +1,54 @@
+# coding=utf-8
+"""The Jellyfin endpoints' `apikey` argument must not be readable from the URL.
+
+That argument is the *Jellyfin* server's key, and the endpoint forwards it as an
+auth token to a URL the caller supplies. flask_restx defaults an argument to
+``location=('json', 'values')`` and ``values`` includes the query string, so the
+query silently wins over the body. The comment above the parser already says
+"POST so apikey rides in the request body instead of the query string", so the
+mitigation was stated but never in effect: a key in a URL still reached browser
+history, reverse-proxy access logs and Referer headers.
+"""
+
+import pytest
+
+from api.jellyfin.endpoints import JellyfinLibraries, JellyfinTestConnection
+
+QUERY_LOCATIONS = {"values", "args", "query_string"}
+
+
+def _locations(parser, name):
+    for argument in parser.args:
+        if argument.name == name:
+            location = argument.location
+            return {location} if isinstance(location, str) else set(location)
+    raise AssertionError(f"{name} argument not found on {parser}")
+
+
+@pytest.mark.parametrize(
+    "resource",
+    [JellyfinTestConnection, JellyfinLibraries],
+    ids=["test-connection", "libraries"],
+)
+def test_the_jellyfin_key_is_never_read_from_the_url(resource):
+    locations = _locations(resource.post_request_parser, "apikey")
+
+    assert not (locations & QUERY_LOCATIONS), (
+        f"{resource.__name__} reads the Jellyfin key from {sorted(locations)}. "
+        "A query-string location puts a third-party credential into browser "
+        "history and access logs, and lets the query override the body."
+    )
+
+
+@pytest.mark.parametrize(
+    "resource",
+    [JellyfinTestConnection, JellyfinLibraries],
+    ids=["test-connection", "libraries"],
+)
+def test_the_body_is_still_accepted(resource):
+    locations = _locations(resource.post_request_parser, "apikey")
+
+    assert "json" in locations and "form" in locations, (
+        f"{resource.__name__} must still accept the key from a JSON or "
+        f"form-encoded body, got {sorted(locations)}"
+    )


### PR DESCRIPTION
## What

Two independent API-key handling bugs on endpoints that make server-side requests to a user-supplied host.

**The `/test/<service>` proxies.** The gate accepted Bazarr's own API key from the `X-API-KEY` header *or* the `apikey` query parameter. On these routes that same query parameter is the TARGET arr's key, which the endpoint forwards to the host it probes. One parameter carried two meanings, with two consequences:

- a caller who authenticated the way Bazarr's API is normally used had Bazarr's own key forwarded to an arbitrary address
- an operator who reuses one key for Sonarr and Bazarr turned the target's key into a valid credential for Bazarr's gate

The gate is header-only now. `@check_login` still applies first and is unchanged.

**The Jellyfin endpoints.** `reqparse` defaults to `location=('json', 'values')`, and `values` includes the query string, so the Jellyfin API key could arrive in the URL and land in access logs and proxy logs. Those arguments are body-only now.

## Tests

`tests/bazarr/test_connection_tester.py` grew the cases that pin the fix: the query-string key is rejected with and without a session, and Bazarr's key reaches the probed host through no path of its own. The characterisation test that documented the gap is inverted rather than deleted, so the history of what changed stays readable. `tests/bazarr/test_jellyfin_apikey_location.py` pins the body-only argument locations. Both are enumerated in CI.

Full backend suite green locally (1571 passed), ruff clean.