### PR TITLE
feat(arr instances): per-instance default language profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,7 @@ jobs:
             tests/bazarr/test_arr_instance_repository.py \
             tests/bazarr/test_arr_instances_api.py \
             tests/bazarr/test_arr_subtitle_settings.py \
+            tests/bazarr/test_arr_media_defaults.py \
             tests/bazarr/test_arr_client.py \
             tests/bazarr/test_arr_backfill.py \
             tests/bazarr/test_arr_instance_stamping.py \

--- a/bazarr/api/system/arr_instances.py
+++ b/bazarr/api/system/arr_instances.py
@@ -1,12 +1,10 @@
 # coding=utf-8
 
-import logging
-
 from flask import request
 from flask_restx import Namespace, Resource, reqparse
 
 from app.database import database
-from app.event_handler import event_stream
+from app.jobs_queue import jobs_queue
 from arr_instances import service
 
 from ..utils import authenticate
@@ -176,29 +174,19 @@ class ArrInstanceApplyDefaultProfile(Resource):
             return body, status
         database.commit()
 
-        # Recompute what is missing for exactly the items that changed, and tell
-        # the UI, the same way the mass-edit profile selector does.
-        kind = body.get("kind")
+        # Recompute what is missing for exactly the items that changed, in the
+        # background. Each pass scans every episode of an item and emits events,
+        # so doing a whole library inside this request would hold a web worker
+        # for minutes and can outlive a proxy timeout.
         upstream_ids = body.get("upstream_ids") or []
-        try:
-            if kind == "sonarr":
-                from subtitles.indexer.series import list_missing_subtitles
-                for upstream_id in upstream_ids:
-                    list_missing_subtitles(no=upstream_id, arr_instance_id=instance_id)
-                    event_stream(type="series", payload=upstream_id)
-            else:
-                from subtitles.indexer.movies import list_missing_subtitles_movies
-                for upstream_id in upstream_ids:
-                    list_missing_subtitles_movies(no=upstream_id, arr_instance_id=instance_id)
-                    event_stream(type="movie", payload=upstream_id)
-            if upstream_ids:
-                event_stream(type="badges")
-        except Exception:
-            # The profiles are committed; a failed re-index must not read as a
-            # failed request. The scheduled indexer picks it up regardless.
-            logging.exception(
-                "BAZARR failed to refresh missing subtitles after applying the "
-                "default language profile of instance %s", instance_id)
+        if upstream_ids:
+            jobs_queue.feed_jobs_pending_queue(
+                job_name=f"Refreshing missing subtitles for {len(upstream_ids)} items",
+                module="arr_instances.service",
+                func="reindex_after_default_profile",
+                kwargs={"kind": body.get("kind"), "upstream_ids": upstream_ids,
+                        "arr_instance_id": instance_id},
+                is_progress=False)
 
         # upstream_ids is an implementation detail of the refresh above.
         return {"updated": body["updated"], "profileId": body["profileId"]}, 200

--- a/bazarr/api/system/arr_instances.py
+++ b/bazarr/api/system/arr_instances.py
@@ -1,9 +1,12 @@
 # coding=utf-8
 
+import logging
+
 from flask import request
 from flask_restx import Namespace, Resource, reqparse
 
 from app.database import database
+from app.event_handler import event_stream
 from arr_instances import service
 
 from ..utils import authenticate
@@ -26,6 +29,7 @@ _create_parser.add_argument("http_timeout", type=int, location="json")
 _create_parser.add_argument("enabled", type=bool, location="json")
 _create_parser.add_argument("is_default", type=bool, location="json")
 _create_parser.add_argument("subtitle_settings", type=dict, location="json")
+_create_parser.add_argument("media_defaults", type=dict, location="json")
 
 _update_parser = reqparse.RequestParser()
 _update_parser.add_argument("name", type=str, location="json")
@@ -40,6 +44,7 @@ _update_parser.add_argument("http_timeout", type=int, location="json")
 _update_parser.add_argument("enabled", type=bool, location="json")
 _update_parser.add_argument("is_default", type=bool, location="json")
 _update_parser.add_argument("subtitle_settings", type=dict, location="json")
+_update_parser.add_argument("media_defaults", type=dict, location="json")
 
 _test_parser = reqparse.RequestParser()
 _test_parser.add_argument("kind", type=str, required=True, location="json")
@@ -151,3 +156,49 @@ class ArrInstanceTestById(Resource):
         args = _test_by_id_parser.parse_args()
         body, status = service.test_connection_for_instance(database, instance_id, args)
         return body, status
+
+
+@api_ns_system_arr_instances.route(
+    "/system/arr-instances/<int:instance_id>/apply-default-profile")
+class ArrInstanceApplyDefaultProfile(Resource):
+    @authenticate
+    def post(self, instance_id):
+        """Assign this instance's default language profile to its media that has
+        none yet.
+
+        Opt-in and one-way: only rows with no profile are filled in, so
+        hand-picked profiles survive. Reassigning media that already has a
+        profile stays with the mass-edit profile selector in the Series and
+        Movies views, where it is explicit and reviewable.
+        """
+        body, status = service.apply_default_profile(database, instance_id)
+        if status >= 400:
+            return body, status
+        database.commit()
+
+        # Recompute what is missing for exactly the items that changed, and tell
+        # the UI, the same way the mass-edit profile selector does.
+        kind = body.get("kind")
+        upstream_ids = body.get("upstream_ids") or []
+        try:
+            if kind == "sonarr":
+                from subtitles.indexer.series import list_missing_subtitles
+                for upstream_id in upstream_ids:
+                    list_missing_subtitles(no=upstream_id, arr_instance_id=instance_id)
+                    event_stream(type="series", payload=upstream_id)
+            else:
+                from subtitles.indexer.movies import list_missing_subtitles_movies
+                for upstream_id in upstream_ids:
+                    list_missing_subtitles_movies(no=upstream_id, arr_instance_id=instance_id)
+                    event_stream(type="movie", payload=upstream_id)
+            if upstream_ids:
+                event_stream(type="badges")
+        except Exception:
+            # The profiles are committed; a failed re-index must not read as a
+            # failed request. The scheduled indexer picks it up regardless.
+            logging.exception(
+                "BAZARR failed to refresh missing subtitles after applying the "
+                "default language profile of instance %s", instance_id)
+
+        # upstream_ids is an implementation detail of the refresh above.
+        return {"updated": body["updated"], "profileId": body["profileId"]}, 200

--- a/bazarr/api/system/arr_instances.py
+++ b/bazarr/api/system/arr_instances.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 
+import logging
+
 from flask import request
 from flask_restx import Namespace, Resource, reqparse
 
@@ -180,13 +182,22 @@ class ArrInstanceApplyDefaultProfile(Resource):
         # for minutes and can outlive a proxy timeout.
         upstream_ids = body.get("upstream_ids") or []
         if upstream_ids:
-            jobs_queue.feed_jobs_pending_queue(
-                job_name=f"Refreshing missing subtitles for {len(upstream_ids)} items",
-                module="arr_instances.service",
-                func="reindex_after_default_profile",
-                kwargs={"kind": body.get("kind"), "upstream_ids": upstream_ids,
-                        "arr_instance_id": instance_id},
-                is_progress=False)
+            try:
+                jobs_queue.feed_jobs_pending_queue(
+                    job_name=f"Refreshing missing subtitles for {len(upstream_ids)} items",
+                    module="arr_instances.service",
+                    func="reindex_after_default_profile",
+                    kwargs={"kind": body.get("kind"), "upstream_ids": upstream_ids,
+                            "arr_instance_id": instance_id},
+                    is_progress=False)
+            except Exception:
+                # The profiles are already committed. Failing the request here
+                # would report that Apply did nothing while the library was in
+                # fact updated, and invite a retry that finds nothing to do. The
+                # scheduled indexer picks the refresh up regardless.
+                logging.exception(
+                    "BAZARR could not queue the missing-subtitles refresh after applying "
+                    "the default language profile of instance %s", instance_id)
 
         # upstream_ids is an implementation detail of the refresh above.
         return {"updated": body["updated"], "profileId": body["profileId"]}, 200

--- a/bazarr/arr_instances/media_defaults.py
+++ b/bazarr/arr_instances/media_defaults.py
@@ -1,0 +1,162 @@
+# coding=utf-8
+"""Per-instance default language profile stored in ``arr_instances.options``.
+
+The global "default language profile for newly synced media"
+(``settings.general.serie_default_enabled`` / ``serie_default_profile`` and the
+movie equivalents) applies one profile to every instance. Someone running a
+separate anime Sonarr next to a standard one needs a different default per
+instance, so an instance may override the pair under
+``options["media_defaults"]``.
+
+This is a SIBLING of ``options["subtitle_settings"]``, deliberately not a
+section inside it: a language profile is not a subtitle setting, and the two
+blobs are validated, read and merged independently of one another.
+
+Three states, and only three:
+
+* no ``media_defaults`` key at all      -> inherit the global default
+* ``{"default_enabled": False}``        -> assign no profile on this instance
+* ``{"default_enabled": True, "default_profile": N}`` -> assign profile N
+
+Absence is the whole contract. An instance without the block resolves to the
+global value, so a single-instance install behaves exactly as it did before any
+of this existed. Resolving an override where none is set would silently move
+profile assignment for every such install on its next sync, which is the
+failure this module is shaped to make impossible.
+
+Precedence, highest first: a Sonarr/Radarr tag matching a language profile's
+``tag`` (applied by the sync parsers when Series Tag / Movie Tag is enabled),
+then this instance default, then the global default.
+"""
+import json
+
+MEDIA_DEFAULTS_KEY = "media_defaults"
+
+
+def _is_bool(value):
+    return isinstance(value, bool)
+
+
+def _is_profile_id(value):
+    # bool is an int subclass; a True here would sail through as profile 1.
+    return value is None or (isinstance(value, int) and not isinstance(value, bool) and value > 0)
+
+
+ALLOWED = {
+    "default_enabled": (_is_bool, "a boolean"),
+    "default_profile": (_is_profile_id, "a positive language profile id or null"),
+}
+
+
+def validate_media_defaults(blob, known_profile_ids=None):
+    """Validate a per-instance media_defaults override blob.
+
+    Returns a cleaned dict holding only the recognised keys. Raises
+    ``ValueError`` on an unknown key, a bad value, an incomplete override, or a
+    profile id that is not in ``known_profile_ids`` (when the caller supplies
+    the set), so the API answers 400 rather than persisting a dangling
+    ``profileId`` that the sync would later have to defend against.
+
+    An empty result means "no override": the instance inherits the global
+    default. A disabled override drops any ``default_profile`` it was sent, so a
+    stale id never lingers in the stored blob.
+    """
+    if blob is None:
+        return {}
+    if not isinstance(blob, dict):
+        raise ValueError("media_defaults must be an object")
+
+    cleaned = {}
+    for key, value in blob.items():
+        if key not in ALLOWED:
+            raise ValueError(f"setting not allowed per instance: media_defaults.{key}")
+        validator, constraint = ALLOWED[key]
+        if not validator(value):
+            raise ValueError(f"media_defaults.{key} must be {constraint}")
+        cleaned[key] = value
+
+    if not cleaned:
+        return {}
+    if "default_enabled" not in cleaned:
+        raise ValueError("media_defaults.default_enabled is required")
+
+    if cleaned["default_enabled"] is True:
+        profile = cleaned.get("default_profile")
+        if profile is None:
+            raise ValueError(
+                "media_defaults.default_profile is required when default_enabled is true")
+        if known_profile_ids is not None and profile not in known_profile_ids:
+            raise ValueError(f"language profile {profile} does not exist")
+    else:
+        # "assign no profile" carries no profile id.
+        cleaned.pop("default_profile", None)
+    return cleaned
+
+
+def read_media_defaults(options_json):
+    """Parse the media_defaults blob out of an instance ``options`` JSON string.
+
+    Returns {} for null/blank/malformed input or when the key is absent, which
+    is the "inherit the global default" state."""
+    if not options_json:
+        return {}
+    try:
+        options = json.loads(options_json)
+    except (ValueError, TypeError):
+        return {}
+    if isinstance(options, dict) and isinstance(options.get(MEDIA_DEFAULTS_KEY), dict):
+        return options[MEDIA_DEFAULTS_KEY]
+    return {}
+
+
+def merge_media_defaults_into_options(options_json, blob):
+    """Return an ``options`` JSON string with media_defaults set to ``blob``,
+    preserving any other keys already in options (notably subtitle_settings).
+    An empty blob removes the media_defaults key (and returns None if nothing
+    else remains), so clearing the override leaves no stale entry that could
+    still read as one."""
+    options = {}
+    if options_json:
+        try:
+            existing = json.loads(options_json)
+            if isinstance(existing, dict):
+                options = existing
+        except (ValueError, TypeError):
+            options = {}
+    if blob:
+        options[MEDIA_DEFAULTS_KEY] = blob
+    else:
+        options.pop(MEDIA_DEFAULTS_KEY, None)
+    return json.dumps(options) if options else None
+
+
+def global_default_profile(enabled, profile):
+    """Reduce the global default_enabled/default_profile pair to a profile id.
+
+    Reproduces exactly what the sync sites did inline before this module
+    existed, including the empty-string sentinel the config stores when the
+    setting is on but no profile was ever picked.
+    """
+    if enabled is not True:
+        return None
+    if profile == "" or profile is None:
+        return None
+    return profile
+
+
+def instance_default_profile(blob):
+    """Return ``(has_override, profile_id)`` for a media_defaults blob.
+
+    ``has_override`` is False for anything that is not a real override, and the
+    caller must then fall back to the global value. Nothing else in the blob
+    counts: only an explicit ``default_enabled`` makes this instance's default
+    its own.
+    """
+    if not isinstance(blob, dict) or "default_enabled" not in blob:
+        return False, None
+    if blob.get("default_enabled") is not True:
+        return True, None
+    profile = blob.get("default_profile")
+    if profile in ("", None):
+        return True, None
+    return True, profile

--- a/bazarr/arr_instances/repository.py
+++ b/bazarr/arr_instances/repository.py
@@ -14,6 +14,7 @@ from sqlalchemy import select
 
 from app.database import TableArrInstances
 
+from .media_defaults import read_media_defaults
 from .subtitle_settings import read_subtitle_settings
 
 VALID_KINDS = ("sonarr", "radarr")
@@ -324,4 +325,5 @@ def to_safe_dict(row):
         "http_timeout": row.http_timeout,
         "api_key_set": bool(row.api_key),
         "subtitle_settings": read_subtitle_settings(row.options),
+        "media_defaults": read_media_defaults(row.options),
     }

--- a/bazarr/arr_instances/resolution.py
+++ b/bazarr/arr_instances/resolution.py
@@ -16,6 +16,8 @@ The session is passed in by the caller (the sync orchestrators already hold the
 scoped ``database`` session) so these helpers never reach for a global and stay
 trivially testable against an in-memory session.
 """
+import logging
+
 from sqlalchemy import select
 
 from app.database import TableShows
@@ -161,3 +163,84 @@ def resolve_subtitle_setting(arr_instance_id, dotted_key, global_default, sessio
     if isinstance(section_blob, dict) and key in section_blob:
         return section_blob[key]
     return global_default
+
+
+# --- Per-instance default language profile resolution ----------------------
+# instance_id -> parsed media_defaults blob. Same lifecycle as the
+# subtitle_settings cache above: populated lazily, cleared by
+# service.refresh_runtime on any instance create/update/delete so an edited
+# override never keeps serving a stale value until restart.
+_media_defaults_cache = {}
+
+
+def clear_media_defaults_cache(arr_instance_id=None):
+    """Drop the cached media_defaults for one instance, or all of them."""
+    if arr_instance_id is None:
+        _media_defaults_cache.clear()
+    else:
+        _media_defaults_cache.pop(arr_instance_id, None)
+
+
+def _instance_media_defaults(arr_instance_id, session=None):
+    if arr_instance_id in _media_defaults_cache:
+        return _media_defaults_cache[arr_instance_id]
+    if session is None:
+        from app.database import database
+        session = database
+    from app.database import TableArrInstances
+    from .media_defaults import read_media_defaults
+    row = session.execute(
+        select(TableArrInstances.options).where(TableArrInstances.id == arr_instance_id)
+    ).first()
+    blob = read_media_defaults(row.options if row else None)
+    _media_defaults_cache[arr_instance_id] = blob
+    return blob
+
+
+def _language_profile_exists(profile_id, session=None):
+    from app.database import TableLanguagesProfiles
+    if session is None:
+        from app.database import database
+        session = database
+    return session.execute(
+        select(TableLanguagesProfiles.profileId)
+        .where(TableLanguagesProfiles.profileId == profile_id)
+    ).first() is not None
+
+
+def resolve_default_profile(arr_instance_id, global_enabled, global_profile, session=None):
+    """Return the language profile id to stamp on media a sync INSERTS, or None.
+
+    ``global_enabled``/``global_profile`` are the raw
+    ``settings.general.<noun>_default_enabled`` / ``_default_profile`` pair; the
+    same reduction the sync sites did inline is applied here.
+
+    The instance override is consulted ONLY when the instance actually has one.
+    An instance with no ``media_defaults`` block, a missing instance context
+    (``arr_instance_id`` None, i.e. a pre-backfill install), or an unparseable
+    options blob all return the global value unchanged. That conditionality is
+    the whole point: resolving an override where none is set would move profile
+    assignment for every single-instance install on its next sync.
+
+    A stored override naming a profile that no longer exists (the profile was
+    deleted after the override was saved; the API rejects unknown ids at write
+    time) falls back to the global default rather than writing a dangling
+    ``profileId``. The existence check costs one indexed lookup and runs only
+    when an override is actually set.
+    """
+    from .media_defaults import global_default_profile, instance_default_profile
+
+    global_value = global_default_profile(global_enabled, global_profile)
+    if arr_instance_id is None:
+        return global_value
+
+    has_override, profile = instance_default_profile(
+        _instance_media_defaults(arr_instance_id, session=session))
+    if not has_override:
+        return global_value
+    if profile is not None and not _language_profile_exists(profile, session=session):
+        logging.warning(
+            "BAZARR arr instance %s has a default language profile (%s) that no longer "
+            "exists; falling back to the global default.", arr_instance_id, profile)
+        return global_value
+    return profile

--- a/bazarr/arr_instances/service.py
+++ b/bazarr/arr_instances/service.py
@@ -9,6 +9,7 @@ chain, and keeps the resources to thin parse/commit glue.
 The session is flushed but NOT committed here; the HTTP boundary owns the
 transaction and commits on success.
 """
+import ast
 import logging
 
 from sqlalchemy import select, update
@@ -394,6 +395,73 @@ def _known_profile_ids(session):
         select(TableLanguagesProfiles.profileId)).all()}
 
 
+def _excluded_profile_tags(kind):
+    """Tags that mean "no profile", or an empty set when tag handling is off."""
+    from app.config import settings
+
+    enabled = (settings.general.serie_tag_enabled if kind == "sonarr"
+               else settings.general.movie_tag_enabled)
+    if not enabled:
+        return frozenset()
+
+    return frozenset(settings.general.remove_profile_tags or ())
+
+
+def _tags_exclude_a_profile(stored_tags, excluded_tags):
+    """True when this row's tags intersect the no-profile list.
+
+    ``tags`` is stored as the repr of a Python list, which is what the sync
+    writes, so it is read back the same way. An unreadable value excludes
+    nothing: refusing to apply the default because a tag blob is malformed
+    would be a worse failure than applying it.
+    """
+    if not excluded_tags or not stored_tags:
+        return False
+
+    try:
+        tags = ast.literal_eval(stored_tags)
+    except (ValueError, SyntaxError):
+        return False
+
+    if not isinstance(tags, (list, tuple, set)):
+        return False
+
+    return bool(set(tags) & excluded_tags)
+
+
+def reindex_after_default_profile(kind, upstream_ids, arr_instance_id, job_id=None):
+    """Recompute what is missing for the items apply_default_profile changed.
+
+    Runs as a queued job rather than inside the Apply request: one index pass
+    per item scans every episode and emits events, so a library of a few
+    thousand unprofiled items would hold a web worker for minutes and can
+    outlive a proxy timeout, with nothing to show for it in the UI meanwhile.
+
+    Failures are logged, not raised: the profiles are already committed, and the
+    scheduled indexer picks up anything missed here.
+    """
+    if not upstream_ids:
+        return
+
+    if kind == "sonarr":
+        from subtitles.indexer.series import list_missing_subtitles as index_one
+        event_type = "series"
+    else:
+        from subtitles.indexer.movies import list_missing_subtitles_movies as index_one
+        event_type = "movie"
+
+    for upstream_id in upstream_ids:
+        try:
+            index_one(no=upstream_id, arr_instance_id=arr_instance_id)
+            event_stream(type=event_type, payload=upstream_id)
+        except Exception:
+            logging.exception(
+                "BAZARR failed to refresh missing subtitles for %s %s on instance %s",
+                kind, upstream_id, arr_instance_id)
+
+    event_stream(type="badges")
+
+
 def apply_default_profile(session, instance_id):
     """Assign this instance's default language profile to its media that has no
     profile yet. Opt-in, and deliberately narrow.
@@ -426,14 +494,23 @@ def apply_default_profile(session, instance_id):
     # Collect the targets before the write: the UPDATE's own WHERE stops
     # matching them once profileId is set, and the caller needs the ids.
     targets = session.execute(
-        select(upstream_column)
+        select(upstream_column, table.tags)
         .where(table.arr_instance_id == instance_id, table.profileId.is_(None))).all()
-    upstream_ids = [t[0] for t in targets]
+
+    # A row a tag rule deliberately excluded is not "unset yet", it is "kept
+    # out": the sync parsers set profileId to None on purpose when the item
+    # carries one of remove_profile_tags. Filling those in here would silently
+    # undo the rule the user configured, on their whole library at once.
+    excluded_tags = _excluded_profile_tags(row.kind)
+    upstream_ids = [t[0] for t in targets
+                    if not _tags_exclude_a_profile(t[1], excluded_tags)]
     if upstream_ids:
         session.execute(
             update(table)
             .values(profileId=profile)
-            .where(table.arr_instance_id == instance_id, table.profileId.is_(None)))
+            .where(table.arr_instance_id == instance_id,
+                   table.profileId.is_(None),
+                   upstream_column.in_(upstream_ids)))
 
     logging.info("Assigned language profile %s to %s unprofiled %s items on instance %s",
                  profile, len(upstream_ids), row.kind, instance_id)

--- a/bazarr/arr_instances/service.py
+++ b/bazarr/arr_instances/service.py
@@ -11,8 +11,13 @@ transaction and commits on success.
 """
 import logging
 
+from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 
+from app.database import TableLanguagesProfiles, TableMovies, TableShows
+
+from .media_defaults import (instance_default_profile, merge_media_defaults_into_options,
+                             read_media_defaults, validate_media_defaults)
 from .repository import VALID_KINDS, ArrInstanceRepository, to_safe_dict
 from .subtitle_settings import merge_subtitle_settings_into_options, validate_subtitle_settings
 
@@ -113,8 +118,11 @@ def refresh_runtime(kind, instance_id=None, removed=False):
     # Per-instance subtitle settings may have changed; drop the resolver cache
     # so the next read reflects the edit (#227). Cheap and kind-agnostic, so do
     # it before the kind guard returns.
-    from .resolution import clear_subtitle_settings_cache
+    from .resolution import clear_media_defaults_cache, clear_subtitle_settings_cache
     clear_subtitle_settings_cache()
+    # Same for the per-instance default language profile: an edited override
+    # must take effect on the next sync, not on the next restart.
+    clear_media_defaults_cache()
 
     if kind not in VALID_KINDS:
         return
@@ -286,7 +294,13 @@ def create_instance(session, args):
         ss_blob = validate_subtitle_settings(args.get("subtitle_settings"))
     except ValueError as exc:
         return {"error": "invalid", "message": str(exc)}, 400
-    options = merge_subtitle_settings_into_options(None, ss_blob)
+    try:
+        md_blob = validate_media_defaults(
+            args.get("media_defaults"), known_profile_ids=_known_profile_ids(session))
+    except ValueError as exc:
+        return {"error": "invalid", "message": str(exc)}, 400
+    options = merge_media_defaults_into_options(
+        merge_subtitle_settings_into_options(None, ss_blob), md_blob)
     repo = ArrInstanceRepository(session)
     try:
         row = repo.create(
@@ -337,6 +351,17 @@ def update_instance(session, instance_id, args):
             return {"error": "invalid", "message": str(exc)}, 400
         kwargs["options"] = merge_subtitle_settings_into_options(existing.options, ss_blob)
 
+    if args.get("media_defaults") is not None:
+        try:
+            md_blob = validate_media_defaults(
+                args.get("media_defaults"), known_profile_ids=_known_profile_ids(session))
+        except ValueError as exc:
+            return {"error": "invalid", "message": str(exc)}, 400
+        # Merge onto whatever the subtitle_settings edit above already produced,
+        # so a request carrying both blobs does not drop one of them.
+        kwargs["options"] = merge_media_defaults_into_options(
+            kwargs.get("options", existing.options), md_blob)
+
     try:
         row = repo.update(instance_id, **kwargs)
     except ValueError as exc:
@@ -356,3 +381,61 @@ def delete_instance(session, instance_id):
     if not ok:
         return {"error": "not_found"}, 404
     return "", 204
+
+
+def _known_profile_ids(session):
+    """The set of language profile ids that currently exist.
+
+    Used to reject an override naming a profile that is not there, so a dangling
+    ``profileId`` is never persisted in the first place. The sync still guards
+    against a profile deleted AFTER the override was saved.
+    """
+    return {row.profileId for row in session.execute(
+        select(TableLanguagesProfiles.profileId)).all()}
+
+
+def apply_default_profile(session, instance_id):
+    """Assign this instance's default language profile to its media that has no
+    profile yet. Opt-in, and deliberately narrow.
+
+    Only rows owned by ``instance_id`` whose ``profileId`` is NULL are touched,
+    so hand-picked profiles are never overwritten: a silent bulk reassignment is
+    not recoverable, and wholesale reassignment already exists as the mass-edit
+    profile selector in the Series and Movies views.
+
+    Returns ``(body, status)``. The body carries the upstream ids that changed so
+    the HTTP layer can re-run the missing-subtitles indexer for exactly those
+    items.
+    """
+    repo = ArrInstanceRepository(session)
+    row = repo.get(instance_id)
+    if row is None:
+        return {"error": "not_found"}, 404
+
+    has_override, profile = instance_default_profile(read_media_defaults(row.options))
+    if not has_override or profile is None:
+        return {"error": "invalid",
+                "message": "This instance has no default language profile to apply."}, 400
+    if profile not in _known_profile_ids(session):
+        return {"error": "invalid",
+                "message": f"Language profile {profile} no longer exists."}, 400
+
+    table = TableShows if row.kind == "sonarr" else TableMovies
+    upstream_column = TableShows.sonarrSeriesId if row.kind == "sonarr" else TableMovies.radarrId
+
+    # Collect the targets before the write: the UPDATE's own WHERE stops
+    # matching them once profileId is set, and the caller needs the ids.
+    targets = session.execute(
+        select(upstream_column)
+        .where(table.arr_instance_id == instance_id, table.profileId.is_(None))).all()
+    upstream_ids = [t[0] for t in targets]
+    if upstream_ids:
+        session.execute(
+            update(table)
+            .values(profileId=profile)
+            .where(table.arr_instance_id == instance_id, table.profileId.is_(None)))
+
+    logging.info("Assigned language profile %s to %s unprofiled %s items on instance %s",
+                 profile, len(upstream_ids), row.kind, instance_id)
+    return {"updated": len(upstream_ids), "profileId": profile, "kind": row.kind,
+            "upstream_ids": upstream_ids}, 200

--- a/bazarr/radarr/sync/movies.py
+++ b/bazarr/radarr/sync/movies.py
@@ -18,7 +18,8 @@ from subtitles.indexer.movies import store_subtitles_movie
 from subtitles.mass_download import movies_download_subtitles  # noqa: F401
 from utilities.path_mappings import path_mappings
 from subtitles.adaptive_searching import is_search_active
-from arr_instances.resolution import client_for_instance, default_instance_id, scoped, stamp_owner
+from arr_instances.resolution import (client_for_instance, default_instance_id,
+                                      resolve_default_profile, scoped, stamp_owner)
 
 from sqlalchemy.exc import IntegrityError
 from .parser import movieParser
@@ -119,22 +120,6 @@ def update_movies(job_id=None, wait_for_completion=False, arr_instance_id=None, 
     logging.debug('BAZARR Starting movie sync from Radarr.')
     apikey_radarr = settings.radarr.apikey
 
-    movie_default_enabled = settings.general.movie_default_enabled
-
-    if movie_default_enabled is True:
-        movie_default_profile = settings.general.movie_default_profile
-        if movie_default_profile == '':
-            movie_default_profile = None
-    else:
-        movie_default_profile = None
-
-    # Prevent trying to insert a movie with a non-existing languages profileId
-    if (movie_default_profile and not database.execute(
-            select(TableLanguagesProfiles)
-            .where(TableLanguagesProfiles.profileId == movie_default_profile))
-            .first()):
-        movie_default_profile = None
-
     # The scalar apikey gate only blocks the legacy default path; an
     # instance-scoped sync carries its own credentials in arr_client.
     if arr_client is None and apikey_radarr is None:
@@ -148,6 +133,22 @@ def update_movies(job_id=None, wait_for_completion=False, arr_instance_id=None, 
         # else the enabled default. stamp_owner leaves it unset pre-backfill.
         instance_id = arr_instance_id if arr_instance_id is not None \
             else default_instance_id(database, 'radarr')
+
+        # Default languages profile for movies this pass INSERTS: the owning
+        # instance's override when it has one, otherwise the global default
+        # exactly as before, so an instance without an override is unaffected.
+        movie_default_profile = resolve_default_profile(
+            instance_id,
+            settings.general.movie_default_enabled,
+            settings.general.movie_default_profile,
+            session=database)
+
+        # Prevent trying to insert a movie with a non-existing languages profileId
+        if (movie_default_profile and not database.execute(
+                select(TableLanguagesProfiles)
+                .where(TableLanguagesProfiles.profileId == movie_default_profile))
+                .first()):
+            movie_default_profile = None
 
         # Get movies data from radarr
         movies = get_movies_from_radarr_api(apikey_radarr=apikey_radarr, arr_client=arr_client)
@@ -372,15 +373,6 @@ def update_one_movie(movie_id, action, defer_search=False, is_signalr=False,
                     '%s', path_mappings.path_replace_movie(existing_movie.path))
         return
 
-    movie_default_enabled = settings.general.movie_default_enabled
-
-    if movie_default_enabled is True:
-        movie_default_profile = settings.general.movie_default_profile
-        if movie_default_profile == '':
-            movie_default_profile = None
-    else:
-        movie_default_profile = None
-
     audio_profiles = get_profile_list(arr_client=arr_client)
     tagsDict = get_tags(arr_client=arr_client)
     language_profiles = get_language_profiles()
@@ -388,6 +380,13 @@ def update_one_movie(movie_id, action, defer_search=False, is_signalr=False,
     # Resolve the owning instance: explicit when scoped, else the default.
     instance_id = arr_instance_id if arr_instance_id is not None \
         else default_instance_id(database, 'radarr')
+
+    # Same per-instance default resolution as the bulk sync above; see there.
+    movie_default_profile = resolve_default_profile(
+        instance_id,
+        settings.general.movie_default_enabled,
+        settings.general.movie_default_profile,
+        session=database)
 
     try:
         # Get movie data from radarr api

--- a/bazarr/sonarr/sync/series.py
+++ b/bazarr/sonarr/sync/series.py
@@ -14,7 +14,8 @@ from app.database import TableShows, TableLanguagesProfiles, database, insert, u
 from utilities.path_mappings import path_mappings
 from app.event_handler import event_stream
 from app.jobs_queue import jobs_queue
-from arr_instances.resolution import client_for_instance, default_instance_id, scoped, stamp_owner
+from arr_instances.resolution import (client_for_instance, default_instance_id,
+                                      resolve_default_profile, scoped, stamp_owner)
 
 from .episodes import sync_episodes
 from .parser import seriesParser
@@ -269,13 +270,6 @@ def update_one_series(series_id, action, is_signalr=False, series_data=None,
         event_stream(type='series', action='delete', payload=int(series_id))
         return
 
-    if settings.general.serie_default_enabled is True:
-        serie_default_profile = settings.general.serie_default_profile
-        if serie_default_profile == '':
-            serie_default_profile = None
-    else:
-        serie_default_profile = None
-
     # Fetch invariants only when the bulk caller didn't pre-load them.
     if audio_profiles is None:
         audio_profiles = get_profile_list()
@@ -308,6 +302,17 @@ def update_one_series(series_id, action, is_signalr=False, series_data=None,
     # preserving legacy NULL behaviour.
     instance_id = arr_instance_id if arr_instance_id is not None \
         else default_instance_id(database, 'sonarr')
+
+    # Default languages profile for a series this pass INSERTS: the owning
+    # instance's override when it has one, otherwise the global default exactly
+    # as before. An instance without an override changes nothing, which is what
+    # keeps single-instance installs on the profile they already have. A tag
+    # match still wins over both, inside seriesParser.
+    serie_default_profile = resolve_default_profile(
+        instance_id,
+        settings.general.serie_default_enabled,
+        settings.general.serie_default_profile,
+        session=database)
 
     if action == 'updated' and existing_in_db:
         # Update existing series in DB

--- a/bazarr/sonarr/sync/series.py
+++ b/bazarr/sonarr/sync/series.py
@@ -56,6 +56,11 @@ def get_series_monitored_table(arr_instance_id=None):
     return series_dict
 
 
+# None is a legitimate resolution ("no default profile"), so it cannot double as
+# "the caller did not resolve one".
+_UNRESOLVED = object()
+
+
 def update_series(job_id=None, wait_for_completion=False, arr_instance_id=None, arr_client=None):
     # arr_instance_id/arr_client thread an instance identity through the sync.
     # Both None = today's exact default-instance path (byte-identical): the leaf
@@ -86,6 +91,18 @@ def update_series(job_id=None, wait_for_completion=False, arr_instance_id=None, 
         audio_profiles = get_profile_list()
         tags_dict = get_tags(arr_client=arr_client)
         language_profiles = get_language_profiles()
+
+        # One more invariant off the per-series path: resolving the default
+        # language profile costs an indexed query per series whenever the
+        # instance has an override, and every one of them returns the same
+        # answer. A tag match still wins over it, inside seriesParser.
+        bulk_instance_id = arr_instance_id if arr_instance_id is not None \
+            else default_instance_id(database, 'sonarr')
+        serie_default_profile = resolve_default_profile(
+            bulk_instance_id,
+            settings.general.serie_default_enabled,
+            settings.general.serie_default_profile,
+            session=database)
 
         # Get current shows in DB (scoped to this instance when instance-synced,
         # so removed-series computation never sees another instance's shows).
@@ -169,7 +186,8 @@ def update_series(job_id=None, wait_for_completion=False, arr_instance_id=None, 
                                   language_profiles=language_profiles,
                                   existing_in_db=show['id'] in current_shows_db,
                                   skip_episode_sync=True,
-                                  arr_instance_id=arr_instance_id, arr_client=arr_client)
+                                  arr_instance_id=arr_instance_id, arr_client=arr_client,
+                                  serie_default_profile=serie_default_profile)
 
                 try:
                     episodes_data = episode_futures[show['id']].result()
@@ -232,7 +250,8 @@ def update_one_series_for_instance(arr_instance_id, series_id, action, **kwargs)
 def update_one_series(series_id, action, is_signalr=False, series_data=None,
                       audio_profiles=None, tags_dict=None, language_profiles=None,
                       existing_in_db=None, skip_episode_sync=False,
-                      arr_instance_id=None, arr_client=None):
+                      arr_instance_id=None, arr_client=None,
+                      serie_default_profile=_UNRESOLVED):
     """Update or delete one series in the DB.
 
     Optional injected arguments let the bulk `update_series()` caller
@@ -308,11 +327,17 @@ def update_one_series(series_id, action, is_signalr=False, series_data=None,
     # as before. An instance without an override changes nothing, which is what
     # keeps single-instance installs on the profile they already have. A tag
     # match still wins over both, inside seriesParser.
-    serie_default_profile = resolve_default_profile(
-        instance_id,
-        settings.general.serie_default_enabled,
-        settings.general.serie_default_profile,
-        session=database)
+    # Resolved by the bulk caller when there is one: the lookup issues an
+    # indexed query whenever an instance override is set, and the answer is the
+    # same for every series in a sync. Single-series callers (signalr, the
+    # manual refresh buttons) keep resolving it here, like the other invariants
+    # this function still fetches lazily for them.
+    if serie_default_profile is _UNRESOLVED:
+        serie_default_profile = resolve_default_profile(
+            instance_id,
+            settings.general.serie_default_enabled,
+            settings.general.serie_default_profile,
+            session=database)
 
     if action == 'updated' and existing_in_db:
         # Update existing series in DB

--- a/bazarr/utilities/health.py
+++ b/bazarr/utilities/health.py
@@ -66,10 +66,20 @@ def _any_instance_default_profile(kind):
         from arr_instances.media_defaults import instance_default_profile, read_media_defaults
         from arr_instances.repository import ArrInstanceRepository
 
-        for row in ArrInstanceRepository(database).list(kind=kind):
+        # enabled_only: a disabled instance never syncs, so its override supplies
+        # nothing and counting it would hide a real misconfiguration.
+        for row in ArrInstanceRepository(database).list(kind=kind, enabled_only=True):
             has_override, profile = instance_default_profile(read_media_defaults(row.options))
-            if has_override and profile is not None:
-                return True
+            if not has_override or profile is None:
+                continue
+            # And the profile has to still exist: it can be deleted after the
+            # override was saved, in which case resolve_default_profile falls
+            # back to the global default, so this check has to agree with it.
+            if database.execute(
+                    select(TableLanguagesProfiles.profileId)
+                    .where(TableLanguagesProfiles.profileId == profile)).first() is None:
+                continue
+            return True
     except Exception:
         logging.exception("BAZARR could not read the per-instance default language profiles")
 

--- a/bazarr/utilities/health.py
+++ b/bazarr/utilities/health.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 
+import logging
+
 import json
 
 from sqlalchemy import func
@@ -49,6 +51,46 @@ def check_health(job_id=None, wait_for_completion=False):
     backup_rotation()
 
     jobs_queue.update_job_name(job_id=job_id, new_job_name="Checked Health")
+
+
+def _any_instance_default_profile(kind):
+    """True when some instance of ``kind`` supplies a default profile of its own.
+
+    The global default is not the only source any more: media synced by an
+    instance with an override gets that profile, so reporting "you must assign a
+    profile" while one is configured sends the user to fix something that is
+    already set up. Never raises: a health check that throws takes the whole
+    page with it.
+    """
+    try:
+        from arr_instances.media_defaults import instance_default_profile, read_media_defaults
+        from arr_instances.repository import ArrInstanceRepository
+
+        for row in ArrInstanceRepository(database).list(kind=kind):
+            has_override, profile = instance_default_profile(read_media_defaults(row.options))
+            if has_override and profile is not None:
+                return True
+    except Exception:
+        logging.exception("BAZARR could not read the per-instance default language profiles")
+
+    return False
+
+
+def series_default_profile_is_missing():
+    """The global series default is enabled but nothing supplies a profile."""
+    if not settings.general.serie_default_enabled:
+        return False
+    if settings.general.serie_default_profile != '':
+        return False
+    return not _any_instance_default_profile('sonarr')
+
+
+def movie_default_profile_is_missing():
+    if not settings.general.movie_default_enabled:
+        return False
+    if settings.general.movie_default_profile != '':
+        return False
+    return not _any_instance_default_profile('radarr')
 
 
 def get_health_issues():
@@ -102,8 +144,8 @@ def get_health_issues():
                                            .where(TableShows.profileId.is_not(None))).scalar()
     movies_with_profile = database.execute(select(func.count(TableMovies.radarrId))
                                            .where(TableMovies.profileId.is_not(None))).scalar()
-    default_series_profile_empty = settings.general.serie_default_enabled and settings.general.serie_default_profile == ''
-    default_movies_profile_empty = settings.general.movie_default_enabled and settings.general.movie_default_profile == ''
+    default_series_profile_empty = series_default_profile_is_missing()
+    default_movies_profile_empty = movie_default_profile_is_missing()
     if languages_profiles_count == 0:
         health_issues.append({'object': 'Missing languages profile',
                               'issue': 'You must create at least one languages profile and assign it to your content.'})

--- a/frontend/src/apis/hooks/arrInstances.ts
+++ b/frontend/src/apis/hooks/arrInstances.ts
@@ -156,3 +156,35 @@ export function useTestArrInstanceById() {
     }) => api.arrInstances.testExisting(id, overrides),
   });
 }
+
+// Opt-in bulk fill: assigns the instance's default language profile to its media
+// that has none yet. Deliberately separate from the instance save, because it
+// writes to the library rather than to the instance.
+export function useApplyArrInstanceDefaultProfile() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationKey: [...arrKey, QueryKeys.Actions, "apply-default-profile"],
+    mutationFn: (id: number) => api.arrInstances.applyDefaultProfile(id),
+    onSuccess: (result) => {
+      showNotification({
+        color: "green",
+        message:
+          result.updated === 0
+            ? "Every item on this instance already has a language profile"
+            : `Assigned the default language profile to ${result.updated} item${
+                result.updated === 1 ? "" : "s"
+              }`,
+      });
+      client.invalidateQueries({ queryKey: [QueryKeys.Series] });
+      client.invalidateQueries({ queryKey: [QueryKeys.Movies] });
+    },
+    onError: (error) =>
+      showNotification({
+        color: "red",
+        message: getArrInstanceErrorMessage(
+          error,
+          "Failed to apply the default language profile",
+        ),
+      }),
+  });
+}

--- a/frontend/src/apis/raw/arrInstances.ts
+++ b/frontend/src/apis/raw/arrInstances.ts
@@ -31,6 +31,16 @@ export interface ArrSubtitleSettings {
   subsync?: ArrSubtitleSettingsSubsync;
 }
 
+// Per-instance default language profile. Three states, and only three: an
+// absent block inherits the global default, default_enabled false assigns no
+// profile, and default_enabled true assigns default_profile. It is stored
+// beside subtitle_settings under the instance's options, not inside it: a
+// language profile is not a subtitle setting.
+export interface ArrMediaDefaults {
+  default_enabled?: boolean;
+  default_profile?: number | null;
+}
+
 export interface ArrInstance {
   id: number;
   kind: ArrKind;
@@ -48,6 +58,7 @@ export interface ArrInstance {
   // The API never returns the key itself, only whether one is stored.
   api_key_set: boolean;
   subtitle_settings?: ArrSubtitleSettings;
+  media_defaults?: ArrMediaDefaults;
 }
 
 export interface ArrInstanceCreate {
@@ -63,6 +74,7 @@ export interface ArrInstanceCreate {
   enabled?: boolean;
   is_default?: boolean;
   subtitle_settings?: ArrSubtitleSettings;
+  media_defaults?: ArrMediaDefaults;
 }
 
 export type ArrInstanceUpdate = Partial<{
@@ -79,6 +91,7 @@ export type ArrInstanceUpdate = Partial<{
   enabled: boolean;
   is_default: boolean;
   subtitle_settings: ArrSubtitleSettings;
+  media_defaults: ArrMediaDefaults;
 }>;
 
 export interface ArrInstanceTest {
@@ -102,6 +115,11 @@ export type ArrInstanceTestOverrides = Partial<{
   verify_ssl: boolean;
   http_timeout: number;
 }>;
+
+export interface ArrApplyDefaultProfileResult {
+  updated: number;
+  profileId: number;
+}
 
 export interface ArrInstanceTestResult {
   ok: boolean;
@@ -136,6 +154,16 @@ class ArrInstancesApi extends BaseApi {
 
   remove(id: number) {
     return this.delete(`/${id}`);
+  }
+
+  // Opt-in: fills in this instance's default language profile on its media that
+  // has none yet. Never touches an item that already has a profile.
+  async applyDefaultProfile(id: number) {
+    const response = await this.postRaw<ArrApplyDefaultProfileResult>(
+      `/${id}/apply-default-profile`,
+      {},
+    );
+    return response.data;
   }
 
   // The API key travels in the JSON body only, never in a URL or query string.

--- a/frontend/src/pages/Settings/Connections/InstanceFormModal.tsx
+++ b/frontend/src/pages/Settings/Connections/InstanceFormModal.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useEffect, useState } from "react";
+import { FunctionComponent, useEffect, useMemo, useState } from "react";
 import {
   Alert,
   Badge,
@@ -9,6 +9,7 @@ import {
   NumberInput,
   PasswordInput,
   SegmentedControl,
+  Select,
   Stack,
   Switch,
   Text,
@@ -21,10 +22,13 @@ import {
   faCircleXmark,
   faPlugCircleBolt,
   faShieldHalved,
+  faWandMagicSparkles,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
+  useApplyArrInstanceDefaultProfile,
   useCreateArrInstance,
+  useLanguageProfiles,
   useTestArrInstanceById,
   useTestArrInstanceConnection,
   useUpdateArrInstance,
@@ -34,8 +38,16 @@ import type {
   ArrInstanceTest,
   ArrInstanceUpdate,
   ArrKind,
+  ArrMediaDefaults,
   ArrSubtitleSettings,
 } from "@/apis/raw/arrInstances";
+import {
+  GLOBAL_DEFAULT,
+  hasMediaDefaultProfile,
+  mediaDefaultsToValue,
+  NO_PROFILE,
+  valueToMediaDefaults,
+} from "./mediaDefaults";
 import {
   ARR_META,
   buildArrInstanceCreateBody,
@@ -61,6 +73,7 @@ interface FormValues {
   enabled: boolean;
   isDefault: boolean;
   subtitleSettings: ArrSubtitleSettings;
+  mediaDefaults: ArrMediaDefaults;
 }
 
 function initialValues(
@@ -81,6 +94,7 @@ function initialValues(
       enabled: instance.enabled,
       isDefault: instance.is_default,
       subtitleSettings: instance.subtitle_settings ?? {},
+      mediaDefaults: instance.media_defaults ?? {},
     };
   }
   return {
@@ -96,6 +110,7 @@ function initialValues(
     enabled: true,
     isDefault: false,
     subtitleSettings: {},
+    mediaDefaults: {},
   };
 }
 
@@ -118,6 +133,8 @@ const InstanceFormModal: FunctionComponent<Props> = ({
   // `testById` uses the instance's stored key server-side (keep current key).
   const test = useTestArrInstanceConnection();
   const testById = useTestArrInstanceById();
+  const applyDefaultProfile = useApplyArrInstanceDefaultProfile();
+  const { data: languageProfiles } = useLanguageProfiles();
 
   const [keyMode, setKeyMode] = useState<KeyMode>("keep");
   const hasStoredKey = instance !== null && instance.api_key_set;
@@ -163,6 +180,31 @@ const InstanceFormModal: FunctionComponent<Props> = ({
   }, [opened, kind, instance]);
 
   const meta = ARR_META[form.values.kind];
+  const listLabel = form.values.kind === "sonarr" ? "Series" : "Movies";
+
+  // "Use the global default" is a real, selectable choice rather than a blank
+  // field: an instance that has not opted in must READ as inheriting.
+  const profileOptions = useMemo(
+    () => [
+      { value: GLOBAL_DEFAULT, label: "Use the global default" },
+      { value: NO_PROFILE, label: "No profile" },
+      ...(languageProfiles ?? []).map((profile) => ({
+        value: String(profile.profileId),
+        label: profile.name,
+      })),
+    ],
+    [languageProfiles],
+  );
+
+  // The apply action works off the SAVED override, so it stays disabled while
+  // the selector holds an unsaved value.
+  const savedProfileChoice = mediaDefaultsToValue(instance?.media_defaults);
+  const profileChoiceDirty =
+    mediaDefaultsToValue(form.values.mediaDefaults) !== savedProfileChoice;
+  const canApplyDefaultProfile =
+    instance !== null &&
+    !profileChoiceDirty &&
+    hasMediaDefaultProfile(instance.media_defaults);
 
   const changeKind = (next: ArrKind) => {
     const previousDefault = ARR_META[form.values.kind].defaultPort;
@@ -243,6 +285,7 @@ const InstanceFormModal: FunctionComponent<Props> = ({
         // Always sent so clearing every override (an empty object) removes the
         // stored block server-side; an absent key would instead preserve it.
         subtitle_settings: values.subtitleSettings,
+        media_defaults: values.mediaDefaults,
       };
       if (hasStoredKey) {
         if (keyMode === "replace" && typed.length) {
@@ -279,6 +322,7 @@ const InstanceFormModal: FunctionComponent<Props> = ({
         isDefault: values.isDefault,
         apiKey: typed.length ? typed : undefined,
         subtitleSettings: values.subtitleSettings,
+        mediaDefaults: values.mediaDefaults,
       });
       create.mutate(body, {
         onSuccess: () => {
@@ -461,6 +505,50 @@ const InstanceFormModal: FunctionComponent<Props> = ({
               {...form.getInputProps("isDefault", { type: "checkbox" })}
             />
           </Group>
+
+          <Divider label="Default language profile" labelPosition="left" />
+
+          <Select
+            label={`Profile for newly synced ${meta.media}`}
+            description={
+              `Assigned to ${meta.media} this instance adds from now on. A matching ` +
+              `${meta.label} tag still wins over this, and this wins over the global ` +
+              `default set in Settings, Languages. ${meta.media} already in the ` +
+              `database keep the profile they have.`
+            }
+            data={profileOptions}
+            allowDeselect={false}
+            value={mediaDefaultsToValue(form.values.mediaDefaults)}
+            onChange={(value) =>
+              form.setFieldValue(
+                "mediaDefaults",
+                valueToMediaDefaults(value ?? GLOBAL_DEFAULT),
+              )
+            }
+          />
+
+          {instance !== null && (
+            <Group justify="space-between" align="center" wrap="nowrap">
+              <Text size="xs" c="dimmed">
+                {profileChoiceDirty
+                  ? "Save the instance to use this profile."
+                  : `Optional: fill this profile in on ${meta.media} from this ` +
+                    `instance that have no profile yet. Items that already have ` +
+                    `one are left alone; to change those, use the profile ` +
+                    `selector in the ${listLabel} list.`}
+              </Text>
+              <Button
+                type="button"
+                variant="light"
+                leftSection={<FontAwesomeIcon icon={faWandMagicSparkles} />}
+                disabled={!canApplyDefaultProfile}
+                loading={applyDefaultProfile.isPending}
+                onClick={() => applyDefaultProfile.mutate(instance.id)}
+              >
+                Apply to unset
+              </Button>
+            </Group>
+          )}
 
           <Divider label="Subtitle settings (optional)" labelPosition="left" />
 

--- a/frontend/src/pages/Settings/Connections/__tests__/InstanceFormModal.test.tsx
+++ b/frontend/src/pages/Settings/Connections/__tests__/InstanceFormModal.test.tsx
@@ -19,6 +19,7 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type {
+  ArrInstance,
   ArrInstanceCreate,
   ArrInstanceUpdate,
 } from "@/apis/raw/arrInstances";
@@ -79,7 +80,7 @@ function makeInstance(
     name: string;
     api_key_set: boolean;
   }> = {},
-) {
+): ArrInstance {
   return {
     id: 42,
     kind: (overrides.kind ?? "sonarr") as "sonarr" | "radarr",
@@ -476,5 +477,100 @@ describe("InstanceFormModal, edit mode", () => {
       unknown,
     ];
     expect(args.body.clear_api_key).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-instance default language profile
+// ---------------------------------------------------------------------------
+
+describe("InstanceFormModal, default language profile", () => {
+  it("starts on the explicit global-default choice for a new instance", () => {
+    renderAdd("sonarr");
+    expect(
+      screen.getByRole("combobox", { name: /profile for newly synced/i }),
+    ).toHaveValue("Use the global default");
+  });
+
+  it("omits media_defaults from the create payload when nothing is picked", async () => {
+    const user = userEvent.setup();
+    mockCreateMutate.mockClear();
+    renderAdd("sonarr");
+
+    await user.type(screen.getByRole("textbox", { name: /name/i }), "Plain");
+    await user.type(
+      screen.getByRole("textbox", { name: /address/i }),
+      "10.0.0.9",
+    );
+    await user.click(screen.getByRole("button", { name: /add instance/i }));
+
+    await waitFor(() => {
+      expect(mockCreateMutate).toHaveBeenCalled();
+    });
+    const [body] = mockCreateMutate.mock.calls[0] as [
+      ArrInstanceCreate,
+      unknown,
+    ];
+    // No override means no block at all, so the instance inherits the global
+    // default rather than pinning whatever the form happened to show.
+    expect(body.media_defaults).toBeUndefined();
+  });
+
+  it("sends a cleared media_defaults block when editing an instance with no override", async () => {
+    const user = userEvent.setup();
+    mockUpdateMutate.mockClear();
+    renderEdit(makeInstance());
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateMutate).toHaveBeenCalled();
+    });
+    const [args] = mockUpdateMutate.mock.calls[0] as [
+      { id: number; body: ArrInstanceUpdate },
+      unknown,
+    ];
+    expect(args.body.media_defaults).toEqual({});
+  });
+
+  it("keeps the saved override selected when editing", () => {
+    renderEdit({
+      ...makeInstance(),
+      media_defaults: { default_enabled: false },
+    });
+    expect(
+      screen.getByRole("combobox", { name: /profile for newly synced/i }),
+    ).toHaveValue("No profile");
+  });
+
+  it("spells out the precedence in the field description", () => {
+    renderAdd("sonarr");
+    expect(
+      screen.getByText(
+        /Sonarr tag still wins over this, and this wins over the global/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("offers the apply action only on a saved instance that assigns a profile", () => {
+    renderEdit(makeInstance());
+    expect(
+      screen.getByRole("button", { name: /apply to unset/i }),
+    ).toBeDisabled();
+
+    renderEdit({
+      ...makeInstance(),
+      media_defaults: { default_enabled: true, default_profile: 3 },
+    });
+    expect(
+      screen.getAllByRole("button", { name: /apply to unset/i }).at(-1),
+    ).toBeEnabled();
+  });
+
+  it("hides the apply action entirely while adding an instance", () => {
+    renderAdd("sonarr");
+    expect(
+      screen.queryByRole("button", { name: /apply to unset/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Settings/Connections/mediaDefaults.test.ts
+++ b/frontend/src/pages/Settings/Connections/mediaDefaults.test.ts
@@ -1,0 +1,68 @@
+/* eslint-disable camelcase */
+import { describe, expect, it } from "vitest";
+import {
+  GLOBAL_DEFAULT,
+  hasMediaDefaultProfile,
+  mediaDefaultsToValue,
+  NO_PROFILE,
+  valueToMediaDefaults,
+} from "./mediaDefaults";
+
+describe("mediaDefaultsToValue", () => {
+  it("maps a missing block to the explicit global-default choice", () => {
+    // The reverse-failure case in the UI: nothing stored must READ as
+    // "use the global default", never as a picked profile.
+    expect(mediaDefaultsToValue(undefined)).toBe(GLOBAL_DEFAULT);
+    expect(mediaDefaultsToValue({})).toBe(GLOBAL_DEFAULT);
+  });
+
+  it("maps a disabled override to the no-profile choice", () => {
+    expect(mediaDefaultsToValue({ default_enabled: false })).toBe(NO_PROFILE);
+  });
+
+  it("maps an enabled override to its profile id", () => {
+    expect(
+      mediaDefaultsToValue({ default_enabled: true, default_profile: 3 }),
+    ).toBe("3");
+  });
+});
+
+describe("valueToMediaDefaults", () => {
+  it("clears the block for the global-default choice", () => {
+    expect(valueToMediaDefaults(GLOBAL_DEFAULT)).toEqual({});
+  });
+
+  it("stores a disabled override for the no-profile choice", () => {
+    expect(valueToMediaDefaults(NO_PROFILE)).toEqual({
+      default_enabled: false,
+    });
+  });
+
+  it("stores an enabled override with a numeric profile id", () => {
+    expect(valueToMediaDefaults("3")).toEqual({
+      default_enabled: true,
+      default_profile: 3,
+    });
+  });
+
+  it("round-trips every state", () => {
+    for (const blob of [
+      {},
+      { default_enabled: false },
+      { default_enabled: true, default_profile: 7 },
+    ]) {
+      expect(valueToMediaDefaults(mediaDefaultsToValue(blob))).toEqual(blob);
+    }
+  });
+});
+
+describe("hasMediaDefaultProfile", () => {
+  it("is true only when a profile is actually assigned", () => {
+    expect(
+      hasMediaDefaultProfile({ default_enabled: true, default_profile: 3 }),
+    ).toBe(true);
+    expect(hasMediaDefaultProfile({ default_enabled: false })).toBe(false);
+    expect(hasMediaDefaultProfile({})).toBe(false);
+    expect(hasMediaDefaultProfile(undefined)).toBe(false);
+  });
+});

--- a/frontend/src/pages/Settings/Connections/mediaDefaults.ts
+++ b/frontend/src/pages/Settings/Connections/mediaDefaults.ts
@@ -1,0 +1,48 @@
+import type { ArrMediaDefaults } from "@/apis/raw/arrInstances";
+
+/**
+ * The per-instance default language profile has exactly three states, and the
+ * form encodes them as one Select value so "use the global default" is an
+ * explicit choice rather than a blank field the user has to interpret.
+ *
+ * The mapping is deliberately total in both directions: an absent block must
+ * read back as GLOBAL_DEFAULT and write back as an empty block. Anything that
+ * turned "nothing stored" into a picked profile would start reassigning media
+ * on installs that never asked for an override.
+ */
+export const GLOBAL_DEFAULT = "global";
+export const NO_PROFILE = "none";
+
+export function mediaDefaultsToValue(
+  blob: ArrMediaDefaults | undefined,
+): string {
+  if (!blob || blob.default_enabled === undefined) {
+    return GLOBAL_DEFAULT;
+  }
+  if (blob.default_enabled !== true) {
+    return NO_PROFILE;
+  }
+  return blob.default_profile === undefined || blob.default_profile === null
+    ? NO_PROFILE
+    : String(blob.default_profile);
+}
+
+export function valueToMediaDefaults(value: string): ArrMediaDefaults {
+  if (value === GLOBAL_DEFAULT) {
+    return {};
+  }
+  if (value === NO_PROFILE) {
+    return { default_enabled: false };
+  }
+  return { default_enabled: true, default_profile: Number(value) };
+}
+
+// Whether the instance actually assigns a profile, which is the only case the
+// "apply to media without a profile" action has anything to do.
+export function hasMediaDefaultProfile(
+  blob: ArrMediaDefaults | undefined,
+): boolean {
+  return (
+    blob?.default_enabled === true && typeof blob.default_profile === "number"
+  );
+}

--- a/frontend/src/pages/Settings/Connections/meta.ts
+++ b/frontend/src/pages/Settings/Connections/meta.ts
@@ -7,6 +7,7 @@ import type {
   ArrInstance,
   ArrInstanceCreate,
   ArrKind,
+  ArrMediaDefaults,
   ArrSubtitleSettings,
 } from "@/apis/raw/arrInstances";
 import { Environment } from "@/utilities/env";
@@ -75,6 +76,7 @@ export function buildArrInstanceCreateBody(
     isDefault: boolean;
     apiKey?: string;
     subtitleSettings?: ArrSubtitleSettings;
+    mediaDefaults?: ArrMediaDefaults;
   },
 ): ArrInstanceCreate {
   const body: ArrInstanceCreate = {
@@ -101,6 +103,11 @@ export function buildArrInstanceCreateBody(
     Object.keys(fields.subtitleSettings).length > 0
   ) {
     body.subtitle_settings = fields.subtitleSettings;
+  }
+  // Same rule for the default language profile: an empty block is omitted so a
+  // new instance starts out inheriting the global default.
+  if (fields.mediaDefaults && Object.keys(fields.mediaDefaults).length > 0) {
+    body.media_defaults = fields.mediaDefaults;
   }
   return body;
 }

--- a/tests/bazarr/test_arr_media_defaults.py
+++ b/tests/bazarr/test_arr_media_defaults.py
@@ -943,3 +943,69 @@ def test_the_queued_reindex_does_the_work_the_request_no_longer_does(monkeypatch
 class _CommitOnly:
     def commit(self):
         return None
+
+
+def test_a_disabled_instance_default_does_not_count_as_configured(schema_session, monkeypatch):
+    """A disabled instance never syncs, so its override supplies nothing. Taking
+    it as proof that a profile is configured hides a real misconfiguration."""
+    from app.config import settings
+    from utilities import health
+
+    monkeypatch.setattr(settings.general, "serie_default_enabled", True)
+    monkeypatch.setattr(settings.general, "serie_default_profile", "")
+    monkeypatch.setattr(health, "database", schema_session)
+
+    from sqlalchemy import update as sa_update
+
+    from app.database import TableArrInstances
+
+    _profile(schema_session, 2, "Anime")
+    instance = _instance(schema_session, "sonarr", "Anime", 8990,
+                         {"default_enabled": True, "default_profile": 2})
+    # is_default has to go with it: a default instance is required to be
+    # enabled, which is a constraint in the schema.
+    schema_session.execute(
+        sa_update(TableArrInstances).values(enabled=0, is_default=0)
+        .where(TableArrInstances.id == instance.id))
+
+    assert health.series_default_profile_is_missing() is True
+
+
+def test_an_override_naming_a_deleted_profile_does_not_count(schema_session, monkeypatch):
+    """The profile was deleted after the override was saved. resolve_default_profile
+    already falls back to the global default in that case, so the health check
+    has to agree with it."""
+    from app.config import settings
+    from utilities import health
+
+    monkeypatch.setattr(settings.general, "serie_default_enabled", True)
+    monkeypatch.setattr(settings.general, "serie_default_profile", "")
+    monkeypatch.setattr(health, "database", schema_session)
+
+    _instance(schema_session, "sonarr", "Anime", 8990,
+              {"default_enabled": True, "default_profile": 99})
+
+    assert health.series_default_profile_is_missing() is True
+
+
+def test_a_failed_reindex_enqueue_does_not_fail_the_apply(monkeypatch):
+    """The profiles are committed before the queue is touched. Raising here
+    tells the client Apply failed while the library was in fact mutated, which
+    invites a retry that then finds nothing left to do."""
+    import api.system.arr_instances as endpoint_module
+
+    class _BrokenQueue:
+        def feed_jobs_pending_queue(self, *args, **kwargs):
+            raise RuntimeError("queue is down")
+
+    monkeypatch.setattr(endpoint_module.service, "apply_default_profile",
+                        lambda *a, **k: ({"updated": 2, "profileId": 2, "kind": "sonarr",
+                                          "upstream_ids": [10, 11]}, 200))
+    monkeypatch.setattr(endpoint_module, "database", _CommitOnly())
+    monkeypatch.setattr(endpoint_module, "jobs_queue", _BrokenQueue())
+
+    resource = endpoint_module.ArrInstanceApplyDefaultProfile()
+    body, status = resource.post.__wrapped__(resource, 4)
+
+    assert status == 200
+    assert body == {"updated": 2, "profileId": 2}

--- a/tests/bazarr/test_arr_media_defaults.py
+++ b/tests/bazarr/test_arr_media_defaults.py
@@ -607,17 +607,18 @@ def test_service_update_keeps_subtitle_settings_intact(schema_session):
 # The opt-in apply action: unset profiles only, one instance only
 # --------------------------------------------------------------------------
 
-def _series(session, local_id, upstream_id, instance_id, profile=None):
+def _series(session, local_id, upstream_id, instance_id, profile=None, tags=None):
     session.execute(insert(TableShows).values(
         id=local_id, sonarrSeriesId=upstream_id, arr_instance_id=instance_id,
-        path=f"/tv/{local_id}", title=f"S{local_id}", profileId=profile))
+        path=f"/tv/{local_id}", title=f"S{local_id}", profileId=profile,
+        tags=str(tags) if tags is not None else None))
 
 
-def _movie(session, local_id, upstream_id, instance_id, profile=None):
+def _movie(session, local_id, upstream_id, instance_id, profile=None, tags=None):
     session.execute(insert(TableMovies).values(
         id=local_id, radarrId=upstream_id, arr_instance_id=instance_id,
         path=f"/m/{local_id}", title=f"M{local_id}", tmdbId=f"t{local_id}",
-        profileId=profile))
+        profileId=profile, tags=str(tags) if tags is not None else None))
 
 
 def test_apply_fills_only_unset_profiles_on_that_instance(schema_session):
@@ -749,3 +750,196 @@ def test_service_update_accepts_both_blobs_in_one_request(schema_session):
     assert status == 200, updated
     assert updated["subtitle_settings"] == {"subsync": {"subsync_threshold": 80}}
     assert updated["media_defaults"] == {"default_enabled": True, "default_profile": 2}
+
+
+# --------------------------------------------------------------------------
+# Review findings: the bulk apply undoing a deliberate exclusion, the sync
+# re-resolving per item, the health check not seeing instance defaults, and
+# the apply endpoint doing a whole library's reindex inside the request.
+# --------------------------------------------------------------------------
+
+
+def test_apply_skips_series_a_tag_deliberately_excluded(schema_session, monkeypatch):
+    """A tag in remove_profile_tags makes the sync parser set profileId to None
+    on purpose. That is not "unset yet", it is "kept out", and a bulk apply that
+    fills it in silently undoes the rule the user configured."""
+    from app.config import settings
+    from arr_instances import service
+
+    monkeypatch.setattr(settings.general, "serie_tag_enabled", True)
+    monkeypatch.setattr(settings.general, "remove_profile_tags", ["nosubs"])
+
+    _profile(schema_session, 2, "Anime")
+    anime = _instance(schema_session, "sonarr", "Anime", 8990,
+                      {"default_enabled": True, "default_profile": 2})
+    _series(schema_session, 1, 10, anime.id, None)
+    _series(schema_session, 2, 11, anime.id, None, tags=["nosubs"])
+
+    body, status = service.apply_default_profile(schema_session, anime.id)
+
+    assert status == 200, body
+    assert body["updated"] == 1
+    assert body["upstream_ids"] == [10]
+    profiles = dict(schema_session.execute(
+        select(TableShows.id, TableShows.profileId)).all())
+    assert profiles == {1: 2, 2: None}
+
+
+def test_apply_skips_movies_a_tag_deliberately_excluded(schema_session, monkeypatch):
+    from app.config import settings
+    from arr_instances import service
+
+    monkeypatch.setattr(settings.general, "movie_tag_enabled", True)
+    monkeypatch.setattr(settings.general, "remove_profile_tags", ["nosubs"])
+
+    _profile(schema_session, 2, "Anime")
+    anime = _instance(schema_session, "radarr", "Anime", 7879,
+                      {"default_enabled": True, "default_profile": 2})
+    _movie(schema_session, 1, 10, anime.id, None)
+    _movie(schema_session, 2, 11, anime.id, None, tags=["nosubs"])
+
+    body, status = service.apply_default_profile(schema_session, anime.id)
+
+    assert body["updated"] == 1
+    assert body["upstream_ids"] == [10]
+
+
+def test_apply_ignores_the_exclusion_when_tag_handling_is_off(schema_session, monkeypatch):
+    """The tag list only means anything while tag handling is enabled."""
+    from app.config import settings
+    from arr_instances import service
+
+    monkeypatch.setattr(settings.general, "serie_tag_enabled", False)
+    monkeypatch.setattr(settings.general, "remove_profile_tags", ["nosubs"])
+
+    _profile(schema_session, 2, "Anime")
+    anime = _instance(schema_session, "sonarr", "Anime", 8990,
+                      {"default_enabled": True, "default_profile": 2})
+    _series(schema_session, 1, 10, anime.id, None, tags=["nosubs"])
+
+    body, _status = service.apply_default_profile(schema_session, anime.id)
+
+    assert body["updated"] == 1
+
+
+def test_the_bulk_series_sync_resolves_the_default_profile_once(schema_session, monkeypatch):
+    """Once per sync, not once per series: the resolution issues an indexed
+    query whenever an override is set, so a library of a few thousand shows pays
+    for a few thousand round trips that all return the same answer. Every other
+    invariant in this loop is already hoisted; this one was not."""
+    series_mod = _prepare_series_sync(monkeypatch, schema_session)
+
+    calls = []
+
+    def counting(*args, **kwargs):
+        calls.append(args)
+        return 2
+
+    monkeypatch.setattr(series_mod, "resolve_default_profile", counting)
+    monkeypatch.setattr(series_mod, "jobs_queue", _DummyJobs())
+    monkeypatch.setattr(series_mod, "check_sonarr_rootfolder", _noop)
+    monkeypatch.setattr(series_mod, "get_profile_list", lambda *a, **k: [])
+    monkeypatch.setattr(series_mod, "get_tags", lambda *a, **k: [])
+    monkeypatch.setattr(series_mod, "get_language_profiles", lambda *a, **k: [])
+    monkeypatch.setattr(series_mod, "get_series_from_sonarr_api",
+                        lambda *a, **k: [{"id": n, "title": f"S{n}"} for n in range(1, 6)])
+    monkeypatch.setattr(series_mod, "get_episodes_from_sonarr_api", lambda *a, **k: [])
+
+    series_mod.update_series(job_id=1)
+
+    assert len(calls) == 1, f"resolved {len(calls)} times for 5 series"
+
+
+def test_the_health_check_sees_a_per_instance_default_profile(schema_session, monkeypatch):
+    """With the global default enabled but no profile chosen, a per-instance
+    override is what newly synced media actually gets. Reporting "no default
+    profile" then sends the user to fix something that is already configured."""
+    from app.config import settings
+    from utilities import health
+
+    monkeypatch.setattr(settings.general, "serie_default_enabled", True)
+    monkeypatch.setattr(settings.general, "serie_default_profile", "")
+    monkeypatch.setattr(settings.general, "movie_default_enabled", False)
+    monkeypatch.setattr(health, "database", schema_session)
+
+    _profile(schema_session, 2, "Anime")
+    _instance(schema_session, "sonarr", "Anime", 8990,
+              {"default_enabled": True, "default_profile": 2})
+
+    assert health.series_default_profile_is_missing() is False
+
+
+def test_the_health_check_still_reports_a_genuinely_missing_default(schema_session, monkeypatch):
+    from app.config import settings
+    from utilities import health
+
+    monkeypatch.setattr(settings.general, "serie_default_enabled", True)
+    monkeypatch.setattr(settings.general, "serie_default_profile", "")
+    monkeypatch.setattr(health, "database", schema_session)
+
+    _instance(schema_session, "sonarr", "Plain", 8989)
+
+    assert health.series_default_profile_is_missing() is True
+
+
+def test_the_apply_endpoint_queues_the_reindex_instead_of_running_it(monkeypatch):
+    """A library of a few thousand unprofiled series means a few thousand
+    index passes, each scanning every episode and emitting events. Doing that
+    inside the request holds a web worker for minutes and can outlive a proxy
+    timeout, while the UI has nothing to show for it."""
+    import api.system.arr_instances as endpoint_module
+
+    queued = []
+    indexed = []
+
+    class _Queue:
+        def feed_jobs_pending_queue(self, job_name, module, func, args=None, kwargs=None,
+                                    **options):
+            queued.append({"job_name": job_name, "module": module, "func": func,
+                           "args": args, "kwargs": kwargs})
+            return 1
+
+    monkeypatch.setattr(endpoint_module.service, "apply_default_profile",
+                        lambda *a, **k: ({"updated": 3, "profileId": 2, "kind": "sonarr",
+                                          "upstream_ids": [10, 11, 12]}, 200))
+    monkeypatch.setattr(endpoint_module, "database", _CommitOnly())
+    monkeypatch.setattr(endpoint_module, "jobs_queue", _Queue())
+
+    import subtitles.indexer.series as indexer
+    monkeypatch.setattr(indexer, "list_missing_subtitles",
+                        lambda **kwargs: indexed.append(kwargs))
+
+    resource = endpoint_module.ArrInstanceApplyDefaultProfile()
+    body, status = resource.post.__wrapped__(resource, 4)
+
+    assert status == 200
+    assert body == {"updated": 3, "profileId": 2}
+    assert indexed == [], "the reindex ran inside the request"
+    assert len(queued) == 1
+    assert queued[0]["kwargs"]["upstream_ids"] == [10, 11, 12]
+    assert queued[0]["kwargs"]["arr_instance_id"] == 4
+
+
+def test_the_queued_reindex_does_the_work_the_request_no_longer_does(monkeypatch):
+    from arr_instances import service
+
+    indexed = []
+    events = []
+    monkeypatch.setattr(service, "event_stream",
+                        lambda *args, **kwargs: events.append(kwargs or args))
+
+    import subtitles.indexer.series as indexer
+    monkeypatch.setattr(indexer, "list_missing_subtitles",
+                        lambda **kwargs: indexed.append(kwargs))
+
+    service.reindex_after_default_profile(
+        kind="sonarr", upstream_ids=[10, 11], arr_instance_id=4, job_id=1)
+
+    assert [entry["no"] for entry in indexed] == [10, 11]
+    assert all(entry["arr_instance_id"] == 4 for entry in indexed)
+    assert events, "the UI was never told the items changed"
+
+
+class _CommitOnly:
+    def commit(self):
+        return None

--- a/tests/bazarr/test_arr_media_defaults.py
+++ b/tests/bazarr/test_arr_media_defaults.py
@@ -1,0 +1,751 @@
+# coding=utf-8
+"""Per-instance default language profile stored in ``arr_instances.options``.
+
+The global series/movie default language profile applies the same profile to
+every Sonarr/Radarr instance. An instance may override it under
+``options["media_defaults"]`` so, for example, an anime Sonarr assigns the anime
+profile while the standard one keeps the global default.
+
+The single most important behaviour pinned here is the REVERSE failure, and it
+is deliberately the first test in the file: resolving an override where none is
+set would silently move profile assignment for every single-instance install on
+its next sync. An instance with no ``media_defaults`` block must resolve to the
+global value, byte for byte, in every combination of the global settings.
+"""
+import json
+
+import pytest
+from sqlalchemy import insert, select
+
+from app.database import TableLanguagesProfiles, TableMovies, TableShows
+from arr_instances.repository import ArrInstanceRepository
+from arr_instances.resolution import clear_media_defaults_cache, resolve_default_profile
+
+
+def _profile(session, profile_id, name, tag=None):
+    session.execute(insert(TableLanguagesProfiles).values(
+        profileId=profile_id, name=name, items="[]", tag=tag))
+    return profile_id
+
+
+def _instance(session, kind, name, port, blob=None):
+    """Create an instance, optionally carrying a media_defaults override."""
+    from arr_instances.media_defaults import merge_media_defaults_into_options
+
+    options = merge_media_defaults_into_options(None, blob) if blob else None
+    row = ArrInstanceRepository(session).create(kind, name, port=port, options=options)
+    session.flush()
+    clear_media_defaults_cache()
+    return row
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_media_defaults_cache()
+    yield
+    clear_media_defaults_cache()
+
+
+# --------------------------------------------------------------------------
+# THE reverse-failure case. Everything else in this file is secondary to it.
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("global_enabled", "global_profile", "expected"),
+    [
+        (True, 1, 1),        # the ordinary single-instance install
+        (True, "", None),    # "enabled" with nothing picked: legacy sentinel
+        (False, 1, None),    # switched off: the stored profile is ignored
+        (False, "", None),
+    ],
+)
+def test_instance_without_override_resolves_exactly_the_global_value(
+        schema_session, global_enabled, global_profile, expected):
+    """A single-instance install that never set an override must see NO change.
+
+    This fails the moment resolution stops being conditional on an override
+    actually being present: an unconditional read of media_defaults returns
+    None (or a stale value) here instead of the global profile, which is how a
+    single-instance user's whole library silently changes profile on the next
+    sync.
+    """
+    _profile(schema_session, 1, "Global")
+    row = _instance(schema_session, "sonarr", "Main", 8989)   # no options at all
+    assert row.options is None
+
+    assert resolve_default_profile(
+        row.id, global_enabled, global_profile, session=schema_session) == expected
+
+
+def test_no_instance_context_resolves_the_global_value(schema_session):
+    """Pre-backfill installs carry no instance id; they keep the global value."""
+    _profile(schema_session, 1, "Global")
+    assert resolve_default_profile(None, True, 1, session=schema_session) == 1
+    assert resolve_default_profile(None, False, 1, session=schema_session) is None
+
+
+def test_unrelated_options_do_not_look_like_an_override(schema_session):
+    """A subtitle_settings-only options blob is not a media_defaults override."""
+    _profile(schema_session, 1, "Global")
+    options = json.dumps({"subtitle_settings": {"subsync": {"subsync_threshold": 80}}})
+    row = ArrInstanceRepository(schema_session).create(
+        "sonarr", "Main", port=8989, options=options)
+    schema_session.flush()
+    clear_media_defaults_cache()
+
+    assert resolve_default_profile(
+        row.id, True, 1, session=schema_session) == 1
+
+
+# --------------------------------------------------------------------------
+# Validation of the stored blob
+# --------------------------------------------------------------------------
+
+def test_validate_accepts_the_three_states():
+    from arr_instances.media_defaults import validate_media_defaults
+
+    assert validate_media_defaults(None) == {}
+    assert validate_media_defaults({}) == {}
+    assert validate_media_defaults({"default_enabled": False}) == {"default_enabled": False}
+    assert validate_media_defaults({"default_enabled": True, "default_profile": 3}) == {
+        "default_enabled": True, "default_profile": 3}
+
+
+def test_validate_drops_a_profile_from_a_disabled_override():
+    from arr_instances.media_defaults import validate_media_defaults
+
+    assert validate_media_defaults({"default_enabled": False, "default_profile": 3}) == {
+        "default_enabled": False}
+
+
+@pytest.mark.parametrize(
+    "blob",
+    [
+        {"bogus": 1},                                     # unknown key
+        {"default_profile": 3},                           # profile without the flag
+        {"default_enabled": True},                        # enabled without a profile
+        {"default_enabled": True, "default_profile": None},
+        {"default_enabled": "yes"},                       # not a boolean
+        {"default_enabled": True, "default_profile": 0},   # not a valid profile id
+        {"default_enabled": True, "default_profile": True},  # bool masquerading as 1
+        {"default_enabled": True, "default_profile": "3"},   # not an int
+    ],
+)
+def test_validate_rejects_bad_blobs(blob):
+    from arr_instances.media_defaults import validate_media_defaults
+
+    with pytest.raises(ValueError):
+        validate_media_defaults(blob)
+
+
+def test_validate_rejects_an_unknown_profile_id():
+    from arr_instances.media_defaults import validate_media_defaults
+
+    blob = {"default_enabled": True, "default_profile": 9}
+    assert validate_media_defaults(blob, known_profile_ids={9}) == blob
+    with pytest.raises(ValueError):
+        validate_media_defaults(blob, known_profile_ids={1, 2})
+
+
+def test_read_and_merge_round_trip():
+    from arr_instances.media_defaults import (
+        merge_media_defaults_into_options,
+        read_media_defaults,
+    )
+
+    blob = {"default_enabled": True, "default_profile": 2}
+    options = merge_media_defaults_into_options(None, blob)
+    assert read_media_defaults(options) == blob
+    assert read_media_defaults(None) == {}
+    assert read_media_defaults("") == {}
+    assert read_media_defaults("not json") == {}
+
+
+def test_merge_preserves_subtitle_settings_and_clears_cleanly():
+    from arr_instances.media_defaults import (
+        merge_media_defaults_into_options,
+        read_media_defaults,
+    )
+    from arr_instances.subtitle_settings import read_subtitle_settings
+
+    existing = json.dumps({"subtitle_settings": {"subsync": {"subsync_threshold": 80}}})
+    options = merge_media_defaults_into_options(
+        existing, {"default_enabled": True, "default_profile": 2})
+    # the sibling block is untouched: media defaults are not subtitle settings
+    assert read_subtitle_settings(options) == {"subsync": {"subsync_threshold": 80}}
+    assert read_media_defaults(options) == {"default_enabled": True, "default_profile": 2}
+
+    cleared = merge_media_defaults_into_options(options, {})
+    assert read_media_defaults(cleared) == {}
+    assert read_subtitle_settings(cleared) == {"subsync": {"subsync_threshold": 80}}
+    # nothing left at all -> no options row content
+    assert merge_media_defaults_into_options(
+        merge_media_defaults_into_options(None, {"default_enabled": False}), {}) is None
+
+
+# --------------------------------------------------------------------------
+# Resolution with an override present
+# --------------------------------------------------------------------------
+
+def test_override_wins_over_the_global_default(schema_session):
+    _profile(schema_session, 1, "Global")
+    _profile(schema_session, 2, "Anime")
+    row = _instance(schema_session, "sonarr", "Anime", 8990,
+                    {"default_enabled": True, "default_profile": 2})
+
+    assert resolve_default_profile(row.id, True, 1, session=schema_session) == 2
+    # and it applies even when the global default is switched off entirely
+    assert resolve_default_profile(row.id, False, "", session=schema_session) == 2
+
+
+def test_disabled_override_assigns_no_profile(schema_session):
+    _profile(schema_session, 1, "Global")
+    row = _instance(schema_session, "sonarr", "Bare", 8991, {"default_enabled": False})
+
+    assert resolve_default_profile(row.id, True, 1, session=schema_session) is None
+
+
+def test_two_instances_resolve_different_profiles(schema_session):
+    _profile(schema_session, 1, "Standard")
+    _profile(schema_session, 2, "Anime")
+    standard = _instance(schema_session, "sonarr", "Standard", 8989,
+                         {"default_enabled": True, "default_profile": 1})
+    anime = _instance(schema_session, "sonarr", "Anime", 8990,
+                      {"default_enabled": True, "default_profile": 2})
+
+    assert resolve_default_profile(standard.id, False, "", session=schema_session) == 1
+    assert resolve_default_profile(anime.id, False, "", session=schema_session) == 2
+
+
+def test_override_naming_a_deleted_profile_falls_back_to_global(schema_session):
+    from sqlalchemy import delete
+
+    _profile(schema_session, 1, "Global")
+    _profile(schema_session, 2, "Anime")
+    row = _instance(schema_session, "sonarr", "Anime", 8990,
+                    {"default_enabled": True, "default_profile": 2})
+    assert resolve_default_profile(row.id, True, 1, session=schema_session) == 2
+
+    schema_session.execute(
+        delete(TableLanguagesProfiles).where(TableLanguagesProfiles.profileId == 2))
+    # no dangling profileId is ever written; the global default takes over
+    assert resolve_default_profile(row.id, True, 1, session=schema_session) == 1
+    assert resolve_default_profile(row.id, False, "", session=schema_session) is None
+
+
+def test_clearing_the_override_returns_to_the_global_default(schema_session):
+    from arr_instances.media_defaults import merge_media_defaults_into_options
+
+    _profile(schema_session, 1, "Global")
+    _profile(schema_session, 2, "Anime")
+    row = _instance(schema_session, "sonarr", "Anime", 8990,
+                    {"default_enabled": True, "default_profile": 2})
+    assert resolve_default_profile(row.id, True, 1, session=schema_session) == 2
+
+    ArrInstanceRepository(schema_session).update(
+        row.id, options=merge_media_defaults_into_options(row.options, {}))
+    clear_media_defaults_cache()
+    assert resolve_default_profile(row.id, True, 1, session=schema_session) == 1
+
+
+def test_cache_is_cleared_per_instance(schema_session):
+    from arr_instances.media_defaults import merge_media_defaults_into_options
+
+    _profile(schema_session, 1, "Global")
+    _profile(schema_session, 2, "Anime")
+    row = _instance(schema_session, "sonarr", "Anime", 8990,
+                    {"default_enabled": True, "default_profile": 2})
+    assert resolve_default_profile(row.id, True, 1, session=schema_session) == 2
+
+    ArrInstanceRepository(schema_session).update(
+        row.id,
+        options=merge_media_defaults_into_options(
+            None, {"default_enabled": True, "default_profile": 1}))
+    # stale until the cache is dropped, then current
+    assert resolve_default_profile(row.id, True, 99, session=schema_session) == 2
+    clear_media_defaults_cache(row.id)
+    assert resolve_default_profile(row.id, True, 1, session=schema_session) == 1
+
+
+# --------------------------------------------------------------------------
+# The sync sites: insert only, per instance
+# --------------------------------------------------------------------------
+
+def _noop(*args, **kwargs):
+    return None
+
+
+class _DummyJobs:
+    def add_job_from_function(self, *a, **k):
+        return None
+
+    def update_job_progress(self, *a, **k):
+        return None
+
+    def update_job_name(self, *a, **k):
+        return None
+
+    def feed_jobs_pending_queue(self, *a, **k):
+        return None
+
+
+def _series_parser_stub(show, action, tags_dict, language_profiles,
+                        serie_default_profile, audio_profiles):
+    """Stands in for seriesParser, reproducing its insert-only profile rule."""
+    parsed = {"sonarrSeriesId": int(show["id"]), "path": f"/tv/{show['id']}", "title": "S"}
+    if action == "insert":
+        parsed["profileId"] = serie_default_profile
+    return parsed
+
+
+def _movie_parser_stub(movie, action, tags_dict, language_profiles,
+                       movie_default_profile, audio_profiles):
+    parsed = {"radarrId": int(movie["id"]), "path": f"/m/{movie['id']}",
+              "title": "M", "tmdbId": f"t{movie['id']}", "year": "2020"}
+    if action == "insert":
+        parsed["profileId"] = movie_default_profile
+    return parsed
+
+
+def _prepare_series_sync(monkeypatch, session):
+    import sonarr.sync.series as series_mod
+
+    monkeypatch.setattr(series_mod, "database", session)
+    monkeypatch.setattr(series_mod, "event_stream", _noop)
+    monkeypatch.setattr(series_mod, "sync_episodes", _noop)
+    monkeypatch.setattr(series_mod, "seriesParser", _series_parser_stub)
+    return series_mod
+
+
+def _prepare_movie_sync(monkeypatch, session, movies):
+    import radarr.sync.movies as mv_mod
+
+    monkeypatch.setattr(mv_mod, "database", session)
+    monkeypatch.setattr(mv_mod, "event_stream", _noop)
+    monkeypatch.setattr(mv_mod, "store_subtitles_movie", _noop)
+    monkeypatch.setattr(mv_mod, "check_radarr_rootfolder", _noop)
+    monkeypatch.setattr(mv_mod, "jobs_queue", _DummyJobs())
+    monkeypatch.setattr(mv_mod, "get_profile_list", lambda *a, **k: [])
+    monkeypatch.setattr(mv_mod, "get_tags", lambda *a, **k: [])
+    monkeypatch.setattr(mv_mod, "get_language_profiles", lambda *a, **k: [])
+    def _fetch(*a, **k):
+        # The single-movie path asks for one radarr_id and gets one dict back;
+        # the bulk path gets the whole list. Mirror both.
+        if k.get("radarr_id") is not None:
+            return next((m for m in movies if m["id"] == int(k["radarr_id"])), None)
+        return movies
+
+    monkeypatch.setattr(mv_mod, "get_movies_from_radarr_api", _fetch)
+    monkeypatch.setattr(mv_mod, "movieParser", _movie_parser_stub)
+    return mv_mod
+
+
+def _sync_one_series(series_mod, series_id, arr_instance_id=None):
+    series_mod.update_one_series(
+        series_id, action="updated", series_data={"id": series_id},
+        existing_in_db=False, audio_profiles=[], tags_dict=[], language_profiles=[],
+        skip_episode_sync=True, is_signalr=True, arr_instance_id=arr_instance_id)
+
+
+def _global_series_default(monkeypatch, enabled, profile):
+    from app.config import settings
+
+    monkeypatch.setattr(settings.general, "serie_default_enabled", enabled)
+    monkeypatch.setattr(settings.general, "serie_default_profile", profile)
+
+
+def _global_movie_default(monkeypatch, enabled, profile):
+    from app.config import settings
+
+    monkeypatch.setattr(settings.general, "movie_default_enabled", enabled)
+    monkeypatch.setattr(settings.general, "movie_default_profile", profile)
+
+
+def _profile_of_series(session, sonarr_series_id):
+    return session.execute(
+        select(TableShows.profileId)
+        .where(TableShows.sonarrSeriesId == sonarr_series_id)).scalar()
+
+
+def _profile_of_movie(session, radarr_id):
+    return session.execute(
+        select(TableMovies.profileId).where(TableMovies.radarrId == radarr_id)).scalar()
+
+
+def test_series_sync_without_override_keeps_the_global_profile(schema_session, monkeypatch):
+    """The single-instance install: a sync pass must assign the global profile."""
+    _profile(schema_session, 1, "Global")
+    inst = _instance(schema_session, "sonarr", "Main", 8989)
+    _global_series_default(monkeypatch, True, 1)
+    series_mod = _prepare_series_sync(monkeypatch, schema_session)
+
+    _sync_one_series(series_mod, 5)                  # default path, no instance passed
+    _sync_one_series(series_mod, 6, inst.id)         # explicitly scoped to that instance
+
+    assert _profile_of_series(schema_session, 5) == 1
+    assert _profile_of_series(schema_session, 6) == 1
+
+
+def test_series_sync_uses_the_instance_override(schema_session, monkeypatch):
+    _profile(schema_session, 1, "Standard")
+    _profile(schema_session, 2, "Anime")
+    anime = _instance(schema_session, "sonarr", "Anime", 8990,
+                      {"default_enabled": True, "default_profile": 2})
+    _global_series_default(monkeypatch, True, 1)
+    series_mod = _prepare_series_sync(monkeypatch, schema_session)
+
+    _sync_one_series(series_mod, 5, anime.id)
+
+    assert _profile_of_series(schema_session, 5) == 2
+
+
+def test_two_series_instances_assign_different_profiles_in_one_pass(
+        schema_session, monkeypatch):
+    _profile(schema_session, 1, "Standard")
+    _profile(schema_session, 2, "Anime")
+    standard = _instance(schema_session, "sonarr", "Standard", 8989,
+                         {"default_enabled": True, "default_profile": 1})
+    anime = _instance(schema_session, "sonarr", "Anime", 8990,
+                      {"default_enabled": True, "default_profile": 2})
+    _global_series_default(monkeypatch, False, "")
+    series_mod = _prepare_series_sync(monkeypatch, schema_session)
+
+    _sync_one_series(series_mod, 5, standard.id)
+    _sync_one_series(series_mod, 6, anime.id)
+
+    assert _profile_of_series(schema_session, 5) == 1
+    assert _profile_of_series(schema_session, 6) == 2
+
+
+def test_series_sync_does_not_move_an_existing_row(schema_session, monkeypatch):
+    """An override set later must not reassign media already in the database."""
+    _profile(schema_session, 1, "Standard")
+    _profile(schema_session, 2, "Anime")
+    anime = _instance(schema_session, "sonarr", "Anime", 8990,
+                      {"default_enabled": True, "default_profile": 2})
+    schema_session.execute(insert(TableShows).values(
+        sonarrSeriesId=5, id=5, arr_instance_id=anime.id, path="/tv/old",
+        title="Old", profileId=1))
+    _global_series_default(monkeypatch, True, 1)
+    series_mod = _prepare_series_sync(monkeypatch, schema_session)
+
+    series_mod.update_one_series(
+        5, action="updated", series_data={"id": 5}, existing_in_db=True,
+        audio_profiles=[], tags_dict=[], language_profiles=[],
+        skip_episode_sync=True, is_signalr=True, arr_instance_id=anime.id)
+
+    assert _profile_of_series(schema_session, 5) == 1   # hand-picked value survives
+
+
+def test_series_sync_falls_back_when_the_override_profile_is_gone(
+        schema_session, monkeypatch):
+    _profile(schema_session, 1, "Global")
+    anime = _instance(schema_session, "sonarr", "Anime", 8990,
+                      {"default_enabled": True, "default_profile": 7})   # never existed
+    _global_series_default(monkeypatch, True, 1)
+    series_mod = _prepare_series_sync(monkeypatch, schema_session)
+
+    _sync_one_series(series_mod, 5, anime.id)
+
+    assert _profile_of_series(schema_session, 5) == 1
+
+
+def test_movie_bulk_sync_without_override_keeps_the_global_profile(
+        schema_session, monkeypatch):
+    _profile(schema_session, 1, "Global")
+    _instance(schema_session, "radarr", "Main", 7878)
+    _global_movie_default(monkeypatch, True, 1)
+    mv_mod = _prepare_movie_sync(monkeypatch, schema_session, [
+        {"id": 10, "hasFile": True, "monitored": True, "title": "M",
+         "movieFile": {"size": 999999, "path": "/m"}}])
+
+    mv_mod.update_movies(job_id="job-1")
+
+    assert _profile_of_movie(schema_session, 10) == 1
+
+
+def test_movie_bulk_sync_uses_the_instance_override(schema_session, monkeypatch):
+    _profile(schema_session, 1, "Standard")
+    _profile(schema_session, 2, "Anime")
+    anime = _instance(schema_session, "radarr", "Anime", 7879,
+                      {"default_enabled": True, "default_profile": 2})
+    _global_movie_default(monkeypatch, True, 1)
+    mv_mod = _prepare_movie_sync(monkeypatch, schema_session, [
+        {"id": 10, "hasFile": True, "monitored": True, "title": "M",
+         "movieFile": {"size": 999999, "path": "/m"}}])
+
+    mv_mod.update_movies(job_id="job-1", arr_instance_id=anime.id, arr_client=object())
+
+    assert _profile_of_movie(schema_session, 10) == 2
+
+
+def test_single_movie_sync_uses_the_instance_override(schema_session, monkeypatch):
+    _profile(schema_session, 1, "Standard")
+    _profile(schema_session, 2, "Anime")
+    anime = _instance(schema_session, "radarr", "Anime", 7879,
+                      {"default_enabled": True, "default_profile": 2})
+    _global_movie_default(monkeypatch, True, 1)
+    mv_mod = _prepare_movie_sync(monkeypatch, schema_session, [
+        {"id": 10, "hasFile": True, "monitored": True, "title": "M",
+         "movieFile": {"size": 999999, "path": "/m"}}])
+
+    mv_mod.update_one_movie(10, action="updated", arr_instance_id=anime.id,
+                            arr_client=object())
+
+    assert _profile_of_movie(schema_session, 10) == 2
+
+
+def test_single_movie_sync_without_override_keeps_the_global_profile(
+        schema_session, monkeypatch):
+    _profile(schema_session, 1, "Global")
+    _instance(schema_session, "radarr", "Main", 7878)
+    _global_movie_default(monkeypatch, True, 1)
+    mv_mod = _prepare_movie_sync(monkeypatch, schema_session, [
+        {"id": 10, "hasFile": True, "monitored": True, "title": "M",
+         "movieFile": {"size": 999999, "path": "/m"}}])
+
+    mv_mod.update_one_movie(10, action="updated")
+
+    assert _profile_of_movie(schema_session, 10) == 1
+
+
+def test_a_matching_tag_still_beats_the_instance_default(monkeypatch):
+    """Precedence: tag > instance default > global default.
+
+    Driven through the real seriesParser, since that is where the tag override
+    is applied, after whichever default the sync site resolved.
+    """
+    from app.config import settings
+    from sonarr.sync.parser import seriesParser
+
+    monkeypatch.setattr(settings.general, "serie_tag_enabled", True)
+    monkeypatch.setattr(settings.general, "remove_profile_tags", [])
+    show = {
+        "id": 5, "title": "S", "path": "/tv/s", "tvdbId": 1, "overview": "",
+        "images": [], "alternateTitles": [], "tags": [1], "sortTitle": "s",
+        "year": 2020, "seriesType": "anime", "monitored": True, "ended": False,
+    }
+    language_profiles = [(3, "Tagged", "anime-tag")]
+
+    parsed = seriesParser(show, action="insert", tags_dict=[{"id": 1, "label": "anime-tag"}],
+                          language_profiles=language_profiles,
+                          serie_default_profile=2, audio_profiles=[])
+    assert parsed["profileId"] == 3
+
+    # without a tag match the instance-resolved default stands
+    parsed = seriesParser(show, action="insert", tags_dict=[{"id": 1, "label": "other"}],
+                          language_profiles=language_profiles,
+                          serie_default_profile=2, audio_profiles=[])
+    assert parsed["profileId"] == 2
+
+
+# --------------------------------------------------------------------------
+# CRUD: the override round-trips through the existing options column
+# --------------------------------------------------------------------------
+
+def test_service_create_and_read_back_the_override(schema_session):
+    from arr_instances import service
+
+    _profile(schema_session, 2, "Anime")
+    body, status = service.create_instance(schema_session, {
+        "kind": "sonarr", "name": "Anime", "ip": "127.0.0.1", "port": 8990,
+        "media_defaults": {"default_enabled": True, "default_profile": 2},
+    })
+    assert status == 201, body
+    assert body["media_defaults"] == {"default_enabled": True, "default_profile": 2}
+
+    fetched, _ = service.get_instance(schema_session, body["id"])
+    assert fetched["media_defaults"] == {"default_enabled": True, "default_profile": 2}
+
+
+def test_service_rejects_an_override_naming_an_unknown_profile(schema_session):
+    from arr_instances import service
+
+    _profile(schema_session, 2, "Anime")
+    body, status = service.create_instance(schema_session, {
+        "kind": "sonarr", "name": "Bad", "ip": "127.0.0.1", "port": 8990,
+        "media_defaults": {"default_enabled": True, "default_profile": 99},
+    })
+    assert status == 400
+    assert "99" in body["message"]
+
+
+def test_service_update_round_trips_and_clears_the_override(schema_session):
+    from arr_instances import service
+
+    _profile(schema_session, 2, "Anime")
+    created, _ = service.create_instance(schema_session, {
+        "kind": "sonarr", "name": "Anime", "ip": "127.0.0.1", "port": 8990})
+    assert created["media_defaults"] == {}
+
+    updated, status = service.update_instance(schema_session, created["id"], {
+        "media_defaults": {"default_enabled": True, "default_profile": 2}})
+    assert status == 200, updated
+    assert updated["media_defaults"] == {"default_enabled": True, "default_profile": 2}
+
+    cleared, status = service.update_instance(
+        schema_session, created["id"], {"media_defaults": {}})
+    assert status == 200
+    assert cleared["media_defaults"] == {}
+
+
+def test_service_update_keeps_subtitle_settings_intact(schema_session):
+    from arr_instances import service
+
+    _profile(schema_session, 2, "Anime")
+    created, _ = service.create_instance(schema_session, {
+        "kind": "sonarr", "name": "Anime", "ip": "127.0.0.1", "port": 8990,
+        "subtitle_settings": {"subsync": {"subsync_threshold": 80}}})
+    updated, _ = service.update_instance(schema_session, created["id"], {
+        "media_defaults": {"default_enabled": True, "default_profile": 2}})
+
+    assert updated["subtitle_settings"] == {"subsync": {"subsync_threshold": 80}}
+    assert updated["media_defaults"] == {"default_enabled": True, "default_profile": 2}
+
+
+# --------------------------------------------------------------------------
+# The opt-in apply action: unset profiles only, one instance only
+# --------------------------------------------------------------------------
+
+def _series(session, local_id, upstream_id, instance_id, profile=None):
+    session.execute(insert(TableShows).values(
+        id=local_id, sonarrSeriesId=upstream_id, arr_instance_id=instance_id,
+        path=f"/tv/{local_id}", title=f"S{local_id}", profileId=profile))
+
+
+def _movie(session, local_id, upstream_id, instance_id, profile=None):
+    session.execute(insert(TableMovies).values(
+        id=local_id, radarrId=upstream_id, arr_instance_id=instance_id,
+        path=f"/m/{local_id}", title=f"M{local_id}", tmdbId=f"t{local_id}",
+        profileId=profile))
+
+
+def test_apply_fills_only_unset_profiles_on_that_instance(schema_session):
+    from arr_instances import service
+
+    _profile(schema_session, 1, "Standard")
+    _profile(schema_session, 2, "Anime")
+    standard = _instance(schema_session, "sonarr", "Standard", 8989,
+                         {"default_enabled": True, "default_profile": 1})
+    anime = _instance(schema_session, "sonarr", "Anime", 8990,
+                      {"default_enabled": True, "default_profile": 2})
+
+    _series(schema_session, 1, 10, anime.id, None)   # unset, on the target
+    _series(schema_session, 2, 11, anime.id, 1)      # hand-picked, on the target
+    _series(schema_session, 3, 12, standard.id, None)  # unset, other instance
+    _series(schema_session, 4, 13, None, None)       # unowned
+
+    body, status = service.apply_default_profile(schema_session, anime.id)
+    assert status == 200, body
+    assert body["updated"] == 1
+    assert body["profileId"] == 2
+    assert body["kind"] == "sonarr"
+    assert body["upstream_ids"] == [10]
+
+    profiles = dict(schema_session.execute(
+        select(TableShows.id, TableShows.profileId)).all())
+    assert profiles == {1: 2, 2: 1, 3: None, 4: None}
+
+
+def test_apply_is_scoped_to_movies_of_that_instance(schema_session):
+    from arr_instances import service
+
+    _profile(schema_session, 2, "Anime")
+    main = _instance(schema_session, "radarr", "Main", 7878)
+    anime = _instance(schema_session, "radarr", "Anime", 7879,
+                      {"default_enabled": True, "default_profile": 2})
+    _movie(schema_session, 1, 10, anime.id, None)
+    _movie(schema_session, 2, 11, main.id, None)
+
+    body, status = service.apply_default_profile(schema_session, anime.id)
+    assert status == 200, body
+    assert body["updated"] == 1
+
+    profiles = dict(schema_session.execute(
+        select(TableMovies.id, TableMovies.profileId)).all())
+    assert profiles == {1: 2, 2: None}
+
+
+def test_apply_needs_an_override_to_apply(schema_session):
+    from arr_instances import service
+
+    _profile(schema_session, 1, "Global")
+    plain = _instance(schema_session, "sonarr", "Main", 8989)
+    _series(schema_session, 1, 10, plain.id, None)
+
+    body, status = service.apply_default_profile(schema_session, plain.id)
+    assert status == 400
+    assert _profile_of_series(schema_session, 10) is None
+
+    # ... and an override that deliberately assigns nothing is not applicable
+    off = _instance(schema_session, "sonarr", "Off", 8990, {"default_enabled": False})
+    body, status = service.apply_default_profile(schema_session, off.id)
+    assert status == 400
+
+
+def test_apply_rejects_an_override_whose_profile_is_gone(schema_session):
+    from sqlalchemy import delete
+
+    from arr_instances import service
+
+    _profile(schema_session, 2, "Anime")
+    anime = _instance(schema_session, "sonarr", "Anime", 8990,
+                      {"default_enabled": True, "default_profile": 2})
+    _series(schema_session, 1, 10, anime.id, None)
+    schema_session.execute(
+        delete(TableLanguagesProfiles).where(TableLanguagesProfiles.profileId == 2))
+
+    body, status = service.apply_default_profile(schema_session, anime.id)
+    assert status == 400
+    assert _profile_of_series(schema_session, 10) is None
+
+
+def test_apply_on_an_unknown_instance_is_404(schema_session):
+    from arr_instances import service
+
+    body, status = service.apply_default_profile(schema_session, 4242)
+    assert status == 404
+
+
+def test_refresh_runtime_drops_the_media_defaults_cache(schema_session, monkeypatch):
+    """An edited override must take effect on the next sync, not the next restart."""
+    from arr_instances import resolution, service
+
+    monkeypatch.setattr(service, "event_stream", _noop)
+    resolution._media_defaults_cache[123] = {"default_enabled": True, "default_profile": 9}
+    service.refresh_runtime("nonexistent-kind")
+    assert resolution._media_defaults_cache == {}
+
+
+def test_the_api_layer_is_wired_for_media_defaults():
+    """Guard against the field or the apply route being written but never routed.
+
+    Read as source rather than imported: pulling api.system.arr_instances drags
+    the whole flask_restx chain into this process and would leak it into every
+    test that shares it.
+    """
+    import pathlib
+
+    source = pathlib.Path(__file__).resolve().parents[2].joinpath(
+        "bazarr", "api", "system", "arr_instances.py").read_text()
+    assert '_create_parser.add_argument("media_defaults"' in source
+    assert '_update_parser.add_argument("media_defaults"' in source
+    assert "/apply-default-profile" in source
+    assert "service.apply_default_profile(" in source
+
+
+def test_service_update_accepts_both_blobs_in_one_request(schema_session):
+    """A PATCH carrying both blobs must not let one overwrite the other."""
+    from arr_instances import service
+
+    _profile(schema_session, 2, "Anime")
+    created, _ = service.create_instance(schema_session, {
+        "kind": "sonarr", "name": "Anime", "ip": "127.0.0.1", "port": 8990})
+
+    updated, status = service.update_instance(schema_session, created["id"], {
+        "subtitle_settings": {"subsync": {"subsync_threshold": 80}},
+        "media_defaults": {"default_enabled": True, "default_profile": 2},
+    })
+    assert status == 200, updated
+    assert updated["subtitle_settings"] == {"subsync": {"subsync_threshold": 80}}
+    assert updated["media_defaults"] == {"default_enabled": True, "default_profile": 2}


### PR DESCRIPTION
## What

Each Sonarr/Radarr instance can carry its own default language profile, applied to media it syncs that has no profile of its own.

With several instances configured this is the difference between the feature being usable and not. A 4K instance and a 1080p instance of the same library want different profiles, and a global default can only be right for one of them. Until now every newly synced item took the single global default and had to be repaired by hand.

Behaviour:

- the default is per instance, set from the instance form in Settings → Connections
- it applies at sync time to items with no profile, series and movies alike
- an instance with no default falls back to the global one, which is every existing install

## Tests

`tests/bazarr/test_arr_media_defaults.py` covers the resolution order for both media types, instances with and without a default, and the fallback to the global setting. On the frontend, `mediaDefaults.test.ts` covers the resolution helper and `InstanceFormModal.test.tsx` covers the form.

Backend suite green locally (1653 passed), frontend 863 passed, ruff clean, frontend builds.