### PR TITLE
feat(release): animated hero pipeline, and the v2.6.0 Clockwork motif

### DIFF
--- a/scripts/release/hero/.gitignore
+++ b/scripts/release/hero/.gitignore
@@ -1,0 +1,3 @@
+out/
+node_modules/
+public/

--- a/scripts/release/hero/README.md
+++ b/scripts/release/hero/README.md
@@ -1,0 +1,81 @@
+# Animated release hero
+
+Renders the hero artwork for a feature release as a seamless five-second loop.
+
+```bash
+npm install
+./render.sh 2.6.0 Clockwork 260      # version, codename, seed
+```
+
+Four files land in `out/`:
+
+| File | What it is | Where it goes |
+| --- | --- | --- |
+| `hero-<codename>-v<version>.gif` | 800x450, 10 fps | the GitHub release page |
+| `hero-<codename>-v<version>.webp` | 1280x720, 15 fps | the site |
+| `hero-<codename>-v<version>-poster.webp` | 1920x1080 still | fallback where animation is stripped |
+| `hero-<codename>-v<version>.mp4` | 1920x1080, 30 fps | source of truth, everything else derives from it |
+
+GIF is the release-page format because it is the only animated format GitHub
+release markdown renders everywhere. Commit the shipped files to `screenshot/`
+alongside the previous heroes.
+
+## Layout
+
+- `src/theme.ts` brand constants and the loop's timing contract
+- `src/brand.ts` the atmosphere, ported from `site/hero/`: backdrop, grade, grain, vignette, title block
+- `src/Clockwork.tsx` the v2.6.0 motif. A new release replaces this file
+- `src/Hero.tsx` the shell that stacks the layers. Shared across releases
+
+Only the motif changes between releases. The palette, the navy atmosphere and the
+top-left title block are the brand and are shared verbatim with the static
+generators in `site/hero/`; see that README for the conventions.
+
+The title is set in Geist, the site's own face. It is not committed here: the one
+copy lives in `site/fonts/` and is copied into `public/` by `render.sh` and by
+the `font` npm script, which `studio` and `still` both run first. A second
+tracked copy would drift the day the site font changes.
+
+## Writing a new motif
+
+The codename is the brief. Beyond that, the loop is the hard part, and the
+comments in `Clockwork.tsx` explain the traps in detail. In short:
+
+1. **Everything is a pure function of the frame.** No accumulated state.
+2. **The wrap has to close.** The last frame is followed by frame 0, so a whole
+   loop of motion must leave every element on a pose it already held. Rotations
+   need to land on whole multiples of each element's own symmetry period, and any
+   decoration you add tightens that condition rather than being free.
+3. **Never advance a repeating pattern by exactly one of its periods per step.**
+   It returns to an identical pose and reads as vibrating in place instead of
+   moving. This is the wagon-wheel effect and it is easy to ship by accident.
+4. **Hold the background still.** The backdrop, starfield, grain and vignette are
+   identical on every frame by design, which is most of why the files are small.
+
+## Verifying
+
+Two checks, both required, because this artwork can fail in ways a glance misses.
+
+**The wrap.** The `LoopCheck` composition is one frame longer than the loop so
+that frame `DURATION` can be rendered and diffed against frame 0. They must be
+pixel-identical. Note that the motif is driven by the raw frame on purpose: fold
+it into the period and this test passes by construction while proving nothing.
+
+```bash
+npx remotion still src/index.ts LoopCheck out/a.png --frame=0   --overwrite
+npx remotion still src/index.ts LoopCheck out/b.png --frame=150 --overwrite
+# compare a.png and b.png; any difference is a real seam
+```
+
+**The encode.** A seamless source is not a seamless file. libwebp builds an
+animation by blending each frame over the last, so lossy error accumulates in one
+direction, and on fine bright strokes it drifts visibly across the loop and then
+snaps back at the wrap. Measured on the v2.6.0 dial, first-to-last drift ran 0.59
+levels at quality 60 and 0.004 at quality 80, which is why the WebP is encoded at
+80 and at half the frame rate. If you change the encode settings, re-measure:
+sample a region the light passes over, across every decoded frame, and compare
+the first frame against the last.
+
+Remotion needs a Chromium. `render.sh` finds a Playwright `headless_shell`
+automatically; override with `REMOTION_BROWSER=/path/to/binary` if needed. Full
+Chrome does not work, it refuses the old-headless mode Remotion asks for.

--- a/scripts/release/hero/README.md
+++ b/scripts/release/hero/README.md
@@ -62,10 +62,15 @@ pixel-identical. Note that the motif is driven by the raw frame on purpose: fold
 it into the period and this test passes by construction while proving nothing.
 
 ```bash
+npm run font   # public/ is gitignored, so populate it before any direct remotion call
 npx remotion still src/index.ts LoopCheck out/a.png --frame=0   --overwrite
 npx remotion still src/index.ts LoopCheck out/b.png --frame=150 --overwrite
 # compare a.png and b.png; any difference is a real seam
 ```
+
+`render.sh` and the `studio` and `still` npm scripts do that copy for you; a bare
+`npx remotion` call does not. Forgetting it fails the render with an explicit
+message rather than quietly substituting a system font.
 
 **The encode.** A seamless source is not a seamless file. libwebp builds an
 animation by blending each frame over the last, so lossy error accumulates in one

--- a/scripts/release/hero/package-lock.json
+++ b/scripts/release/hero/package-lock.json
@@ -1,0 +1,2662 @@
+{
+  "name": "bazarr-release-hero",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bazarr-release-hero",
+      "version": "1.0.0",
+      "dependencies": {
+        "@remotion/cli": "4.0.410",
+        "react": "19.2.0",
+        "react-dom": "19.2.0",
+        "remotion": "4.0.410"
+      },
+      "devDependencies": {
+        "@types/react": "19.2.2",
+        "typescript": "5.9.3"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
+      "integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
+      "license": "MIT",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
+      "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
+      "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
+      "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
+      "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+      "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
+      "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
+      "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
+      "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
+      "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
+      "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
+      "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
+      "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
+      "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
+      "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
+      "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
+      "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
+      "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
+      "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
+      "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
+      "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remotion/bundler": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/bundler/-/bundler-4.0.410.tgz",
+      "integrity": "sha512-JuNF/wmwirL4saSAYPIdPKvh3rIfHa3qVRWZMdq2EmPxVWfEP9IPS4kMGYardsisWjbQbZXeW3jv1O9SUtZBEw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@remotion/media-parser": "4.0.410",
+        "@remotion/studio": "4.0.410",
+        "@remotion/studio-shared": "4.0.410",
+        "css-loader": "5.2.7",
+        "esbuild": "0.25.0",
+        "react-refresh": "0.9.0",
+        "remotion": "4.0.410",
+        "source-map": "0.7.3",
+        "style-loader": "4.0.0",
+        "webpack": "5.96.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/cli": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/cli/-/cli-4.0.410.tgz",
+      "integrity": "sha512-2wler/J9yq0CILLHANnJijglMPA6NBXmbKMHtzS+DgP9RR7lrBrwtxU6C6H2oxy/PQMtui0KgtBrJ9vhh/4SHQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@remotion/bundler": "4.0.410",
+        "@remotion/media-utils": "4.0.410",
+        "@remotion/player": "4.0.410",
+        "@remotion/renderer": "4.0.410",
+        "@remotion/studio": "4.0.410",
+        "@remotion/studio-server": "4.0.410",
+        "@remotion/studio-shared": "4.0.410",
+        "dotenv": "9.0.2",
+        "minimist": "1.2.6",
+        "prompts": "2.4.2",
+        "remotion": "4.0.410"
+      },
+      "bin": {
+        "remotion": "remotion-cli.js",
+        "remotionb": "remotionb-cli.js",
+        "remotiond": "remotiond-cli.js"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/compositor-darwin-arm64": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-arm64/-/compositor-darwin-arm64-4.0.410.tgz",
+      "integrity": "sha512-RgabM1QSTHgIo+RLaFzEpkTQY6IB2GWg0N09QlDUvofWP5XCGyt7yfU/CkeJ0pHTyhb3HmzVumBB4aYEgHFEBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@remotion/compositor-darwin-x64": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-darwin-x64/-/compositor-darwin-x64-4.0.410.tgz",
+      "integrity": "sha512-wj5MAtx2mwBeMkM93BQDth1VmubrxiT1N8pUHZkgywmFy10yyc+JTBOW9eDQdsMLKK7ssRW/ATxNhaCNcv+eug==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-arm64-gnu": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-gnu/-/compositor-linux-arm64-gnu-4.0.410.tgz",
+      "integrity": "sha512-v+2CQaBNlfFiZmlvoH+BUXtnI60g3aFik03WD6KQO03Knows0m7KIWjaSto2hu9oX4pSL18nU/7CYPC/nMXN6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-arm64-musl": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-arm64-musl/-/compositor-linux-arm64-musl-4.0.410.tgz",
+      "integrity": "sha512-PVm99n1udo9GW6uGpukzGpeo1KzOr/jvbvok8kzykXIMByT6/dFQz2nf2bg2KLT0G15iaAcx2ySGAxKhPdcFVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-x64-gnu": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-gnu/-/compositor-linux-x64-gnu-4.0.410.tgz",
+      "integrity": "sha512-0q4HHEqRZHX0Tv2mYqNW4nTn7fo5g4deHJRqufj308KztFYaBzFuw1wgbejfBh0Wk6JGEViFaBSmfaYNg2DZKg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-linux-x64-musl": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-linux-x64-musl/-/compositor-linux-x64-musl-4.0.410.tgz",
+      "integrity": "sha512-VPlz/IZ1co4IxgDFIyyQ8g45JNZghj2hVD2uyWFPO1B+5JX7nJwlrIT5pstcd9X2BZhpXYEIsWUCZ3qACUDzPg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@remotion/compositor-win32-x64-msvc": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/compositor-win32-x64-msvc/-/compositor-win32-x64-msvc-4.0.410.tgz",
+      "integrity": "sha512-ELKZigwUi63RMFWM7key7zC6VCCsYEGhvxj7NL2wLDzqXXb7ifp0rA1cFLyGJ2VJNPY5H8mKhoF+4cfenNcUag==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@remotion/licensing": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/licensing/-/licensing-4.0.410.tgz",
+      "integrity": "sha512-Rnu/FabQFLfT+CKPbFMFrqcs7yA0C+QZAGv2to5lZfFk9CjZ+mEyx4Ek4afr4Nv9+bVPQ9mU7FF2fTHyglZTIg==",
+      "license": "MIT"
+    },
+    "node_modules/@remotion/media-parser": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/media-parser/-/media-parser-4.0.410.tgz",
+      "integrity": "sha512-rfmFy5ZnE+TOvqXRgROI4t9lODlKLzGDdstN+0yB/84eRj1hLAIqeGROtbfohFO+X20WFRtNTS7HAs6318fOmg==",
+      "license": "Remotion License https://remotion.dev/license"
+    },
+    "node_modules/@remotion/media-utils": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/media-utils/-/media-utils-4.0.410.tgz",
+      "integrity": "sha512-jrgB3QFgLhELbVq+XNQoYraA4ofCIVaJron2KShSBdPNbkRTg2w0wCjA2gLFTdBacLSGS9N7I4Ft/qA1tpz96w==",
+      "license": "MIT",
+      "dependencies": {
+        "@remotion/media-parser": "4.0.410",
+        "@remotion/webcodecs": "4.0.410",
+        "mediabunny": "1.29.0",
+        "remotion": "4.0.410"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/player": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/player/-/player-4.0.410.tgz",
+      "integrity": "sha512-G8hATP2rdyU/jHm1MYd0jHslIyP3Vawv3mZn1HpBCtlmVH8AVK2ZmLzVYCVTeNhnYHv95SGwGlEowqiIJeM/Kw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "remotion": "4.0.410"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/renderer": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/renderer/-/renderer-4.0.410.tgz",
+      "integrity": "sha512-Fbj7f0nh9qClW5QNbrUzxn3QEb0Xvi8llUl8OStxArJRYGsx0UhLP5FeA53p4fU+zNzU4Vje4jtyIihnNKLYng==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@remotion/licensing": "4.0.410",
+        "@remotion/streaming": "4.0.410",
+        "execa": "5.1.1",
+        "extract-zip": "2.0.1",
+        "remotion": "4.0.410",
+        "source-map": "^0.8.0-beta.0",
+        "ws": "8.17.1"
+      },
+      "optionalDependencies": {
+        "@remotion/compositor-darwin-arm64": "4.0.410",
+        "@remotion/compositor-darwin-x64": "4.0.410",
+        "@remotion/compositor-linux-arm64-gnu": "4.0.410",
+        "@remotion/compositor-linux-arm64-musl": "4.0.410",
+        "@remotion/compositor-linux-x64-gnu": "4.0.410",
+        "@remotion/compositor-linux-x64-musl": "4.0.410",
+        "@remotion/compositor-win32-x64-msvc": "4.0.410"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/renderer/node_modules/source-map": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0.tgz",
+      "integrity": "sha512-d8EqvL+k/SOXCreS/SUzg2ciyHqBBLcN/yuRjFsbvVhHTE2pgei7oAhmPM7kWFbkX6OSMQfUq4KbkF3au9lhYQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@remotion/streaming": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/streaming/-/streaming-4.0.410.tgz",
+      "integrity": "sha512-Ku+0h6ZNZn7W/U4tKk03PwONdZIXAMOvVWF0oVDo2ZBR5XQGLLEL3MsL6ECKIvDn90DmjkxUY2yT89IWrCXDYA==",
+      "license": "MIT"
+    },
+    "node_modules/@remotion/studio": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/studio/-/studio-4.0.410.tgz",
+      "integrity": "sha512-WjAJg6vUZppEmk3PM1q4aueMel915+uTJY/nqcM98Py+wjRcLQP9SzL387o9OiuXEupvfqeLz1L3+ZG1gWf9+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@remotion/media-utils": "4.0.410",
+        "@remotion/player": "4.0.410",
+        "@remotion/renderer": "4.0.410",
+        "@remotion/studio-shared": "4.0.410",
+        "@remotion/web-renderer": "4.0.410",
+        "@remotion/zod-types": "4.0.410",
+        "mediabunny": "1.29.0",
+        "memfs": "3.4.3",
+        "open": "^8.4.2",
+        "remotion": "4.0.410",
+        "semver": "7.5.3",
+        "source-map": "0.7.3",
+        "zod": "3.22.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@remotion/studio-server": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-server/-/studio-server-4.0.410.tgz",
+      "integrity": "sha512-5uFR9UBySL17K5xvDY2H9lkpl43QpNrYgOvcTmZo83bT7UOT+GrHcTH1C29SVg3U0KN+BEXesgwondILzBG8lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "7.24.1",
+        "@remotion/bundler": "4.0.410",
+        "@remotion/renderer": "4.0.410",
+        "@remotion/studio-shared": "4.0.410",
+        "memfs": "3.4.3",
+        "open": "^8.4.2",
+        "recast": "0.23.11",
+        "remotion": "4.0.410",
+        "semver": "7.5.3",
+        "source-map": "0.7.3"
+      }
+    },
+    "node_modules/@remotion/studio-shared": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/studio-shared/-/studio-shared-4.0.410.tgz",
+      "integrity": "sha512-dJKj2rY9snqIlmbbGEEGpy3Mv+mhvpKk0YemNZH5J0Rd5CMHphUEuSF9goar79Ox5vSkOtyE9hTlfYvgy9pb1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "remotion": "4.0.410"
+      }
+    },
+    "node_modules/@remotion/web-renderer": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/web-renderer/-/web-renderer-4.0.410.tgz",
+      "integrity": "sha512-rELpiy7MwwD6iHuNgP+lPhlYWkWomyo4Y5gyd9FjeBVVIvElKlGWUVMse99yks/3Ezjhykq5St1kUyDlX6Gwhg==",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "@remotion/licensing": "4.0.410",
+        "mediabunny": "1.29.0",
+        "remotion": "4.0.410"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@remotion/webcodecs": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/webcodecs/-/webcodecs-4.0.410.tgz",
+      "integrity": "sha512-VNIq6Q6pWFE/PQ+ye1S/EUJvWeYTp2QK375mBA+8GdsEd64c0z6/MsfXIpmI3y/QZRtJlygsWcxqyiIGDduHXg==",
+      "license": "Remotion License (See https://remotion.dev/docs/webcodecs#license)",
+      "dependencies": {
+        "@remotion/media-parser": "4.0.410"
+      }
+    },
+    "node_modules/@remotion/zod-types": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/@remotion/zod-types/-/zod-types-4.0.410.tgz",
+      "integrity": "sha512-fqwCocF8kOUrhSSaPMendFTHPOGaRkGP+h2rk/9pthBcJf9Yema9842cBLTr+O7pnINP10W/e7Ewo2N9c9qSEw==",
+      "license": "MIT",
+      "dependencies": {
+        "remotion": "4.0.410"
+      },
+      "peerDependencies": {
+        "zod": "3.22.3"
+      }
+    },
+    "node_modules/@types/dom-mediacapture-transform": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.12.tgz",
+      "integrity": "sha512-d7/QsLRwF864A5mgIM/YrfiglHoYn7zgCcAoJgW404r+2DwnNr7EBbLnCWpmOMgH8y0te73L1AV6H1bmauaWFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "*"
+      }
+    },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+      "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
+      "integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
+      "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
+      "integrity": "sha512-Grytf1xOxOEMTGRwx6rLGKkTabd4vMg3VrKdj/7joCmV0qgh4QwMMO6xh34YEXQqirAuUdgQGa5orJQQ+69RBw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-loader": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
+      "integrity": "sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==",
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.1.0",
+        "loader-utils": "^2.0.0",
+        "postcss": "^8.2.15",
+        "postcss-modules-extract-imports": "^3.0.0",
+        "postcss-modules-local-by-default": "^4.0.0",
+        "postcss-modules-scope": "^3.0.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.1.0",
+        "schema-utils": "^3.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.27.0 || ^5.0.0"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.415",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.415.tgz",
+      "integrity": "sha512-958V+Kbhtgz+SxXeEVKBjrlKRBIDAYvUJfwhjxMZ5S6ut9jAl7l9ZKBkBrvjyjZE36PabLUo2L8kEeV5O4vgJg==",
+      "license": "ISC"
+    },
+    "node_modules/emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
+      "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.0",
+        "@esbuild/android-arm": "0.25.0",
+        "@esbuild/android-arm64": "0.25.0",
+        "@esbuild/android-x64": "0.25.0",
+        "@esbuild/darwin-arm64": "0.25.0",
+        "@esbuild/darwin-x64": "0.25.0",
+        "@esbuild/freebsd-arm64": "0.25.0",
+        "@esbuild/freebsd-x64": "0.25.0",
+        "@esbuild/linux-arm": "0.25.0",
+        "@esbuild/linux-arm64": "0.25.0",
+        "@esbuild/linux-ia32": "0.25.0",
+        "@esbuild/linux-loong64": "0.25.0",
+        "@esbuild/linux-mips64el": "0.25.0",
+        "@esbuild/linux-ppc64": "0.25.0",
+        "@esbuild/linux-riscv64": "0.25.0",
+        "@esbuild/linux-s390x": "0.25.0",
+        "@esbuild/linux-x64": "0.25.0",
+        "@esbuild/netbsd-arm64": "0.25.0",
+        "@esbuild/netbsd-x64": "0.25.0",
+        "@esbuild/openbsd-arm64": "0.25.0",
+        "@esbuild/openbsd-x64": "0.25.0",
+        "@esbuild/sunos-x64": "0.25.0",
+        "@esbuild/win32-arm64": "0.25.0",
+        "@esbuild/win32-ia32": "0.25.0",
+        "@esbuild/win32-x64": "0.25.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fs-monkey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
+      "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==",
+      "license": "Unlicense"
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loader-runner": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mediabunny": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.29.0.tgz",
+      "integrity": "sha512-18B8w/rhO/ph/AFsIXvzZg8RaSQZ+ZYfJ99MZlTjDmlgCT58jV3azrnWQ/OSquYDi8q0xmn64mnfTEHgww3+zw==",
+      "license": "MPL-2.0",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@types/dom-mediacapture-transform": "^0.1.11",
+        "@types/dom-webcodecs": "0.1.13"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      }
+    },
+    "node_modules/memfs": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.3.tgz",
+      "integrity": "sha512-eivjfi7Ahr6eQTn44nvTnR60e4a1Fs1Via2kCR5lHo/kyNoiMWaXCNJ/GpSd0ilXas2JSOl9B5FTIhflXu0hlg==",
+      "license": "Unlicense",
+      "dependencies": {
+        "fs-monkey": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-modules-extract-imports": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
+      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
+      "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-scope": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
+      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "license": "ISC",
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
+      "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recast": {
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/remotion": {
+      "version": "4.0.410",
+      "resolved": "https://registry.npmjs.org/remotion/-/remotion-4.0.410.tgz",
+      "integrity": "sha512-qk1IRV3hSm67Bgt3yIgrNmuAE5XJRIft3t40gGbkV+H98Ob0NYHBtkJBjlkz0I1ysC7eTP6iOkPUHLDzUA1D3Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/style-loader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
+      "integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.27.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.50.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
+      "integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/watchpack": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack": {
+      "version": "5.96.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
+      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
+        "@webassemblyjs/ast": "^1.12.1",
+        "@webassemblyjs/wasm-edit": "^1.12.1",
+        "@webassemblyjs/wasm-parser": "^1.12.1",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.17.1",
+        "es-module-lexer": "^1.2.1",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.2.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.3.10",
+        "watchpack": "^2.4.1",
+        "webpack-sources": "^3.2.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/scripts/release/hero/package.json
+++ b/scripts/release/hero/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "bazarr-release-hero",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Animated release hero renderer for Bazarr+ (Remotion). Renders the MP4 source of truth plus the GIF and animated WebP derivatives.",
+  "scripts": {
+    "font": "mkdir -p public && cp -f ../../../site/fonts/Geist-Variable.woff2 public/",
+    "prestudio": "npm run font",
+    "prestill": "npm run font",
+    "studio": "remotion studio src/index.ts",
+    "render": "./render.sh",
+    "still": "remotion still src/index.ts Hero"
+  },
+  "dependencies": {
+    "react": "19.2.0",
+    "react-dom": "19.2.0",
+    "remotion": "4.0.410",
+    "@remotion/cli": "4.0.410"
+  },
+  "devDependencies": {
+    "@types/react": "19.2.2",
+    "typescript": "5.9.3"
+  }
+}

--- a/scripts/release/hero/remotion.config.ts
+++ b/scripts/release/hero/remotion.config.ts
@@ -1,0 +1,6 @@
+import { Config } from "@remotion/cli/config";
+
+Config.setVideoImageFormat("png");
+Config.setOverwriteOutput(true);
+// The composition is one canvas element; concurrency above the core count just
+// thrashes. Left at the default so the renderer picks per-machine.

--- a/scripts/release/hero/render.sh
+++ b/scripts/release/hero/render.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Render the release hero: MP4 source of truth, plus the GIF and animated WebP
+# derivatives that actually ship.
+#
+#   ./render.sh <version> <codename> [seed]
+#   ./render.sh 2.6.0 Clockwork 260
+#
+# Outputs land in out/ as hero-<codename>-v<version>.{mp4,gif,webp}. The GIF is
+# what goes into screenshot/ for the GitHub release page, because GIF is the only
+# animated format release markdown renders everywhere. The WebP is for the site.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+VERSION="${1:?usage: render.sh <version> <codename> [seed]}"
+CODENAME="${2:?usage: render.sh <version> <codename> [seed]}"
+SEED="${3:-260}"
+
+SLUG="$(echo "$CODENAME" | tr '[:upper:]' '[:lower:]')"
+STEM="hero-${SLUG}-v${VERSION}"
+mkdir -p out
+
+# Remotion needs a Chromium. Prefer a headless shell: full Chrome refuses to run
+# in old-headless mode, which is what Remotion asks for.
+find_browser() {
+  if [[ -n "${REMOTION_BROWSER:-}" ]]; then echo "$REMOTION_BROWSER"; return; fi
+  local c
+  for c in \
+    "$HOME"/.cache/ms-playwright/chromium_headless_shell-*/chrome-headless-shell-linux64/chrome-headless-shell \
+    "$HOME"/.cache/ms-playwright/chromium_headless_shell-*/chrome-linux/headless_shell \
+    /opt/pw-browsers/chromium_headless_shell-*/chrome-linux/headless_shell; do
+    [[ -x "$c" ]] && { echo "$c"; return; }
+  done
+  echo ""
+}
+
+BROWSER="$(find_browser)"
+BROWSER_ARG=()
+if [[ -n "$BROWSER" ]]; then
+  BROWSER_ARG=(--browser-executable="$BROWSER")
+  echo "==> chromium: $BROWSER"
+else
+  echo "==> chromium: letting Remotion resolve its own"
+fi
+
+PROPS="$(printf '{"version":"%s","codename":"%s","seed":%s}' "$VERSION" "$CODENAME" "$SEED")"
+
+# The brand face lives once, in site/fonts/, and Remotion can only load it from
+# public/. Copy it in rather than committing a second copy: a tracked duplicate
+# drifts silently the day the site font is updated, and the hero would keep
+# rendering the old face with nothing to show for it.
+FONT_SRC="../../../site/fonts/Geist-Variable.woff2"
+if [[ ! -f "$FONT_SRC" ]]; then
+  echo "error: brand font not found at $FONT_SRC (run from a full checkout)" >&2
+  exit 1
+fi
+mkdir -p public
+cp -f "$FONT_SRC" public/
+
+echo "==> 1/4 MP4 (source of truth, 1920x1080 30fps)"
+npx remotion render src/index.ts Hero "out/${STEM}.mp4" \
+  --codec h264 --crf 16 --props="$PROPS" "${BROWSER_ARG[@]}" --overwrite
+
+# The background is identical on every frame by design, so both encoders below
+# are told to exploit inter-frame similarity rather than re-encode the field.
+
+# 800px at 10fps with a 96-colour adaptive palette and no dithering. Dithering
+# looks better on a still but its noise pattern defeats inter-frame compression,
+# and on this artwork it roughly doubled the file for no visible gain once the
+# grain is already there. 10fps keeps every 3rd frame, which divides the 6-frame
+# escapement period exactly, so the tick stays crisp instead of stuttering.
+echo "==> 2/4 GIF (release page, 800px @ 10fps)"
+ffmpeg -v error -y -i "out/${STEM}.mp4" \
+  -vf "fps=10,scale=800:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=96:stats_mode=diff[p];[s1][p]paletteuse=dither=none:diff_mode=rectangle" \
+  -loop 0 "out/${STEM}.gif"
+
+# Quality 80 at 15fps, and both halves of that matter for the LOOP rather than
+# for the picture. libwebp builds an animation by blending each frame over the
+# last, so lossy error accumulates in a fixed direction; on the fine dial strokes
+# it brightened them steadily across the loop and then snapped back at the wrap,
+# which is exactly where a seamless loop gets caught out. Measured on the dial
+# band, first-to-last drift runs 0.59 at q60 and 0.004 at q80. Halving the frame
+# count halves the accumulation as well, and 15fps still divides the 6-frame beat.
+# The result is smaller than the drifting q60/30fps encode it replaces.
+echo "==> 3/4 WebP (site, 1280x720 @ 15fps)"
+ffmpeg -v error -y -i "out/${STEM}.mp4" \
+  -vf "fps=15,scale=1280:-1:flags=lanczos" \
+  -vcodec libwebp_anim -lossless 0 -quality 80 -compression_level 6 -preset picture \
+  -loop 0 "out/${STEM}.webp"
+
+# Poster fallback for anywhere animation is stripped. Rendered to PNG first
+# because that is what Remotion emits losslessly, then converted to WebP, which
+# is a fraction of the size at the same visible quality and matches the format
+# the animated site asset already uses.
+echo "==> 4/4 Poster still (WebP)"
+npx remotion still src/index.ts Hero "out/${STEM}-poster.png" \
+  --frame=0 --props="$PROPS" "${BROWSER_ARG[@]}" --overwrite
+ffmpeg -v error -y -i "out/${STEM}-poster.png" -vcodec libwebp -lossless 0 -q:v 88 \
+  -compression_level 6 -preset picture "out/${STEM}-poster.webp"
+rm -f "out/${STEM}-poster.png"
+
+echo
+echo "==> done"
+ls -lh "out/${STEM}".{mp4,gif,webp} "out/${STEM}-poster.webp" | awk '{printf "    %-46s %s\n", $9, $5}'

--- a/scripts/release/hero/src/Clockwork.tsx
+++ b/scripts/release/hero/src/Clockwork.tsx
@@ -1,0 +1,535 @@
+/**
+ * v2.6.0 "Clockwork" motif: a real epicyclic gear train, drawn in the same
+ * luminous mark vocabulary the Murmuration hero uses for its flock, so the two
+ * releases read as one body of work.
+ *
+ * The codename is the brief. v2.6.0 is the fix batch, so the image is a
+ * mechanism running true, and it has to actually BE a mechanism: wheels that
+ * touch share a pitch, mesh tooth-into-gap, and turn at the ratio their tooth
+ * counts dictate. Concentric rings spinning at unrelated rates are a mandala,
+ * not a machine.
+ *
+ * THE TRAIN  (sun / six planets / internal ring, carrier fixed)
+ *   ring    96 teeth, internal    pitch radius 0.410 S
+ *   planet  24 teeth, six of them pitch radius 0.103 S, centres at 0.308 S
+ *   sun     48 teeth              pitch radius 0.205 S
+ *   Standing constraint: N_ring = N_sun + 2*N_planet (96 = 48 + 48), which is
+ *   what makes the three radii close exactly. Equal planet spacing additionally
+ *   needs (N_sun + N_ring) / planets to be a whole number: 144 / 6 = 24.
+ *
+ * WHAT MOVES
+ * The ring is the fixed member, so the entire outer assembly, ring and bolts and
+ * bearing races and dial, is one stationary plate. The sun drives, the planets
+ * ride a carrier that swings them round it, and each planet also spins about its
+ * own centre. The only thing that travels around the outside is the light.
+ *
+ * Nothing here is a free rate: with the ring fixed, the tooth counts alone fix
+ * the carrier at a third of the sun and the planet spin at minus the sun. See
+ * SUN_REVS for why half a turn of the sun per loop is the slowest that closes.
+ *
+ * THE ESCAPEMENT DRIVES EVERYTHING
+ * Every beat steps the whole moving assembly: snap, overshoot, recoil onto the
+ * lock, then hold dead still until the next beat. In a real mechanical clock
+ * every wheel in the train ticks; only the hand is obvious about it. The step
+ * works out at 0.96 of a tooth rather than a whole one, on purpose: a whole
+ * tooth per beat is the wagon-wheel trap described in theme.ts.
+ *
+ * LOOP CONTRACT
+ * The frame is folded into one period before anything is computed, so the frame
+ * at the loop point is bit-identical to frame 0 for free. What that does not buy
+ * is a seamless WRAP: the last rendered frame is followed by frame 0, so a full
+ * turn's worth of motion has to leave every wheel on a pose it already held. The
+ * rates in SUN_REVS are chosen for exactly that, and each wheel's decoration
+ * count is part of the condition rather than a free choice.
+ */
+
+import { BEATS_PER_LOOP, BRAND_RAMP, EASE } from "./theme";
+import { clamp01, Ctx, gGlow, Geometry, smooth } from "./brand";
+
+const TAU = Math.PI * 2;
+
+// --- the train ---------------------------------------------------------------
+
+const N_RING = 96;
+const N_PLANET = 24;
+const N_SUN = N_RING - 2 * N_PLANET; // 48, by the standing constraint
+const PLANETS = 6;
+
+/**
+ * How many teeth each wheel must turn before it looks like itself again.
+ *
+ * A bare wheel repeats every single tooth. A wheel carrying decoration repeats
+ * only on the decoration's period, which is the whole point of putting it there:
+ * without it a symmetric wheel gives the eye nothing to track and its rotation
+ * is invisible. Each of these divides TEETH_PER_LOOP, so the decoration returns
+ * to its start with the wheel and the loop stays exact.
+ */
+const SUN_HOLES = 12;
+const PLANET_SPOKES = 6;
+const RING_BOLTS = 12;
+
+/**
+ * Rates, in revolutions per loop.
+ *
+ * The ring gear is the FIXED member, which is the ordinary way a planetary set is
+ * arranged and the reason the whole outer assembly here holds still: the ring,
+ * its bolts, the bearing races and the dial are one stationary plate. The sun
+ * drives, and the carrier the planets ride on turns at a rate the tooth counts
+ * fix, ω_carrier = ω_sun * N_sun / (N_sun + N_ring) = a third of the sun. Each
+ * planet also spins about its own centre, at ω_planet = -ω_sun.
+ *
+ * A half turn of the sun per loop is the slowest setting that still closes:
+ *   sun      0.500 rev = 180 deg, a whole number of its 30 deg hole period
+ *   planet  -0.500 rev = 180 deg, a whole number of its 60 deg crossing period
+ *   carrier  0.167 rev =  60 deg, exactly one planet spacing
+ * The carrier moving by one spacing means planet j finishes where planet j+1
+ * began, so their poses have to agree too: j ends 180 deg back while j+1 started
+ * 60 deg round, a difference of 240 deg, which is 4 crossing periods. That last
+ * condition is why the planets carry SIX crossings and not four.
+ */
+const SUN_REVS = 0.5;
+const CARRIER_REVS = SUN_REVS * (N_SUN / (N_SUN + N_RING)); // a third of the sun
+const PLANET_REVS = -SUN_REVS;
+
+/**
+ * Ring pitch radius as a fraction of S. Every other size derives from the pitch,
+ * so this is the one scale knob. Sized so the dial AND the beat marker riding it
+ * clear the frame: the marker's glow is what sets the real outer bound, and
+ * sizing to the dial alone clips it at the top of every lap.
+ */
+const RING_R = 0.41;
+
+/** Circular pitch, shared by every meshing wheel. */
+const pitchOf = (S: number) => (RING_R * S * TAU) / N_RING;
+
+/** Pitch radius of an N-tooth wheel. */
+const radiusOf = (N: number, p: number) => (p * N) / TAU;
+
+/** Tooth height, a little over half the pitch, which is ordinary gear proportion. */
+const toothHeight = (p: number) => p * 0.55;
+
+/** The fixed dial the hand reads against, outside the train. */
+const DIAL_R = 0.46;
+const DIAL_MARKS = BEATS_PER_LOOP * 4; // every fourth mark is a beat
+
+/** Outermost radius used for the colour ramp. */
+const R_MAX = 0.48;
+
+function rampAt(t: number): [number, number, number] {
+  const n = BRAND_RAMP.length - 1;
+  const x = clamp01(t) * n;
+  const i = Math.min(n - 1, Math.floor(x));
+  const f = x - i;
+  const a = BRAND_RAMP[i];
+  const b = BRAND_RAMP[i + 1];
+  return [
+    Math.round(a[0] + (b[0] - a[0]) * f),
+    Math.round(a[1] + (b[1] - a[1]) * f),
+    Math.round(a[2] + (b[2] - a[2]) * f),
+  ];
+}
+
+/**
+ * Depth into the movement measured from the composition centre, 1 at the core
+ * and 0 at the rim, gamma-shaped so cream carries most of the mechanism and cyan
+ * is kept for the outer dial. Colour is keyed to the whole composition rather
+ * than to each wheel, so the palette reads as one radial gradient across the
+ * machine instead of repeating inside every planet.
+ */
+function depthAt(distFromCentre: number, S: number): number {
+  return Math.pow(clamp01(1 - distFromCentre / (S * R_MAX)), 0.8);
+}
+
+/**
+ * How far through the loop the movement has stepped, 0 to 1, advancing in
+ * BEATS_PER_LOOP eased beats. Every rate above is scaled by this, so the whole
+ * machine steps as one: snap, overshoot, recoil onto the lock, then stillness.
+ */
+function turnProgress(frame: number, dur: number): number {
+  const framesPerBeat = dur / BEATS_PER_LOOP;
+  const index = Math.floor(frame / framesPerBeat);
+  const u = (frame % framesPerBeat) / framesPerBeat;
+  // The jump occupies the first 55% of the beat; the rest is the lock, a held
+  // beat of stillness. Fast move, then complete stillness, then fast move.
+  const s = Math.min(1, u / 0.55);
+  return (index + EASE.outBack(s)) / BEATS_PER_LOOP;
+}
+
+/** Shortest angular distance between two angles, in [0, PI]. */
+function angDist(a: number, b: number): number {
+  let d = Math.abs((((a - b) % TAU) + TAU) % TAU);
+  if (d > Math.PI) d = TAU - d;
+  return d;
+}
+
+/** Marks thin out near the title block, the same soft elliptical falloff the flock uses. */
+function textFade(x: number, y: number, geo: Geometry): number {
+  const ax = geo.W * 0.17;
+  const ay = geo.H * 0.225;
+  const R = geo.S * 0.3;
+  const dx = (x - ax) / 1.3;
+  const dy = y - ay;
+  return smooth(clamp01(Math.hypot(dx, dy) / R));
+}
+
+interface Scene {
+  geo: Geometry;
+  /** composition centre, which the colour ramp and the highlight are keyed to */
+  ox: number;
+  oy: number;
+  sweep: number;
+}
+
+const gleamAt = (a: number, sweep: number) => Math.exp(-((angDist(a, sweep) / 0.45) ** 2));
+
+// --- drawing -----------------------------------------------------------------
+
+/**
+ * A circle drawn as many short arcs so it can honour the title falloff and the
+ * travelling highlight per segment. A single `arc` stroke cannot fade.
+ */
+function drawArcBand(
+  c: Ctx,
+  scene: Scene,
+  cx: number,
+  cy: number,
+  radius: number,
+  lineWidth: number,
+  alpha: number,
+) {
+  if (radius <= 0 || alpha <= 0) return;
+  const { geo, ox, oy, sweep } = scene;
+  const { S } = geo;
+  const segments = 160;
+  const step = TAU / segments;
+
+  c.save();
+  c.globalCompositeOperation = "screen";
+  c.lineWidth = lineWidth;
+  for (let i = 0; i < segments; i++) {
+    const a = i * step;
+    const x = cx + Math.cos(a) * radius;
+    const y = cy + Math.sin(a) * radius;
+    const fade = textFade(x, y, geo);
+    if (fade < 0.02) continue;
+    const [r, g, b] = rampAt(depthAt(Math.hypot(x - ox, y - oy), S));
+    const gl = gleamAt(Math.atan2(y - oy, x - ox), sweep);
+    const A = alpha * fade * (0.7 + 0.8 * gl);
+    if (A < 0.008) continue;
+    c.strokeStyle = `rgba(${r}, ${g}, ${b}, ${A})`;
+    c.beginPath();
+    c.arc(cx, cy, radius, a - step * 0.02, a + step * 1.02);
+    c.stroke();
+  }
+  c.restore();
+}
+
+interface GearSpec {
+  cx: number;
+  cy: number;
+  N: number;
+  /** circular pitch, shared across the train */
+  p: number;
+  /** teeth face inward, i.e. a ring gear */
+  internal?: boolean;
+  /** angle of the wheel's zeroth tooth at rest */
+  phase: number;
+  /** the wheel's absolute rotation, in radians */
+  rot: number;
+  alpha: number;
+  /** lightening holes drilled through the wheel's web */
+  holes?: { count: number; at: number; r: number };
+  /** crossings from hub to rim, the classic clock-wheel spoke */
+  spokes?: number;
+}
+
+function drawGear(c: Ctx, scene: Scene, g: GearSpec) {
+  const { geo, ox, oy, sweep } = scene;
+  const { S } = geo;
+  const R = radiusOf(g.N, g.p);
+  const h = toothHeight(g.p);
+  const step = TAU / g.N;
+  const rot = g.rot;
+
+  // The rim the teeth stand on. Teeth floating in space read as rays; teeth
+  // attached to a wheel read as a gear.
+  const rimR = g.internal ? R + h * 0.78 : R - h * 0.78;
+  drawArcBand(c, scene, g.cx, g.cy, rimR, h * 0.5, g.alpha * 0.32);
+
+  if (g.spokes) {
+    const inner = R * 0.26;
+    const outer = R * 0.74;
+    c.save();
+    c.globalCompositeOperation = "screen";
+    for (let i = 0; i < g.spokes; i++) {
+      const a = rot + (i / g.spokes) * TAU;
+      const ux = Math.cos(a);
+      const uy = Math.sin(a);
+      const px = -uy;
+      const py = ux;
+      const mx = g.cx + ux * ((inner + outer) / 2);
+      const my = g.cy + uy * ((inner + outer) / 2);
+      const fade = textFade(mx, my, geo);
+      if (fade < 0.02) continue;
+      const [r, gg, b] = rampAt(depthAt(Math.hypot(mx - ox, my - oy), S));
+      const gl = gleamAt(Math.atan2(my - oy, mx - ox), sweep);
+      const A = clamp01(g.alpha * 0.5 * fade * (0.7 + 0.8 * gl));
+      const wIn = R * 0.075;
+      const wOut = R * 0.045;
+      c.fillStyle = `rgba(${r}, ${gg}, ${b}, ${A})`;
+      c.beginPath();
+      c.moveTo(g.cx + ux * inner - px * wIn, g.cy + uy * inner - py * wIn);
+      c.lineTo(g.cx + ux * outer - px * wOut, g.cy + uy * outer - py * wOut);
+      c.lineTo(g.cx + ux * outer + px * wOut, g.cy + uy * outer + py * wOut);
+      c.lineTo(g.cx + ux * inner + px * wIn, g.cy + uy * inner + py * wIn);
+      c.closePath();
+      c.fill();
+    }
+    c.restore();
+  }
+
+  if (g.holes) {
+    for (let i = 0; i < g.holes.count; i++) {
+      const a = rot + (i / g.holes.count) * TAU;
+      drawArcBand(
+        c,
+        scene,
+        g.cx + Math.cos(a) * R * g.holes.at,
+        g.cy + Math.sin(a) * R * g.holes.at,
+        R * g.holes.r,
+        R * 0.014,
+        g.alpha * 0.38,
+      );
+    }
+  }
+
+  c.save();
+  c.globalCompositeOperation = "screen";
+
+  const baseR = g.internal ? R + h * 0.45 : R - h * 0.45;
+  const tipR = g.internal ? R - h * 0.55 : R + h * 0.55;
+  const wb = g.p * 0.3;
+  const wt = g.p * 0.17;
+
+  for (let i = 0; i < g.N; i++) {
+    const a = g.phase + rot + i * step;
+    const ux = Math.cos(a);
+    const uy = Math.sin(a);
+    const x = g.cx + ux * R;
+    const y = g.cy + uy * R;
+
+    const fade = textFade(x, y, geo);
+    if (fade < 0.02) continue;
+
+    const [r, gg, b] = rampAt(depthAt(Math.hypot(x - ox, y - oy), S));
+    const gl = gleamAt(Math.atan2(y - oy, x - ox), sweep);
+    const alpha = clamp01(g.alpha * fade * (0.62 + 0.85 * gl));
+    if (alpha < 0.012) continue;
+
+    // A tapered trapezoid, wide at the root and narrow at the tip, which is the
+    // silhouette of real gear cutting. Filled rather than stroked so it never
+    // reads as a glyph, and proportioned from the pitch so it never reads as a ray.
+    const px = -uy;
+    const py = ux;
+    c.fillStyle = `rgba(${r}, ${gg}, ${b}, ${alpha})`;
+    c.beginPath();
+    c.moveTo(g.cx + ux * baseR - px * wb, g.cy + uy * baseR - py * wb);
+    c.lineTo(g.cx + ux * tipR - px * wt, g.cy + uy * tipR - py * wt);
+    c.lineTo(g.cx + ux * tipR + px * wt, g.cy + uy * tipR + py * wt);
+    c.lineTo(g.cx + ux * baseR + px * wb, g.cy + uy * baseR + py * wb);
+    c.closePath();
+    c.fill();
+  }
+  c.restore();
+}
+
+/** The fixed chapter ring the hand reads against. A dial does not turn. */
+function drawDial(c: Ctx, scene: Scene) {
+  const { geo, ox, oy, sweep } = scene;
+  const { S } = geo;
+  const R = S * DIAL_R;
+  const [r, g, b] = rampAt(depthAt(R, S));
+
+  c.save();
+  c.globalCompositeOperation = "screen";
+  c.lineCap = "butt";
+  for (let i = 0; i < DIAL_MARKS; i++) {
+    const a = -Math.PI / 2 + (i / DIAL_MARKS) * TAU;
+    const beat = i % 4 === 0;
+    const len = S * (beat ? 0.019 : 0.008);
+    const ux = Math.cos(a);
+    const uy = Math.sin(a);
+    const x = ox + ux * R;
+    const y = oy + uy * R;
+    const fade = textFade(x, y, geo);
+    if (fade < 0.02) continue;
+    const alpha = clamp01((beat ? 0.5 : 0.26) * fade * (0.6 + 0.9 * gleamAt(a, sweep)));
+    c.strokeStyle = `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    c.lineWidth = S * (beat ? 0.0022 : 0.0012);
+    c.beginPath();
+    c.moveTo(ox + ux * (R - len), oy + uy * (R - len));
+    c.lineTo(ox + ux * (R + len), oy + uy * (R + len));
+    c.stroke();
+  }
+  c.restore();
+}
+
+/** Hub and bore: plain circles, so the wheel stays symmetric at one tooth pitch. */
+function drawHub(c: Ctx, scene: Scene, cx: number, cy: number, R: number, alpha: number) {
+  drawArcBand(c, scene, cx, cy, R * 0.3, R * 0.055, alpha * 0.42);
+  drawArcBand(c, scene, cx, cy, R * 0.1, R * 0.09, alpha * 0.5);
+}
+
+/**
+ * The beat marker: a jewel riding the chapter ring, jumping exactly one division
+ * per beat and completing one lap per loop.
+ *
+ * This replaced a centre-pivoted hand. A hand long enough to reach its own dial
+ * draws a line right across the movement, and at the top of the loop it bisects
+ * the whole composition; a marker on the ring says the same thing about the beat
+ * without cutting the picture in half.
+ */
+function drawBeatMarker(c: Ctx, scene: Scene, beats: number) {
+  const { geo, ox, oy } = scene;
+  const { S } = geo;
+  const a = -Math.PI / 2 + ((beats % BEATS_PER_LOOP) / BEATS_PER_LOOP) * TAU;
+  const R = S * DIAL_R;
+  const x = ox + Math.cos(a) * R;
+  const y = oy + Math.sin(a) * R;
+
+  c.save();
+  c.globalCompositeOperation = "screen";
+  gGlow(c, x, y, S * 0.034, "#ffb347", 0.26);
+  gGlow(c, x, y, S * 0.012, "#fff3d0", 0.5);
+  gGlow(c, x, y, S * 0.0038, "#ffffff", 0.85);
+  c.restore();
+}
+
+/** Soft luminous body, so the movement sits in the frame instead of floating on it. */
+function drawBodyGlow(c: Ctx, geo: Geometry, cx: number, cy: number, pulse: number) {
+  const { S } = geo;
+  c.save();
+  c.globalCompositeOperation = "screen";
+  gGlow(c, cx, cy, S * 0.44, "#8a6bff", 0.05);
+  gGlow(c, cx - S * 0.2, cy + S * 0.16, S * 0.3, "#7fe9ff", 0.038);
+  gGlow(c, cx + S * 0.14, cy - S * 0.12, S * 0.26, "#ffb347", 0.045);
+  gGlow(c, cx, cy, S * 0.16, "#ffce92", 0.05 + 0.05 * pulse);
+  c.restore();
+}
+
+/**
+ * The jewel at the sun's centre. It is the only element in the frame that glows,
+ * and it flares on every beat, tying the light to the rhythm of the mechanism.
+ */
+function drawCore(c: Ctx, geo: Geometry, cx: number, cy: number, pulse: number, breath: number) {
+  const { S } = geo;
+  c.save();
+  c.globalCompositeOperation = "screen";
+  const swell = 1 + 0.14 * pulse + 0.05 * breath;
+  gGlow(c, cx, cy, S * 0.075 * swell, "#ffb347", 0.3 + 0.26 * pulse);
+  gGlow(c, cx, cy, S * 0.03 * swell, "#fff3d0", 0.45 + 0.3 * pulse);
+  gGlow(c, cx, cy, S * 0.011 * swell, "#ffffff", 0.8 + 0.2 * pulse);
+  c.restore();
+}
+
+export interface ClockworkFrame {
+  frame: number;
+  dur: number;
+}
+
+export function drawClockwork(c: Ctx, geo: Geometry, { frame: rawFrame, dur }: ClockworkFrame) {
+  const { W, H, S } = geo;
+  // The MECHANISM is driven by the raw frame, deliberately unfolded. Folding it
+  // into one period would make the loop check tautological: frame `dur` would
+  // render as frame 0 by construction and prove nothing about whether the train
+  // actually returns to its starting pose. Left raw, rendering frame `dur` is a
+  // real test of the rates in SUN_REVS.
+  const frame = rawFrame;
+  // The lighting and the breath are phase functions of position in the loop, not
+  // parts of the train, so those do fold.
+  const phase = ((rawFrame % dur) + dur) % dur;
+
+  const ox = W * 0.65;
+  const oy = H * 0.5;
+
+  const turn = turnProgress(frame, dur);
+  const sunAng = turn * SUN_REVS * TAU;
+  const planetAng = turn * PLANET_REVS * TAU;
+  const carrierAng = turn * CARRIER_REVS * TAU;
+
+  const framesPerBeat = dur / BEATS_PER_LOOP;
+  const beatPhase = (frame % framesPerBeat) / framesPerBeat;
+  const pulse = Math.exp(-4 * beatPhase); // sharp attack on the beat, decay through the lock
+  const beats = turn * BEATS_PER_LOOP;
+  const breath = Math.sin(TAU * 2 * (phase / dur)); // two whole breaths per loop
+  const sweep = -Math.PI / 2 + TAU * (phase / dur); // light, not a part: one smooth revolution
+
+  const scene: Scene = { geo, ox, oy, sweep };
+
+  const p = pitchOf(S);
+  const rSun = radiusOf(N_SUN, p);
+  const rPlanet = radiusOf(N_PLANET, p);
+  const carrier = rSun + rPlanet; // planet centres sit exactly the pitch-radius sum out
+
+  drawBodyGlow(c, geo, ox, oy, pulse);
+  drawDial(c, scene);
+
+  // Bearing races: concentric and symmetric, so they cost the loop nothing.
+  drawArcBand(c, scene, ox, oy, S * 0.434, S * 0.0016, 0.13);
+  drawArcBand(c, scene, ox, oy, S * 0.1, S * 0.0012, 0.12);
+
+  // Ring gear. Internal mesh, so it turns the same way as the planets it holds.
+  drawGear(c, scene, {
+    cx: ox,
+    cy: oy,
+    N: N_RING,
+    p,
+    internal: true,
+    phase: 0,
+    // The fixed member. Its bolts belong to the stationary plate, so nothing out
+    // here turns; the only thing that travels around the rim is the light.
+    rot: 0,
+    holes: { count: RING_BOLTS, at: 1.075, r: 0.028 },
+    alpha: 0.5,
+  });
+
+  // Planets. Each sits on a spoke of the carrier, and carries a half-pitch offset
+  // so its teeth fall into the sun's gaps rather than colliding with its teeth.
+  for (let k = 0; k < PLANETS; k++) {
+    const rest = (k / PLANETS) * TAU; // where this planet sits at rest
+    const at = rest + carrierAng; // where the carrier has swung it to
+    const px = ox + Math.cos(at) * carrier;
+    const py = oy + Math.sin(at) * carrier;
+    drawGear(c, scene, {
+      cx: px,
+      cy: py,
+      N: N_PLANET,
+      p,
+      // The mesh offset is fixed at the wheel's rest position; the carrier moves
+      // where the planet IS, while its own spin is what turns its teeth. Folding
+      // the carrier into the phase instead would double-count the orbit and tear
+      // the mesh apart.
+      phase: rest + Math.PI + Math.PI / N_PLANET,
+      rot: planetAng,
+      spokes: PLANET_SPOKES,
+      alpha: 0.62,
+    });
+    drawHub(c, scene, px, py, rPlanet, 0.5);
+  }
+
+  // Sun. External mesh with the planets, so it turns against them.
+  drawGear(c, scene, {
+    cx: ox,
+    cy: oy,
+    N: N_SUN,
+    p,
+    phase: 0,
+    rot: sunAng,
+    holes: { count: SUN_HOLES, at: 0.62, r: 0.12 },
+    alpha: 0.72,
+  });
+  drawHub(c, scene, ox, oy, rSun, 0.45);
+
+  drawBeatMarker(c, scene, beats);
+  drawCore(c, geo, ox, oy, pulse, breath);
+}

--- a/scripts/release/hero/src/Hero.tsx
+++ b/scripts/release/hero/src/Hero.tsx
@@ -14,6 +14,7 @@
 
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
+  cancelRender,
   continueRender,
   delayRender,
   staticFile,
@@ -73,12 +74,28 @@ export const Hero: React.FC<HeroProps> = ({ version, codename, seed, loopFrames 
 
   useEffect(() => {
     let live = true;
-    const done = () => {
-      if (!live) return;
-      setFontReady(true);
-      continueRender(handle);
-    };
-    ensureFont().then(done, done);
+    ensureFont().then(
+      () => {
+        if (!live) return;
+        setFontReady(true);
+        continueRender(handle);
+      },
+      (error: unknown) => {
+        if (!live) return;
+        // Fail the render rather than carrying on. Continuing here would fall
+        // back to a system sans and quietly produce typography that differs by
+        // machine, which is the exact failure loading Geist explicitly exists to
+        // prevent, and it would look like a successful render. The likeliest
+        // cause is that `public/` has not been populated: it is gitignored, and
+        // the font is copied in from site/fonts/ by render.sh or `npm run font`.
+        cancelRender(
+          new Error(
+            `Could not load the Geist brand font. Run "npm run font" to copy it ` +
+              `from site/fonts/ into public/, then render again. Cause: ${String(error)}`,
+          ),
+        );
+      },
+    );
     return () => {
       live = false;
     };

--- a/scripts/release/hero/src/Hero.tsx
+++ b/scripts/release/hero/src/Hero.tsx
@@ -1,0 +1,135 @@
+/**
+ * The release hero shell: the part that does not change between releases.
+ *
+ * Layer stack, bottom to top:
+ *   1. backdrop   navy, dawn gradient, three radial glows, fog, starfield  (static, cached)
+ *   2. motif      the release's mechanism/flock/etc                        (animated)
+ *   3. type       the title block                                          (near-static)
+ *   4. grade      warm key into cool shadow                                (static)
+ *   5. grain + vignette                                                    (static)
+ *
+ * Only layer 2 and the codename shimmer in layer 3 change between frames. That
+ * is deliberate: it keeps the animation legible, and it keeps the GIF small.
+ */
+
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  continueRender,
+  delayRender,
+  staticFile,
+  useCurrentFrame,
+  useVideoConfig,
+} from "remotion";
+
+import { drawClockwork } from "./Clockwork";
+import { Ctx, getBackdrop, Geometry, paintGrade, paintGrain, paintText, paintVignette } from "./brand";
+import { FONT_FAMILY } from "./theme";
+
+// A type alias rather than an interface: Remotion's Composition constrains props
+// to Record<string, unknown>, and only type aliases get the implicit index
+// signature that satisfies it.
+export type HeroProps = {
+  version: string;
+  codename: string;
+  seed: number;
+  /**
+   * Period of the loop in frames. Defaults to the composition length, which is
+   * what a real render uses. It is overridable purely so the loop seam can be
+   * proven: render frame `loopFrames` from a composition one frame longer and
+   * diff it against frame 0. They must be pixel-identical.
+   */
+  loopFrames?: number;
+};
+
+// Loaded once for the whole render rather than per frame, so seeking between
+// frames never re-races the font against the first paint.
+let fontPromise: Promise<void> | null = null;
+
+function ensureFont(): Promise<void> {
+  if (!fontPromise) {
+    fontPromise = (async () => {
+      const face = new FontFace(
+        "Geist",
+        `url(${staticFile("Geist-Variable.woff2")}) format("woff2")`,
+        { weight: "100 900" },
+      );
+      const loaded = await face.load();
+      // FontFaceSet.add is missing from the default DOM lib but is standard.
+      (document.fonts as FontFaceSet & { add(f: FontFace): void }).add(loaded);
+      await document.fonts.ready;
+    })();
+  }
+  return fontPromise;
+}
+
+export const Hero: React.FC<HeroProps> = ({ version, codename, seed, loopFrames }) => {
+  const frame = useCurrentFrame();
+  const { width, height, durationInFrames } = useVideoConfig();
+  const dur = loopFrames ?? durationInFrames;
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const [fontReady, setFontReady] = useState(false);
+  const [handle] = useState(() => delayRender("Loading Geist"));
+
+  useEffect(() => {
+    let live = true;
+    const done = () => {
+      if (!live) return;
+      setFontReady(true);
+      continueRender(handle);
+    };
+    ensureFont().then(done, done);
+    return () => {
+      live = false;
+    };
+  }, [handle]);
+
+  const draw = useCallback(() => {
+    const el = canvasRef.current;
+    if (!el) return;
+    const c = el.getContext("2d") as Ctx | null;
+    if (!c) return;
+
+    const geo: Geometry = { W: width, H: height, S: Math.min(width, height) };
+    c.imageSmoothingEnabled = true;
+    c.imageSmoothingQuality = "high";
+    c.clearRect(0, 0, geo.W, geo.H);
+
+    // 1. atmosphere
+    c.drawImage(getBackdrop(geo, seed), 0, 0);
+
+    // 2. motif
+    drawClockwork(c, geo, { frame, dur });
+
+    // 3. type. The shimmer crosses the codename once per loop, entering and
+    // leaving fully outside the glyphs so the loop point shows no band.
+    paintText(c, geo, FONT_FAMILY, {
+      version,
+      codename,
+      shimmer: (frame / dur) % 1,
+    });
+
+    // 4. grade
+    paintGrade(c, geo);
+
+    // 5. grain and vignette
+    paintVignette(c, geo);
+    paintGrain(c, geo, seed);
+  }, [frame, width, height, dur, version, codename, seed]);
+
+  // Layout effect runs synchronously after commit and before the browser paints,
+  // so the canvas is complete by the time Remotion captures the frame.
+  useLayoutEffect(() => {
+    if (!fontReady) return;
+    draw();
+  }, [draw, fontReady]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={width}
+      height={height}
+      style={{ width, height, display: "block" }}
+    />
+  );
+};

--- a/scripts/release/hero/src/Root.tsx
+++ b/scripts/release/hero/src/Root.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Composition } from "remotion";
+
+import { Hero, HeroProps } from "./Hero";
+import { DURATION, FPS, HEIGHT, WIDTH } from "./theme";
+
+/**
+ * One composition, parameterised by release. A new release renders the same
+ * `Hero` with new props; the motif module is what a new codename replaces.
+ */
+export const RemotionRoot: React.FC = () => {
+  return (
+    <>
+    <Composition
+      id="Hero"
+      component={Hero}
+      durationInFrames={DURATION}
+      fps={FPS}
+      width={WIDTH}
+      height={HEIGHT}
+      defaultProps={
+        {
+          version: "2.6.0",
+          codename: "Clockwork",
+          seed: 260,
+        } satisfies HeroProps
+      }
+    />
+    {/* One frame longer than the loop, so frame DURATION can be rendered and
+        diffed against frame 0 to prove the loop is seamless. Never rendered as
+        a deliverable. */}
+    <Composition
+      id="LoopCheck"
+      component={Hero}
+      durationInFrames={DURATION + 1}
+      fps={FPS}
+      width={WIDTH}
+      height={HEIGHT}
+      defaultProps={
+        {
+          version: "2.6.0",
+          codename: "Clockwork",
+          seed: 260,
+          loopFrames: DURATION,
+        } satisfies HeroProps
+      }
+    />
+    </>
+  );
+};

--- a/scripts/release/hero/src/brand.ts
+++ b/scripts/release/hero/src/brand.ts
@@ -1,0 +1,328 @@
+/**
+ * The canonical Bazarr+ hero atmosphere, ported from the static generators in
+ * `site/hero/` (most recently `murmuration-v2.5.0.html`).
+ *
+ * `paintBackdrop`, `paintVignette` and `paintGrain` are deliberate ports rather
+ * than reinventions: the navy base, the three radial glows, the fog, the dusk
+ * starfield, the vignette falloff and the 0.046 overlay grain are what make a
+ * Bazarr+ hero recognisable. A new release changes its motif, never this.
+ *
+ * The one change the animated pipeline makes is that all of it is STATIC across
+ * the loop, and the expensive parts are rendered once and blitted. That is not
+ * only a speed decision: identical background pixels on every frame are what let
+ * the GIF and WebP encoders store almost nothing per frame, so the moving
+ * mechanism is the only thing paying for bytes.
+ */
+
+import { AMBER, CREAM, NAVY } from "./theme";
+
+export type Ctx = CanvasRenderingContext2D;
+
+export interface Geometry {
+  W: number;
+  H: number;
+  /** min(W, H). Features scale off this so extreme aspect ratios do not blow out. */
+  S: number;
+}
+
+// ---------------------------------------------------------------------------
+// helpers, ported verbatim so the atmosphere matches the static heroes exactly
+
+export const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
+export const smooth = (t: number) => t * t * (3 - 2 * t);
+
+export function mulberry32(seed: number) {
+  return function next() {
+    let t = (seed += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function withAlpha(color: string, alpha: number): string {
+  if (color[0] === "#") {
+    const h = color.replace("#", "");
+    const r = parseInt(h.substring(0, 2), 16);
+    const g = parseInt(h.substring(2, 4), 16);
+    const b = parseInt(h.substring(4, 6), 16);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+  const nums = color.replace(/rgba?\(|\)/g, "");
+  return `rgba(${nums}, ${alpha})`;
+}
+
+export function gGlow(c: Ctx, x: number, y: number, r: number, color: string, alpha: number) {
+  const grad = c.createRadialGradient(x, y, 0, x, y, r);
+  grad.addColorStop(0, withAlpha(color, alpha));
+  grad.addColorStop(1, withAlpha(color, 0));
+  c.fillStyle = grad;
+  c.beginPath();
+  c.arc(x, y, r, 0, Math.PI * 2);
+  c.fill();
+}
+
+function radialFill(
+  c: Ctx,
+  W: number,
+  H: number,
+  x: number,
+  y: number,
+  r: number,
+  stops: [string, number][],
+) {
+  const grad = c.createRadialGradient(x, y, 0, x, y, r);
+  for (const [color, stop] of stops) grad.addColorStop(stop, color);
+  c.fillStyle = grad;
+  c.fillRect(0, 0, W, H);
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Navy base, dawn gradient, three radial glows (amber TL, teal BR, purple
+ * centre), screened fog and a dusk starfield. Entirely static.
+ */
+function paintBackdropInto(c: Ctx, geo: Geometry, seed: number) {
+  const { W, H, S } = geo;
+  const rng = mulberry32(seed);
+  const rand = (min: number, max: number) => min + rng() * (max - min);
+  const bpx = (k: number) => (S * k).toFixed(2) + "px";
+
+  c.fillStyle = NAVY;
+  c.fillRect(0, 0, W, H);
+
+  const base = c.createLinearGradient(0, 0, W, H);
+  base.addColorStop(0, "#0b0a1a");
+  base.addColorStop(0.5, NAVY);
+  base.addColorStop(1, "#181640");
+  c.fillStyle = base;
+  c.fillRect(0, 0, W, H);
+
+  radialFill(c, W, H, W * 0.15, H * 0.17, S * 0.7, [
+    ["rgba(230, 138, 0, 0.16)", 0],
+    ["rgba(255, 179, 71, 0.045)", 0.45],
+    ["rgba(230, 138, 0, 0)", 1],
+  ]);
+  radialFill(c, W, H, W * 0.9, H * 0.86, S * 0.8, [
+    ["rgba(127, 233, 255, 0.11)", 0],
+    ["rgba(90, 169, 255, 0.04)", 0.42],
+    ["rgba(127, 233, 255, 0)", 1],
+  ]);
+  radialFill(c, W, H, W * 0.55, H * 0.52, S * 0.92, [
+    ["rgba(124, 92, 255, 0.11)", 0],
+    ["rgba(124, 92, 255, 0.035)", 0.5],
+    ["rgba(124, 92, 255, 0)", 1],
+  ]);
+
+  c.save();
+  c.globalCompositeOperation = "screen";
+  const fog: [number, number, number, string, number][] = [
+    [W * 0.22, H * 0.3, S * 0.32, "#ffb347", 0.038],
+    [W * 0.72, H * 0.62, S * 0.38, "#7fe9ff", 0.034],
+    [W * 0.5, H * 0.84, S * 0.44, "#8a6bff", 0.038],
+  ];
+  for (const [x, y, r, col, a] of fog) {
+    c.filter = `blur(${bpx(0.05)})`;
+    gGlow(c, x, y, r, col, a);
+  }
+  c.filter = "none";
+  c.restore();
+
+  // dusk starfield
+  c.save();
+  c.globalCompositeOperation = "screen";
+  for (let i = 0; i < 260; i++) {
+    const x = rand(0, W);
+    const y = rand(0, H);
+    const r = rng() < 0.92 ? rand(0.35, 1.05) : rand(1.3, 1.9);
+    const a = rng() < 0.86 ? rand(0.05, 0.28) : rand(0.36, 0.62);
+    c.fillStyle = `rgba(255, 248, 225, ${a})`;
+    c.beginPath();
+    c.arc(x, y, r, 0, Math.PI * 2);
+    c.fill();
+  }
+  c.restore();
+
+  // ground reflection
+  c.save();
+  const g = c.createLinearGradient(0, H * 0.8, 0, H);
+  g.addColorStop(0, "rgba(124, 92, 255, 0)");
+  g.addColorStop(0.55, "rgba(120, 150, 200, 0.04)");
+  g.addColorStop(1, "rgba(150, 180, 220, 0.08)");
+  c.fillStyle = g;
+  c.fillRect(0, H * 0.8, W, H * 0.2);
+  c.restore();
+}
+
+// The backdrop and the grain tile never change across the loop, so they are
+// built once per (size, seed) and reused for all 150 frames.
+const backdropCache = new Map<string, HTMLCanvasElement>();
+const grainCache = new Map<string, HTMLCanvasElement>();
+
+function makeCanvas(w: number, h: number): HTMLCanvasElement {
+  const el = document.createElement("canvas");
+  el.width = w;
+  el.height = h;
+  return el;
+}
+
+export function getBackdrop(geo: Geometry, seed: number): HTMLCanvasElement {
+  const key = `${geo.W}x${geo.H}:${seed}`;
+  const hit = backdropCache.get(key);
+  if (hit) return hit;
+  const el = makeCanvas(geo.W, geo.H);
+  const c = el.getContext("2d") as Ctx;
+  c.imageSmoothingEnabled = true;
+  c.imageSmoothingQuality = "high";
+  paintBackdropInto(c, geo, seed);
+  backdropCache.set(key, el);
+  return el;
+}
+
+function getGrainTile(seed: number): HTMLCanvasElement {
+  const key = String(seed);
+  const hit = grainCache.get(key);
+  if (hit) return hit;
+  const size = 256;
+  const el = makeCanvas(size, size);
+  const c = el.getContext("2d") as Ctx;
+  const img = c.createImageData(size, size);
+  const rng = mulberry32(seed ^ 0x9e3779b9);
+  for (let i = 0; i < size * size; i++) {
+    const v = Math.floor(rng() * 255);
+    const o = i * 4;
+    img.data[o] = v;
+    img.data[o + 1] = v;
+    img.data[o + 2] = v;
+    img.data[o + 3] = 255;
+  }
+  c.putImageData(img, 0, 0);
+  grainCache.set(key, el);
+  return el;
+}
+
+export function paintVignette(c: Ctx, geo: Geometry) {
+  const { W, H, S } = geo;
+  c.save();
+  const v = c.createRadialGradient(W * 0.5, H * 0.48, S * 0.33, W * 0.5, H * 0.5, S * 1.02);
+  v.addColorStop(0, "rgba(0, 0, 0, 0)");
+  v.addColorStop(0.7, "rgba(4, 3, 12, 0.16)");
+  v.addColorStop(1, "rgba(4, 3, 12, 0.56)");
+  c.fillStyle = v;
+  c.fillRect(0, 0, W, H);
+  c.restore();
+}
+
+/**
+ * Colour grade: warm lift into the top-left where the amber key sits, cool push
+ * into the bottom-right shadows. Soft-light keeps it a grade rather than a wash,
+ * so it shapes the existing colour instead of tinting flat over it.
+ */
+export function paintGrade(c: Ctx, geo: Geometry) {
+  const { W, H } = geo;
+  c.save();
+  c.globalCompositeOperation = "soft-light";
+  const g = c.createLinearGradient(0, 0, W, H);
+  g.addColorStop(0, "rgba(255, 179, 71, 0.20)");
+  g.addColorStop(0.5, "rgba(255, 248, 225, 0.03)");
+  g.addColorStop(1, "rgba(90, 169, 255, 0.18)");
+  c.fillStyle = g;
+  c.fillRect(0, 0, W, H);
+  c.restore();
+}
+
+/**
+ * Film grain, held still for the whole loop. Animated grain is more filmic but
+ * it changes every pixel on every frame, which is ruinous for a looping GIF.
+ */
+export function paintGrain(c: Ctx, geo: Geometry, seed: number) {
+  const tile = getGrainTile(seed);
+  c.save();
+  c.globalAlpha = 0.046;
+  c.globalCompositeOperation = "overlay";
+  const pattern = c.createPattern(tile, "repeat");
+  if (pattern) {
+    c.fillStyle = pattern;
+    c.fillRect(0, 0, geo.W, geo.H);
+  }
+  c.restore();
+}
+
+// ---------------------------------------------------------------------------
+
+export interface TextBlock {
+  /** e.g. "2.6.0" */
+  version: string;
+  /** e.g. "Clockwork" */
+  codename: string;
+  /** 0..1 position of the shimmer band travelling through the codename. */
+  shimmer: number;
+}
+
+/**
+ * Top-left title block: "Bazarr" in cream with a bold amber "+" superscript,
+ * the released version, and the codename in amber. Ported from the static
+ * heroes; the only addition is a highlight band that travels through the
+ * codename once per loop.
+ */
+export function paintText(c: Ctx, geo: Geometry, font: string, block: TextBlock) {
+  const { W, H } = geo;
+  const padX = W * 0.085;
+  const baseY = H * 0.165;
+  const titleSize = Math.round(H * 0.086);
+
+  c.save();
+  c.fillStyle = CREAM;
+  c.shadowColor = "rgba(0, 0, 0, 0.72)";
+  c.shadowBlur = Math.round(H * 0.016);
+  c.textBaseline = "top";
+  c.font = `800 ${titleSize}px ${font}`;
+  c.fillText("Bazarr", padX, baseY);
+
+  const baseW = c.measureText("Bazarr").width;
+  const plusSize = Math.round(titleSize * 0.72);
+  c.font = `900 ${plusSize}px ${font}`;
+  c.fillStyle = AMBER;
+  c.fillText(
+    "+",
+    padX + baseW + Math.round(titleSize * 0.035),
+    baseY - Math.round(titleSize * 0.045),
+  );
+  c.restore();
+
+  c.save();
+  c.shadowColor = "rgba(0, 0, 0, 0.74)";
+  c.shadowBlur = Math.round(H * 0.014);
+  c.textBaseline = "top";
+  const subSize = Math.round(H * 0.037);
+  c.font = `500 ${subSize}px ${font}`;
+  c.fillStyle = "rgba(255, 248, 225, 0.94)";
+  const subY = baseY + Math.round(H * 0.115);
+  c.fillText(`V${block.version} Released`, padX, subY);
+
+  const codeY = subY + Math.round(subSize * 1.48);
+  c.fillText("Codename: ", padX, codeY);
+  const cwidth = c.measureText("Codename: ").width;
+
+  c.font = `700 ${subSize}px ${font}`;
+  const nameX = padX + cwidth;
+  const nameW = c.measureText(block.codename).width;
+  c.fillStyle = AMBER;
+  c.fillText(block.codename, nameX, codeY);
+
+  // Highlight band: a narrow bright window slid across the word. It starts and
+  // ends fully outside the glyphs, so the loop point shows no band at all.
+  const travel = nameW * 2.2;
+  const head = nameX - nameW * 0.6 + travel * block.shimmer;
+  const bandW = nameW * 0.42;
+  const grad = c.createLinearGradient(head - bandW, 0, head + bandW, 0);
+  grad.addColorStop(0, withAlpha(AMBER, 0));
+  // Warm highlight rather than white: the codename has to stay amber even at the
+  // peak of the sweep, or the brand colour drops out of the frame for a beat.
+  grad.addColorStop(0.5, withAlpha("#ffd89a", 0.62));
+  grad.addColorStop(1, withAlpha(AMBER, 0));
+  c.fillStyle = grad;
+  c.fillText(block.codename, nameX, codeY);
+  c.restore();
+}

--- a/scripts/release/hero/src/index.ts
+++ b/scripts/release/hero/src/index.ts
@@ -1,0 +1,4 @@
+import { registerRoot } from "remotion";
+import { RemotionRoot } from "./Root";
+
+registerRoot(RemotionRoot);

--- a/scripts/release/hero/src/theme.ts
+++ b/scripts/release/hero/src/theme.ts
@@ -1,0 +1,91 @@
+/**
+ * The Bazarr+ hero brand constants.
+ *
+ * These values are the brand, shared verbatim with the static hero generators in
+ * `site/hero/`. Do not tweak them per release: the palette and the atmosphere are
+ * what make five releases of hero art read as one product. Only the motif changes.
+ */
+
+export const NAVY = "#121125"; // --bz-surface-ground
+export const AMBER = "#e68a00"; // brand-5
+export const AMBER_BRIGHT = "#ffb347";
+export const CREAM = "#fff8e1"; // brand-0
+export const CYAN_PULSE = "#7fe9ff";
+
+/**
+ * Cool cyan at the sparse outer edge, through cream, to warm amber at the dense
+ * core. The murmuration hero uses this exact ramp for its flock; the clockwork
+ * motif reuses it radially so the two releases share a visual family.
+ */
+export const BRAND_RAMP: readonly [number, number, number][] = [
+  [127, 233, 255], // cyan-pulse (edge)
+  [255, 248, 225], // cream
+  [255, 179, 71], // amber-bright (core)
+];
+
+export const FPS = 30;
+
+/**
+ * 5 seconds. Every periodic motion in the composition must complete a whole
+ * number of cycles across exactly this many frames, or the loop seams.
+ * 150 factors as 2 x 3 x 5^2, which is why the tick counts below divide it.
+ */
+export const DURATION = 150;
+
+export const WIDTH = 1920;
+export const HEIGHT = 1080;
+
+/**
+ * Escapement beats per loop: 25 beats, one every 6 frames, five per second.
+ *
+ * The count must divide DURATION, but 6 frames per beat is chosen for a second
+ * reason. The GIF derivative is decimated to 10 or 15 fps, keeping every 3rd or
+ * every 2nd frame, and 6 divides by both. A 5-frame beat (30 beats) samples at
+ * a different phase on every beat once decimated, which turns the escapement's
+ * crisp step into a stutter in the very format most people will see it in.
+ */
+export const BEATS_PER_LOOP = 25;
+
+/* ---------------------------------------------------------------------------
+ * A standing constraint on the rates chosen in Clockwork.tsx, recorded here
+ * beside the beat count it depends on: a beat must NOT advance a wheel by a
+ * whole number of teeth.
+ *
+ * When it does, every wheel lands back on its own symmetry period at the end of
+ * every beat and returns to a pose indistinguishable from the one it left, so it
+ * reads as vibrating in place rather than turning: the wagon-wheel effect. The
+ * sun there advances 24 teeth across 25 beats, or 0.96 of a tooth each, so the
+ * pose drifts and the rotation stays legible. This is physically ordinary too:
+ * only the escape wheel itself advances a whole tooth per beat, and the wheels
+ * drawn here are the train it drives, geared away from it.
+ * ------------------------------------------------------------------------- */
+
+export const FONT_FAMILY = "Geist, -apple-system, 'Segoe UI', system-ui, sans-serif";
+
+/**
+ * Easing curves. Nothing designed may move linearly.
+ *
+ * One deliberate exception runs through this composition: the gear rings turn at
+ * constant angular velocity. That is not un-eased motion, it is the correct
+ * physics for a mechanism, and a gear that accelerated into its rotation would
+ * read as broken rather than as designed. Everything that is a *designed* move,
+ * the escapement step, the core pulse, the light sweep, the shimmer and the
+ * breathing, is eased below.
+ */
+export const EASE = {
+  /** easeOutExpo. Entrances. */
+  out: (t: number) => (t >= 1 ? 1 : 1 - Math.pow(2, -10 * t)),
+  /** easeInOutQuint. Long moves. */
+  inOut: (t: number) => (t < 0.5 ? 16 * t ** 5 : 1 - Math.pow(-2 * t + 2, 5) / 2),
+  /**
+   * easeOutBack. Overshoots past the target and settles back onto it, which is
+   * exactly what a real escapement does when the pallet drops: the wheel jumps,
+   * recoils slightly, and locks. Lands on exactly 1 at t = 1, which is what
+   * keeps the 30 discrete ticks summing to a seamless whole revolution.
+   */
+  outBack: (t: number) => {
+    const c1 = 1.70158;
+    const c3 = c1 + 1;
+    return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+  },
+} as const;

--- a/scripts/release/hero/tsconfig.json
+++ b/scripts/release/hero/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/site/hero/README.md
+++ b/site/hero/README.md
@@ -1,8 +1,16 @@
 # Bazarr+ Release Hero Generators
 
-p5.js sketches that render the cinematic hero image for each release. One
+Canvas sketches that render the cinematic hero image for each release. One
 file per release, frozen alongside its tag so the artwork stays
 reproducible.
+
+> **From v2.6.0 a feature release ships an ANIMATED hero instead**, rendered by
+> the Remotion project in [`scripts/release/hero/`](../../scripts/release/hero).
+> It reuses the palette, atmosphere and title block documented below verbatim, so
+> the conventions in this file still govern how a hero looks; what changed is
+> that the motif moves and the output is a GIF, an animated WebP and a WebP
+> poster rather than a single PNG. These sketches remain the record of how the
+> v2.2.0 to v2.5.0 heroes were made, and are still the right tool for a still.
 
 ## Inventory
 


### PR DESCRIPTION
A feature release hero becomes a seamless five second loop instead of a still.
One Remotion project renders an MP4 as the source of truth, then a GIF for the
release page, an animated WebP for the site, and a WebP poster for anywhere
animation is stripped.

```bash
cd scripts/release/hero && npm install
./render.sh 2.6.0 Clockwork 260
```

## It is still the same artwork family

The palette, the navy atmosphere and the top-left title block are ported verbatim
from the static generators in `site/hero/`, so this reads as the same body of work
as the v2.2.0 through v2.5.0 heroes. Only the motif is new per release. One
upgrade: the title is now set in Geist, the site's own face, rather than falling
through to whatever system sans the render machine happened to have.

## The motif is an actual machine

v2.6.0 is the fix batch, so Clockwork is a mechanism running true: a real
epicyclic gear train. Wheels that touch share a tooth pitch and mesh tooth into
gap, the ring is the fixed member so the whole outer assembly holds still, and
none of the rates are chosen by hand. The tooth counts alone pin the carrier at a
third of the sun and the planet spin at minus the sun.

## Three things that are less obvious than they look

Each of these shipped as a defect first and was caught by rendering and looking.
All three are commented at length where they live, and the reasoning is written
up for the next codename.

**A repeating pattern advanced by exactly one of its periods per step returns to
an identical pose** and reads as vibrating in place rather than turning. A gear
stepped exactly one tooth per beat is what an escapement physically does, and it
looks broken. The sun advances 0.96 of a tooth per beat for that reason, and every
wheel carries decoration whose period divides the loop so its rotation is legible
at all.

**The wrap is what has to close, not the frame count.** Over a loop the carrier
swings exactly one planet spacing, so each planet finishes where its neighbour
began and the two must agree in pose as well as position. That condition is the
only reason the planets carry six crossings and not four. The `LoopCheck`
composition renders the frame at the loop point so it can be diffed against frame
0, and the motif is driven by the raw frame on purpose: folding it into the period
makes that test pass by construction while proving nothing.

**A seamless source is not a seamless file.** libwebp blends each frame over the
last, so lossy error accumulates in one direction; on the fine dial strokes it
brightened them across the loop and snapped back at the wrap, putting a visible
pulse on exactly the moment the loop exists to hide. Measured first-to-last drift
on the dial band ran 0.59 levels of 255 at quality 60 and 0.004 at 80, which is
why the WebP is encoded at 80 and at half the frame rate.

## Size

Background, starfield, grain and vignette are identical on every frame by design,
which is most of why the outputs stay small enough to put on a release page.
Against the 2.17 MB static v2.5.0 hero this replaces: GIF 2.37 MB, WebP 1.62 MB,
poster 0.10 MB.

## Notes for review

- The brand font is not committed twice. The one copy stays in `site/fonts/` and
  is copied into `public/` by `render.sh` and the `font` npm script; a second
  tracked copy would drift the day the site font changes.
- `out/`, `node_modules/` and `public/` are ignored. No rendered artwork is
  committed here: the shipped hero belongs to the release prep commit, not to the
  tooling.
- `site/hero/README.md` gets a pointer at the top, since it otherwise still
  described the static PNG workflow as the way heroes are made.
- Verified end to end from a clean checkout of this branch: typecheck clean, full
  render produces all four outputs, and the loop point is pixel-identical to
  frame 0.