### PR TITLE
fix(subsync): treat the maximum offset as an acceptance threshold, and report per-engine outcomes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
             tests/bazarr/test_sync_progress_report.py \
             tests/bazarr/test_subsync_engines.py \
             tests/bazarr/test_sync_instance_overrides.py \
+            tests/bazarr/test_sync_outcome_reporting.py \
             tests/bazarr/test_subzero_keep_lyrics.py \
             tests/bazarr/test_archive_extraction.py \
             tests/bazarr/test_security_guards.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
             tests/bazarr/test_processing_postprocessing.py \
             tests/bazarr/test_sync_progress_report.py \
             tests/bazarr/test_subsync_engines.py \
+            tests/bazarr/test_sync_offset_acceptance.py \
             tests/bazarr/test_sync_instance_overrides.py \
             tests/bazarr/test_subzero_keep_lyrics.py \
             tests/bazarr/test_archive_extraction.py \

--- a/bazarr/subtitles/sync.py
+++ b/bazarr/subtitles/sync.py
@@ -9,10 +9,75 @@ from app.jobs_queue import jobs_queue
 from subtitles.tools.subsyncer import SubSyncer
 from subtitles.tools.subsync_engines import (
     DEFAULT_ENABLED_ENGINES,
+    ENGINE_LABELS,
     OUTPUT_MODE_KEEP_ALL,
+    REASON_ENGINE_DECLINED,
+    REASON_ENGINE_FAILED,
+    REASON_FAILURE_THRESHOLD,
+    REASON_GENERATED_SOURCE,
+    REASON_MISSING_ENGINE,
+    REASON_OUTPUT_EXISTS,
+    REASON_RESULT_REJECTED,
     is_sync_engine_output,
     normalize_enabled_engines,
 )
+
+
+# How a per-engine outcome is phrased for the user. Every reason code the runner can
+# emit gets a sentence here: the point of the vocabulary is that "ALASS is not
+# installed" and "ALASS ran and rejected this file" are different problems and only
+# one of them is the user's to fix.
+_ENGINE_OUTCOME_SENTENCES = {
+    REASON_MISSING_ENGINE: "{label} is not installed.",
+    REASON_FAILURE_THRESHOLD: "{label} was skipped after repeated failures.",
+    REASON_OUTPUT_EXISTS: "{label} output already existed and was kept.",
+    REASON_ENGINE_DECLINED: ("{label} rejected its own result as unreliable, which is normal "
+                             "when it cannot confidently align a file."),
+    REASON_RESULT_REJECTED: "{label} result rejected: {message}",
+    REASON_ENGINE_FAILED: "{label} failed: {message}",
+}
+_ENGINE_MESSAGE_LIMIT = 160
+
+
+def _short_engine_message(message, engine=None):
+    """Flatten an engine message to one bounded line the label can be prefixed to.
+
+    Two things get in the way. An engine failure message can be a whole captured
+    stderr, and this text lands in a job card in the notification drawer, so it has to
+    stay a sentence. And engines name themselves in their own messages, which reads as
+    a stutter once the sentence already starts with the engine label, so a leading
+    engine token is dropped.
+    """
+    text = " ".join(str(message or "").split())
+    if engine and text.lower().startswith(f"{engine.lower()} "):
+        text = text[len(engine) + 1:]
+    if not text:
+        return ""
+    if len(text) > _ENGINE_MESSAGE_LIMIT:
+        return f"{text[:_ENGINE_MESSAGE_LIMIT].rstrip()}..."
+    return text
+
+
+def _engine_outcome_sentence(engine_result):
+    if engine_result.reason == REASON_GENERATED_SOURCE:
+        return "A generated sync output cannot be synchronized again."
+
+    label = ENGINE_LABELS.get(engine_result.engine, engine_result.engine)
+    template = _ENGINE_OUTCOME_SENTENCES.get(engine_result.reason)
+    if not template:
+        return f"{label} produced no output."
+
+    message = _short_engine_message(engine_result.message, engine_result.engine)
+    sentence = template.format(label=label, message=message)
+    return sentence if sentence.endswith((".", "...")) else f"{sentence}."
+
+
+def _engine_outcome_sentences(engine_results):
+    return [_engine_outcome_sentence(item) for item in engine_results]
+
+
+def _unsuccessful_results(sync_result):
+    return [item for item in sync_result.results if not item.success]
 
 
 def _sync_complete_job_name(srt_path, sync_result):
@@ -23,6 +88,12 @@ def _sync_complete_job_name(srt_path, sync_result):
         successes = sync_result.successful_results
         if sync_result.output_mode == OUTPUT_MODE_KEEP_ALL:
             count = len(successes)
+            # Keep-all asks every enabled engine, so the result list is the roll call.
+            # Naming both numbers is the whole point: "Generated 1 sync output" reads
+            # like a complete run when two of the three engines produced nothing.
+            attempted = len(sync_result.results)
+            if count < attempted:
+                return f"Generated {count} of {attempted} sync outputs for {srt_path}"
             noun = "output" if count == 1 else "outputs"
             return f"Generated {count} sync {noun} for {srt_path}"
         engine = successes[0].engine if successes else "sync engine"
@@ -32,6 +103,38 @@ def _sync_complete_job_name(srt_path, sync_result):
         return f"Skipped sync for {srt_path}"
 
     return f"Failed to sync {srt_path}"
+
+
+def _sync_outcome_message(sync_result):
+    """The progress line the notification drawer shows under the job name.
+
+    This is the only place a user sees why an engine produced nothing: the runner's own
+    account of it goes to System > Logs, which nobody opens after being told the job
+    succeeded.
+    """
+    if not sync_result:
+        return "Sync failed"
+
+    unsuccessful = _unsuccessful_results(sync_result)
+
+    if sync_result.success:
+        # Overwrite mode stops at the first success, so the engines behind it were
+        # never asked to run and a count would be meaningless. Only keep-all, which
+        # asks every engine, can report a partial outcome.
+        if not unsuccessful or sync_result.output_mode != OUTPUT_MODE_KEEP_ALL:
+            return "Sync complete"
+        produced = len(sync_result.successful_results)
+        attempted = len(sync_result.results)
+        head = f"Sync partially complete: {produced} of {attempted} engines produced output."
+        return " ".join([head] + _engine_outcome_sentences(unsuccessful))
+
+    if sync_result.skipped_results and not sync_result.failed_results:
+        head = "Sync skipped: no engine produced output."
+    else:
+        count = len(unsuccessful)
+        noun = "engine" if count == 1 else "engines"
+        head = f"Sync failed: no output from {count} {noun}."
+    return " ".join([head] + _engine_outcome_sentences(unsuccessful))
 
 
 def _sync_progress_total(enabled_engines):
@@ -234,13 +337,8 @@ def sync_subtitles(video_path,
         else:
             return bool(sync_result and sync_result.success)
         finally:
-            if sync_result and sync_result.success:
-                progress_message = 'Sync complete'
-            elif sync_result and sync_result.skipped_results and not sync_result.failed_results:
-                progress_message = 'Sync skipped'
-            else:
-                progress_message = 'Sync failed'
-            report(progress_message, value='max', name=_sync_complete_job_name(srt_path, sync_result))
+            report(_sync_outcome_message(sync_result), value='max',
+                   name=_sync_complete_job_name(srt_path, sync_result))
             del subsync
             gc.collect()
 

--- a/bazarr/subtitles/tools/subsync_engines.py
+++ b/bazarr/subtitles/tools/subsync_engines.py
@@ -20,8 +20,55 @@ RESULT_SUCCESS = 'success'
 RESULT_FAILED = 'failed'
 RESULT_SKIPPED = 'skipped'
 
+# Why an engine produced no output. This is reporting vocabulary: every code here is
+# rendered into a sentence for the user in subtitles/sync.py, so the four ways a run
+# can come back empty stay distinguishable without opening System > Logs.
+#
+#   generated_source  the source subtitle is itself a generated sync output
+#   output_exists     a current output for this engine was already on disk
+#   missing_engine    the executable or Python package is absent
+#   failure_threshold the engine was skipped after repeated failures on this file
+#   engine_declined   the engine ran to completion and rejected its own result
+#   result_rejected   the engine returned a result Bazarr refused to accept
+#   engine_failed     the engine errored out
+REASON_GENERATED_SOURCE = 'generated_source'
+REASON_OUTPUT_EXISTS = 'output_exists'
+REASON_MISSING_ENGINE = 'missing_engine'
+REASON_FAILURE_THRESHOLD = 'failure_threshold'
+REASON_ENGINE_DECLINED = 'engine_declined'
+REASON_RESULT_REJECTED = 'result_rejected'
+REASON_ENGINE_FAILED = 'engine_failed'
+
+ENGINE_LABELS = {
+    'ffsubsync': 'FFsubsync',
+    'autosubsync': 'Autosubsync',
+    'alass': 'ALASS',
+}
+
 
 class MissingSyncEngineError(RuntimeError):
+    def __init__(self, engine, message):
+        super().__init__(message)
+        self.engine = engine
+
+
+class SyncResultRejectedError(RuntimeError):
+    """An engine produced an output the host refuses to accept."""
+
+    def __init__(self, engine, message):
+        super().__init__(message)
+        self.engine = engine
+
+
+class SyncEngineDeclinedError(RuntimeError):
+    """An engine ran to completion and rejected its own result.
+
+    Distinct from a crash: nothing went wrong, the engine simply could not align this
+    file and said so. autosubsync does this routinely, its ``synchronize`` returns
+    False when its own quality check fails. Reporting that as a failure with a
+    traceback tells the user to go fix an installation that is not broken.
+    """
+
     def __init__(self, engine, message):
         super().__init__(message)
         self.engine = engine
@@ -298,7 +345,7 @@ class SubsyncEngineRunner:
             result.results.append(SyncEngineResult(
                 engine='all',
                 status=RESULT_SKIPPED,
-                reason='generated_source',
+                reason=REASON_GENERATED_SOURCE,
                 message='Generated sync output is not used as a source subtitle.',
             ))
             return result
@@ -315,7 +362,7 @@ class SubsyncEngineRunner:
                     engine=engine,
                     status=RESULT_SKIPPED,
                     output_path=str(final_engine_output_path),
-                    reason='failure_threshold',
+                    reason=REASON_FAILURE_THRESHOLD,
                     message=f'{engine} skipped after {self.failure_threshold} consecutive failures.',
                 ))
                 continue
@@ -326,7 +373,7 @@ class SubsyncEngineRunner:
                         engine=engine,
                         status=RESULT_SKIPPED,
                         output_path=str(final_engine_output_path),
-                        reason='output_exists',
+                        reason=REASON_OUTPUT_EXISTS,
                         message='Generated sync output already exists.',
                     ))
                     continue
@@ -366,20 +413,57 @@ class SubsyncEngineRunner:
                     engine=engine,
                     status=RESULT_SKIPPED,
                     output_path=str(final_engine_output_path),
-                    reason='missing_engine',
+                    reason=REASON_MISSING_ENGINE,
                     message=str(exc),
                 ))
-            except Exception as exc:
-                logging.exception('BAZARR %s sync engine failed for %s', engine, srt_path)
-                if output_path.is_file():
-                    output_path.unlink()
-                self.failure_store.record_failure(srt_path, engine, str(exc)[:500])
+            except SyncEngineDeclinedError as exc:
+                # The engine ran and rejected its own result. Nothing is broken, so
+                # this is logged as a plain warning: a traceback here reads like a
+                # crash and sends users hunting for a missing dependency.
+                logging.warning('BAZARR %s declined its own sync result for %s: %s', engine, srt_path, exc)
+                self._discard_engine_output(srt_path, engine, output_path, exc)
                 result.results.append(SyncEngineResult(
                     engine=engine,
                     status=RESULT_FAILED,
                     output_path=str(final_engine_output_path),
-                    reason='engine_failed',
+                    reason=REASON_ENGINE_DECLINED,
+                    message=str(exc),
+                ))
+
+            except SyncResultRejectedError as exc:
+                # The engine reported success but Bazarr refused the result, so the
+                # engine is not at fault either. Same reasoning as above.
+                logging.warning('BAZARR rejected the %s sync result for %s: %s', engine, srt_path, exc)
+                self._discard_engine_output(srt_path, engine, output_path, exc)
+                result.results.append(SyncEngineResult(
+                    engine=engine,
+                    status=RESULT_FAILED,
+                    output_path=str(final_engine_output_path),
+                    reason=REASON_RESULT_REJECTED,
+                    message=str(exc),
+                ))
+
+            except Exception as exc:
+                logging.exception('BAZARR %s sync engine failed for %s', engine, srt_path)
+                self._discard_engine_output(srt_path, engine, output_path, exc)
+                result.results.append(SyncEngineResult(
+                    engine=engine,
+                    status=RESULT_FAILED,
+                    output_path=str(final_engine_output_path),
+                    reason=REASON_ENGINE_FAILED,
                     message=str(exc),
                 ))
 
         return result
+
+    def _discard_engine_output(self, srt_path, engine, output_path, exc):
+        """Drop whatever the engine left behind and count the attempt against it.
+
+        Shared by every outcome that produced no usable output. A decline and a
+        rejection differ from a crash only in how they are reported: they still cost
+        the engine a strike towards the failure threshold, and they still must not
+        leave a half-written file next to the subtitle.
+        """
+        if output_path.is_file():
+            output_path.unlink()
+        self.failure_store.record_failure(srt_path, engine, str(exc)[:500])

--- a/bazarr/subtitles/tools/subsync_engines.py
+++ b/bazarr/subtitles/tools/subsync_engines.py
@@ -16,6 +16,14 @@ OUTPUT_MODE_KEEP_ALL = 'keep_all'
 SUPPORTED_OUTPUT_MODES = (OUTPUT_MODE_OVERWRITE, OUTPUT_MODE_KEEP_ALL)
 FAILURE_THRESHOLD = 3
 
+# Handed to ffsubsync in place of the user's maximum offset so it searches without a
+# window. ffsubsync masks out-of-window candidates in MaxScoreAligner.transform, i.e.
+# after the full correlation is computed, so a window never saves work: it only hides
+# the alignment the engine would otherwise have chosen, and makes it return the best
+# in-window candidate instead. A day is beyond any real audio/subtitle offset, so the
+# mask is a no-op while still exercising ffsubsync's normal (non-None) code path.
+UNCONSTRAINED_MAX_OFFSET_SECONDS = 86400.0
+
 RESULT_SUCCESS = 'success'
 RESULT_FAILED = 'failed'
 RESULT_SKIPPED = 'skipped'
@@ -25,6 +33,68 @@ class MissingSyncEngineError(RuntimeError):
     def __init__(self, engine, message):
         super().__init__(message)
         self.engine = engine
+
+
+class SyncResultRejectedError(RuntimeError):
+    """An engine produced an output the host refuses to accept."""
+
+    def __init__(self, engine, message):
+        super().__init__(message)
+        self.engine = engine
+
+
+def acceptance_limit_seconds(max_offset_seconds):
+    """Normalize the configured maximum offset into a positive float, or None.
+
+    None means "no limit": an unset, unparsable or non-positive setting must not
+    silently reject every alignment.
+    """
+    if max_offset_seconds is None:
+        return None
+    try:
+        limit = abs(float(max_offset_seconds))
+    except (TypeError, ValueError):
+        return None
+    return limit or None
+
+
+def validate_engine_result(engine, raw_result, max_offset_seconds):
+    """Accept or reject what an engine returned. Raises SyncResultRejectedError.
+
+    The engines search without an offset window, so the configured maximum is applied
+    here, on the host, as an acceptance threshold. Two things get rejected:
+
+    1. A run the engine itself reports as unsuccessful. ffsubsync writes an output file
+       even then (an anti-correlated alignment, or the untouched subtitles when it
+       declines to shift them), so "a non-empty file exists" is not evidence of a sync.
+    2. An alignment whose absolute offset is larger than the configured maximum.
+
+    Only ffsubsync reports an offset, so only ffsubsync is held to the maximum. That is
+    a knowing inconsistency: autosubsync and alass report success or failure and nothing
+    measurable, and there is no way to bound their shift short of re-deriving it from
+    their output. They are still held to condition 1.
+    """
+    if not isinstance(raw_result, dict):
+        return
+
+    for key in ('sync_was_successful', 'success'):
+        if key in raw_result and not raw_result[key]:
+            raise SyncResultRejectedError(
+                engine, f'{engine} reported the synchronization as unsuccessful.')
+
+    limit = acceptance_limit_seconds(max_offset_seconds)
+    offset_seconds = raw_result.get('offset_seconds')
+    if limit is None or offset_seconds is None:
+        return
+    try:
+        offset_seconds = float(offset_seconds)
+    except (TypeError, ValueError):
+        return
+    if abs(offset_seconds) > limit:
+        raise SyncResultRejectedError(
+            engine,
+            f'{engine} aligned the subtitles by {abs(offset_seconds):.3f} seconds, '
+            f'more than the {limit:g} second maximum offset.')
 
 
 @dataclass

--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -12,9 +12,11 @@ from sonarr.history import history_log
 from subtitles.processing import ProcessSubtitlesResult
 from subtitles.tools.subsync_engines import (
     DEFAULT_ENABLED_ENGINES,
+    ENGINE_LABELS,
     OUTPUT_MODE_OVERWRITE,
     SubsyncEngineRunner,
     MissingSyncEngineError,
+    SyncEngineDeclinedError,
     normalize_enabled_engines,
     normalize_output_mode,
 )
@@ -25,13 +27,6 @@ from app.config import settings
 from app.database import TableMovies, TableShows, database, select
 from app.get_args import args
 from arr_instances.resolution import scoped, default_instance_id
-
-
-ENGINE_LABELS = {
-    'ffsubsync': 'FFsubsync',
-    'autosubsync': 'Autosubsync',
-    'alass': 'ALASS',
-}
 
 
 def _autosubsync_model_file():
@@ -306,7 +301,7 @@ class SubSyncer:
         except subprocess.CalledProcessError as exc:
             details = (getattr(exc, 'stderr', None) or getattr(exc, 'stdout', None) or str(exc)).strip()
             raise RuntimeError(
-                f'{engine} failed with exit code {exc.returncode}: {details}'
+                f'{engine} exited with code {exc.returncode}: {details}'
             ) from exc
         return {
             'stdout': completed.stdout,
@@ -330,7 +325,10 @@ class SubSyncer:
             raise
 
         if not success:
-            raise RuntimeError('autosubsync completed but did not meet the quality threshold.')
+            # autosubsync's own quality check said no. That is a verdict, not a
+            # fault, so it is reported as a decline rather than an engine failure.
+            raise SyncEngineDeclinedError(
+                'autosubsync', 'autosubsync completed but did not meet its quality threshold.')
 
         return {
             'success': success,

--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -13,10 +13,12 @@ from subtitles.processing import ProcessSubtitlesResult
 from subtitles.tools.subsync_engines import (
     DEFAULT_ENABLED_ENGINES,
     OUTPUT_MODE_OVERWRITE,
+    UNCONSTRAINED_MAX_OFFSET_SECONDS,
     SubsyncEngineRunner,
     MissingSyncEngineError,
     normalize_enabled_engines,
     normalize_output_mode,
+    validate_engine_result,
 )
 from languages.get_languages import audio_language_from_name, language_from_alpha2
 from utilities.path_mappings import path_mappings
@@ -202,15 +204,24 @@ class SubSyncer:
         self.ffmpeg_path = os.path.dirname(ffmpeg_exe)
         return self.ffmpeg_path
 
-    def _build_ffsubsync_args(self, output_path, max_offset_seconds, no_fix_framerate, gss, reference=None,
+    def _build_ffsubsync_args(self, output_path, no_fix_framerate, gss, reference=None,
                               sonarr_series_id=None, sonarr_episode_id=None, radarr_id=None, force_sync=False,
                               arr_instance_id=None):
+        """Build the ffsubsync argument namespace.
+
+        The configured maximum offset is deliberately NOT passed as
+        ``--max-offset-seconds``: that flag is a search window, and a window makes
+        ffsubsync return the best alignment *inside* it rather than the one it would
+        really have picked, so a subtitle that is further out than the maximum comes
+        back looking synchronized. The engine searches unconstrained and the host
+        applies the maximum afterwards, in ``validate_engine_result``.
+        """
         from ffsubsync.ffsubsync import make_parser
 
         ffmpeg_path = self._ensure_ffmpeg_path()
         unparsed_args = [self.reference, '-i', self.srtin, '-o', str(output_path), '--ffmpegpath', ffmpeg_path,
                          '--vad', self.vad, '--log-dir-path', self.log_dir_path, '--max-offset-seconds',
-                         max_offset_seconds, '--output-encoding', 'same']
+                         str(UNCONSTRAINED_MAX_OFFSET_SECONDS), '--output-encoding', 'same']
 
         if no_fix_framerate:
             unparsed_args.append('--no-fix-framerate')
@@ -263,14 +274,13 @@ class SubSyncer:
         parser = make_parser()
         return parser.parse_args(args=unparsed_args)
 
-    def _run_ffsubsync_engine(self, output_path, max_offset_seconds, no_fix_framerate, gss, reference=None,
+    def _run_ffsubsync_engine(self, output_path, no_fix_framerate, gss, reference=None,
                               sonarr_series_id=None, sonarr_episode_id=None, radarr_id=None, force_sync=False,
                               arr_instance_id=None):
         from ffsubsync.ffsubsync import run
 
         self.args = self._build_ffsubsync_args(
             output_path=output_path,
-            max_offset_seconds=max_offset_seconds,
             no_fix_framerate=no_fix_framerate,
             gss=gss,
             reference=reference,
@@ -415,7 +425,6 @@ class SubSyncer:
             if engine == 'ffsubsync':
                 raw_result = self._run_ffsubsync_engine(
                     output_path=output_path,
-                    max_offset_seconds=max_offset_seconds,
                     no_fix_framerate=no_fix_framerate,
                     gss=gss,
                     reference=reference,
@@ -427,6 +436,10 @@ class SubSyncer:
                 )
             else:
                 raw_result = self._run_external_engine(engine=engine, output_path=output_path, video_path=video_path)
+            # The engines search unconstrained, so the maximum offset is enforced here.
+            # Raising leaves the runner to delete the engine output, keep the original
+            # subtitle and move on to the next engine.
+            validate_engine_result(engine, raw_result, max_offset_seconds)
             self._report_progress(
                 f'Finished {engine_label} ({engine_position}/{progress_total})',
                 engine_position,

--- a/frontend/src/pages/Settings/Subtitles/index.tsx
+++ b/frontend/src/pages/Settings/Subtitles/index.tsx
@@ -600,7 +600,12 @@ const SettingsSubtitlesView: FunctionComponent = () => {
               defaultValue={60}
             ></Selector>
             <Message>
-              The max allowed offset seconds for any subtitle segment.
+              Acceptance threshold: a synchronization that has to shift the
+              subtitles further than this is rejected, and the next enabled
+              engine is tried with the original subtitles. Engines search
+              without a limit, so the offset checked here is the one they
+              actually settled on. Only FFsubsync reports an offset, so the
+              threshold applies to FFsubsync.
             </Message>
             <Check
               label="Generate Debug File Instead of Synchronizing"

--- a/tests/bazarr/_module_isolation.py
+++ b/tests/bazarr/_module_isolation.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+"""Undo a module's import side effects without breaking C extensions.
+
+Several test modules install mocks in sys.modules, import the module under
+test so it binds against them, and then put sys.modules back. Restoring by
+deleting everything that appeared is too broad: a third-party package first
+imported during that window gets deleted too, and an extension module cannot
+be imported a second time in one process. CPython raises
+
+    ImportError: cannot load module more than once per process
+
+which surfaces much later, in whichever unrelated test imports numpy next, and
+only when the suite runs in an order that reaches this module first.
+
+Only the mocks and this repo's own modules need dropping: nothing else was
+replaced, so nothing else has a stale binding to undo.
+"""
+
+import os
+import sys
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _is_replaceable(module):
+    """True for a mock or one of our own modules, false for anything installed."""
+    origin = getattr(module, "__file__", None)
+    if not origin:
+        # A mock, or a namespace package we introduced. Either way it is ours.
+        return True
+
+    return os.path.abspath(origin).startswith(_REPO_ROOT + os.sep)
+
+
+def restore(before):
+    """Return sys.modules to ``before``, leaving installed packages alone."""
+    for name in list(sys.modules):
+        if name in before:
+            continue
+        if _is_replaceable(sys.modules[name]):
+            del sys.modules[name]
+
+    for name, module in before.items():
+        sys.modules[name] = module

--- a/tests/bazarr/test_combine_api_dto.py
+++ b/tests/bazarr/test_combine_api_dto.py
@@ -7,17 +7,15 @@
 # so importing the real `api`/`api.utils` here does not leak into later tests.
 import sys
 
+from tests.bazarr import _module_isolation
+
 _SYS_BEFORE = dict(sys.modules)
 sys.modules.pop("api.utils", None)
 sys.modules.pop("api", None)
 
 from api.utils import _subtitle_language_details  # noqa: E402
 
-for _k in list(sys.modules):
-    if _k not in _SYS_BEFORE:
-        del sys.modules[_k]
-for _k, _v in _SYS_BEFORE.items():
-    sys.modules[_k] = _v
+_module_isolation.restore(_SYS_BEFORE)
 
 
 def test_plain_language_has_no_modifier():

--- a/tests/bazarr/test_combine_api_episodes.py
+++ b/tests/bazarr/test_combine_api_episodes.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, patch
 
 # Snapshot sys.modules so we can fully restore it after importing the module
 # under test, preventing mock/transitive-import leakage into later test files.
+from tests.bazarr import _module_isolation
+
 _SYS_BEFORE = dict(sys.modules)
 
 
@@ -106,11 +108,7 @@ import api.episodes.episodes_subtitles as episodes_subtitles_module  # noqa: E40
 
 # Fully restore sys.modules to its pre-import state: drop everything this module
 # added (mocks + transitive imports) and put back any originals we replaced.
-for _k in list(sys.modules):
-    if _k not in _SYS_BEFORE:
-        del sys.modules[_k]
-for _k, _v in _SYS_BEFORE.items():
-    sys.modules[_k] = _v
+_module_isolation.restore(_SYS_BEFORE)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/bazarr/test_combine_api_movies.py
+++ b/tests/bazarr/test_combine_api_movies.py
@@ -12,6 +12,8 @@ from unittest.mock import MagicMock, patch
 # Snapshot sys.modules so we can fully restore it after importing the module
 # under test. Without this, the mocks and transitively-imported modules leak
 # into later test files (e.g. test_editor_api) and break them.
+from tests.bazarr import _module_isolation
+
 _SYS_BEFORE = dict(sys.modules)
 
 
@@ -107,11 +109,7 @@ import api.movies.movies_subtitles as movies_subtitles_module  # noqa: E402
 # Fully restore sys.modules to its pre-import state: drop everything this module
 # added (mocks + transitive imports) and put back any originals we replaced.
 # The captured `movies_subtitles_module` reference stays valid for our tests.
-for _k in list(sys.modules):
-    if _k not in _SYS_BEFORE:
-        del sys.modules[_k]
-for _k, _v in _SYS_BEFORE.items():
-    sys.modules[_k] = _v
+_module_isolation.restore(_SYS_BEFORE)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/bazarr/test_combine_api_series.py
+++ b/tests/bazarr/test_combine_api_series.py
@@ -13,6 +13,8 @@ from unittest.mock import MagicMock, patch
 
 # Snapshot sys.modules so we can fully restore it after importing the module
 # under test, preventing mock/transitive-import leakage into later test files.
+from tests.bazarr import _module_isolation
+
 _SYS_BEFORE = dict(sys.modules)
 
 
@@ -132,11 +134,7 @@ import api.series.series as series_module  # noqa: E402
 
 # Fully restore sys.modules to its pre-import state: drop everything this module
 # added (mocks + transitive imports) and put back any originals we replaced.
-for _k in list(sys.modules):
-    if _k not in _SYS_BEFORE:
-        del sys.modules[_k]
-for _k, _v in _SYS_BEFORE.items():
-    sys.modules[_k] = _v
+_module_isolation.restore(_SYS_BEFORE)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/bazarr/test_sync_offset_acceptance.py
+++ b/tests/bazarr/test_sync_offset_acceptance.py
@@ -1,0 +1,218 @@
+# coding=utf-8
+"""The maximum sync offset is an acceptance threshold, not a search window.
+
+The setting used to be handed to ffsubsync as ``--max-offset-seconds``, which makes
+the engine mask every candidate alignment outside the window *after* computing the
+full correlation, then return the best of whatever is left. A subtitle whose real
+offset sits outside the window therefore came back with a plausible looking but wrong
+in-window offset, reported as a success, and in overwrite mode it replaced the original
+and short-circuited the rest of the engine chain.
+
+The engine now searches unconstrained and the host validates the result: an engine that
+reports failure is rejected even when it wrote an output file, and an alignment whose
+absolute offset exceeds the configured maximum is rejected too. Both rejections raise,
+so the runner deletes the engine output, leaves the original subtitle alone and moves on
+to the next engine.
+"""
+
+import pytest
+
+import app.database  # noqa: F401
+
+
+def _write(path, content):
+    path.write_text(content, encoding='utf-8')
+
+
+@pytest.fixture
+def in_memory_runner(monkeypatch):
+    """Run the real SubsyncEngineRunner, but keep its failure bookkeeping in memory."""
+    from subtitles.tools import subsyncer as subsyncer_module
+    from subtitles.tools.subsync_engines import InMemorySubsyncFailureStore, SubsyncEngineRunner
+
+    monkeypatch.setattr(
+        subsyncer_module,
+        'SubsyncEngineRunner',
+        lambda: SubsyncEngineRunner(InMemorySubsyncFailureStore()),
+    )
+
+
+def _sync(subtitle, tmp_path, enabled_engines, max_offset_seconds='60', output_mode='overwrite'):
+    from subtitles.tools.subsyncer import SubSyncer
+
+    return SubSyncer().sync(
+        video_path=str(tmp_path / 'Movie.mkv'),
+        srt_path=str(subtitle),
+        srt_lang='en',
+        hi=False,
+        forced=False,
+        max_offset_seconds=max_offset_seconds,
+        no_fix_framerate=True,
+        gss=False,
+        force_sync=True,
+        output_mode=output_mode,
+        enabled_engines=enabled_engines,
+        write_history=False,
+    )
+
+
+def test_ffsubsync_searches_without_an_offset_window(monkeypatch):
+    """The configured maximum must not narrow the engine's search.
+
+    ffsubsync 0.5.0 masks out-of-window candidates in MaxScoreAligner.transform, i.e.
+    after the correlation is computed, so an unconstrained search costs nothing and is
+    the only way to learn the offset the engine would really have chosen.
+    """
+    from subtitles.tools.subsync_engines import UNCONSTRAINED_MAX_OFFSET_SECONDS
+    from subtitles.tools.subsyncer import SubSyncer
+
+    syncer = SubSyncer()
+    monkeypatch.setattr(SubSyncer, '_ensure_ffmpeg_path', lambda self: '/usr/bin')
+
+    args = syncer._build_ffsubsync_args(
+        output_path='/tmp/out.srt',
+        no_fix_framerate=True,
+        gss=False,
+    )
+
+    assert args.max_offset_seconds == UNCONSTRAINED_MAX_OFFSET_SECONDS
+
+
+def test_offset_beyond_the_maximum_is_rejected_and_the_next_engine_runs(monkeypatch, in_memory_runner, tmp_path):
+    subtitle = tmp_path / 'Movie.en.srt'
+    _write(subtitle, 'original')
+    calls = []
+
+    def fake_ffsubsync(self, output_path, **kwargs):
+        calls.append('ffsubsync')
+        _write(output_path, 'badly synced')
+        return {'retval': 0, 'sync_was_successful': True, 'offset_seconds': -200.0,
+                'framerate_scale_factor': 1.0}
+
+    def fake_external(self, engine, output_path, video_path):
+        calls.append(engine)
+        _write(output_path, f'{engine} result')
+        return {'returncode': 0}
+
+    from subtitles.tools.subsyncer import SubSyncer
+    monkeypatch.setattr(SubSyncer, '_run_ffsubsync_engine', fake_ffsubsync)
+    monkeypatch.setattr(SubSyncer, '_run_external_engine', fake_external)
+
+    result = _sync(subtitle, tmp_path, ['ffsubsync', 'autosubsync'])
+
+    assert calls == ['ffsubsync', 'autosubsync']
+    assert [item.engine for item in result.failed_results] == ['ffsubsync']
+    assert '200.0' in result.failed_results[0].message
+    assert [item.engine for item in result.successful_results] == ['autosubsync']
+    assert subtitle.read_text(encoding='utf-8') == 'autosubsync result'
+
+
+def test_engine_reported_failure_is_rejected_even_with_an_output_file(monkeypatch, in_memory_runner, tmp_path):
+    subtitle = tmp_path / 'Movie.en.srt'
+    _write(subtitle, 'original')
+
+    def fake_ffsubsync(self, output_path, **kwargs):
+        _write(output_path, 'unsynced passthrough')
+        return {'retval': 0, 'sync_was_successful': False, 'offset_seconds': 1.5,
+                'framerate_scale_factor': 1.0}
+
+    from subtitles.tools.subsyncer import SubSyncer
+    monkeypatch.setattr(SubSyncer, '_run_ffsubsync_engine', fake_ffsubsync)
+
+    result = _sync(subtitle, tmp_path, ['ffsubsync'])
+
+    assert not result.success
+    assert [item.engine for item in result.failed_results] == ['ffsubsync']
+    assert subtitle.read_text(encoding='utf-8') == 'original'
+
+
+def test_negative_offset_within_the_maximum_is_accepted(monkeypatch, in_memory_runner, tmp_path):
+    subtitle = tmp_path / 'Movie.en.srt'
+    _write(subtitle, 'original')
+
+    def fake_ffsubsync(self, output_path, **kwargs):
+        _write(output_path, 'well synced')
+        return {'retval': 0, 'sync_was_successful': True, 'offset_seconds': -45.5,
+                'framerate_scale_factor': 1.0}
+
+    from subtitles.tools.subsyncer import SubSyncer
+    monkeypatch.setattr(SubSyncer, '_run_ffsubsync_engine', fake_ffsubsync)
+
+    result = _sync(subtitle, tmp_path, ['ffsubsync'])
+
+    assert result.success
+    assert [item.engine for item in result.successful_results] == ['ffsubsync']
+    assert subtitle.read_text(encoding='utf-8') == 'well synced'
+
+
+def test_rejection_leaves_the_original_untouched_when_it_is_the_only_engine(monkeypatch, in_memory_runner, tmp_path):
+    subtitle = tmp_path / 'Movie.en.srt'
+    _write(subtitle, 'original')
+
+    def fake_ffsubsync(self, output_path, **kwargs):
+        _write(output_path, 'badly synced')
+        return {'retval': 0, 'sync_was_successful': True, 'offset_seconds': 61.0,
+                'framerate_scale_factor': 1.0}
+
+    from subtitles.tools.subsyncer import SubSyncer
+    monkeypatch.setattr(SubSyncer, '_run_ffsubsync_engine', fake_ffsubsync)
+
+    result = _sync(subtitle, tmp_path, ['ffsubsync'])
+
+    assert not result.success
+    assert subtitle.read_text(encoding='utf-8') == 'original'
+    assert [path.name for path in tmp_path.iterdir()] == ['Movie.en.srt']
+
+
+def test_keep_all_mode_discards_the_rejected_engine_output(monkeypatch, in_memory_runner, tmp_path):
+    from subtitles.tools.subsync_engines import engine_output_path
+
+    subtitle = tmp_path / 'Movie.en.srt'
+    _write(subtitle, 'original')
+
+    def fake_ffsubsync(self, output_path, **kwargs):
+        _write(output_path, 'badly synced')
+        return {'retval': 0, 'sync_was_successful': True, 'offset_seconds': 300.0,
+                'framerate_scale_factor': 1.0}
+
+    from subtitles.tools.subsyncer import SubSyncer
+    monkeypatch.setattr(SubSyncer, '_run_ffsubsync_engine', fake_ffsubsync)
+
+    result = _sync(subtitle, tmp_path, ['ffsubsync'], output_mode='keep_all')
+
+    assert not result.success
+    assert not engine_output_path(str(subtitle), 'ffsubsync').exists()
+    assert subtitle.read_text(encoding='utf-8') == 'original'
+
+
+@pytest.mark.parametrize(
+    'raw_result,max_offset_seconds',
+    [
+        ({'sync_was_successful': True, 'offset_seconds': 60.0}, '60'),
+        ({'sync_was_successful': True, 'offset_seconds': -60.0}, 60),
+        ({'sync_was_successful': True, 'offset_seconds': 1000.0}, None),
+        ({'success': True}, '60'),
+        ({'returncode': 0, 'stdout': '', 'stderr': ''}, '60'),
+        (None, '60'),
+    ],
+)
+def test_acceptable_results_are_not_rejected(raw_result, max_offset_seconds):
+    from subtitles.tools.subsync_engines import validate_engine_result
+
+    validate_engine_result('ffsubsync', raw_result, max_offset_seconds)
+
+
+@pytest.mark.parametrize(
+    'raw_result,max_offset_seconds',
+    [
+        ({'sync_was_successful': True, 'offset_seconds': 60.1}, '60'),
+        ({'sync_was_successful': True, 'offset_seconds': -60.1}, 60),
+        ({'sync_was_successful': False, 'offset_seconds': 0.0}, '60'),
+        ({'success': False}, '60'),
+    ],
+)
+def test_unacceptable_results_are_rejected(raw_result, max_offset_seconds):
+    from subtitles.tools.subsync_engines import SyncResultRejectedError, validate_engine_result
+
+    with pytest.raises(SyncResultRejectedError):
+        validate_engine_result('ffsubsync', raw_result, max_offset_seconds)

--- a/tests/bazarr/test_sync_outcome_reporting.py
+++ b/tests/bazarr/test_sync_outcome_reporting.py
@@ -1,0 +1,517 @@
+# coding=utf-8
+
+"""Per-engine sync outcome reporting.
+
+A sync run used to collapse to a single line: any one engine producing output made
+the whole run an unqualified success, and the engines that failed were visible only
+as a traceback in System > Logs. These tests pin the vocabulary the runner emits for
+each way an engine can fail to produce output, and the sentences the job queue shows
+for them.
+"""
+
+import logging
+
+import pytest
+
+import app.database  # noqa: F401
+
+
+def _write(path, content):
+    path.write_text(content, encoding='utf-8')
+
+
+def _keep_all_run(results):
+    from subtitles.tools.subsync_engines import OUTPUT_MODE_KEEP_ALL, SyncRunResult
+
+    run = SyncRunResult(source_path='/subs/movie.hu.srt', output_mode=OUTPUT_MODE_KEEP_ALL)
+    run.results = results
+    return run
+
+
+def _result(engine, status, reason=None, message=None):
+    from subtitles.tools.subsync_engines import SyncEngineResult
+
+    return SyncEngineResult(engine=engine, status=status, reason=reason, message=message)
+
+
+# --------------------------------------------------------------------------------------
+# Runner vocabulary: the four ways an engine can come back without an output.
+# --------------------------------------------------------------------------------------
+
+
+def test_engine_that_declines_its_own_result_is_not_reported_as_a_crash(tmp_path):
+    """autosubsync rejecting its own output is normal, and must not read like a bug."""
+    from subtitles.tools.subsync_engines import (
+        OUTPUT_MODE_KEEP_ALL,
+        REASON_ENGINE_DECLINED,
+        RESULT_FAILED,
+        InMemorySubsyncFailureStore,
+        SubsyncEngineRunner,
+        SyncEngineDeclinedError,
+    )
+
+    subtitle = tmp_path / 'Movie.en.srt'
+    _write(subtitle, 'original')
+
+    def execute(engine, output_path):
+        _write(output_path, 'partial')
+        raise SyncEngineDeclinedError(engine, 'autosubsync completed but did not meet the quality threshold.')
+
+    result = SubsyncEngineRunner(InMemorySubsyncFailureStore()).run(
+        srt_path=str(subtitle),
+        output_mode=OUTPUT_MODE_KEEP_ALL,
+        enabled_engines=['autosubsync'],
+        execute_engine=execute,
+    )
+
+    declined = result.results[0]
+    assert declined.status == RESULT_FAILED
+    assert declined.reason == REASON_ENGINE_DECLINED
+    assert 'quality threshold' in declined.message
+    # The engine's own partial output must not be left behind.
+    assert not (tmp_path / 'Movie.en.autosubsync.srt').exists()
+    assert subtitle.read_text(encoding='utf-8') == 'original'
+
+
+def test_declined_engine_is_logged_without_a_traceback(tmp_path, caplog):
+    from subtitles.tools.subsync_engines import (
+        OUTPUT_MODE_KEEP_ALL,
+        InMemorySubsyncFailureStore,
+        SubsyncEngineRunner,
+        SyncEngineDeclinedError,
+    )
+
+    subtitle = tmp_path / 'Movie.en.srt'
+    _write(subtitle, 'original')
+
+    def execute(engine, output_path):
+        raise SyncEngineDeclinedError(engine, 'did not meet the quality threshold.')
+
+    with caplog.at_level(logging.DEBUG):
+        SubsyncEngineRunner(InMemorySubsyncFailureStore()).run(
+            srt_path=str(subtitle),
+            output_mode=OUTPUT_MODE_KEEP_ALL,
+            enabled_engines=['autosubsync'],
+            execute_engine=execute,
+        )
+
+    assert not [record for record in caplog.records if record.exc_info]
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
+
+
+def test_rejected_engine_result_has_its_own_reason(tmp_path):
+    """A result the host refuses is neither a crash nor the engine's own verdict."""
+    from subtitles.tools.subsync_engines import (
+        OUTPUT_MODE_KEEP_ALL,
+        REASON_RESULT_REJECTED,
+        RESULT_FAILED,
+        InMemorySubsyncFailureStore,
+        SubsyncEngineRunner,
+        SyncResultRejectedError,
+    )
+
+    subtitle = tmp_path / 'Movie.en.srt'
+    _write(subtitle, 'original')
+
+    def execute(engine, output_path):
+        _write(output_path, 'shifted too far')
+        raise SyncResultRejectedError(
+            engine, 'ffsubsync aligned the subtitles by 200.000 seconds, more than the 60 second maximum offset.')
+
+    result = SubsyncEngineRunner(InMemorySubsyncFailureStore()).run(
+        srt_path=str(subtitle),
+        output_mode=OUTPUT_MODE_KEEP_ALL,
+        enabled_engines=['ffsubsync'],
+        execute_engine=execute,
+    )
+
+    rejected = result.results[0]
+    assert rejected.status == RESULT_FAILED
+    assert rejected.reason == REASON_RESULT_REJECTED
+    assert 'maximum offset' in rejected.message
+    assert not (tmp_path / 'Movie.en.ffsubsync.srt').exists()
+
+
+def test_unexpected_engine_error_still_reports_engine_failed(tmp_path):
+    from subtitles.tools.subsync_engines import (
+        OUTPUT_MODE_KEEP_ALL,
+        REASON_ENGINE_FAILED,
+        RESULT_FAILED,
+        InMemorySubsyncFailureStore,
+        SubsyncEngineRunner,
+    )
+
+    subtitle = tmp_path / 'Movie.en.srt'
+    _write(subtitle, 'original')
+
+    def execute(engine, output_path):
+        raise RuntimeError('alass failed with exit code 1: could not read the video stream')
+
+    result = SubsyncEngineRunner(InMemorySubsyncFailureStore()).run(
+        srt_path=str(subtitle),
+        output_mode=OUTPUT_MODE_KEEP_ALL,
+        enabled_engines=['alass'],
+        execute_engine=execute,
+    )
+
+    failed = result.results[0]
+    assert failed.status == RESULT_FAILED
+    assert failed.reason == REASON_ENGINE_FAILED
+
+
+@pytest.mark.parametrize('error_name', ['SyncEngineDeclinedError', 'SyncResultRejectedError'])
+def test_declined_and_rejected_results_still_count_towards_the_failure_threshold(tmp_path, error_name):
+    """Reporting-only change: a decline or a rejection must keep costing a strike."""
+    import subtitles.tools.subsync_engines as engines_module
+
+    error = getattr(engines_module, error_name)
+    subtitle = tmp_path / 'Movie.en.srt'
+    _write(subtitle, 'original')
+    store = engines_module.InMemorySubsyncFailureStore()
+
+    def execute(engine, output_path):
+        raise error(engine, 'nope')
+
+    engines_module.SubsyncEngineRunner(store).run(
+        srt_path=str(subtitle),
+        output_mode=engines_module.OUTPUT_MODE_KEEP_ALL,
+        enabled_engines=['alass'],
+        execute_engine=execute,
+    )
+
+    assert store.failure_count(str(subtitle), 'alass') == 1
+
+
+def test_autosubsync_quality_check_raises_a_decline_not_a_generic_error(monkeypatch, tmp_path):
+    from subtitles.tools.subsync_engines import SyncEngineDeclinedError
+    from subtitles.tools.subsyncer import SubSyncer
+
+    subtitle = tmp_path / 'Movie.en.srt'
+    _write(subtitle, 'original')
+
+    monkeypatch.setattr('subtitles.tools.subsyncer._autosubsync_model_file', lambda: 'model.bin')
+    monkeypatch.setattr('subtitles.tools.subsyncer._run_autosubsync_api', lambda **kwargs: False)
+
+    subsyncer = SubSyncer()
+    subsyncer.srtin = str(subtitle)
+    subsyncer.reference = None
+
+    with pytest.raises(SyncEngineDeclinedError) as excinfo:
+        subsyncer._run_autosubsync_engine(output_path=tmp_path / 'out.srt', video_path='/video.mkv')
+
+    assert excinfo.value.engine == 'autosubsync'
+    assert 'quality' in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------------------
+# Job name: how many engines were asked for, how many produced output.
+# --------------------------------------------------------------------------------------
+
+
+def test_partial_keep_all_run_names_the_engine_counts():
+    from subtitles.sync import _sync_complete_job_name
+    from subtitles.tools.subsync_engines import (
+        REASON_ENGINE_DECLINED,
+        REASON_MISSING_ENGINE,
+        RESULT_FAILED,
+        RESULT_SKIPPED,
+        RESULT_SUCCESS,
+    )
+
+    run = _keep_all_run([
+        _result('ffsubsync', RESULT_SUCCESS),
+        _result('autosubsync', RESULT_FAILED, REASON_ENGINE_DECLINED, 'did not meet the quality threshold.'),
+        _result('alass', RESULT_SKIPPED, REASON_MISSING_ENGINE, 'alass executable not found on PATH'),
+    ])
+
+    assert _sync_complete_job_name('/subs/movie.hu.srt', run) == (
+        'Generated 1 of 3 sync outputs for /subs/movie.hu.srt'
+    )
+
+
+def test_fully_successful_keep_all_run_reads_exactly_as_it_does_today():
+    from subtitles.sync import _sync_complete_job_name
+    from subtitles.tools.subsync_engines import RESULT_SUCCESS
+
+    run = _keep_all_run([
+        _result('ffsubsync', RESULT_SUCCESS),
+        _result('alass', RESULT_SUCCESS),
+    ])
+
+    assert _sync_complete_job_name('/subs/movie.hu.srt', run) == (
+        'Generated 2 sync outputs for /subs/movie.hu.srt'
+    )
+
+
+def test_overwrite_run_name_is_unaffected_by_an_earlier_engine_failure():
+    from subtitles.sync import _sync_complete_job_name
+    from subtitles.tools.subsync_engines import (
+        OUTPUT_MODE_OVERWRITE,
+        REASON_RESULT_REJECTED,
+        RESULT_FAILED,
+        RESULT_SUCCESS,
+        SyncRunResult,
+    )
+
+    run = SyncRunResult(source_path='/subs/movie.hu.srt', output_mode=OUTPUT_MODE_OVERWRITE)
+    run.results = [
+        _result('ffsubsync', RESULT_FAILED, REASON_RESULT_REJECTED, 'more than the 60 second maximum offset.'),
+        _result('autosubsync', RESULT_SUCCESS),
+    ]
+
+    assert _sync_complete_job_name('/subs/movie.hu.srt', run) == (
+        'Synced /subs/movie.hu.srt using autosubsync'
+    )
+
+
+# --------------------------------------------------------------------------------------
+# Outcome message: the engines that failed, and why, without opening the log.
+# --------------------------------------------------------------------------------------
+
+
+def test_partial_run_message_names_every_engine_that_produced_nothing():
+    from subtitles.sync import _sync_outcome_message
+    from subtitles.tools.subsync_engines import (
+        REASON_ENGINE_DECLINED,
+        REASON_MISSING_ENGINE,
+        RESULT_FAILED,
+        RESULT_SKIPPED,
+        RESULT_SUCCESS,
+    )
+
+    run = _keep_all_run([
+        _result('ffsubsync', RESULT_SUCCESS),
+        _result('autosubsync', RESULT_FAILED, REASON_ENGINE_DECLINED, 'did not meet the quality threshold.'),
+        _result('alass', RESULT_SKIPPED, REASON_MISSING_ENGINE, 'alass executable not found on PATH'),
+    ])
+
+    message = _sync_outcome_message(run)
+
+    assert message.startswith('Sync partially complete: 1 of 3 engines produced output.')
+    assert 'Autosubsync' in message
+    assert 'ALASS is not installed.' in message
+
+
+def test_autosubsync_self_rejection_reads_as_normal_behaviour():
+    from subtitles.sync import _sync_outcome_message
+    from subtitles.tools.subsync_engines import REASON_ENGINE_DECLINED, RESULT_FAILED, RESULT_SUCCESS
+
+    run = _keep_all_run([
+        _result('ffsubsync', RESULT_SUCCESS),
+        _result('autosubsync', RESULT_FAILED, REASON_ENGINE_DECLINED, 'did not meet the quality threshold.'),
+    ])
+
+    message = _sync_outcome_message(run)
+
+    assert 'Autosubsync rejected its own result' in message
+    assert 'normal' in message
+    # It must not read like a missing dependency or a crash.
+    assert 'not installed' not in message
+    assert 'failed:' not in message
+
+
+def test_missing_engine_reads_differently_from_an_engine_that_ran_and_failed():
+    from subtitles.sync import _sync_outcome_message
+    from subtitles.tools.subsync_engines import (
+        REASON_ENGINE_FAILED,
+        REASON_MISSING_ENGINE,
+        RESULT_FAILED,
+        RESULT_SKIPPED,
+        RESULT_SUCCESS,
+    )
+
+    missing = _sync_outcome_message(_keep_all_run([
+        _result('ffsubsync', RESULT_SUCCESS),
+        _result('alass', RESULT_SKIPPED, REASON_MISSING_ENGINE, 'alass executable not found on PATH'),
+    ]))
+    ran_and_failed = _sync_outcome_message(_keep_all_run([
+        _result('ffsubsync', RESULT_SUCCESS),
+        _result('alass', RESULT_FAILED, REASON_ENGINE_FAILED, 'alass exited with code 1: bad stream'),
+    ]))
+
+    assert 'ALASS is not installed.' in missing
+    assert 'ALASS failed: exited with code 1: bad stream' in ran_and_failed
+    assert missing != ran_and_failed
+
+
+def test_engine_naming_itself_in_its_message_is_not_repeated_after_the_label():
+    from subtitles.sync import _sync_outcome_message
+    from subtitles.tools.subsync_engines import REASON_ENGINE_FAILED, RESULT_FAILED, RESULT_SUCCESS
+
+    message = _sync_outcome_message(_keep_all_run([
+        _result('ffsubsync', RESULT_SUCCESS),
+        _result('alass', RESULT_FAILED, REASON_ENGINE_FAILED, 'alass exited with code 1: bad stream'),
+    ]))
+
+    assert 'ALASS failed: exited with code 1: bad stream.' in message
+    assert 'alass' not in message
+
+
+def test_threshold_skip_reads_as_skipped_rather_than_failed():
+    from subtitles.sync import _sync_outcome_message
+    from subtitles.tools.subsync_engines import REASON_FAILURE_THRESHOLD, RESULT_SKIPPED, RESULT_SUCCESS
+
+    message = _sync_outcome_message(_keep_all_run([
+        _result('ffsubsync', RESULT_SUCCESS),
+        _result('alass', RESULT_SKIPPED, REASON_FAILURE_THRESHOLD,
+                'alass skipped after 3 consecutive failures.'),
+    ]))
+
+    assert 'ALASS was skipped after repeated failures.' in message
+    assert 'ALASS failed' not in message
+
+
+def test_rejected_result_message_explains_the_offset_limit():
+    from subtitles.sync import _sync_outcome_message
+    from subtitles.tools.subsync_engines import REASON_RESULT_REJECTED, RESULT_FAILED, RESULT_SUCCESS
+
+    message = _sync_outcome_message(_keep_all_run([
+        _result('alass', RESULT_SUCCESS),
+        _result('ffsubsync', RESULT_FAILED, REASON_RESULT_REJECTED,
+                'ffsubsync aligned the subtitles by 200.000 seconds, more than the 60 second maximum offset.'),
+    ]))
+
+    assert 'FFsubsync result rejected:' in message
+    assert 'more than the 60 second maximum offset.' in message
+
+
+def test_fully_successful_run_message_is_unchanged():
+    from subtitles.sync import _sync_outcome_message
+    from subtitles.tools.subsync_engines import RESULT_SUCCESS
+
+    run = _keep_all_run([
+        _result('ffsubsync', RESULT_SUCCESS),
+        _result('alass', RESULT_SUCCESS),
+    ])
+
+    assert _sync_outcome_message(run) == 'Sync complete'
+
+
+def test_overwrite_run_message_is_unaffected_by_an_earlier_engine_failure():
+    from subtitles.sync import _sync_outcome_message
+    from subtitles.tools.subsync_engines import (
+        OUTPUT_MODE_OVERWRITE,
+        REASON_ENGINE_FAILED,
+        RESULT_FAILED,
+        RESULT_SUCCESS,
+        SyncRunResult,
+    )
+
+    run = SyncRunResult(source_path='/subs/movie.hu.srt', output_mode=OUTPUT_MODE_OVERWRITE)
+    run.results = [
+        _result('ffsubsync', RESULT_FAILED, REASON_ENGINE_FAILED, 'boom'),
+        _result('autosubsync', RESULT_SUCCESS),
+    ]
+
+    assert _sync_outcome_message(run) == 'Sync complete'
+
+
+def test_run_where_every_engine_failed_still_reports_failure_with_counts():
+    from subtitles.sync import _sync_complete_job_name, _sync_outcome_message
+    from subtitles.tools.subsync_engines import (
+        REASON_ENGINE_DECLINED,
+        REASON_ENGINE_FAILED,
+        REASON_RESULT_REJECTED,
+        RESULT_FAILED,
+    )
+
+    run = _keep_all_run([
+        _result('ffsubsync', RESULT_FAILED, REASON_RESULT_REJECTED, 'more than the 60 second maximum offset.'),
+        _result('autosubsync', RESULT_FAILED, REASON_ENGINE_DECLINED, 'did not meet the quality threshold.'),
+        _result('alass', RESULT_FAILED, REASON_ENGINE_FAILED, 'alass exited with code 1: bad stream'),
+    ])
+
+    assert _sync_complete_job_name('/subs/movie.hu.srt', run) == 'Failed to sync /subs/movie.hu.srt'
+    message = _sync_outcome_message(run)
+    assert message.startswith('Sync failed: no output from 3 engines.')
+    assert 'ALASS failed:' in message
+
+
+def test_run_where_every_engine_was_skipped_reports_skipped_with_reasons():
+    from subtitles.sync import _sync_complete_job_name, _sync_outcome_message
+    from subtitles.tools.subsync_engines import REASON_MISSING_ENGINE, RESULT_SKIPPED
+
+    run = _keep_all_run([
+        _result('autosubsync', RESULT_SKIPPED, REASON_MISSING_ENGINE, 'autosubsync Python package not installed'),
+        _result('alass', RESULT_SKIPPED, REASON_MISSING_ENGINE, 'alass executable not found on PATH'),
+    ])
+
+    assert _sync_complete_job_name('/subs/movie.hu.srt', run) == 'Skipped sync for /subs/movie.hu.srt'
+    message = _sync_outcome_message(run)
+    assert message.startswith('Sync skipped: no engine produced output.')
+    assert 'Autosubsync is not installed.' in message
+    assert 'ALASS is not installed.' in message
+
+
+def test_engine_message_is_truncated_so_a_stderr_dump_cannot_flood_the_job_card():
+    from subtitles.sync import _sync_outcome_message
+    from subtitles.tools.subsync_engines import REASON_ENGINE_FAILED, RESULT_FAILED, RESULT_SUCCESS
+
+    message = _sync_outcome_message(_keep_all_run([
+        _result('ffsubsync', RESULT_SUCCESS),
+        _result('alass', RESULT_FAILED, REASON_ENGINE_FAILED, 'x' * 5000),
+    ]))
+
+    assert len(message) < 500
+    assert message.endswith('...')
+
+
+# --------------------------------------------------------------------------------------
+# End to end through sync_subtitles: what the jobs drawer shows.
+# --------------------------------------------------------------------------------------
+
+
+def test_sync_subtitles_reports_a_partial_run_to_the_jobs_queue(mocker):
+    from subtitles import sync as sync_module
+    from subtitles.tools.subsync_engines import (
+        REASON_ENGINE_DECLINED,
+        REASON_MISSING_ENGINE,
+        RESULT_FAILED,
+        RESULT_SKIPPED,
+        RESULT_SUCCESS,
+        SyncEngineResult,
+        SyncRunResult,
+    )
+
+    mock_jobs_queue = mocker.patch.object(sync_module, 'jobs_queue')
+    sync_result = SyncRunResult(source_path='/subtitle.hu.srt', output_mode='keep_all')
+    sync_result.results = [
+        SyncEngineResult(engine='ffsubsync', status=RESULT_SUCCESS,
+                         output_path='/subtitle.hu.ffsubsync.srt'),
+        SyncEngineResult(engine='autosubsync', status=RESULT_FAILED, reason=REASON_ENGINE_DECLINED,
+                         message='autosubsync completed but did not meet the quality threshold.'),
+        SyncEngineResult(engine='alass', status=RESULT_SKIPPED, reason=REASON_MISSING_ENGINE,
+                         message='alass executable not found on PATH'),
+    ]
+
+    class FakeSubSyncer:
+        def sync(self, **kwargs):
+            return sync_result
+
+    mocker.patch.object(sync_module, 'SubSyncer', return_value=FakeSubSyncer())
+    mocker.patch.object(sync_module, '_index_keep_all_outputs')
+
+    assert sync_module.sync_subtitles(
+        video_path='/video.mkv',
+        srt_path='/subtitle.hu.srt',
+        srt_lang='hu',
+        forced=False,
+        hi=False,
+        percent_score=0,
+        job_id=99,
+        force_sync=True,
+        output_mode='keep_all',
+        enabled_engines=['ffsubsync', 'autosubsync', 'alass'],
+    ) is True
+
+    mock_jobs_queue.update_job_name.assert_any_call(
+        job_id=99,
+        new_job_name='Generated 1 of 3 sync outputs for /subtitle.hu.srt',
+    )
+    final = [call.kwargs for call in mock_jobs_queue.update_job_progress.call_args_list
+             if call.kwargs.get('progress_value') == 'max']
+    assert final, 'the run never reported completion'
+    outcome = final[-1]['progress_message']
+    assert outcome.startswith('Sync partially complete: 1 of 3 engines produced output.')
+    assert 'Autosubsync rejected its own result' in outcome
+    assert 'ALASS is not installed.' in outcome


### PR DESCRIPTION
## The offset threshold

The configured maximum sync offset was passed to ffsubsync as `--max-offset-seconds`. That does not narrow the search: ffsubsync computes the full correlation and then masks every candidate outside the window in `MaxScoreAligner.transform`, returning the best of whatever is left. A subtitle whose real offset lies outside the window therefore came back with a plausible-looking but wrong in-window offset, reported as a success, and in overwrite mode it replaced the original and short-circuited the rest of the engine chain.

The engines now search unconstrained and the host validates the result. A non-positive maximum means no limit, including a negative one: the sync API takes an arbitrary integer, not just the settings page's choices.

## Decline vs rejection

The two ways a result can be turned down are different events and are now different types:

- `SyncEngineDeclinedError` is the engine's verdict on its own output. autosubsync's quality check refuses its own result routinely on hard audio, and ffsubsync setting `sync_was_successful=False` is the same act. Nothing is broken, so it is logged as a warning rather than a traceback that sends users hunting for a missing dependency, **and it costs the engine no strike** towards the consecutive-failure quarantine. Three routine declines used to make the engine skip that subtitle entirely, even after the user changed the reference or the settings.
- `SyncResultRejectedError` is Bazarr overruling an engine that claimed success. That still costs a strike: the engine is confidently producing an answer this file cannot use.

Either way the runner deletes the engine output, leaves the original subtitle alone, and moves on to the next engine.

## Reporting

The sync report gives one line per engine with its own status and reason instead of a single success line for the whole chain, so "two engines declined, the third worked" is legible.

## Also in this branch

A test-isolation fix this branch exposed rather than caused. Four test modules restored `sys.modules` by deleting everything that appeared while they imported the module under test, which took third-party packages with it. A C extension cannot be imported twice in one process, so numpy came back as `ImportError: cannot load module more than once per process` in whichever later test imported it first. Only mocks and this repo's own modules are dropped now. Without it the suite is order-dependent, and adding one test file was enough to flip the order.

## Tests

`tests/bazarr/test_sync_offset_acceptance.py` and `tests/bazarr/test_sync_outcome_reporting.py`, both enumerated in CI: the unconstrained search, an out-of-window offset falling through to the next engine, a self-reported failure with an output file present, an accepted negative offset, the original left untouched, keep-all mode discarding rejected output, non-positive maxima meaning no limit, and the strike accounting for each outcome.

Full backend suite green locally (1606 passed), ruff clean.