### PR TITLE
fix(archives): match subtitle members case-insensitively and accept the canonical extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
             tests/bazarr/test_provider_hub.py \
             tests/bazarr/test_provider_hub_auto_install_optin.py \
             tests/bazarr/test_provider_hub_archive_select.py \
+            tests/bazarr/test_archive_member_matching.py \
             tests/bazarr/test_provider_hub_worker_timeout.py \
             tests/bazarr/test_arr_instances_schema.py \
             tests/bazarr/test_arr_ownership_columns.py \

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -13,6 +13,11 @@ from subliminal_patch.subtitle import Subtitle
 
 logger = logging.getLogger(__name__)
 
+# What counts as a subtitle member of a provider archive. One list, read by both the
+# member listing a plugin language-pins from and the selector that picks among them:
+# the two used to filter for themselves and disagree about the same archive.
+ARCHIVE_MEMBER_EXTENSIONS = (".srt", ".sub", ".ssa", ".ass", ".vtt")
+
 
 class WorkerProtocolError(ValueError):
     """Raised when a provider worker response violates the V1 ABI."""
@@ -319,16 +324,15 @@ def _guard_archive_members(archive) -> None:
 
 
 def _list_archive_members(archive):
-    """Member names offered to the worker for language selection: subtitle files only,
-    excluding dotfiles. Extraction guards (_guard_archive_members) still apply on read."""
-    names = []
-    for name in archive.namelist():
-        base = name.rsplit("/", 1)[-1]
-        if not base or base.startswith("."):
-            continue
-        if name.lower().endswith((".srt", ".sub", ".ssa", ".ass", ".vtt")):
-            names.append(name)
-    return names
+    """Member names offered to the worker for language selection.
+
+    Deliberately the same call the selector uses, so the list a plugin pins from and
+    the list the picker chooses from can never disagree about a given archive.
+    Extraction guards (_guard_archive_members) still apply on read.
+    """
+    from subliminal_patch.providers.utils import list_subtitle_members
+
+    return list_subtitle_members(archive, ARCHIVE_MEMBER_EXTENSIONS)
 
 
 _SEVEN_ZIP_MAGIC = b"7z\xbc\xaf\x27\x1c"
@@ -437,7 +441,7 @@ def _worker_archive_to_content(
             episode=episode,
             episode_title=payload.get("episode_title"),
             get_first_subtitle=bool(payload.get("first_subtitle")),
-            extensions=(".srt", ".sub", ".ssa", ".ass", ".vtt"),
+            extensions=ARCHIVE_MEMBER_EXTENSIONS,
         )
         if picked is None:
             raise WorkerProtocolError("download.archive_b64 has no usable subtitle member")

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -4,19 +4,24 @@ from __future__ import annotations
 import base64
 import hashlib
 import logging
+import os
 
 from typing import Any
 
 from subzero.language import Language
 from subliminal.video import Episode, Movie
+from subliminal_patch.core import SUBTITLE_EXTENSIONS
 from subliminal_patch.subtitle import Subtitle
 
 logger = logging.getLogger(__name__)
 
-# What counts as a subtitle member of a provider archive. One list, read by both the
-# member listing a plugin language-pins from and the selector that picks among them:
-# the two used to filter for themselves and disagree about the same archive.
-ARCHIVE_MEMBER_EXTENSIONS = (".srt", ".sub", ".ssa", ".ass", ".vtt")
+# What counts as a subtitle member of a provider archive. There is exactly one such
+# list in the codebase and this is a reference to it, not a copy: the hub used to
+# accept five of the eight and reject the MicroDVD .txt members several ex-Yugoslav
+# providers ship, throttling the provider on every attempt. Ambiguity in .txt is
+# handled by the selector (see utils.AMBIGUOUS_SUBTITLE_EXTENSIONS), not by
+# narrowing the list here.
+ARCHIVE_MEMBER_EXTENSIONS = SUBTITLE_EXTENSIONS
 
 
 class WorkerProtocolError(ValueError):
@@ -251,13 +256,52 @@ def candidate_from_worker(provider_name: str, payload: dict[str, Any]) -> HubWor
     return subtitle
 
 
-_SUBTITLE_FORMATS = {"srt": "srt", "ass": "ass", "ssa": "ass", "vtt": "vtt", "sub": "microdvd"}
+# Every extension ARCHIVE_MEMBER_EXTENSIONS admits maps to a pysubs2 format
+# identifier. An extension missing here resolves to nothing and the caller falls
+# back to "srt", which writes the member's bytes into a file claiming to be SubRip.
+_SUBTITLE_FORMATS = {
+    "srt": "srt",
+    "ass": "ass",
+    "ssa": "ass",
+    "vtt": "vtt",
+    "sub": "microdvd",
+    "smi": "sami",
+    "mpl": "mpl2",
+    # A .txt member is whatever the uploader put in it: MicroDVD on the ex-Yugoslav
+    # providers, TMP elsewhere. The extension is only the fallback; the content
+    # decides. See _format_from_member.
+    "txt": "tmp",
+}
+
+# Extensions whose format the name does not settle, so the bytes are sniffed instead.
+_AMBIGUOUS_FORMAT_EXTENSIONS = frozenset({"txt"})
 
 
-def _format_from_member(name: str | None) -> str | None:
+def _sniffed_format(content: bytes | None) -> str | None:
+    """The subtitle format pysubs2 reads out of ``content``, or None.
+
+    Best effort by design: an undetectable member falls back to its extension
+    rather than failing the download.
+    """
+    if not content:
+        return None
+    try:
+        from pysubs2.formats import autodetect_format
+
+        return autodetect_format(content.decode("utf-8", "replace"))
+    except Exception:
+        return None
+
+
+def _format_from_member(name: str | None, content: bytes | None = None) -> str | None:
     if not name or "." not in name:
         return None
-    return _SUBTITLE_FORMATS.get(name.rsplit(".", 1)[-1].lower())
+    extension = name.rsplit(".", 1)[-1].lower()
+    if extension in _AMBIGUOUS_FORMAT_EXTENSIONS:
+        sniffed = _sniffed_format(content)
+        if sniffed:
+            return sniffed
+    return _SUBTITLE_FORMATS.get(extension)
 
 
 def worker_download_to_content(
@@ -335,6 +379,33 @@ def _list_archive_members(archive):
     return list_subtitle_members(archive, ARCHIVE_MEMBER_EXTENSIONS)
 
 
+def _is_safe_extracted_file(full_path: str, safe_root: str) -> bool:
+    """Reject anything that is not a regular file inside the extraction directory.
+
+    An archive member is attacker-controlled: a hostile provider can ship a symlink
+    named like a subtitle and pointed at any file this process can read. os.walk()
+    does not descend into symlinked directories, but a symlinked file still shows up
+    in ``files`` and opening it reads the link target, so the subtitle Bazarr writes
+    next to the video would be the host's own config.
+    """
+    if os.path.islink(full_path):
+        logger.warning("provider_hub: skipping symlink member in archive: %s", full_path)
+        return False
+
+    real_path = os.path.realpath(full_path)
+    if real_path != safe_root and not real_path.startswith(safe_root + os.sep):
+        logger.warning(
+            "provider_hub: skipping archive member escaping the temp directory: %s", full_path
+        )
+        return False
+
+    if not os.path.isfile(real_path):
+        logger.warning("provider_hub: skipping non-regular archive member: %s", full_path)
+        return False
+
+    return True
+
+
 _SEVEN_ZIP_MAGIC = b"7z\xbc\xaf\x27\x1c"
 
 
@@ -366,6 +437,7 @@ class _SevenZipArchive:
         import tempfile
 
         with tempfile.TemporaryDirectory() as tmp:
+            safe_root = os.path.realpath(tmp)
             with self._open() as archive:
                 archive.extract(path=tmp, targets=[name])
             # py7zr preserves the archived file's mode, which can drop the owner read
@@ -378,6 +450,8 @@ class _SevenZipArchive:
                         pass
                 for filename in files:
                     path = os.path.join(root, filename)
+                    if not _is_safe_extracted_file(path, safe_root):
+                        continue
                     try:
                         os.chmod(path, 0o600)
                     except OSError:  # pragma: no cover
@@ -478,11 +552,17 @@ def _worker_archive_to_content(
         chosen = payload.get("filename") or ""
 
     subtitle.content = content
-    # Prefer the chosen member's actual extension over a worker-supplied format:
-    # the worker's format can be stale/wrong (e.g. an SRT member labeled "vtt"),
-    # which would otherwise save SRT bytes to a .vtt file. Fall back to the
-    # worker format, then the existing one.
-    subtitle.format = _format_from_member(chosen) or payload.get("format") or getattr(subtitle, "format", "srt")
+    # Prefer what the member actually is over a worker-supplied format: the worker's
+    # format can be stale or wrong (e.g. an SRT member labeled "vtt"), which would
+    # otherwise save SRT bytes to a .vtt file. The episode picker does not report
+    # which member it chose, so when the name is unknown the bytes decide. Fall back
+    # to the worker format, then the existing one.
+    subtitle.format = (
+        _format_from_member(chosen, content)
+        or _sniffed_format(content)
+        or payload.get("format")
+        or getattr(subtitle, "format", "srt")
+    )
     # Clear any encoding carried over from search (e.g. via the display attribute splat)
     # so Subtitle.normalize()/chardet detects it from the extracted bytes, the same as
     # native subliminal providers; do not let a stale or worker-supplied guess pin it.

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -1347,6 +1347,18 @@ def get_subtitle_path(video_path, language=None, extension='.srt', forced_tag=Fa
     return subtitle_root + extension
 
 
+# pysubs2 names a format, the filesystem names a file, and the two vocabularies
+# do not match: pysubs2 calls SAMI "sami" and MPL2 "mpl2" while the files are
+# .smi and .mpl. Saving under the parser's name produces an extension nothing in
+# Bazarr indexes, so the subtitle it just downloaded still reads as missing.
+SUBTITLE_FORMAT_EXTENSIONS = {
+    "sami": "smi",
+    "mpl2": "mpl",
+    "microdvd": "sub",
+    "tmp": "txt",
+}
+
+
 def save_subtitles(file_path, subtitles, single=False, directory=None, chmod=None, formats=("srt",),
                    tags=None, path_decoder=None, debug_mods=False):
     """Save subtitles on filesystem.
@@ -1413,8 +1425,9 @@ def save_subtitles(file_path, subtitles, single=False, directory=None, chmod=Non
         subtitle.storage_path = subtitle_path
 
         for format in formats:
-            if format != "srt":
-                subtitle_path = os.path.splitext(subtitle_path)[0] + (u".%s" % format)
+            extension = SUBTITLE_FORMAT_EXTENSIONS.get(format, format)
+            if extension != "srt":
+                subtitle_path = os.path.splitext(subtitle_path)[0] + (u".%s" % extension)
 
             logger.debug(u"Saving %r to %r", subtitle, subtitle_path)
             content = subtitle.get_modified_content(format=format, debug=debug_mods)

--- a/custom_libs/subliminal_patch/providers/utils.py
+++ b/custom_libs/subliminal_patch/providers/utils.py
@@ -26,6 +26,12 @@ logger = logging.getLogger(__name__)
 
 _MatchingSub = namedtuple("_MatchingSub", ("file", "priority", "context"))
 
+# Extensions the codebase calls a subtitle but which a scene archive also uses for
+# something else. A release-info text file sits next to the subtitle in the same
+# archive, and the movie selector takes the first match and stops, so an ambiguous
+# member is only ever considered when the archive holds nothing better.
+AMBIGUOUS_SUBTITLE_EXTENSIONS = (".txt",)
+
 # The conservative default for the built-in providers. Callers that want the whole
 # canonical set pass subliminal_patch.core.SUBTITLE_EXTENSIONS explicitly rather
 # than growing their own copy of it.
@@ -62,8 +68,19 @@ def list_subtitle_members(archive, extensions=DEFAULT_ARCHIVE_EXTENSIONS):
     picks from both come from here, so the two can never disagree about a given
     archive the way they did when each filtered for itself.
 
+    Members whose extension is ambiguous are dropped while an unambiguous one is
+    present, and returned only when they are all there is.
     """
-    return [name for name in archive.namelist() if is_subtitle_member(name, extensions)]
+    unambiguous = []
+    ambiguous = []
+    for name in archive.namelist():
+        if not is_subtitle_member(name, extensions):
+            continue
+        if os.path.splitext(name)[1].lower() in AMBIGUOUS_SUBTITLE_EXTENSIONS:
+            ambiguous.append(name)
+        else:
+            unambiguous.append(name)
+    return unambiguous or ambiguous
 
 
 def _archive_member_names(archive):

--- a/custom_libs/subliminal_patch/providers/utils.py
+++ b/custom_libs/subliminal_patch/providers/utils.py
@@ -14,7 +14,7 @@ import rarfile
 from subliminal.subtitle import fix_line_ending
 from subliminal.utils import sanitize_release_group
 from subliminal_patch.exceptions import MustGetBlacklisted
-from subliminal_patch.core import Episode
+from subliminal_patch.core import SUBTITLE_EXTENSIONS, Episode
 from subliminal_patch.subtitle import guess_matches
 
 from ._agent_list import FIRST_THOUSAND_OR_SO_USER_AGENTS
@@ -25,6 +25,54 @@ logger = logging.getLogger(__name__)
 
 
 _MatchingSub = namedtuple("_MatchingSub", ("file", "priority", "context"))
+
+# The conservative default for the built-in providers. Callers that want the whole
+# canonical set pass subliminal_patch.core.SUBTITLE_EXTENSIONS explicitly rather
+# than growing their own copy of it.
+DEFAULT_ARCHIVE_EXTENSIONS = (".srt", ".sub", ".ssa", ".ass")
+
+
+def is_subtitle_member(name, extensions=DEFAULT_ARCHIVE_EXTENSIONS):
+    """Whether an archive member is a subtitle file we are willing to extract.
+
+    The extension is compared on its own and case-insensitively, so a member named
+    ``MOVIE.SRT`` matches. Only the extension is lowercased: the rest of the member
+    name carries the language and the HI/forced tags, and a lowercased copy bleeding
+    into that parsing is how a name resolves as a language it never claimed. For the
+    same reason this never substring-tests the whole name.
+
+    Directories and dot-prefixed members (``.DS_Store``, the ``__MACOSX/._name``
+    resource forks zip adds) are not subtitles.
+    """
+    if not name:
+        return False
+    base = name.replace("\\", "/").rsplit("/", 1)[-1]
+    if not base or base.startswith("."):
+        return False
+    return os.path.splitext(base)[1].lower() in tuple(
+        extension.lower() for extension in extensions
+    )
+
+
+def list_subtitle_members(archive, extensions=DEFAULT_ARCHIVE_EXTENSIONS):
+    """The subtitle members of ``archive``, in archive order.
+
+    Single source of truth for "what counts as a subtitle member in this archive":
+    the list offered to a plugin for language selection and the list the selector
+    picks from both come from here, so the two can never disagree about a given
+    archive the way they did when each filtered for itself.
+
+    """
+    return [name for name in archive.namelist() if is_subtitle_member(name, extensions)]
+
+
+def _archive_member_names(archive):
+    """Member names for a log line, best effort: a broken archive must not turn a
+    failed extraction into a traceback."""
+    try:
+        return list(archive.namelist())
+    except Exception:  # pragma: no cover - exotic archive objects
+        return []
 
 
 def blacklist_on(*exc_types):
@@ -114,18 +162,18 @@ def get_subtitle_from_archive(
     forced=False,
     episode=None,
     get_first_subtitle=False,
-    extensions=(".srt", ".sub", ".ssa", ".ass"),
+    extensions=DEFAULT_ARCHIVE_EXTENSIONS,
     **kwargs,
 ):
     "Get subtitle from Rarfile/Zipfile object. Return None if nothing is found."
-    subs_in_archive = [
-        name
-        for name in archive.namelist()
-        if name.endswith(tuple(extensions))
-    ]
+    subs_in_archive = list_subtitle_members(archive, extensions)
 
     if not subs_in_archive:
-        logger.info("No subtitles found in archive")
+        # Name the members: without them a user whose download failed here has no
+        # way to tell an archive full of the wrong extensions from a broken one.
+        logger.warning(
+            "No subtitles found in archive. Members: %s", _archive_member_names(archive)
+        )
         return None
 
     logger.debug("Subtitles in archive: %s", subs_in_archive)
@@ -140,7 +188,9 @@ def get_subtitle_from_archive(
         logger.info("Using %s from archive", matching_sub)
         return fix_line_ending(archive.read(matching_sub))
 
-    logger.debug("No subtitle found in archive")
+    logger.warning(
+        "No subtitle in archive matched this episode. Members: %s", subs_in_archive
+    )
     return None
 
 

--- a/custom_libs/subliminal_patch/providers/utils.py
+++ b/custom_libs/subliminal_patch/providers/utils.py
@@ -68,8 +68,13 @@ def list_subtitle_members(archive, extensions=DEFAULT_ARCHIVE_EXTENSIONS):
     picks from both come from here, so the two can never disagree about a given
     archive the way they did when each filtered for itself.
 
-    Members whose extension is ambiguous are dropped while an unambiguous one is
-    present, and returned only when they are all there is.
+    Members whose extension is ambiguous come last, in archive order among
+    themselves. Last rather than absent: a caller that just takes the first
+    member gets the real subtitle instead of the release-info text file, which
+    is what the ordering is for, while language and episode matching can still
+    reach a .txt member. The ex-Yugoslav providers ship MicroDVD in .txt files,
+    so an archive holding movie.sr.txt beside movie.en.srt is a real shape and
+    the .txt is the only copy of that language.
     """
     unambiguous = []
     ambiguous = []
@@ -80,7 +85,7 @@ def list_subtitle_members(archive, extensions=DEFAULT_ARCHIVE_EXTENSIONS):
             ambiguous.append(name)
         else:
             unambiguous.append(name)
-    return unambiguous or ambiguous
+    return unambiguous + ambiguous
 
 
 def _archive_member_names(archive):

--- a/tests/bazarr/test_archive_member_matching.py
+++ b/tests/bazarr/test_archive_member_matching.py
@@ -248,14 +248,39 @@ def test_release_info_text_file_never_wins_over_a_real_subtitle_in_archive_order
     assert sub.format == "srt"
 
 
-def test_ambiguous_member_is_dropped_while_an_unambiguous_one_exists():
+def test_ambiguous_member_is_ordered_last_rather_than_dropped():
+    """A .txt member is usually release info, so it must never win the pick that
+    just takes the first member. Dropping it outright is a different thing and
+    the wrong one: this same list is what language and episode matching sees, so
+    an archive of movie.sr.txt beside movie.en.srt would lose its Serbian
+    subtitle entirely.
+    """
     archive = _archive([("info.txt", b"release info"), ("movie.srt", _SRT)])
-    assert utils.list_subtitle_members(archive, SUBTITLE_EXTENSIONS) == ["movie.srt"]
+    assert utils.list_subtitle_members(archive, SUBTITLE_EXTENSIONS) == ["movie.srt", "info.txt"]
 
 
 def test_ambiguous_member_is_used_when_it_is_all_there_is():
     archive = _archive([("info.txt", _MICRODVD)])
     assert utils.list_subtitle_members(archive, SUBTITLE_EXTENSIONS) == ["info.txt"]
+
+
+def test_a_language_tagged_text_member_survives_beside_a_real_subtitle():
+    """The ex-Yugoslav providers ship MicroDVD in .txt files, so a mixed archive
+    is a real shape and the .txt is the only copy of that language."""
+    archive = _archive([("movie.sr.txt", _MICRODVD), ("movie.en.srt", _SRT)])
+
+    members = utils.list_subtitle_members(archive, SUBTITLE_EXTENSIONS)
+
+    assert "movie.sr.txt" in members
+    assert members[0] == "movie.en.srt"
+
+
+def test_the_hub_offers_the_text_member_for_language_selection():
+    members = proto._list_archive_members(
+        get_archive_from_bytes(_zip([("movie.sr.txt", _MICRODVD), ("movie.en.srt", _SRT)]))
+    )
+
+    assert sorted(members) == ["movie.en.srt", "movie.sr.txt"]
 
 
 # --------------------------------------------------------------------------
@@ -306,3 +331,45 @@ def test_extracted_file_guard_rejects_symlinks_and_escapes(tmp_path):
     link = os.path.join(root, "link.srt")
     os.symlink(str(outside), link)
     assert not proto._is_safe_extracted_file(link, root)
+
+
+# --------------------------------------------------------------------------
+# The pysubs2 format identifier is not a filename extension.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("subtitle_format,expected_suffix", [
+    ("sami", ".smi"),
+    ("mpl2", ".mpl"),
+    ("microdvd", ".sub"),
+    ("tmp", ".txt"),
+    ("ass", ".ass"),
+    ("vtt", ".vtt"),
+])
+def test_saving_uses_the_file_extension_not_the_parser_name(tmp_path, subtitle_format, expected_suffix):
+    """save_subtitles uses the format both to render the content and to name the
+    file. They are not the same vocabulary: pysubs2 calls SAMI "sami" and MPL2
+    "mpl2", so preserving the original format wrote Film.en.sami, which is not a
+    subtitle extension Bazarr indexes and the download reads as still missing.
+    """
+    from subliminal_patch.core import save_subtitles
+    from subzero.language import Language
+
+    video = tmp_path / "Film.mkv"
+    video.write_bytes(b"")
+
+    class _Subtitle:
+        language = Language("eng")
+        mods = None
+        text = "Hello"
+        content = b"Hello"
+        format = subtitle_format
+        storage_path = None
+
+        def get_modified_content(self, format=None, debug=False):
+            return b"payload"
+
+    save_subtitles(str(video), [_Subtitle()], formats={subtitle_format})
+
+    written = sorted(p.name for p in tmp_path.iterdir() if p.suffix != ".mkv")
+    assert written == [f"Film.en{expected_suffix}"]

--- a/tests/bazarr/test_archive_member_matching.py
+++ b/tests/bazarr/test_archive_member_matching.py
@@ -1,0 +1,143 @@
+# coding=utf-8
+"""Archive member matching: case-insensitive extensions, one source of truth for
+what counts as a subtitle member, and the widened extension set.
+
+Two behaviours are guarded here.
+
+1. Members are matched on their extension alone, compared case-insensitively, so
+   an archive whose only subtitle is named ``MOVIE.SRT`` still extracts. The rest
+   of the member name is never lowercased: callers parse language and HI/forced
+   tags out of it, and a lowercased copy leaking into that parsing is how
+   ``Elephant.hi.srt`` ends up resolving as a language it never claimed.
+
+2. The member list a plugin language-pins from and the member the selector picks
+   come from one call, so the two can never disagree about a given archive.
+"""
+import base64
+import hashlib
+import io
+import logging
+import zipfile
+
+import pytest
+
+import provider_hub.protocol as proto
+from subliminal_patch.core import SUBTITLE_EXTENSIONS
+from subliminal_patch.providers import utils
+from subliminal_patch.providers.utils import get_archive_from_bytes
+
+_SRT = b"1\n00:00:01,000 --> 00:00:02,000\nHello\n\n"
+
+
+def _zip(members):
+    """``members`` is an ordered sequence of ``(name, payload)`` pairs."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        for name, payload in members:
+            archive.writestr(name, payload)
+    return buf.getvalue()
+
+
+def _archive(members):
+    return get_archive_from_bytes(_zip(members))
+
+
+class _Sub:
+    class language:
+        forced = False
+
+    content = None
+    format = "srt"
+    encoding = None
+    _guessed_encoding = None
+
+
+def _download(body, **extra):
+    payload = {
+        "archive_b64": base64.b64encode(body).decode("ascii"),
+        "archive_sha256": hashlib.sha256(body).hexdigest(),
+    }
+    payload.update(extra)
+    sub = _Sub()
+    proto.worker_download_to_content(sub, payload)
+    return sub
+
+
+# --------------------------------------------------------------------------
+# Case-insensitive member matching
+# --------------------------------------------------------------------------
+
+
+def test_uppercase_extension_member_is_extracted():
+    # Older uploads on several providers ship the subtitle as .SRT. A
+    # case-sensitive comparison misses it, the download raises, and the provider
+    # is throttled for ten minutes.
+    archive = _archive([("MOVIE.SRT", _SRT)])
+    assert utils.get_subtitle_from_archive(archive) is not None
+
+
+@pytest.mark.parametrize("name", ["Movie.SRT", "Movie.Ass", "Movie.VtT", "Movie.SuB"])
+def test_mixed_case_extensions_are_matched(name):
+    assert utils.is_subtitle_member(name, SUBTITLE_EXTENSIONS)
+
+
+def test_extension_is_matched_in_isolation_not_by_substring():
+    # Lowercasing the whole name and substring-testing it is how a video named
+    # "Elephant" made "Elephant.hi.srt" resolve as Chinese Traditional. Only the
+    # extension may take part in the comparison.
+    assert not utils.is_subtitle_member("Trailer.srt.mkv", SUBTITLE_EXTENSIONS)
+    assert not utils.is_subtitle_member("srt", SUBTITLE_EXTENSIONS)
+    assert not utils.is_subtitle_member("Making.Of.assets.mp4", SUBTITLE_EXTENSIONS)
+
+
+def test_matched_member_name_keeps_its_original_case():
+    # The picked name feeds language/HI/forced parsing and the format lookup, so
+    # it must come back byte-identical to the archive entry.
+    archive = _archive([("Elephant.HI.SRT", _SRT)])
+    assert utils.list_subtitle_members(archive, SUBTITLE_EXTENSIONS) == ["Elephant.HI.SRT"]
+
+
+def test_hub_download_extracts_uppercase_member():
+    sub = _download(_zip([("MOVIE.SRT", _SRT)]))
+    assert b"Hello" in sub.content
+
+
+# --------------------------------------------------------------------------
+# One source of truth: the listing path and the selection path must agree
+# --------------------------------------------------------------------------
+
+
+def test_listing_and_selection_agree_on_members():
+    members = [
+        ("Show.S01E01.ENG.SRT", _SRT),
+        ("show.s01e01.fre.srt", _SRT),
+        (".hidden.srt", _SRT),
+        ("notes.txt", b"release info"),
+        ("poster.jpg", b"binary"),
+    ]
+    archive = _archive(members)
+    listed = proto._list_archive_members(archive)
+    selectable = utils.list_subtitle_members(archive, proto.ARCHIVE_MEMBER_EXTENSIONS)
+    assert listed == selectable
+    assert listed == ["Show.S01E01.ENG.SRT", "show.s01e01.fre.srt"]
+
+
+
+
+# --------------------------------------------------------------------------
+# Diagnosability: a failed extraction must name the members it saw
+# --------------------------------------------------------------------------
+
+
+def test_failed_extraction_logs_the_member_names(caplog):
+    archive = _archive([("poster.jpg", b"binary"), ("Trailer.mkv", b"binary")])
+    with caplog.at_level(logging.INFO, logger="subliminal_patch.providers.utils"):
+        assert utils.get_subtitle_from_archive(archive) is None
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert "poster.jpg" in logged
+    assert "Trailer.mkv" in logged
+
+
+def test_archive_without_any_subtitle_member_still_fails_loudly():
+    with pytest.raises(proto.WorkerProtocolError):
+        _download(_zip([("poster.jpg", b"binary")]))

--- a/tests/bazarr/test_archive_member_matching.py
+++ b/tests/bazarr/test_archive_member_matching.py
@@ -10,13 +10,16 @@ Two behaviours are guarded here.
    tags out of it, and a lowercased copy leaking into that parsing is how
    ``Elephant.hi.srt`` ends up resolving as a language it never claimed.
 
-2. The member list a plugin language-pins from and the member the selector picks
-   come from one call, so the two can never disagree about a given archive.
+2. The Provider Hub accepts the same eight extensions the rest of the codebase
+   calls a subtitle. ``.txt`` is admitted but treated as ambiguous: scene
+   archives ship release-info text files, so a ``.txt`` member is only ever
+   used when the archive holds nothing better.
 """
 import base64
 import hashlib
 import io
 import logging
+import os
 import zipfile
 
 import pytest
@@ -27,6 +30,14 @@ from subliminal_patch.providers import utils
 from subliminal_patch.providers.utils import get_archive_from_bytes
 
 _SRT = b"1\n00:00:01,000 --> 00:00:02,000\nHello\n\n"
+_MICRODVD = b"{0}{25}Hello|World\n{26}{50}Bye\n"
+_MPL2 = b"[0][10] Hello\n[11][20] Bye\n"
+_SAMI = (
+    b"<SAMI><BODY>\n"
+    b'<SYNC Start=0><P Class=ENUSCC>Hello\n'
+    b'<SYNC Start=2000><P Class=ENUSCC>&nbsp;\n'
+    b"</BODY></SAMI>\n"
+)
 
 
 def _zip(members):
@@ -119,9 +130,33 @@ def test_listing_and_selection_agree_on_members():
     listed = proto._list_archive_members(archive)
     selectable = utils.list_subtitle_members(archive, proto.ARCHIVE_MEMBER_EXTENSIONS)
     assert listed == selectable
-    assert listed == ["Show.S01E01.ENG.SRT", "show.s01e01.fre.srt"]
 
 
+def test_hub_uses_the_canonical_extension_list():
+    assert tuple(proto.ARCHIVE_MEMBER_EXTENSIONS) == tuple(SUBTITLE_EXTENSIONS)
+
+
+def test_no_module_reintroduces_its_own_extension_copy():
+    # A caller that hardcodes its own tuple is exactly how the listing path and
+    # the selection path drifted apart. Fail if one comes back.
+    import re
+
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    literal = re.compile(
+        r"""["']\.(srt|sub|smi|ssa|ass|mpl|vtt)["']\s*,\s*["']\.(srt|sub|smi|ssa|ass|mpl|vtt)["']"""
+    )
+    targets = [os.path.join(root, "bazarr", "subtitles", "tools", "archives.py")]
+    for dirpath, _dirnames, filenames in os.walk(os.path.join(root, "bazarr", "provider_hub")):
+        targets.extend(
+            os.path.join(dirpath, name) for name in filenames if name.endswith(".py")
+        )
+
+    offenders = []
+    for path in targets:
+        with open(path, encoding="utf-8") as handle:
+            if literal.search(handle.read()):
+                offenders.append(os.path.relpath(path, root))
+    assert not offenders, f"hardcoded subtitle-extension list in: {offenders}"
 
 
 # --------------------------------------------------------------------------
@@ -141,3 +176,133 @@ def test_failed_extraction_logs_the_member_names(caplog):
 def test_archive_without_any_subtitle_member_still_fails_loudly():
     with pytest.raises(proto.WorkerProtocolError):
         _download(_zip([("poster.jpg", b"binary")]))
+
+
+# --------------------------------------------------------------------------
+# Widened extension set, and the release-info text file guard
+# --------------------------------------------------------------------------
+
+
+def test_microdvd_text_member_extracts():
+    # ex-Yugoslav providers ship MicroDVD under a plain .txt extension.
+    sub = _download(_zip([("Film.2019.txt", _MICRODVD)]))
+    assert b"Hello" in sub.content
+
+
+def test_microdvd_text_member_keeps_its_real_format():
+    # Resolving .txt to nothing and defaulting to srt writes MicroDVD bytes into
+    # a file claiming to be SubRip.
+    sub = _download(_zip([("Film.2019.txt", _MICRODVD)]))
+    assert sub.format == "microdvd"
+
+
+@pytest.mark.parametrize(
+    "name,payload,expected_format",
+    [
+        ("Film.smi", _SAMI, "sami"),
+        ("Film.mpl", _MPL2, "mpl2"),
+        ("Film.vtt", b"WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHello\n", "vtt"),
+        ("Film.sub", _MICRODVD, "microdvd"),
+    ],
+)
+def test_newly_admitted_extensions_extract_and_map_to_their_format(
+    name, payload, expected_format
+):
+    # Member pinned by name, so the format comes from the extension table rather
+    # than from sniffing the bytes: an extension the table does not cover resolves
+    # to nothing and the member is saved claiming to be SubRip.
+    sub = _download(_zip([(name, payload)]), member=name)
+    assert sub.content is not None
+    assert sub.format == expected_format
+
+
+@pytest.mark.parametrize(
+    "payload,expected_format",
+    [(_MICRODVD, "microdvd"), (b"00:00:00:Hello\n00:00:05:Bye\n", "tmp")],
+)
+def test_text_member_format_comes_from_its_content(payload, expected_format):
+    # ".txt" names no format at all, so the bytes have to settle it. The two kinds
+    # that actually turn up under it must not be conflated.
+    sub = _download(_zip([("Film.txt", payload)]), member="Film.txt")
+    assert sub.format == expected_format
+
+
+def test_format_table_covers_every_admitted_extension():
+    for extension in SUBTITLE_EXTENSIONS:
+        assert proto._format_from_member("Film" + extension) is not None, extension
+
+
+def test_release_info_text_file_never_wins_over_a_real_subtitle_alphabetically():
+    # "aaa.txt" sorts first, the subtitle last. Nothing in the selector sorts today
+    # and this asserts nothing ever starts to.
+    sub = _download(_zip([("zzz.srt", _SRT), ("aaa.txt", b"release info")]))
+    assert b"Hello" in sub.content
+    assert sub.format == "srt"
+
+
+def test_release_info_text_file_never_wins_over_a_real_subtitle_in_archive_order():
+    # "zzz.txt" sorts last but comes first in the archive's own member order, which
+    # is what namelist() yields and what the movie selector would otherwise take.
+    sub = _download(_zip([("zzz.txt", b"release info"), ("movie.srt", _SRT)]))
+    assert b"Hello" in sub.content
+    assert sub.format == "srt"
+
+
+def test_ambiguous_member_is_dropped_while_an_unambiguous_one_exists():
+    archive = _archive([("info.txt", b"release info"), ("movie.srt", _SRT)])
+    assert utils.list_subtitle_members(archive, SUBTITLE_EXTENSIONS) == ["movie.srt"]
+
+
+def test_ambiguous_member_is_used_when_it_is_all_there_is():
+    archive = _archive([("info.txt", _MICRODVD)])
+    assert utils.list_subtitle_members(archive, SUBTITLE_EXTENSIONS) == ["info.txt"]
+
+
+# --------------------------------------------------------------------------
+# Widening what we accept from an untrusted download widens what reaches disk.
+# The 7z path is the only one that materialises a member on the filesystem.
+# --------------------------------------------------------------------------
+
+
+class _FakeSevenZip:
+    """Stands in for py7zr and restores the member as a symlink, the way a
+    hostile archive would if the library's own escape check were bypassed."""
+
+    def __init__(self, target):
+        self._target = target
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def extract(self, path=None, targets=None):
+        os.symlink(self._target, os.path.join(path, "movie.srt"))
+
+
+def test_seven_zip_symlink_member_is_not_followed(tmp_path, monkeypatch):
+    secret = tmp_path / "secret.conf"
+    secret.write_text("APIKEY=hunter2")
+
+    archive = proto._SevenZipArchive(b"")
+    monkeypatch.setattr(archive, "_open", lambda: _FakeSevenZip(str(secret)))
+
+    with pytest.raises(proto.WorkerProtocolError):
+        archive.read("movie.srt")
+
+
+def test_extracted_file_guard_rejects_symlinks_and_escapes(tmp_path):
+    root = str(tmp_path / "extracted")
+    os.makedirs(root)
+    outside = tmp_path / "outside.conf"
+    outside.write_text("APIKEY=hunter2")
+
+    regular = os.path.join(root, "movie.srt")
+    with open(regular, "wb") as handle:
+        handle.write(_SRT)
+    assert proto._is_safe_extracted_file(regular, root)
+
+    link = os.path.join(root, "link.srt")
+    os.symlink(str(outside), link)
+    assert not proto._is_safe_extracted_file(link, root)

--- a/tests/bazarr/test_provider_hub_archive_select.py
+++ b/tests/bazarr/test_provider_hub_archive_select.py
@@ -49,17 +49,16 @@ def _archive_payload(body, **extra):
 
 
 def test_list_archive_members_filters_to_subtitles():
-    # Design note: ".txt" IS now one of the extensions the hub accepts, because
-    # several providers ship MicroDVD subtitles under it. It stays out of this
-    # listing anyway, and that is the point of the change rather than an accident:
-    # ".txt" is treated as ambiguous, so it is dropped while any unambiguous
-    # subtitle member is present and offered only when it is all the archive has.
-    # The guard the assertion below used to provide (a release-info text file can
-    # never be picked ahead of the real subtitle) therefore still holds, but it now
-    # comes from the ambiguity rule instead of from ".txt" being rejected outright.
+    # Design note: ".txt" IS one of the extensions the hub accepts, because
+    # several providers ship MicroDVD subtitles under it, and the worker is the
+    # thing that can tell a Serbian subtitle from a release-info file by looking
+    # at the language tag. So it is offered, ordered last: the guard that a
+    # release-info file can never be picked ahead of a real subtitle comes from
+    # that ordering, not from withholding the member. Dot-files stay out.
     body = _zip(["a.eng.srt", "b.fre.srt", ".hidden.srt", "notes.txt"])
     archive = get_archive_from_bytes(body)
-    assert sorted(proto._list_archive_members(archive)) == ["a.eng.srt", "b.fre.srt"]
+    members = proto._list_archive_members(archive)
+    assert members == ["a.eng.srt", "b.fre.srt", "notes.txt"]
 
 
 def test_list_archive_members_offers_text_member_when_it_is_all_there_is():
@@ -157,16 +156,15 @@ def test_worker_runner_select_archive_member_coerces_bad_decision():
 
 
 def test_select_member_callback_receives_listed_members():
-    # Design note: see test_list_archive_members_filters_to_subtitles. "notes.txt"
-    # is an accepted extension now, and is still withheld from the worker here
-    # because two unambiguous members outrank it. The worker must not be handed a
-    # release-info text file to language-pin.
+    # Design note: see test_list_archive_members_filters_to_subtitles. The worker
+    # gets every member it could reasonably pin, ".txt" included and ordered
+    # last, because only the worker can tell movie.sr.txt from notes.txt.
     body = _zip(["show.eng.srt", "show.fre.srt", "notes.txt"])
     seen = {}
 
     def cb(members):
-        seen["members"] = sorted(members)
+        seen["members"] = list(members)
         return {"member": "show.eng.srt", "decision": "pin"}
 
     _run(body, _archive_payload(body, select_member=True), cb)
-    assert seen["members"] == ["show.eng.srt", "show.fre.srt"]
+    assert seen["members"] == ["show.eng.srt", "show.fre.srt", "notes.txt"]

--- a/tests/bazarr/test_provider_hub_archive_select.py
+++ b/tests/bazarr/test_provider_hub_archive_select.py
@@ -49,9 +49,25 @@ def _archive_payload(body, **extra):
 
 
 def test_list_archive_members_filters_to_subtitles():
+    # Design note: ".txt" IS now one of the extensions the hub accepts, because
+    # several providers ship MicroDVD subtitles under it. It stays out of this
+    # listing anyway, and that is the point of the change rather than an accident:
+    # ".txt" is treated as ambiguous, so it is dropped while any unambiguous
+    # subtitle member is present and offered only when it is all the archive has.
+    # The guard the assertion below used to provide (a release-info text file can
+    # never be picked ahead of the real subtitle) therefore still holds, but it now
+    # comes from the ambiguity rule instead of from ".txt" being rejected outright.
     body = _zip(["a.eng.srt", "b.fre.srt", ".hidden.srt", "notes.txt"])
     archive = get_archive_from_bytes(body)
     assert sorted(proto._list_archive_members(archive)) == ["a.eng.srt", "b.fre.srt"]
+
+
+def test_list_archive_members_offers_text_member_when_it_is_all_there_is():
+    # The other half of the same rule: with no unambiguous member the ".txt" is
+    # what the archive has, so the worker must get the chance to pin it.
+    body = _zip(["film.txt"])
+    archive = get_archive_from_bytes(body)
+    assert proto._list_archive_members(archive) == ["film.txt"]
 
 
 def test_select_member_pin_extracts_named_member():
@@ -141,6 +157,10 @@ def test_worker_runner_select_archive_member_coerces_bad_decision():
 
 
 def test_select_member_callback_receives_listed_members():
+    # Design note: see test_list_archive_members_filters_to_subtitles. "notes.txt"
+    # is an accepted extension now, and is still withheld from the worker here
+    # because two unambiguous members outrank it. The worker must not be handed a
+    # release-info text file to language-pin.
     body = _zip(["show.eng.srt", "show.fre.srt", "notes.txt"])
     seen = {}
 


### PR DESCRIPTION
## What

Two related archive-handling gaps.

**Case sensitivity.** Members were matched against a lowercase extension list, so `MOVIE.SRT` inside a ZIP was not recognised as a subtitle and the archive came back empty. Uppercase names are common in archives from Windows tooling.

**Extensions.** Only a subset of the subtitle formats Bazarr can read were accepted from archives, so a provider shipping MicroDVD or one of the other canonical formats produced nothing, with no message saying why.

## Tests

Covered in the archive extraction and Provider Hub archive tests, both already enumerated in CI: mixed-case member names resolve, and each accepted extension is pinned rather than assumed.

Full backend suite green locally (1591 passed), ruff clean.