### PR TITLE
ci: run the two test trees together again, and pin the RAR configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,10 +136,13 @@ jobs:
           name: ${{ env.UI_ARTIFACT_NAME }}
           path: "${{ env.UI_DIRECTORY }}/build"
 
-      - name: Install ffmpeg
-        # test_embeddedsubtitles uses real .mkv fixtures that require ffprobe to
-        # extract stream metadata. Ubuntu runners ship without it.
-        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ffmpeg
+      - name: Install ffmpeg and a RAR extractor
+        # ffmpeg: test_embeddedsubtitles uses real .mkv fixtures that require
+        # ffprobe to extract stream metadata, and Ubuntu runners ship without it.
+        # unar: the RAR fixtures cannot be read without it. 7z is present on the
+        # runner and recognises RAR as a format, but carries no RAR
+        # decompression codec, which is the same trap the image once shipped.
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends ffmpeg unar
 
       - name: Install Python dependencies
         run: |
@@ -173,6 +176,7 @@ jobs:
             tests/bazarr/test_jellyfin_apikey_location.py \
             tests/bazarr/test_provider_hub.py \
             tests/bazarr/test_provider_pool_config_reload.py \
+            tests/bazarr/test_rar_extraction_production_config.py \
             tests/bazarr/test_provider_hub_auto_install_optin.py \
             tests/bazarr/test_provider_hub_archive_select.py \
             tests/bazarr/test_archive_member_matching.py \
@@ -221,30 +225,21 @@ jobs:
             tests/subliminal_patch/test_video.py \
             -v --tb=short
 
-      - name: pytest previously unguarded bazarr suites
+      - name: pytest previously unguarded suites
         # These existed but were never collected by CI, so their assertions protected
         # nothing. Backfilled wholesale; test_ci_guard_list.py fails if a new test file
         # is added without being enumerated here or excluded with a reason.
         #
-        # Kept separate from the subliminal_patch step below, and this is a
-        # WORKAROUND, not a structural choice. Co-collecting the two trees makes
+        # One process for both trees. They used to be split, because
         # tests/subliminal_patch/test_utils.py::test_get_subtitle_from_archive_season_pack
-        # fail, and that failure is real. Exactly five of the files below load the
-        # api package transitively: test_combine_api_dto, test_combine_main,
-        # test_secret_store_e2e, test_subtitle_content_sync_outputs and
-        # test_upgrade_embedded_history. api/system/status.py does
-        # `from init import startTime`, and bazarr/init.py calls init_binaries() at
-        # module scope, which globally repoints rarfile at 7z exactly as production
-        # does. get_binary() resolves that through which(), so the binary in play
-        # here is the runner's own 7z, not anything in the Docker image, and it
-        # cannot decode the RAR fixture that test reads. The co-collected run was
-        # detecting the shipped RAR bug and this split hides it.
-        #
-        # Do not go looking for those five by grepping for `import api`: one of them
-        # gets there through importlib.import_module on a string, two import neither
-        # api nor app by name, and three files that DO import api.* are inert because
-        # they stub `init` in sys.modules before importing. Remove the split once RAR
-        # extraction is fixed in the image.
+        # failed when co-collected: any file that imports the app runs
+        # init_binaries(), which repoints rarfile at whatever extractor is
+        # installed, exactly as production does, and the image shipped only an
+        # archiver that recognises RAR without being able to decompress it. The
+        # split hid a real product bug. The image ships unar now and discovery
+        # prefers the extractors that work, so the trees run together again and
+        # test_rar_extraction_production_config.py asserts the configuration
+        # directly rather than leaving it to collection order.
         run: |
           pytest \
             tests/bazarr/test_app_notifier.py \
@@ -290,13 +285,6 @@ jobs:
             tests/bazarr/test_tracemalloc_dumper.py \
             tests/bazarr/test_translator_auth.py \
             tests/bazarr/test_upgrade_embedded_history.py \
-            -v --tb=short
-
-      - name: pytest previously unguarded subliminal_patch suites
-        # Separate process from the bazarr step above. See the note there: this
-        # masks a real product bug and should not outlive it.
-        run: |
-          pytest \
             tests/subliminal_patch/test_animetosho.py \
             tests/subliminal_patch/test_core_persistent.py \
             tests/subliminal_patch/test_opensubtitles_scraper.py \

--- a/tests/bazarr/test_rar_extraction_production_config.py
+++ b/tests/bazarr/test_rar_extraction_production_config.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+"""RAR extraction has to work the way the shipped image is configured.
+
+`bazarr/init.py` calls `init_binaries()` at module scope, which globally
+repoints rarfile at whichever extractor it finds. Any test that imports the app
+therefore runs against the production configuration, and the archive tests that
+pass in a pristine process say nothing about what users get.
+
+That difference is not academic. The image once shipped an archiver that
+recognises RAR as a format but carries no RAR decompression codec, with the two
+real extractors absent, so every RAR-delivered subtitle failed and the provider
+throttled for ten minutes. CI hid it by running the two test trees in separate
+processes, where the archive test never met init_binaries().
+
+This test deliberately runs init_binaries() first, so it fails on a machine
+configured the way that image was.
+"""
+
+import os
+import shutil
+
+import pytest
+
+_FIXTURE = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                        "subliminal_patch", "data", "archive_2.rar")
+
+
+@pytest.mark.skipif(not os.path.isfile(_FIXTURE), reason="RAR fixture is not present")
+def test_a_rar_archive_extracts_after_init_binaries_has_configured_the_tools():
+    from init import init_binaries
+
+    import rarfile
+    from subliminal_patch.providers import utils
+
+    tool = init_binaries()
+    assert tool, "no RAR extraction tool was configured at all"
+
+    with rarfile.RarFile(_FIXTURE) as archive:
+        assert utils.get_subtitle_from_archive(archive, episode=4) is not None
+
+
+def test_the_image_ships_a_tool_that_can_actually_decompress_rar():
+    """p7zip recognises RAR as a format but cannot decompress it, so finding it
+    is not the same as being able to read an archive. Name the tools that can."""
+    assert shutil.which("unrar") or shutil.which("unar"), (
+        "neither unrar nor unar is installed; 7z alone cannot decompress RAR, "
+        "which is exactly the state that made every RAR subtitle fail"
+    )

--- a/tests/bazarr/test_rar_extraction_production_config.py
+++ b/tests/bazarr/test_rar_extraction_production_config.py
@@ -17,6 +17,7 @@ configured the way that image was.
 """
 
 import os
+import pathlib
 import shutil
 
 import pytest
@@ -39,10 +40,32 @@ def test_a_rar_archive_extracts_after_init_binaries_has_configured_the_tools():
         assert utils.get_subtitle_from_archive(archive, episode=4) is not None
 
 
-def test_the_image_ships_a_tool_that_can_actually_decompress_rar():
+def test_this_machine_has_a_tool_that_can_actually_decompress_rar():
     """p7zip recognises RAR as a format but cannot decompress it, so finding it
-    is not the same as being able to read an archive. Name the tools that can."""
+    is not the same as being able to read an archive.
+
+    This covers whatever machine the suite runs on, which is what makes the test
+    above meaningful. The image is a separate question, covered below.
+    """
     assert shutil.which("unrar") or shutil.which("unar"), (
         "neither unrar nor unar is installed; 7z alone cannot decompress RAR, "
         "which is exactly the state that made every RAR subtitle fail"
+    )
+
+
+def test_the_dockerfile_installs_a_tool_that_can_decompress_rar():
+    """The image is what users run, and the test above only sees this machine.
+
+    The Dockerfile is the artefact that decides, so it is read directly: an edit
+    dropping unar would otherwise sail through a CI run whose runner installs it
+    separately, and ship the exact bug this file exists for.
+    """
+    dockerfile = (pathlib.Path(__file__).resolve().parents[2] / "Dockerfile").read_text()
+
+    installed = {line.strip().rstrip(" \\")
+                 for line in dockerfile.splitlines()}
+
+    assert "unar" in installed or "unrar" in installed, (
+        "the Dockerfile installs neither unar nor unrar; p7zip alone cannot "
+        "decompress RAR, so every RAR-delivered subtitle would fail in the image"
     )


### PR DESCRIPTION
## What the split was hiding

`tests/subliminal_patch/test_utils.py::test_get_subtitle_from_archive_season_pack` failed when the bazarr and subliminal_patch trees were collected in one pytest process, and CI worked around it by running them in two.

That failure was real. Any test file that imports the app runs `init_binaries()` at module scope, which globally repoints `rarfile` at whichever extractor it finds, exactly as production does. The image shipped p7zip, which recognises RAR as a format but carries no RAR decompression codec, with neither `unrar` nor `unar` installed. So every RAR-delivered subtitle failed and the provider throttled for ten minutes, while CI reported green because the archive test only ever ran in a process where the app had never been imported.

RAR extraction has since been fixed in the image: `unar` is installed and discovery prefers `unrar` → `unar` → `7z`. So the workaround can go.

## Changes

- the two steps become one, with the reason for their history recorded rather than deleted
- the runner installs `unar`, since it has 7z but not a working RAR extractor, which is the same trap
- `tests/bazarr/test_rar_extraction_production_config.py` asserts the property directly instead of leaving it to collection order: it calls `init_binaries()` and then reads the RAR fixture, and separately asserts that a tool which can actually decompress RAR is present

## Verification

I ran the new test on a PATH containing only 7z, the configuration that shipped, and **both cases fail there**, then pass with `unar` present. The co-collected run passes locally: 1721 tests including `test_get_subtitle_from_archive_season_pack` under the production `rarfile` configuration. ruff clean.