### PR TITLE
fix(provider hub): score hub candidates on their release information

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,7 @@ jobs:
             tests/bazarr/test_logging_filters.py \
             tests/bazarr/test_provider_hub_install_serialization.py \
             tests/bazarr/test_provider_hub_language_fallback.py \
+            tests/bazarr/test_provider_hub_release_scoring.py \
             tests/bazarr/test_scheduler_session_cleanup.py \
             tests/bazarr/test_secret_store_crypto.py \
             tests/bazarr/test_secret_store_e2e.py \

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -186,6 +186,9 @@ def video_to_payload(video) -> dict[str, Any]:
 # setattr raises and discards the provider's entire result set.
 _RESERVED_DISPLAY_ATTRS = frozenset({
     "language",
+    # Host scoring policy, not something a worker gets to set: sending False
+    # would put the release-scoring bug back for that plugin alone, silently.
+    "matches_need_video",
     "language_type",
     "id",
     "numeric_id",

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -51,6 +51,10 @@ class HubWorkerSubtitle(Subtitle):
         self.score_without_hash = None
         self.score_out_of = None
 
+    # The worker sends a lean set of identifier matches, so the download scorer
+    # must recompute against the video instead of reusing it: see get_matches.
+    matches_need_video = True
+
     @property
     def id(self):
         return f"{self.source_provider}:{self.worker_id}"

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -684,6 +684,49 @@ class SZProviderPool(ProviderPool):
 
         return True
 
+    @classmethod
+    def _score_subtitles(cls, subtitles, video, languages, hearing_impaired):
+        """(subtitle, score, score_without_hash, matches, orig_matches) tuples, best first."""
+        use_hearing_impaired = hearing_impaired in ("prefer", "force HI")
+        unsorted_subtitles = []
+
+        for s in subtitles:
+            # get the matches
+            if s.language.basename not in [x.basename for x in languages]:
+                logger.debug("%r: Skipping, language not searched for", s)
+                continue
+
+            try:
+                cached = s.matches if hasattr(s, 'matches') and isinstance(s.matches, set) \
+                    and len(s.matches) else None
+                # A candidate may declare that its match set is only complete once it
+                # has seen the video. Provider Hub candidates arrive from the worker
+                # with a lean set of identifier matches already populated, so reusing
+                # it here scored every one of them identically and the first listed
+                # won, handing a user searching for a 2160p WEB release a Blu-ray
+                # subtitle for another release group. Declared on the candidate rather
+                # than sniffed from its class name, which a rename or a subclass would
+                # silently defeat. Recomputation is idempotent: the augmented set is
+                # derived from a frozen base, so the priority-ordered listing path,
+                # which already computed it, gets the same answer twice.
+                if cached is None or getattr(s, 'matches_need_video', False):
+                    matches = s.get_matches(video)
+                else:
+                    matches = cached
+
+            except AttributeError:
+                logger.error("%r: Match computation failed: %s", s, traceback.format_exc())
+                continue
+
+            orig_matches = matches.copy()
+
+            logger.debug('%r: Found matches %r', s, matches)
+            score, score_without_hash = compute_score(matches, s, video, use_hearing_impaired)
+            unsorted_subtitles.append(
+                (s, score, score_without_hash, matches, orig_matches))
+
+        return sorted(unsorted_subtitles, key=operator.itemgetter(1, 2), reverse=True)
+
     def download_best_subtitles(self, subtitles, video, languages, min_score=0, hearing_impaired=False, only_one=False,
                                 use_original_format=False, fallback_allowed=False):
         """Download the best matching subtitles.
@@ -712,32 +755,7 @@ class SZProviderPool(ProviderPool):
         is_episode = isinstance(video, Episode)
         max_score = MAX_SCORES['episode' if is_episode else 'movie']
 
-        # sort subtitles by score
-        unsorted_subtitles = []
-
-        for s in subtitles:
-            # get the matches
-            if s.language.basename not in [x.basename for x in languages]:
-                logger.debug("%r: Skipping, language not searched for", s)
-                continue
-
-            try:
-                matches = s.matches if hasattr(s, 'matches') and isinstance(s.matches, set) and len(s.matches) \
-                        else s.get_matches(video)
-
-            except AttributeError:
-                logger.error("%r: Match computation failed: %s", s, traceback.format_exc())
-                continue
-
-            orig_matches = matches.copy()
-
-            logger.debug('%r: Found matches %r', s, matches)
-            score, score_without_hash = compute_score(matches, s, video, use_hearing_impaired)
-            unsorted_subtitles.append(
-                (s, score, score_without_hash, matches, orig_matches))
-
-        # sort subtitles by score
-        scored_subtitles = sorted(unsorted_subtitles, key=operator.itemgetter(1, 2), reverse=True)
+        scored_subtitles = self._score_subtitles(subtitles, video, languages, hearing_impaired)
 
         # download best subtitles, falling back on the next on error
         downloaded_subtitles = []

--- a/tests/bazarr/test_provider_hub_release_scoring.py
+++ b/tests/bazarr/test_provider_hub_release_scoring.py
@@ -131,3 +131,12 @@ def test_release_information_is_what_separates_the_candidates(release_info, expe
     matches = subtitle.get_matches(video)
 
     assert ("release_group" in matches) is expected
+
+
+def test_a_worker_cannot_switch_the_capability_off_through_display():
+    """The display dictionary is cosmetic worker-supplied data. A plugin that
+    happened to send matches_need_video=False would put the scoring bug back for
+    itself, silently, and the host would have no idea."""
+    from provider_hub import protocol
+
+    assert "matches_need_video" in protocol._RESERVED_DISPLAY_ATTRS

--- a/tests/bazarr/test_provider_hub_release_scoring.py
+++ b/tests/bazarr/test_provider_hub_release_scoring.py
@@ -1,0 +1,133 @@
+# coding=utf-8
+"""Hub candidates must be scored on their release information, not just their ids.
+
+The download scorer reuses a subtitle's match set when it is already populated
+rather than recomputing it. A Provider Hub candidate arrives from the worker
+with a lean set already in place: title, year, imdb id. So the recomputation
+that adds source, resolution and release-group matches never ran on that path,
+every hub candidate scored identically, and the first one listed won. A user
+searching for a 2160p WEB release could be handed a Blu-ray subtitle for a
+different release group.
+
+The priority-ordered listing path calls get_matches itself, which is why this
+only showed up with Provider Priority disabled and why manual search looked
+right.
+"""
+
+import pytest
+from subzero.language import Language
+
+import app.database  # noqa: F401
+
+
+VIDEO_RELEASE = "Show.S01E01.2160p.WEB-DL.DDP5.1.H.265-NTb"
+OTHER_RELEASE = "Show.S01E01.1080p.BluRay.x264-GRP"
+
+
+def _video():
+    from subliminal_patch.core import Episode
+
+    video = Episode(VIDEO_RELEASE + ".mkv", "Show", 1, 1)
+    video.release_group = "NTb"
+    video.resolution = "2160p"
+    video.source = "Web"
+    video.year = 2019
+    return video
+
+
+class _LeanSubtitle:
+    """A candidate that arrives with a lean match set, like a hub worker sends."""
+
+    provider_name = "hub-provider"
+    hearing_impaired_verifiable = False
+    hash_verifiable = False
+
+    def __init__(self, release_info, matches_need_video):
+        self.language = Language("eng")
+        self.release_info = release_info
+        self.matches = {"series", "year"}
+        self.hearing_impaired = False
+        self.matches_need_video = matches_need_video
+        self.get_matches_calls = 0
+
+    def get_matches(self, video):
+        from subliminal_patch.providers.utils import update_matches
+
+        self.get_matches_calls += 1
+        matches = {"series", "year"}
+        update_matches(matches, video, self.release_info)
+        self.matches = set(matches)
+        return matches
+
+
+def _score(subtitle, video):
+    from subliminal_patch.score import compute_score
+
+    matches = (subtitle.get_matches(video)
+               if getattr(subtitle, "matches_need_video", False) or not subtitle.matches
+               else subtitle.matches)
+    return compute_score(matches, subtitle, video, "don't prefer")[0]
+
+
+def test_the_hub_subtitle_class_declares_that_it_needs_the_video():
+    """The capability is declared on the candidate rather than inferred from its
+    class name: a rename or a subclass would silently put the bug back."""
+    from provider_hub.protocol import HubWorkerSubtitle
+
+    assert getattr(HubWorkerSubtitle, "matches_need_video", False) is True
+
+
+def test_the_download_scorer_recomputes_for_a_candidate_that_asks_for_it():
+    from subliminal_patch.core import SZProviderPool
+
+    video = _video()
+    matching = _LeanSubtitle(VIDEO_RELEASE, matches_need_video=True)
+    mismatching = _LeanSubtitle(OTHER_RELEASE, matches_need_video=True)
+
+    scored = SZProviderPool._score_subtitles(
+        [matching, mismatching], video, [Language("eng")], "don't prefer")
+
+    assert [s for s, *_ in scored][0] is matching, (
+        "the candidate matching the video's source, resolution and release group "
+        "did not come first"
+    )
+    assert scored[0][1] > scored[1][1]
+
+
+def test_a_candidate_that_does_not_ask_is_scored_on_what_it_arrived_with():
+    """Every other provider computes its matches when it lists. Recomputing for
+    them would change behaviour well outside this fix."""
+    from subliminal_patch.core import SZProviderPool
+
+    video = _video()
+    ordinary = _LeanSubtitle(VIDEO_RELEASE, matches_need_video=False)
+
+    SZProviderPool._score_subtitles([ordinary], video, [Language("eng")], "don't prefer")
+
+    assert ordinary.get_matches_calls == 0
+
+
+def test_recomputing_twice_gives_the_same_answer():
+    """The priority-enabled path already calls get_matches while listing, so the
+    download path calls it a second time. The set is derived from a frozen base
+    each time, so the second call has to agree with the first."""
+    video = _video()
+    subtitle = _LeanSubtitle(VIDEO_RELEASE, matches_need_video=True)
+
+    first = subtitle.get_matches(video)
+    second = subtitle.get_matches(video)
+
+    assert first == second
+
+
+@pytest.mark.parametrize("release_info,expected", [
+    (VIDEO_RELEASE, True),
+    (OTHER_RELEASE, False),
+])
+def test_release_information_is_what_separates_the_candidates(release_info, expected):
+    video = _video()
+    subtitle = _LeanSubtitle(release_info, matches_need_video=True)
+
+    matches = subtitle.get_matches(video)
+
+    assert ("release_group" in matches) is expected


### PR DESCRIPTION
## The bug

With Provider Priority turned **off**, automatic searches pick the wrong subtitle. Every Provider Hub candidate receives an identical score derived only from identifiers (title, year, imdb id), so they all tie and the first one listed wins. A user searching for a 2160p WEB release can be handed a Blu-ray subtitle for a different source, resolution and release group.

Two reasonable-looking decisions interact:

1. the download scorer reuses `subtitle.matches` when it is already populated, instead of recomputing
2. hub candidates arrive from the worker with a lean match set already populated

So the recomputation that would add the release-derived matches never runs. The priority-ordered listing path calls `get_matches` itself, which is why the bug only appears with Provider Priority disabled and why manual search looks correct.

## The fix

The candidate declares the requirement (`matches_need_video = True` on `HubWorkerSubtitle`) and the scorer honours it. Declared rather than sniffed from the class name: a rename or a subclass would silently put the bug back, which is what the review of the contributed patch flagged.

Recomputation is safe to run twice: the augmented set is derived from a frozen base each time, so the priority-enabled path, which already computes it during listing, gets an identical result on the second call. Nothing changes for any other provider, which is asserted rather than assumed.

The scoring loop moves into `SZProviderPool._score_subtitles` unchanged, so the behaviour can be tested without driving a whole download.

## Tests

`tests/bazarr/test_provider_hub_release_scoring.py`, enumerated in CI:

- a candidate matching the video's source, resolution and release group outscores one that does not, and sorts first
- a candidate that does not declare the requirement is never recomputed (`get_matches` call count is zero)
- the hub subtitle class declares the capability
- recomputing twice gives the same set
- release information is what separates the two candidates

Reverting the two production files makes three of them fail, which I checked before committing.

Backend suite green locally, ruff clean.

Note: `tests/subliminal_patch/test_core.py` has 8 failures that predate this branch, from upstream tests comparing `pool.providers` (a list) to a set. The file is not enumerated in CI. Separate PR.