### PR TITLE
fix(video): carry edition and other through fromguess

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
             tests/subliminal_patch/test_filebot_refiner.py \
             tests/subliminal_patch/test_mods.py \
             tests/subliminal_patch/test_mods_keep_lyrics.py \
+            tests/subliminal_patch/test_video.py \
             -v --tb=short
 
       - name: pytest cross-instance isolation guards (isolated per file)

--- a/custom_libs/subliminal_patch/__init__.py
+++ b/custom_libs/subliminal_patch/__init__.py
@@ -66,5 +66,41 @@ if not getattr(subliminal.video.Episode, '_bazarr_episode_init_patched', False):
     subliminal.video.Episode.episode = property(get_episode, set_episode)
     subliminal.video.Episode._bazarr_episode_init_patched = True
 
+# subliminal's Episode.fromguess and Movie.fromguess predate the extra fields
+# this fork's Video carries, so they build the video without them and throw away
+# work guessit already did. Two of the dropped fields are used for matching:
+# `edition`, which is worth 30 points when a movie is scored, and `other`, which
+# guess_matches compares but does not score. Both were always unset on the video
+# side, and guess_matches counts "neither side names one" as a match, so an
+# edition-less subtitle matched the edition of every edition-tagged movie.
+#
+# The builders are patched here rather than overridden on
+# subliminal_patch.video.Video, because Video.fromguess only dispatches, and it
+# dispatches to the subliminal.video module globals. An override on the subclass
+# is never reached from scan_video, which imports Video from subliminal.video.
+_GUESS_ATTRS_DROPPED_BY_FROMGUESS = ('edition', 'other')
+
+
+def _patch_fromguess(video_cls):
+    original_fromguess = video_cls.__dict__['fromguess'].__func__
+
+    def fromguess(cls, name, guess):
+        video = original_fromguess(cls, name, guess)
+        for attr in _GUESS_ATTRS_DROPPED_BY_FROMGUESS:
+            value = guess.get(attr)
+            if value is not None:
+                setattr(video, attr, value)
+        return video
+
+    video_cls.fromguess = classmethod(fromguess)
+    video_cls._bazarr_fromguess_patched = True
+
+
+for _video_cls in (subliminal.video.Episode, subliminal.video.Movie):
+    # Checked on the class itself, not through inheritance: Episode and Movie
+    # share a base, so getattr would report the second one as already patched.
+    if not _video_cls.__dict__.get('_bazarr_fromguess_patched', False):
+        _patch_fromguess(_video_cls)
+
 # add our own list_all_subtitles
 subliminal.list_all_subtitles = subliminal.core.list_all_subtitles = list_all_subtitles

--- a/tests/bazarr/test_ci_guard_list.py
+++ b/tests/bazarr/test_ci_guard_list.py
@@ -255,20 +255,7 @@ EXCLUDED = {
     # Currently failing for reasons that are not network flakiness. Each needs a
     # fix, not an exemption; the reason names what is wrong so it cannot be
     # forgotten again.
-    "tests/subliminal_patch/test_video.py": (
-        "three failures, none of them a network problem, and none of them what "
-        "this entry claimed until now. test_video_fromguess_episode and "
-        "test_video_fromguess_movie hand fromguess a guess dict with no title "
-        "key, so subliminal raises GuessingError, 'Insufficient data to process "
-        "the guess', before any attribute is assigned: the tests are wrong, not "
-        "the code. Only test_video_fromname_movie is a dropped attribute, "
-        "video.other is None where it expects 'Proper', and it is dropped by "
-        "fromguess: Video.fromname is one line, `return cls.fromguess(name, "
-        "guessit(name))`, and Movie.fromguess never passes `other` through. "
-        "Written the other way round here twice; the direction is fromname to "
-        "fromguess, so a reader sent to fromname will find nothing to fix."
-    ),
-    # These two are fully requests_mock-ed, so they are deterministic and touch
+    # These are fully requests_mock-ed, so they are deterministic and touch
     # no network, and they still fail for a real reason: a product bug in
     # CFSession. Excluded only so the guard-list backfill is not blocked by it.
     #

--- a/tests/subliminal_patch/test_video.py
+++ b/tests/subliminal_patch/test_video.py
@@ -1,25 +1,67 @@
+from guessit import guessit
 from subliminal import Episode, Movie
+from subliminal_patch import subtitle
 from subliminal_patch.video import Video
 
 
 def test_video_fromguess_episode():
+    # subliminal's Episode.fromguess refuses a guess without a title or an
+    # episode number, so both keys are part of the minimum a caller must hand
+    # it. Without them this never reached an assertion, it raised GuessingError.
     video = Video.fromguess(
         "Breaking.Bad.S01E01.Bluray.mkv",
-        {"type": "episode", "streaming_service": "foo", "random_key": "bar"},
+        {
+            "type": "episode",
+            "title": "Breaking Bad",
+            "season": 1,
+            "episode": 1,
+            "streaming_service": "foo",
+            "random_key": "bar",
+        },
     )
     assert video.streaming_service == "foo"
     assert video.other is None
     assert isinstance(video, Episode)
 
 
+def test_video_fromguess_episode_keeps_other():
+    video = Video.fromguess(
+        "Breaking.Bad.S01E01.Proper.Bluray.mkv",
+        {
+            "type": "episode",
+            "title": "Breaking Bad",
+            "season": 1,
+            "episode": 1,
+            "other": "Proper",
+        },
+    )
+    assert video.other == "Proper"
+
+
 def test_video_fromguess_movie():
+    # Movie.fromguess needs a title for the same reason.
     video = Video.fromguess(
         "Taxi.Driver.1976.Bluray.mkv",
-        {"type": "movie", "edition": "foo", "random_key": "bar", "other": "Proper"},
+        {
+            "type": "movie",
+            "title": "Taxi Driver",
+            "edition": "foo",
+            "random_key": "bar",
+            "other": "Proper",
+        },
     )
     assert video.edition == "foo"
     assert video.other == "Proper"
     assert isinstance(video, Movie)
+
+
+def test_video_fromguess_movie_without_optional_keys():
+    video = Video.fromguess(
+        "Taxi.Driver.1976.Bluray.mkv",
+        {"type": "movie", "title": "Taxi Driver"},
+    )
+    assert video.edition is None
+    assert video.other is None
 
 
 def test_video_fromname_episode():
@@ -46,3 +88,47 @@ def test_video_fromname_movie():
     assert video.resolution == "2160p"
     assert video.video_codec == "H.265"
     assert video.audio_codec == "FLAC"
+
+
+def test_video_fromname_movie_edition():
+    video = Video.fromname(
+        "Some.Flick.2022.Directors.Cut.1080p.BluRay.x264-FOO.mkv"
+    )
+
+    assert video.edition == "Director's Cut"
+
+
+# Edition is worth 30 points on a movie, so dropping it did not only lose an
+# attribute: guess_matches treats "neither side names an edition" as a match,
+# and with the video side always empty that fired for every edition-less
+# subtitle. These pin the scoring input rather than the attribute alone.
+def test_edition_less_subtitle_does_not_match_edition_tagged_movie():
+    video = Video.fromname(
+        "Some.Flick.2022.Directors.Cut.1080p.BluRay.x264-FOO.mkv"
+    )
+    matches = subtitle.guess_matches(
+        video, guessit("Some.Flick.2022.1080p.BluRay.x264-FOO.mkv")
+    )
+
+    assert "edition" not in matches
+
+
+def test_same_edition_subtitle_still_matches_edition_tagged_movie():
+    video = Video.fromname(
+        "Some.Flick.2022.Directors.Cut.1080p.BluRay.x264-FOO.mkv"
+    )
+    matches = subtitle.guess_matches(
+        video, guessit("Some.Flick.2022.Directors.Cut.1080p.BluRay.x264-BAR.mkv")
+    )
+
+    assert "edition" in matches
+
+
+def test_edition_less_movie_is_unaffected():
+    video = Video.fromname("Some.Flick.2022.1080p.BluRay.x264-FOO.mkv")
+    matches = subtitle.guess_matches(
+        video, guessit("Some.Flick.2022.1080p.BluRay.x264-BAR.mkv")
+    )
+
+    assert video.edition is None
+    assert "edition" in matches


### PR DESCRIPTION
## What

`Video.fromname` is one line: `return cls.fromguess(name, guessit(name))`. `Episode.fromguess` and `Movie.fromguess` build the video from a whitelist of guess keys, and `edition` and `other` were not on it, so both were silently dropped for every video Bazarr constructs from a filename.

That matters for scoring. `edition` is one of the match keys, and `_check_optional` counts "neither side names one" as a match, so an attribute that is permanently empty on the video matched every subtitle. A subtitle for the theatrical cut scored an edition match against a director's cut file, and vice versa.

## Why the exclusion goes with it

`tests/subliminal_patch/test_video.py` was in the CI guard's exclusion list with a long note about three failures. Only one of them was this bug; the other two were tests handing `fromguess` a guess dict with no `title`, which makes subliminal raise `GuessingError` before any attribute is assigned. Those two tests were wrong, not the code, and they are corrected here. The file now runs in CI, so the exclusion is gone: the guard refuses a file that is both excluded and enumerated.

## Tests

`tests/subliminal_patch/test_video.py` runs in CI for the first time, all ten passing, including the attribute pass-through for both episodes and movies.

Full backend suite green locally (1561 passed), ruff clean.