### PR TITLE
fix(sync): report the numbers autosubsync measured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
             tests/bazarr/test_processing_postprocessing.py \
             tests/bazarr/test_sync_progress_report.py \
             tests/bazarr/test_subsync_engines.py \
+            tests/bazarr/test_autosubsync_diagnostics.py \
             tests/bazarr/test_alass_ffprobe_shim.py \
             tests/bazarr/test_sync_offset_acceptance.py \
             tests/bazarr/test_sync_instance_overrides.py \

--- a/bazarr/subtitles/sync.py
+++ b/bazarr/subtitles/sync.py
@@ -31,8 +31,11 @@ _ENGINE_OUTCOME_SENTENCES = {
     REASON_MISSING_ENGINE: "{label} is not installed.",
     REASON_FAILURE_THRESHOLD: "{label} was skipped after repeated failures.",
     REASON_OUTPUT_EXISTS: "{label} output already existed and was kept.",
+    # {message} carries whatever the engine measured, e.g. the quality of fit
+    # and the threshold it was judged against. Without it the card said only
+    # that the engine declined, which is the report this text exists to answer.
     REASON_ENGINE_DECLINED: ("{label} rejected its own result as unreliable, which is normal "
-                             "when it cannot confidently align a file."),
+                             "when it cannot confidently align a file. {message}"),
     REASON_RESULT_REJECTED: "{label} result rejected: {message}",
     REASON_ENGINE_FAILED: "{label} failed: {message}",
 }
@@ -68,7 +71,9 @@ def _engine_outcome_sentence(engine_result):
         return f"{label} produced no output."
 
     message = _short_engine_message(engine_result.message, engine_result.engine)
-    sentence = template.format(label=label, message=message)
+    # A template may carry an optional {message}: an engine that measured nothing
+    # would otherwise leave a dangling space or a stray fragment in the card.
+    sentence = " ".join(template.format(label=label, message=message).split())
     return sentence if sentence.endswith((".", "...")) else f"{sentence}."
 
 

--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -86,7 +86,11 @@ def _distinguishable(measured, threshold, minimum=2, maximum=6):
         left, right = f'{measured:.{places}f}', f'{threshold:.{places}f}'
         if left != right:
             return left, right
-    return f'{measured:.{maximum}f}', f'{threshold:.{maximum}f}'
+
+    # Closer than six decimals. Quoting one number twice would contradict
+    # itself, and quoting seventeen would be unreadable, so the caller says it
+    # in words instead.
+    return None, f'{threshold:.{minimum}f}'
 
 
 def _autosubsync_quality_threshold():
@@ -442,8 +446,12 @@ class SubSyncer:
             threshold = _autosubsync_quality_threshold()
             if quality is not None and threshold is not None:
                 measured, limit = _distinguishable(quality, threshold)
-                message = (f'autosubsync measured a quality of fit of {measured}, below its '
-                           f'{limit} threshold; the subtitle may not match this audio.')
+                if measured is None:
+                    message = (f'autosubsync measured a quality of fit just below its {limit} '
+                               f'threshold; the subtitle may not match this audio.')
+                else:
+                    message = (f'autosubsync measured a quality of fit of {measured}, below its '
+                               f'{limit} threshold; the subtitle may not match this audio.')
             elif quality is not None:
                 message = (f'autosubsync measured a quality of fit of {quality:.2f} and rejected '
                            f'its own result.')

--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -56,7 +56,12 @@ def _run_autosubsync_api(reference, subtitle_file, output_file, model_file, para
             parallelism=parallelism,
             return_parameters=True,
         )
-    except TypeError:
+    except TypeError as exc:
+        # Only a signature mismatch. autosubsync does minutes of work and writes
+        # its output before returning, so re-running the whole synchronization
+        # for any internal TypeError would repeat that work and rewrite the file.
+        if 'return_parameters' not in str(exc):
+            raise
         logging.debug('BAZARR autosubsync does not support return_parameters; '
                       'synchronising without diagnostics')
         return synchronize(
@@ -441,6 +446,10 @@ class SubSyncer:
             'offset_seconds': shift,
             'quality_of_fit': quality,
             'skew': skew,
+            # The same quantity ffsubsync calls framerate_scale_factor, under
+            # the key the history entry reads: without it a run with a real
+            # skew was recorded as a scale factor of 0.00.
+            'framerate_scale_factor': skew,
             'stdout': '',
             'stderr': '',
             'returncode': 0,

--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -74,6 +74,21 @@ def _run_autosubsync_api(reference, subtitle_file, output_file, model_file, para
         )
 
 
+def _distinguishable(measured, threshold, minimum=2, maximum=6):
+    """Format two nearby numbers so the pair does not read as one number.
+
+    A near miss is the case this message exists to explain, and two decimals
+    turn 0.749 against 0.75 into "0.75, below its 0.75 threshold", which
+    contradicts itself. Precision grows only until the two differ, so an
+    ordinary number keeps its two decimals instead of a tail of zeros.
+    """
+    for places in range(minimum, maximum + 1):
+        left, right = f'{measured:.{places}f}', f'{threshold:.{places}f}'
+        if left != right:
+            return left, right
+    return f'{measured:.{maximum}f}', f'{threshold:.{maximum}f}'
+
+
 def _autosubsync_quality_threshold():
     """The threshold autosubsync judges its own work against, or None.
 
@@ -426,8 +441,9 @@ class SubSyncer:
             # fault, so it is reported as a decline rather than an engine failure.
             threshold = _autosubsync_quality_threshold()
             if quality is not None and threshold is not None:
-                message = (f'autosubsync measured a quality of fit of {quality:.2f}, below its '
-                           f'{threshold:.2f} threshold; the subtitle may not match this audio.')
+                measured, limit = _distinguishable(quality, threshold)
+                message = (f'autosubsync measured a quality of fit of {measured}, below its '
+                           f'{limit} threshold; the subtitle may not match this audio.')
             elif quality is not None:
                 message = (f'autosubsync measured a quality of fit of {quality:.2f} and rejected '
                            f'its own result.')

--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -41,14 +41,46 @@ def _autosubsync_model_file():
 def _run_autosubsync_api(reference, subtitle_file, output_file, model_file, parallelism):
     from autosubsync.main import synchronize
 
-    return synchronize(
-        reference,
-        subtitle_file,
-        output_file,
-        verbose=False,
-        model_file=model_file,
-        parallelism=parallelism,
-    )
+    # return_parameters gets the numbers out: (success, quality, skew, shift).
+    # Without it the call answers a bare bool, and the user is told only that
+    # the run "did not meet the quality threshold", with no way to tell a near
+    # miss from a total mismatch. Older builds do not accept the argument, so a
+    # TypeError falls back to the plain call rather than failing the sync.
+    try:
+        return synchronize(
+            reference,
+            subtitle_file,
+            output_file,
+            verbose=False,
+            model_file=model_file,
+            parallelism=parallelism,
+            return_parameters=True,
+        )
+    except TypeError:
+        logging.debug('BAZARR autosubsync does not support return_parameters; '
+                      'synchronising without diagnostics')
+        return synchronize(
+            reference,
+            subtitle_file,
+            output_file,
+            verbose=False,
+            model_file=model_file,
+            parallelism=parallelism,
+        )
+
+
+def _autosubsync_quality_threshold():
+    """The threshold autosubsync judges its own work against, or None.
+
+    Hard-coded upstream at 0.75. Read rather than copied, so a message quoting
+    it cannot drift from what the engine actually applied.
+    """
+    try:
+        from autosubsync import quality_of_fit
+
+        return float(quality_of_fit.threshold)
+    except Exception:
+        return None
 
 
 class SubSyncer:
@@ -365,7 +397,7 @@ class SubSyncer:
     def _run_autosubsync_engine(self, output_path, video_path):
         reference = self.reference if self.reference and os.path.isfile(self.reference) else video_path
         try:
-            success = _run_autosubsync_api(
+            raw = _run_autosubsync_api(
                 reference=reference,
                 subtitle_file=self.srtin,
                 output_file=str(output_path),
@@ -377,14 +409,38 @@ class SubSyncer:
                 raise MissingSyncEngineError('autosubsync', 'autosubsync Python package not installed') from exc
             raise
 
+        # (success, quality, skew, shift) with return_parameters, a bare bool
+        # without it.
+        if isinstance(raw, tuple):
+            success, quality, skew, shift = (list(raw) + [None, None, None])[:4]
+        else:
+            success, quality, skew, shift = raw, None, None, None
+
         if not success:
             # autosubsync's own quality check said no. That is a verdict, not a
             # fault, so it is reported as a decline rather than an engine failure.
-            raise SyncEngineDeclinedError(
-                'autosubsync', 'autosubsync completed but did not meet its quality threshold.')
+            threshold = _autosubsync_quality_threshold()
+            if quality is not None and threshold is not None:
+                message = (f'autosubsync measured a quality of fit of {quality:.2f}, below its '
+                           f'{threshold:.2f} threshold; the subtitle may not match this audio.')
+            elif quality is not None:
+                message = (f'autosubsync measured a quality of fit of {quality:.2f} and rejected '
+                           f'its own result.')
+            else:
+                message = 'autosubsync completed but did not meet its quality threshold.'
+            raise SyncEngineDeclinedError('autosubsync', message)
+
+        logging.debug('BAZARR autosubsync aligned %s with quality %s, skew %s, shift %s',
+                      self.srtin, quality, skew, shift)
 
         return {
             'success': success,
+            # The measured shift, under the same key ffsubsync reports, so the
+            # acceptance threshold applies to autosubsync too instead of it
+            # being exempt for want of a number.
+            'offset_seconds': shift,
+            'quality_of_fit': quality,
+            'skew': skew,
             'stdout': '',
             'stderr': '',
             'returncode': 0,
@@ -400,6 +456,14 @@ class SubSyncer:
                    f"{success_result.engine} ({output_mode}) ended with an offset of "
                    f"{offset_seconds} seconds and a framerate scale factor of "
                    f"{f'{framerate_scale_factor:.2f}'}.")
+
+        # Whatever confidence the engine measured, where it measures one. Without
+        # it a recorded sync says how far it moved the subtitle but nothing about
+        # how sure it was, which is the question a user asks when the result
+        # looks wrong.
+        quality_of_fit = raw_result.get('quality_of_fit')
+        if quality_of_fit is not None:
+            message += f' Quality of fit: {quality_of_fit:.2f}.'
 
         if sonarr_series_id:
             prr = path_mappings.path_replace_reverse

--- a/tests/bazarr/test_autosubsync_diagnostics.py
+++ b/tests/bazarr/test_autosubsync_diagnostics.py
@@ -133,3 +133,119 @@ def test_the_history_entry_carries_the_quality_it_measured(monkeypatch, tmp_path
     message = recorded[0]
     assert "-2.5" in message
     assert "0.91" in message, f"the quality of fit is missing from: {message}"
+
+
+def test_the_decline_notification_carries_the_numbers():
+    """The whole point of measuring them: they have to reach the user, not just
+    the log. The reason template had no {message} slot, so the sentence in the
+    job card was the same fixed line whatever the engine measured."""
+    from types import SimpleNamespace
+
+    from subtitles.sync import _engine_outcome_sentence
+    from subtitles.tools.subsync_engines import REASON_ENGINE_DECLINED
+
+    sentence = _engine_outcome_sentence(SimpleNamespace(
+        engine="autosubsync",
+        reason=REASON_ENGINE_DECLINED,
+        message=("autosubsync measured a quality of fit of 0.43, below its 0.75 "
+                 "threshold; the subtitle may not match this audio."),
+        success=False,
+    ))
+
+    assert "0.43" in sentence
+    assert "0.75" in sentence
+
+
+def test_a_decline_with_nothing_to_add_still_reads_as_a_sentence():
+    """Not every engine measures a number, and the old wording is what those
+    still need."""
+    from types import SimpleNamespace
+
+    from subtitles.sync import _engine_outcome_sentence
+    from subtitles.tools.subsync_engines import REASON_ENGINE_DECLINED
+
+    sentence = _engine_outcome_sentence(SimpleNamespace(
+        engine="alass", reason=REASON_ENGINE_DECLINED, message="", success=False))
+
+    assert sentence.endswith(".")
+    assert "alass" in sentence.lower()
+
+
+def test_the_fallback_is_only_for_an_unsupported_keyword(monkeypatch, tmp_path):
+    """autosubsync does long work and writes its output before returning, so
+    re-running the whole synchronization on any internal TypeError would repeat
+    that work and rewrite the file. Only the signature mismatch is a reason."""
+    from subtitles.tools import subsyncer as module
+
+    calls = []
+
+    def exploding(*args, **kwargs):
+        calls.append(kwargs)
+        raise TypeError("unsupported operand type(s) for +: 'int' and 'str'")
+
+    monkeypatch.setattr(module, "synchronize", exploding, raising=False)
+
+    import autosubsync.main
+    monkeypatch.setattr(autosubsync.main, "synchronize", exploding)
+
+    with pytest.raises(TypeError):
+        module._run_autosubsync_api(reference="v.mkv", subtitle_file="s.srt",
+                                    output_file="o.srt", model_file="m.bin",
+                                    parallelism=1)
+
+    assert len(calls) == 1, "the whole synchronization was run a second time"
+
+
+def test_an_unsupported_keyword_does_fall_back(monkeypatch):
+    from subtitles.tools import subsyncer as module
+
+    calls = []
+
+    def picky(*args, **kwargs):
+        calls.append(kwargs)
+        if "return_parameters" in kwargs:
+            raise TypeError("synchronize() got an unexpected keyword argument "
+                            "'return_parameters'")
+        return True
+
+    import autosubsync.main
+    monkeypatch.setattr(autosubsync.main, "synchronize", picky)
+
+    assert module._run_autosubsync_api(reference="v.mkv", subtitle_file="s.srt",
+                                       output_file="o.srt", model_file="m.bin",
+                                       parallelism=1) is True
+    assert len(calls) == 2
+
+
+def test_the_measured_skew_reaches_the_history_entry(monkeypatch, tmp_path):
+    """End to end from the engine, because the two halves speak different
+    vocabularies: autosubsync measures a skew, the history entry reads
+    framerate_scale_factor and defaults it to zero. A run with a real skew was
+    recorded as a scale factor of 0.00.
+    """
+    from types import SimpleNamespace
+
+    from subtitles.tools import subsyncer as module
+
+    syncer, _module = _syncer(monkeypatch, tmp_path, (True, 0.91, 1.04, -2.5))
+    raw_result = syncer._run_autosubsync_engine(output_path=tmp_path / "out.srt",
+                                                video_path=str(tmp_path / "Movie.mkv"))
+
+    recorded = []
+    monkeypatch.setattr(module, "language_from_alpha2", lambda code: "English")
+    monkeypatch.setattr(module, "history_log",
+                        lambda **kwargs: recorded.append(kwargs["result"].message))
+    monkeypatch.setattr(module, "path_mappings",
+                        SimpleNamespace(path_replace_reverse=lambda p: p,
+                                        path_replace_reverse_movie=lambda p: p))
+    syncer.reference = str(tmp_path / "Movie.mkv")
+
+    syncer._log_sync_history(
+        SimpleNamespace(engine="autosubsync",
+                        output_path=str(tmp_path / "Movie.en.srt"),
+                        raw_result=raw_result),
+        "overwrite", "en", False, False, sonarr_series_id=1, sonarr_episode_id=2)
+
+    assert recorded
+    assert "1.04" in recorded[0], f"the measured skew is missing from: {recorded[0]}"
+    assert "0.91" in recorded[0], f"the quality of fit is missing from: {recorded[0]}"

--- a/tests/bazarr/test_autosubsync_diagnostics.py
+++ b/tests/bazarr/test_autosubsync_diagnostics.py
@@ -251,7 +251,7 @@ def test_the_measured_skew_reaches_the_history_entry(monkeypatch, tmp_path):
     assert "0.91" in recorded[0], f"the quality of fit is missing from: {recorded[0]}"
 
 
-@pytest.mark.parametrize("quality", [0.749, 0.7499, 0.74999])
+@pytest.mark.parametrize("quality", [0.749, 0.7499, 0.74999, 0.7499999])
 def test_a_near_miss_does_not_read_as_equal_to_the_threshold(monkeypatch, tmp_path, quality):
     """Two decimals turn 0.749 into "0.75, below its 0.75 threshold", which
     contradicts itself, and the near miss is exactly the case this message
@@ -265,9 +265,13 @@ def test_a_near_miss_does_not_read_as_equal_to_the_threshold(monkeypatch, tmp_pa
                                        video_path=str(tmp_path / "Movie.mkv"))
 
     message = str(raised.value)
-    measured, threshold = message.split("quality of fit of ")[1].split(", below its ")
-    threshold = threshold.split(" ")[0]
-    assert measured != threshold, message
+    if "quality of fit of " in message:
+        measured, threshold = message.split("quality of fit of ")[1].split(", below its ")
+        assert measured != threshold.split(" ")[0], message
+    else:
+        # Too close to separate at any sane precision, so the message says so
+        # in words rather than quoting one number twice.
+        assert "just below" in message, message
 
 
 def test_a_clear_miss_stays_readable(monkeypatch, tmp_path):

--- a/tests/bazarr/test_autosubsync_diagnostics.py
+++ b/tests/bazarr/test_autosubsync_diagnostics.py
@@ -249,3 +249,36 @@ def test_the_measured_skew_reaches_the_history_entry(monkeypatch, tmp_path):
     assert recorded
     assert "1.04" in recorded[0], f"the measured skew is missing from: {recorded[0]}"
     assert "0.91" in recorded[0], f"the quality of fit is missing from: {recorded[0]}"
+
+
+@pytest.mark.parametrize("quality", [0.749, 0.7499, 0.74999])
+def test_a_near_miss_does_not_read_as_equal_to_the_threshold(monkeypatch, tmp_path, quality):
+    """Two decimals turn 0.749 into "0.75, below its 0.75 threshold", which
+    contradicts itself, and the near miss is exactly the case this message
+    exists to explain."""
+    from subtitles.tools.subsync_engines import SyncEngineDeclinedError
+
+    syncer, _module = _syncer(monkeypatch, tmp_path, (False, quality, 1.0, -2.5))
+
+    with pytest.raises(SyncEngineDeclinedError) as raised:
+        syncer._run_autosubsync_engine(output_path=tmp_path / "out.srt",
+                                       video_path=str(tmp_path / "Movie.mkv"))
+
+    message = str(raised.value)
+    measured, threshold = message.split("quality of fit of ")[1].split(", below its ")
+    threshold = threshold.split(" ")[0]
+    assert measured != threshold, message
+
+
+def test_a_clear_miss_stays_readable(monkeypatch, tmp_path):
+    """Precision is only spent where it is needed: an ordinary number keeps its
+    two decimals rather than growing a tail of zeros."""
+    from subtitles.tools.subsync_engines import SyncEngineDeclinedError
+
+    syncer, _module = _syncer(monkeypatch, tmp_path, (False, 0.43, 1.0, -2.5))
+
+    with pytest.raises(SyncEngineDeclinedError) as raised:
+        syncer._run_autosubsync_engine(output_path=tmp_path / "out.srt",
+                                       video_path=str(tmp_path / "Movie.mkv"))
+
+    assert "0.43," in str(raised.value)

--- a/tests/bazarr/test_autosubsync_diagnostics.py
+++ b/tests/bazarr/test_autosubsync_diagnostics.py
@@ -1,0 +1,135 @@
+# coding=utf-8
+"""autosubsync's own numbers, instead of an opaque refusal.
+
+autosubsync runs to completion, writes a synchronised subtitle, and then judges
+its own work against a hard-coded quality threshold of 0.75. Bazarr called it
+without return_parameters, so all it got back was a bare False, and the message
+it produced was:
+
+    autosubsync completed but did not meet the quality threshold.
+
+No quality number, no threshold, nothing to say whether the fit was 0.74 or
+0.05. To the reporter that read as a broken installation rather than as a file
+this engine could not align.
+
+The gate itself is upstream's and stays: what changes is that the numbers reach
+the user, the log and the sync report.
+"""
+
+import pytest
+
+
+def _syncer(monkeypatch, tmp_path, result):
+    from subtitles.tools import subsyncer as module
+
+    monkeypatch.setattr(module, "_autosubsync_model_file", lambda: "model.bin")
+    monkeypatch.setattr(module, "_run_autosubsync_api", lambda **kwargs: result)
+
+    syncer = module.SubSyncer()
+    syncer.srtin = str(tmp_path / "Movie.en.srt")
+    syncer.reference = None
+    return syncer, module
+
+
+def test_a_decline_names_the_quality_and_the_threshold(monkeypatch, tmp_path):
+    from subtitles.tools.subsync_engines import SyncEngineDeclinedError
+
+    syncer, _module = _syncer(monkeypatch, tmp_path, (False, 0.43, 1.0, -2.5))
+
+    with pytest.raises(SyncEngineDeclinedError) as raised:
+        syncer._run_autosubsync_engine(output_path=tmp_path / "out.srt",
+                                       video_path=str(tmp_path / "Movie.mkv"))
+
+    message = str(raised.value)
+    assert "0.43" in message
+    assert "0.75" in message, "the threshold the quality is being judged against"
+
+
+def test_a_successful_run_reports_the_numbers_it_measured(monkeypatch, tmp_path):
+    syncer, _module = _syncer(monkeypatch, tmp_path, (True, 0.91, 1.0, -2.5))
+
+    result = syncer._run_autosubsync_engine(output_path=tmp_path / "out.srt",
+                                            video_path=str(tmp_path / "Movie.mkv"))
+
+    assert result["success"] is True
+    assert result["quality_of_fit"] == 0.91
+    assert result["skew"] == 1.0
+    assert result["offset_seconds"] == -2.5
+
+
+def test_the_measured_offset_is_held_to_the_configured_maximum(monkeypatch, tmp_path):
+    """autosubsync reports its shift, so it can be held to the acceptance
+    threshold like ffsubsync is, instead of being exempt for want of a number."""
+    from subtitles.tools.subsync_engines import SyncResultRejectedError, validate_engine_result
+
+    syncer, _module = _syncer(monkeypatch, tmp_path, (True, 0.91, 1.0, -900.0))
+
+    result = syncer._run_autosubsync_engine(output_path=tmp_path / "out.srt",
+                                            video_path=str(tmp_path / "Movie.mkv"))
+
+    with pytest.raises(SyncResultRejectedError):
+        validate_engine_result("autosubsync", result, "60")
+
+
+def test_an_older_autosubsync_that_returns_a_bare_bool_still_works(monkeypatch, tmp_path):
+    """return_parameters is not ancient. A build without it returns a plain
+    bool, and that has to keep working rather than raising a TypeError inside
+    the sync."""
+    syncer, _module = _syncer(monkeypatch, tmp_path, True)
+
+    result = syncer._run_autosubsync_engine(output_path=tmp_path / "out.srt",
+                                            video_path=str(tmp_path / "Movie.mkv"))
+
+    assert result["success"] is True
+    assert result.get("quality_of_fit") is None
+
+
+def test_a_bare_false_still_declines_with_a_usable_message(monkeypatch, tmp_path):
+    from subtitles.tools.subsync_engines import SyncEngineDeclinedError
+
+    syncer, _module = _syncer(monkeypatch, tmp_path, False)
+
+    with pytest.raises(SyncEngineDeclinedError) as raised:
+        syncer._run_autosubsync_engine(output_path=tmp_path / "out.srt",
+                                       video_path=str(tmp_path / "Movie.mkv"))
+
+    assert "autosubsync" in str(raised.value)
+
+
+def test_the_history_entry_carries_the_quality_it_measured(monkeypatch, tmp_path):
+    """The numbers have to survive into what the user reads later, or the run
+    that succeeded is as opaque as the one that declined."""
+    from types import SimpleNamespace
+
+    from subtitles.tools import subsyncer as module
+
+    recorded = []
+    monkeypatch.setattr(module, "history_log", lambda *args, **kwargs: recorded.append(args))
+    # languages_dict is only populated once the app has booted against a real
+    # database; the label is not what this test is about.
+    monkeypatch.setattr(module, "language_from_alpha2", lambda code: "English")
+    monkeypatch.setattr(module, "path_mappings",
+                        SimpleNamespace(path_replace_reverse=lambda p: p,
+                                        path_replace_reverse_movie=lambda p: p))
+
+    syncer = module.SubSyncer()
+    syncer.srtin = str(tmp_path / "Movie.en.srt")
+
+    result = SimpleNamespace(
+        engine="autosubsync",
+        output_path=str(tmp_path / "Movie.en.srt"),
+        raw_result={"success": True, "offset_seconds": -2.5, "quality_of_fit": 0.91,
+                    "skew": 1.0},
+    )
+    syncer.reference = str(tmp_path / "Movie.mkv")
+
+    monkeypatch.setattr(module, "history_log",
+                        lambda **kwargs: recorded.append(kwargs["result"].message))
+
+    syncer._log_sync_history(result, "overwrite", "en", False, False,
+                             sonarr_series_id=1, sonarr_episode_id=2)
+
+    assert recorded, "nothing was written to history"
+    message = recorded[0]
+    assert "-2.5" in message
+    assert "0.91" in message, f"the quality of fit is missing from: {message}"


### PR DESCRIPTION
## The report

> `RuntimeError: autosubsync completed but did not meet the quality threshold.`

No quality number, no threshold, no way to tell whether the fit was 0.74 or 0.05. The reporter read it as "autosubsync is broken or needs a manual install".

## What is actually happening

`autosubsync.synchronize()` computes skew and shift, writes the transformed subtitle **unconditionally**, then sets `success = quality > quality_of_fit.threshold`, where the threshold is hard-coded at 0.75. Called without `return_parameters=True` it answers a bare bool, so every diagnostic it computed was discarded.

That gate is a confidence metric on speech-detection correlation. Anime with sparse dialogue, a heavy score, or audio in a language the model handles poorly legitimately scores lower even when the computed offset is right, which is why this shows up on some files and never on others.

## Changes

- `return_parameters=True`, so the run yields `(success, quality, skew, shift)`. A build that does not accept the argument raises `TypeError` and falls back to the plain call, so nothing breaks on an older autosubsync.
- the decline names the measured quality and the threshold: *"autosubsync measured a quality of fit of 0.43, below its 0.75 threshold; the subtitle may not match this audio."* The threshold is read from the package rather than copied, so the message cannot drift from what was applied.
- a successful run returns `quality_of_fit`, `skew` and `offset_seconds`. The shift goes under the key ffsubsync already uses, which means **autosubsync is now held to the configured maximum offset** instead of being exempt for want of a number.
- the history entry carries the quality, so a sync that looks wrong later can be judged on what the engine thought at the time.

The upstream gate itself is unchanged: this is about the numbers reaching the user, not about accepting worse results. Note that a decline already costs the engine no strike towards the failure quarantine, which landed separately.

## Tests

`tests/bazarr/test_autosubsync_diagnostics.py`, enumerated in CI: the decline message names both numbers, a successful run reports what it measured, the measured offset is held to the acceptance threshold, a build returning a bare bool still works in both directions, and the history entry carries the quality.

Backend suite green locally (1716 passed), ruff clean.