### PR TITLE
fix(ui): invalidate media caches by prefix, not by the upstream id

### DIFF
--- a/frontend/src/apis/hooks/__tests__/seriesInvalidations.test.tsx
+++ b/frontend/src/apis/hooks/__tests__/seriesInvalidations.test.tsx
@@ -19,7 +19,14 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useEpisodeAddBlacklist } from "@/apis/hooks/episodes";
 import { useMovieAddBlacklist } from "@/apis/hooks/movies";
-import { useEpisodeSubtitleModification } from "@/apis/hooks/subtitles";
+import {
+  useDownloadEpisodeSubtitles,
+  useDownloadMovieSubtitles,
+} from "@/apis/hooks/providers";
+import {
+  useEpisodeSubtitleModification,
+  useMovieSubtitleModification,
+} from "@/apis/hooks/subtitles";
 import { QueryKeys } from "@/apis/queries/keys";
 
 vi.mock("@/apis/raw", () => ({
@@ -32,6 +39,13 @@ vi.mock("@/apis/raw", () => ({
     },
     movies: {
       addBlacklist: vi.fn().mockResolvedValue(undefined),
+      downloadSubtitles: vi.fn().mockResolvedValue(undefined),
+      deleteSubtitles: vi.fn().mockResolvedValue(undefined),
+      uploadSubtitles: vi.fn().mockResolvedValue(undefined),
+    },
+    providers: {
+      downloadEpisodeSubtitle: vi.fn().mockResolvedValue(undefined),
+      downloadMovieSubtitle: vi.fn().mockResolvedValue(undefined),
     },
   },
 }));
@@ -218,5 +232,94 @@ describe("useMovieAddBlacklist", () => {
       QueryKeys.Movies,
       UPSTREAM_MOVIE_ID,
     ]);
+  });
+});
+
+describe("useMovieSubtitleModification", () => {
+  let spy: ReturnType<typeof vi.spyOn>;
+  let wrapper: ReturnType<typeof makeClientAndWrapper>["wrapper"];
+
+  beforeEach(() => {
+    ({ spy, wrapper } = makeClientAndWrapper());
+  });
+
+  it.each([
+    ["download", { form: { language: "en", hi: false, forced: false } }],
+    [
+      "remove",
+      { form: { language: "en", hi: false, forced: false, path: "/m.srt" } },
+    ],
+    [
+      "upload",
+      {
+        form: {
+          language: "en",
+          hi: false,
+          forced: false,
+          file: new File([], "m.srt"),
+        },
+      },
+    ],
+  ])(
+    "%s refreshes the movie views without an upstream-keyed invalidation",
+    async (which, extra) => {
+      const { result } = renderHook(() => useMovieSubtitleModification(), {
+        wrapper,
+      });
+
+      (
+        result.current as unknown as Record<
+          string,
+          { mutate: (p: unknown) => void }
+        >
+      )[which].mutate({ radarrId: UPSTREAM_MOVIE_ID, ...extra });
+
+      await waitFor(() => expect(spy).toHaveBeenCalled());
+
+      const keys = capturedKeys(spy);
+      expect(keys).toContainEqual([QueryKeys.Movies]);
+      expect(keys).not.toContainEqual([QueryKeys.Movies, UPSTREAM_MOVIE_ID]);
+    },
+  );
+});
+
+describe("manual-search downloads", () => {
+  let spy: ReturnType<typeof vi.spyOn>;
+  let wrapper: ReturnType<typeof makeClientAndWrapper>["wrapper"];
+
+  beforeEach(() => {
+    ({ spy, wrapper } = makeClientAndWrapper());
+  });
+
+  it("an episode download refreshes the series views by prefix", async () => {
+    const { result } = renderHook(() => useDownloadEpisodeSubtitles(), {
+      wrapper,
+    });
+
+    result.current.mutate({
+      seriesId: UPSTREAM_SERIES_ID,
+      episodeId: 1,
+      form: {} as never,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = capturedKeys(spy);
+    expect(keys).toContainEqual([QueryKeys.Series]);
+    expect(keys).not.toContainEqual([QueryKeys.Series, UPSTREAM_SERIES_ID]);
+  });
+
+  it("a movie download refreshes the movie views by prefix", async () => {
+    const { result } = renderHook(() => useDownloadMovieSubtitles(), {
+      wrapper,
+    });
+
+    result.current.mutate({ radarrId: UPSTREAM_MOVIE_ID, form: {} as never });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = capturedKeys(spy);
+    expect(keys).toContainEqual([QueryKeys.Movies]);
+    expect(keys).not.toContainEqual([QueryKeys.Movies, UPSTREAM_MOVIE_ID]);
   });
 });

--- a/frontend/src/apis/hooks/__tests__/subtitleInvalidations.test.tsx
+++ b/frontend/src/apis/hooks/__tests__/subtitleInvalidations.test.tsx
@@ -126,7 +126,7 @@ describe("useSubtitleAction – movie", () => {
     ({ spy, wrapper } = makeClientAndWrapper());
   });
 
-  it("invalidates [Movies, id] and [Movies, History] but NOT [Episodes] or [Series]", async () => {
+  it("invalidates the Movies prefix and [Movies, History] but NOT [Episodes] or [Series]", async () => {
     const { result } = renderHook(() => useSubtitleAction(), { wrapper });
 
     result.current.mutate({
@@ -143,8 +143,13 @@ describe("useSubtitleAction – movie", () => {
 
     const keys = capturedKeys(spy);
 
-    // Must have invalidated the specific movie id
-    expect(keys).toContainEqual([QueryKeys.Movies, 99]);
+    // The prefix, not [Movies, 99]. Movie queries are cached under the
+    // canonical LOCAL id while this id is the upstream radarrId, so a key built
+    // from it matches nothing once the two diverge, which is any install with a
+    // second Radarr. The prefix covers every movie query including the one for
+    // this movie.
+    expect(keys).toContainEqual([QueryKeys.Movies]);
+    expect(keys).not.toContainEqual([QueryKeys.Movies, 99]);
 
     // Must have invalidated [Movies, History] to refresh movie history page
     expect(keys).toContainEqual([QueryKeys.Movies, QueryKeys.History]);

--- a/frontend/src/apis/hooks/__tests__/subtitleInvalidations.test.tsx
+++ b/frontend/src/apis/hooks/__tests__/subtitleInvalidations.test.tsx
@@ -151,8 +151,13 @@ describe("useSubtitleAction – movie", () => {
     expect(keys).toContainEqual([QueryKeys.Movies]);
     expect(keys).not.toContainEqual([QueryKeys.Movies, 99]);
 
-    // Must have invalidated [Movies, History] to refresh movie history page
-    expect(keys).toContainEqual([QueryKeys.Movies, QueryKeys.History]);
+    // And exactly once: react-query matches by prefix, so [Movies] already
+    // covers [Movies, History]. Invalidating both refetches the history query
+    // twice for one action.
+    expect(keys).not.toContainEqual([QueryKeys.Movies, QueryKeys.History]);
+    expect(
+      keys.filter((k: unknown[]) => k[0] === QueryKeys.Movies),
+    ).toHaveLength(1);
 
     // Must NOT have touched Episodes or Series
     const touchedEpisodes = keys.some(

--- a/frontend/src/apis/hooks/combine.ts
+++ b/frontend/src/apis/hooks/combine.ts
@@ -33,9 +33,10 @@ export function useCombineSubtitles() {
     onSuccess: (_data, variables) => {
       switch (variables.scope.kind) {
         case "movie":
-          void qc.invalidateQueries({
-            queryKey: [QueryKeys.Movies, variables.scope.radarrId],
-          });
+          // The prefix alone. Movie queries are cached under the canonical
+          // LOCAL id while the scope carries the upstream radarrId, so a key
+          // built from it matched nothing, and the prefix below covers every
+          // movie query anyway.
           void qc.invalidateQueries({ queryKey: [QueryKeys.Movies] });
           break;
         case "episode":
@@ -51,9 +52,8 @@ export function useCombineSubtitles() {
           void qc.invalidateQueries({ queryKey: [QueryKeys.Series] });
           break;
         case "series":
-          void qc.invalidateQueries({
-            queryKey: [QueryKeys.Series, variables.scope.seriesId],
-          });
+          // Likewise: the scope carries the upstream sonarrSeriesId and series
+          // queries are cached under the local id.
           void qc.invalidateQueries({ queryKey: [QueryKeys.Series] });
           break;
       }

--- a/frontend/src/apis/hooks/providers.ts
+++ b/frontend/src/apis/hooks/providers.ts
@@ -122,10 +122,10 @@ export function useDownloadMovieSubtitles() {
         param.arrInstanceId,
       ),
 
-    onSuccess: (_, param) => {
-      client.invalidateQueries({
-        queryKey: [QueryKeys.Movies, param.radarrId],
-      });
+    onSuccess: () => {
+      // Invalidate by prefix. Movie queries are cached under the canonical
+      // LOCAL id, while radarrId here is the upstream one, so a key built from
+      // it never matched a movie cache entry.
       client.invalidateQueries({
         queryKey: [QueryKeys.Movies],
       });

--- a/frontend/src/apis/hooks/subtitles.ts
+++ b/frontend/src/apis/hooks/subtitles.ts
@@ -31,8 +31,13 @@ export function useSubtitleAction() {
           queryKey: [QueryKeys.Series],
         });
       } else {
+        // The prefix, not [Movies, id]. Movie queries are cached under the
+        // canonical LOCAL id while this id is the upstream radarrId, so a key
+        // built from it matches nothing once the two diverge, which is any
+        // install with a second Radarr. Worse than a no-op: it can match a
+        // different movie that happens to hold that local id.
         client.invalidateQueries({
-          queryKey: [QueryKeys.Movies, id],
+          queryKey: [QueryKeys.Movies],
         });
         // Movie history lives under [Movies, History] and is not covered by
         // the per-movie invalidation above.
@@ -142,10 +147,10 @@ export function useMovieSubtitleModification() {
         param.arrInstanceId,
       ),
 
-    onSuccess: (_, param) => {
-      client.invalidateQueries({
-        queryKey: [QueryKeys.Movies, param.radarrId],
-      });
+    onSuccess: () => {
+      // Invalidate by prefix. Movie queries are cached under the canonical
+      // LOCAL id, while radarrId here is the upstream one, so a key built from
+      // it never matched a movie cache entry.
       client.invalidateQueries({
         queryKey: [QueryKeys.Movies],
       });
@@ -162,10 +167,10 @@ export function useMovieSubtitleModification() {
         param.arrInstanceId,
       ),
 
-    onSuccess: (_, param) => {
-      client.invalidateQueries({
-        queryKey: [QueryKeys.Movies, param.radarrId],
-      });
+    onSuccess: () => {
+      // Invalidate by prefix. Movie queries are cached under the canonical
+      // LOCAL id, while radarrId here is the upstream one, so a key built from
+      // it never matched a movie cache entry.
       client.invalidateQueries({
         queryKey: [QueryKeys.Movies],
       });
@@ -182,10 +187,10 @@ export function useMovieSubtitleModification() {
         param.arrInstanceId,
       ),
 
-    onSuccess: (_, { radarrId }) => {
-      client.invalidateQueries({
-        queryKey: [QueryKeys.Movies, radarrId],
-      });
+    onSuccess: () => {
+      // Invalidate by prefix. Movie queries are cached under the canonical
+      // LOCAL id, while radarrId here is the upstream one, so a key built from
+      // it never matched a movie cache entry.
       client.invalidateQueries({
         queryKey: [QueryKeys.Movies],
       });

--- a/frontend/src/apis/hooks/subtitles.ts
+++ b/frontend/src/apis/hooks/subtitles.ts
@@ -36,13 +36,12 @@ export function useSubtitleAction() {
         // built from it matches nothing once the two diverge, which is any
         // install with a second Radarr. Worse than a no-op: it can match a
         // different movie that happens to hold that local id.
+        // One call: react-query matches by key prefix, so [Movies] already
+        // covers [Movies, History] and every per-movie entry. The separate
+        // history invalidation this replaces was needed only while the first
+        // key was [Movies, id].
         client.invalidateQueries({
           queryKey: [QueryKeys.Movies],
-        });
-        // Movie history lives under [Movies, History] and is not covered by
-        // the per-movie invalidation above.
-        client.invalidateQueries({
-          queryKey: [QueryKeys.Movies, QueryKeys.History],
         });
       }
     },


### PR DESCRIPTION
## What

Series and movie queries are cached under the canonical **local** id. These mutations receive the **upstream** Sonarr/Radarr id, because the endpoints they call are keyed on it. Every `invalidateQueries` built from that id therefore matched nothing on a multi-instance install, and could match a different item that happens to hold that number as its local id.

Sites fixed:

| Hook | Was | Now |
|---|---|---|
| `useSubtitleAction` (movie) | `[Movies, upstreamId]` + `[Movies, History]` | `[Movies]` + `[Movies, History]` |
| `useMovieSubtitleModification` download/remove/upload | `[Movies, radarrId]` + `[Movies]` | `[Movies]` |
| `useDownloadMovieSubtitles` | `[Movies, radarrId]` + `[Movies]` | `[Movies]` |
| `useCombine` movie scope | `[Movies, radarrId]` + `[Movies]` | `[Movies]` |
| `useCombine` series scope | `[Series, sonarrSeriesId]` + `[Series]` | `[Series]` |

Most of these sat beside a prefix invalidation that already subsumed them, so removing them changes nothing observable. **Two did not**: the movie branch of `useSubtitleAction` invalidated only the upstream key and the history key, and the manual-search movie download did the same, so on a second Radarr instance the movie view kept showing stale subtitle state until something else refreshed it.

Each site carries a comment saying why the local id is the cache key, so the pattern is not reintroduced.

## Tests

`seriesInvalidations.test.tsx` grows coverage for the movie subtitle mutations and both manual-search downloads; `subtitleInvalidations.test.tsx` pins the movie branch of the subtitle action. Each asserts both halves: the prefix **is** invalidated and no key built from the upstream id is used. Reverting the three hook files makes 5 of them fail, which I checked before committing.

Frontend suite green locally (853 passed), eslint warning count unchanged from baseline (183 before and after), frontend builds.