### PR TITLE
fix(jobs): reserve the slot before spawning the worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,7 @@ jobs:
             tests/bazarr/test_arr_rootfolder.py \
             tests/bazarr/test_arr_local_id_cutover_migration.py \
             tests/bazarr/test_jobs_queue_progress.py \
+            tests/bazarr/test_jobs_concurrency_limit.py \
             tests/bazarr/test_processing_sync_substep.py \
             tests/bazarr/test_mass_download_path_mapping.py \
             tests/bazarr/test_processing_postprocessing.py \

--- a/bazarr/app/jobs_queue.py
+++ b/bazarr/app/jobs_queue.py
@@ -530,11 +530,22 @@ class JobsQueue:
         :return: A boolean value indicating whether the job was successfully initiated.
         :rtype: bool
         """
-        for job in self.jobs_pending_queue:
-            if job.job_id == job_id and job.status == 'pending':
-                self._run_job(job_instance=job)
-                return True
-        return False
+        with self._queue_lock:
+            job = next((item for item in self.jobs_pending_queue
+                        if item.job_id == job_id and item.status == 'pending'), None)
+            if job is None:
+                return False
+
+            # Deliberately without a capacity check: forcing a job is an
+            # explicit user action. It still reserves the same way, so the job
+            # is counted exactly once and never sits in neither queue.
+            self.jobs_pending_queue.remove(job)
+            self.jobs_running_queue.append(job)
+
+        job_thread = Thread(target=self._run_job, args=(job,))
+        job_thread.daemon = True
+        job_thread.start()
+        return True
 
     def empty_jobs_queue(self, queue_name: str):
         """
@@ -566,34 +577,61 @@ class JobsQueue:
         """
         while True:
             try:
-                if self.jobs_pending_queue:
-                    with self._queue_lock:
-                        next_job = self.jobs_pending_queue[0] if self.jobs_pending_queue else None
-                        if next_job:
-                            is_translation = 'translat' in (next_job.job_name or '').lower()
-                            if is_translation:
-                                # Translation jobs respect their own concurrency limit
-                                running_translations = sum(
-                                    1 for j in self.jobs_running_queue
-                                    if 'translat' in (j.job_name or '').lower()
-                                )
-                                max_translations = settings.translator.openrouter_max_concurrent
-                                can_run_job = running_translations < max_translations
-                            else:
-                                can_run_job = len(self.jobs_running_queue) < settings.general.concurrent_jobs
-                        else:
-                            can_run_job = False
-
-                    if can_run_job:
-                        job_thread = Thread(target=self._run_job)
-                        job_thread.daemon = True
-                        job_thread.start()
-                    else:
-                        sleep(0.5)
-                else:
+                job = self._reserve_next_job()
+                if job is None:
                     sleep(0.5)
+                    continue
+
+                job_thread = Thread(target=self._run_job, args=(job,))
+                job_thread.daemon = True
+                job_thread.start()
             except (KeyboardInterrupt, SystemExit):
                 break
+
+    def _has_capacity_for(self, job) -> bool:
+        """Whether ``job`` may start now. Call with ``_queue_lock`` held.
+
+        The general limit applies to every job. The translation lane is a
+        sub-limit inside it, not a parallel gate: the settings field says
+        "Number of concurrent jobs allowed in the jobs manager", and a
+        translation admitted purely against its own lane meant a translation
+        plus a general job ran under a configured limit of 1.
+        """
+        if len(self.jobs_running_queue) >= settings.general.concurrent_jobs:
+            return False
+
+        if 'translat' not in (job.job_name or '').lower():
+            return True
+
+        running_translations = sum(
+            1 for running in self.jobs_running_queue
+            if 'translat' in (running.job_name or '').lower()
+        )
+        return running_translations < settings.translator.openrouter_max_concurrent
+
+    def _reserve_next_job(self):
+        """Take the next runnable job off pending and put it on running, or None.
+
+        One critical section for the whole decision. The check and the act used
+        to be separate: capacity was compared under the lock, the lock was
+        released, a worker was spawned, and only that worker appended the job to
+        the running queue. In between, the job was in neither queue, so the
+        consumer's next iteration read a running count that was one too low and
+        started another worker. With a limit of 1 and a backlog, the loop has no
+        sleep on that path and won the race essentially every time, which is why
+        two jobs ran and stayed at two.
+        """
+        with self._queue_lock:
+            if not self.jobs_pending_queue:
+                return None
+
+            job = self.jobs_pending_queue[0]
+            if not self._has_capacity_for(job):
+                return None
+
+            self.jobs_pending_queue.popleft()
+            self.jobs_running_queue.append(job)
+            return job
 
     def _run_job(self, job_instance=None) -> bool:
         """
@@ -608,15 +646,10 @@ class JobsQueue:
             True if the job was successfully completed, otherwise False.
         :rtype: bool
         """
-        with self._queue_lock:
-            if job_instance:
-                job = job_instance
-                self.jobs_pending_queue.remove(job)
-            else:
-                if not self.jobs_pending_queue:
-                    return False
-                job = self.jobs_pending_queue.popleft()
-    
+        # The caller reserved this job: it is already off pending and on
+        # running, which is what keeps the capacity check honest. This method
+        # only runs it.
+        job = job_instance
         if not job:
             sleep(0.1)
             return False
@@ -625,7 +658,6 @@ class JobsQueue:
             job.last_run_time = datetime.now()
             if 'job_id' not in job.kwargs or not job.kwargs['job_id']:
                 job.kwargs['job_id'] = job.job_id
-            self.jobs_running_queue.append(job)
 
             # sending event to update the status of progress jobs
             payload = {"job_id": job.job_id, "status": job.status}
@@ -648,20 +680,23 @@ class JobsQueue:
             job.status = 'completed'
             job.progress_message = "Cancelled by user"
             job.last_run_time = datetime.now()
-            self.jobs_running_queue.remove(job)
+            with self._queue_lock:
+                self.jobs_running_queue.remove(job)
             self.jobs_completed_queue.append(job)
             return False
         except Exception as e:
             logging.exception(f"Exception raised while running function: {e}")  # noqa: G004
             job.status = 'failed'
             job.last_run_time = datetime.now()
-            self.jobs_running_queue.remove(job)
+            with self._queue_lock:
+                self.jobs_running_queue.remove(job)
             self.jobs_failed_queue.append(job)
             return False
         else:
             job.status = 'completed'
             job.last_run_time = datetime.now()
-            self.jobs_running_queue.remove(job)
+            with self._queue_lock:
+                self.jobs_running_queue.remove(job)
             self.jobs_completed_queue.append(job)
             return True
         finally:

--- a/tests/bazarr/test_jobs_concurrency_limit.py
+++ b/tests/bazarr/test_jobs_concurrency_limit.py
@@ -1,0 +1,176 @@
+# coding=utf-8
+"""The Jobs Manager must never run more jobs than the configured limit.
+
+Reported with Concurrent Jobs set to 1 and two jobs consistently in Running
+while a backlog sat in Pending.
+
+It is a check-then-act race across two threads. The consumer took the lock,
+compared len(jobs_running_queue) against the limit, and released the lock before
+acting on the answer. The job it then spawned entered jobs_running_queue only
+inside the worker, and that append happened outside the lock. Between the spawn
+and the append the job was invisible: already gone from pending, not yet in
+running. The consumer loop has no sleep on the success path, so it immediately
+re-read a running count that was stale-low and started a second worker. With a
+limit of 1 and a backlog the second spawn won essentially every time, which is
+why the reporter saw exactly 2 rather than an unbounded pile.
+
+Reserving the slot is therefore one critical section: check capacity, take the
+job off pending, and put it on running, before any thread is spawned. These
+tests drive that reservation directly rather than trying to win a race, because
+a test that only sometimes reproduces a race protects nothing.
+"""
+
+import pytest
+
+import app.database  # noqa: F401
+
+
+@pytest.fixture
+def queue(monkeypatch):
+    from app.jobs_queue import JobsQueue
+
+    monkeypatch.setattr("app.jobs_queue.event_stream", lambda *args, **kwargs: None)
+    return JobsQueue()
+
+
+def _enqueue(queue, count, name="Job"):
+    for index in range(count):
+        queue.feed_jobs_pending_queue(
+            job_name=f"{name} {index}",
+            module="tests.fake",
+            func="work",
+            # Distinct kwargs: the queue refuses a job whose module, function and
+            # arguments match one already queued.
+            kwargs={"index": index},
+        )
+
+
+@pytest.mark.parametrize("limit", [1, 2, 3])
+def test_no_more_slots_are_handed_out_than_the_limit(queue, monkeypatch, limit):
+    from app.config import settings
+
+    monkeypatch.setattr(settings.general, "concurrent_jobs", limit)
+    _enqueue(queue, limit + 3)
+
+    reserved = []
+    for _ in range(limit + 3):
+        job = queue._reserve_next_job()
+        if job is None:
+            break
+        reserved.append(job)
+
+    assert len(reserved) == limit
+    assert len(queue.jobs_running_queue) == limit
+    assert len(queue.jobs_pending_queue) == 3
+
+
+def test_a_reserved_job_leaves_pending_and_joins_running_at_once(queue, monkeypatch):
+    """The window the race lived in. Nothing may observe the job in neither
+    queue, because that is exactly when the capacity check reads stale-low."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings.general, "concurrent_jobs", 1)
+    _enqueue(queue, 2)
+
+    job = queue._reserve_next_job()
+
+    assert job is not None
+    assert job in queue.jobs_running_queue
+    assert job not in queue.jobs_pending_queue
+    assert queue._reserve_next_job() is None, "a second slot was handed out"
+
+
+def test_a_finished_job_frees_its_slot(queue, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings.general, "concurrent_jobs", 1)
+    _enqueue(queue, 2)
+
+    first = queue._reserve_next_job()
+    assert queue._reserve_next_job() is None
+
+    queue.jobs_running_queue.remove(first)
+
+    assert queue._reserve_next_job() is not None
+
+
+def test_an_empty_queue_reserves_nothing(queue, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings.general, "concurrent_jobs", 4)
+
+    assert queue._reserve_next_job() is None
+
+
+def test_a_translation_counts_against_the_general_limit_too(queue, monkeypatch):
+    """The settings field says 'Number of concurrent jobs allowed in the jobs
+    manager'. A translation admitted purely against its own lane meant a
+    translation plus a general job ran under a configured limit of 1, which is
+    not what that sentence promises.
+    """
+    from app.config import settings
+
+    monkeypatch.setattr(settings.general, "concurrent_jobs", 1)
+    monkeypatch.setattr(settings.translator, "openrouter_max_concurrent", 5)
+
+    queue.feed_jobs_pending_queue(job_name="Translating something", module="tests.fake",
+                                  func="work", kwargs={"index": 0})
+    queue.feed_jobs_pending_queue(job_name="Syncing series", module="tests.fake",
+                                  func="work", kwargs={"index": 1})
+
+    assert queue._reserve_next_job() is not None
+    assert queue._reserve_next_job() is None, (
+        "a second job ran alongside a translation under a limit of 1"
+    )
+
+
+def test_the_translation_lane_still_caps_translations_below_the_general_limit(queue, monkeypatch):
+    """The lane is a sub-limit, not a parallel gate: it can only ever admit
+    fewer translations than the general cap would, never more."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings.general, "concurrent_jobs", 4)
+    monkeypatch.setattr(settings.translator, "openrouter_max_concurrent", 1)
+
+    for index in range(3):
+        queue.feed_jobs_pending_queue(job_name=f"Translating {index}", module="tests.fake",
+                                      func="work", kwargs={"index": index})
+
+    assert queue._reserve_next_job() is not None
+    assert queue._reserve_next_job() is None, "the translation lane admitted a second one"
+
+
+def test_a_forced_job_bypasses_the_limit_without_double_counting(queue, monkeypatch):
+    """Forcing a job is an explicit user action and is meant to bypass the cap.
+    It must still leave the queues consistent: counted once in running, gone
+    from pending."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings.general, "concurrent_jobs", 1)
+    monkeypatch.setattr("app.jobs_queue.Thread", _ImmediateThread)
+    _enqueue(queue, 2)
+
+    running = queue._reserve_next_job()
+    forced_id = queue.jobs_pending_queue[0].job_id
+
+    queue.force_start_pending_job(forced_id)
+
+    assert running in queue.jobs_running_queue
+    assert all(job.job_id != forced_id for job in queue.jobs_pending_queue)
+    assert [job.job_id for job in queue.jobs_running_queue].count(forced_id) <= 1
+
+
+class _ImmediateThread:
+    """Runs the target inline, so a test never leaves a thread behind."""
+
+    def __init__(self, target=None, args=(), kwargs=None, **_ignored):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+        self.daemon = False
+
+    def start(self):
+        try:
+            self._target(*self._args, **self._kwargs)
+        except Exception:
+            pass


### PR DESCRIPTION
Fixes https://github.com/LavX/bazarr/issues/331

## The report

Concurrent Jobs set to **1**, and the Jobs Manager consistently shows **2** running with a backlog in Pending.

## Root cause

A check-then-act race across two threads:

1. the consumer takes `_queue_lock`, compares `len(jobs_running_queue)` against the limit, and **releases the lock** before acting on the answer
2. it spawns a worker; the job enters `jobs_running_queue` only inside that worker, and that append is **outside** the lock
3. in between, the job is in neither queue: gone from pending, not yet in running
4. the consumer loop has **no sleep on the success path**, so it immediately re-reads a running count that is one too low and starts a second worker

With a limit of 1 and a backlog the second spawn wins essentially every time. It settles at exactly 2 rather than growing without bound because once both workers have appended themselves the count finally reads 2, which matches the report precisely.

## The fix

Reservation is one critical section: check capacity, pop from pending, append to running, and only then hand the job to a thread. `_run_job` takes the reserved job and no longer touches the pending queue. The exception paths remove from the running queue under the lock too.

`force_start_pending_job` still bypasses the limit, which is intended for an explicit user action, but it now reserves the same way, so a forced job is counted exactly once and never sits in neither queue.

## The translation lane

The ticket asked for a decision here. It was a **parallel gate**: a job whose name contains "translat" was admitted against `openrouter_max_concurrent` alone, ignoring the general cap, so a translation plus a general job ran under a configured limit of 1.

It is now a **sub-limit inside** the general cap. The settings field reads "Number of concurrent jobs allowed in the jobs manager", and a limit that some jobs ignore is not that. The lane can still hold translations below the general cap, never above it.

If you would rather keep two independent lanes, say so and I will revert that half and reword the setting instead: the fix for the race does not depend on it.

## Tests

`tests/bazarr/test_jobs_concurrency_limit.py`, enumerated in CI. They drive the reservation directly rather than trying to win a race, because a test that only sometimes reproduces one protects nothing: at limits 1, 2 and 3 no more slots are handed out than the limit; a reserved job is out of pending and in running at the same instant; a finished job frees its slot; a translation counts against the general limit; the lane still caps translations below it; and a forced job bypasses the cap without double-counting.

All nine fail against the old code. Full backend suite green locally (1813 passed), ruff clean.