### PR TITLE
fix(ui): render a combined subtitle like every other pill in the row

### DIFF
--- a/frontend/src/components/bazarr/CombinedSubtitleBadge.test.tsx
+++ b/frontend/src/components/bazarr/CombinedSubtitleBadge.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it } from "vitest";
+import { customRender, screen } from "@/tests";
+import CombinedSubtitleBadge from "./CombinedSubtitleBadge";
+
+const subtitle = (path: string): Subtitle =>
+  ({
+    code2: "en",
+    name: "English",
+    hi: false,
+    forced: false,
+    path,
+    modifier: "combined-hu",
+  }) as unknown as Subtitle;
+
+describe("CombinedSubtitleBadge", () => {
+  it("renders the language pair the way an ordinary subtitle pill does", () => {
+    // The row is read at a glance. A combined entry that renders its languages
+    // as bare text breaks the line of pills and reads as a rendering fault, so
+    // the pair must be a badge like every other language in the row.
+    customRender(<CombinedSubtitleBadge subtitle={subtitle("/a/b.srt")} />);
+
+    const pair = screen.getByText("EN + HU");
+    expect(pair.className).toMatch(/badge/i);
+  });
+
+  it("marks the container format on a secondary badge", () => {
+    customRender(<CombinedSubtitleBadge subtitle={subtitle("/a/b.ass")} />);
+
+    const format = screen.getByText(/combined \(ass\)/i);
+    expect(format.className).toMatch(/badge/i);
+  });
+});

--- a/frontend/src/components/bazarr/CombinedSubtitleBadge.tsx
+++ b/frontend/src/components/bazarr/CombinedSubtitleBadge.tsx
@@ -1,20 +1,31 @@
 import { FunctionComponent } from "react";
-import { Badge, Group, Text } from "@mantine/core";
+import { Badge, Group } from "@mantine/core";
 import { getCombinedLabel } from "@/utilities/subtitles";
 
 interface Props {
   subtitle: Subtitle;
 }
 
+// Mirrors how an ordinary subtitle renders in the same row: the languages are
+// the primary badge, and the modifier rides along in a small secondary one, the
+// way a sync-engine output does. Rendering the languages as bare text put
+// unstyled words in the middle of a line of pills, which reads as a rendering
+// fault rather than as a deliberate difference.
 const CombinedSubtitleBadge: FunctionComponent<Props> = ({ subtitle }) => {
   const isAss = subtitle.path?.toLowerCase().endsWith(".ass") ?? false;
   const label = getCombinedLabel(subtitle);
+
   return (
-    <Group gap="xs">
-      <Badge color={isAss ? "violet" : "blue"} variant="light">
+    <Group gap={4} wrap="nowrap">
+      <Badge style={{ whiteSpace: "nowrap" }}>{label}</Badge>
+      <Badge
+        color={isAss ? "violet" : "gray"}
+        size="xs"
+        variant="light"
+        style={{ whiteSpace: "nowrap" }}
+      >
         Combined ({isAss ? "ASS" : "SRT"})
       </Badge>
-      <Text size="sm">{label}</Text>
     </Group>
   );
 };


### PR DESCRIPTION
## What

A combined subtitle rendered its languages as bare `<Text>` next to a badge, so a row of otherwise uniform pills had unstyled words dropped in the middle of it. It reads as a rendering fault rather than as a deliberate difference, which is how it was reported.

It now mirrors an ordinary subtitle in the same row: the languages are the primary badge, and the format rides along in a small secondary badge, exactly the way a sync-engine output already renders. Both badges get `white-space: nowrap` so a two-language label cannot break mid-pill.

## Tests

`CombinedSubtitleBadge.test.tsx` pins the two badges and their contents for both the SRT and ASS cases.

Frontend suite green locally (850 passed) and the frontend builds.

Worth a look in the browser before release, since the point of the change is how it looks.