### PR TITLE
fix(db): start against a database created by upstream Bazarr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,9 @@ jobs:
             tests/bazarr/test_path_mappings_instance.py \
             tests/bazarr/test_threading_followup.py \
             tests/bazarr/test_mass_operations.py \
-            tests/bazarr/test_release_type_mismatch_migration.py ; do
+            tests/bazarr/test_release_type_mismatch_migration.py \
+            tests/bazarr/test_upstream_db_adoption.py \
+            tests/bazarr/test_upstream_db_adoption_pg.py ; do
             echo "::group::$f"
             pytest "$f" -p no:cacheprovider -q
             echo "::endgroup::"

--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -21,6 +21,8 @@ from flask_sqlalchemy import SQLAlchemy
 
 from .config import settings
 from .get_args import args
+from .upstream_adoption import (adopt_upstream_database, explain_unknown_revision,
+                               known_revisions, stamped_revision)
 
 logger = logging.getLogger(__name__)
 
@@ -828,6 +830,26 @@ def migrate_db(app):
     alembic_temp_tables_list = [x for x in insp.get_table_names() if x.startswith('_alembic_tmp_')]
     for table in alembic_temp_tables_list:
         database.execute(text(f"DROP TABLE IF EXISTS {table}"))
+
+    # A database created by upstream Bazarr carries a revision this fork has no
+    # script for, and has had the columns the indexer reads dropped out from
+    # under it. Alembic cannot start against it at all, so this runs first.
+    try:
+        with engine.begin() as connection:
+            adopt_upstream_database(connection)
+    except Exception:
+        logging.exception("Upstream database adoption failed; continuing to the normal upgrade")
+
+    # Alembic's own account of a revision it has no script for is one line with
+    # no hint of where such a database comes from, and it exits before anything
+    # else is logged. Say it plainly first.
+    try:
+        with engine.connect() as connection:
+            pending = stamped_revision(connection)
+        if pending and pending not in known_revisions(migrations_directory):
+            logging.error(explain_unknown_revision(pending))
+    except Exception:
+        logging.exception("Could not check the database migration revision before upgrading")
 
     with app.app_context():
         flask_migrate.Migrate(app, db, render_as_batch=True)

--- a/bazarr/app/upstream_adoption.py
+++ b/bazarr/app/upstream_adoption.py
@@ -48,26 +48,38 @@ _REVISION_ASSIGNMENT = re.compile(r"^revision = ['\"]([^'\"]+)['\"]", re.M)
 
 
 def legacy_subtitle_value(rows):
-    """Build the value ``store_subtitles`` writes, from upstream's split rows.
+    """Build the value the indexer writes, from upstream's split rows.
 
     ``rows`` are mappings with ``language``, ``hi``, ``forced``, ``path`` and
     ``size``, optionally ``embedded_track_id``. The result is the repr of a
     list of ``[language, path, size]``, which is what the indexer reads back
     with ``ast.literal_eval``.
+
+    A row with no file is an in-container track, which the fork records as
+    ``[language, None, None]`` and whose file checks short-circuit on the falsy
+    path. Those have to survive the conversion: dropping them would make
+    migrated media look as if it had lost its embedded languages, and set off
+    searches for subtitles that are already inside the file.
     """
     subtitles = []
     for row in rows:
-        # Upstream keeps in-container tracks in the same table. The fork's
-        # legacy column only ever held files on disk, and the indexer stats
-        # every path in it, so an embedded row has no place here.
-        if row.get('embedded_track_id') is not None:
-            continue
         path = row.get('path')
-        if not path:
+        embedded = row.get('embedded_track_id') is not None or not path
+        language = row.get('language') or ''
+
+        if embedded:
+            # The embedded pass goes through normalize_subtitle_language_variant,
+            # which puts hi first and can emit both variants.
+            variants = []
+            if row.get('hi'):
+                variants.append('hi')
+            if row.get('forced'):
+                variants.append('forced')
+            subtitles.append([':'.join([language] + variants), None, None])
             continue
 
-        language = row.get('language') or ''
-        # store_subtitles tests forced first, so a row flagged both is forced.
+        # store_subtitles picks a single suffix and tests forced first, so a
+        # file flagged both is forced.
         if row.get('forced'):
             language = f'{language}:forced'
         elif row.get('hi'):

--- a/bazarr/app/upstream_adoption.py
+++ b/bazarr/app/upstream_adoption.py
@@ -1,0 +1,226 @@
+# coding=utf-8
+"""Adopt a database created by upstream Bazarr.
+
+Upstream's migration chain runs ``... 309dc062d2e4 -> 7e9a2b1c4d5f ->
+0124f9e278fb``. This fork re-parented ``7e9a2b1c4d5f`` behind its own work and
+never adopted ``0124f9e278fb``, so a database from a current upstream install
+is stamped with a revision this codebase has no script for. Alembic refuses to
+start and Bazarr+ crash-loops, which is how a user first ran into it.
+
+The stamp is only half of it. ``0124f9e278fb`` also moves the per-item subtitle
+list out of ``table_episodes.subtitles`` and ``table_movies.subtitles`` into
+new ``table_episodes_subtitles`` / ``table_movies_subtitles`` tables, then
+drops the source columns. This fork never took that split: it still models
+``subtitles`` as a Text column and the indexer reads it everywhere.
+``create_all()`` does not add a column to a table that already exists, so
+correcting the stamp alone would produce an install that boots and then falls
+over the first time it indexes anything.
+
+So adoption is both halves, in that order: put the column back and fold the
+rows into it, then rewrite the stamp.
+"""
+
+import logging
+import os
+import re
+
+import sqlalchemy as sa
+
+# Upstream-only revisions, each mapped to the newest revision in this fork's
+# chain all of whose ancestors that database has provably applied.
+#
+# For 0124f9e278fb that is 309dc062d2e4 rather than 7e9a2b1c4d5f. Both are in
+# upstream's chain and an upstream database has run both, but in this fork's
+# chain 7e9a2b1c4d5f sits behind 4bb94a033f93 and f2f74f2d6d0a, which that
+# database has never seen. Alembic walks a line, not a set, so claiming
+# 7e9a2b1c4d5f would silently claim those two as well.
+UPSTREAM_REVISION_EQUIVALENTS = {
+    '0124f9e278fb': '309dc062d2e4',
+}
+
+# (item table, split table, the column joining them)
+_SPLIT_SUBTITLE_TABLES = (
+    ('table_episodes', 'table_episodes_subtitles', 'sonarrEpisodeId'),
+    ('table_movies', 'table_movies_subtitles', 'radarrId'),
+)
+
+_REVISION_ASSIGNMENT = re.compile(r"^revision = ['\"]([^'\"]+)['\"]", re.M)
+
+
+def legacy_subtitle_value(rows):
+    """Build the value ``store_subtitles`` writes, from upstream's split rows.
+
+    ``rows`` are mappings with ``language``, ``hi``, ``forced``, ``path`` and
+    ``size``, optionally ``embedded_track_id``. The result is the repr of a
+    list of ``[language, path, size]``, which is what the indexer reads back
+    with ``ast.literal_eval``.
+    """
+    subtitles = []
+    for row in rows:
+        # Upstream keeps in-container tracks in the same table. The fork's
+        # legacy column only ever held files on disk, and the indexer stats
+        # every path in it, so an embedded row has no place here.
+        if row.get('embedded_track_id') is not None:
+            continue
+        path = row.get('path')
+        if not path:
+            continue
+
+        language = row.get('language') or ''
+        # store_subtitles tests forced first, so a row flagged both is forced.
+        if row.get('forced'):
+            language = f'{language}:forced'
+        elif row.get('hi'):
+            language = f'{language}:hi'
+
+        size = row.get('size')
+        # The indexer compares this against os.stat().st_size. None would raise
+        # there; zero simply never matches and the file is indexed again.
+        subtitles.append([language, path, int(size) if size is not None else 0])
+
+    return str(subtitles)
+
+
+def _table_columns(connection, table_name):
+    inspector = sa.inspect(connection)
+    try:
+        return {column['name'] for column in inspector.get_columns(table_name)}
+    except sa.exc.NoSuchTableError:
+        return set()
+
+
+def restore_legacy_subtitle_columns(connection):
+    """Put ``subtitles`` back and fill it from upstream's split tables.
+
+    Returns the item tables it wrote to. Both steps are skipped where they are
+    not needed, so this is safe to run against a database that never came from
+    upstream and safe to run twice.
+    """
+    written = []
+    inspector = sa.inspect(connection)
+    existing_tables = set(inspector.get_table_names())
+
+    for item_table, split_table, join_column in _SPLIT_SUBTITLE_TABLES:
+        if item_table not in existing_tables:
+            continue
+
+        if 'subtitles' not in _table_columns(connection, item_table):
+            connection.execute(sa.text(f'ALTER TABLE {item_table} ADD COLUMN subtitles TEXT'))
+            # The inspector caches per call; the column list below is read
+            # fresh, so nothing here relies on the stale one.
+            logging.info('BAZARR restored the %s.subtitles column dropped by upstream', item_table)
+
+        if split_table not in existing_tables:
+            # Nothing to fold in. A fork database reaches here and is left
+            # exactly as the indexer wrote it.
+            continue
+
+        split_columns = _table_columns(connection, split_table)
+        selected = [column for column in
+                    ('language', 'hi', 'forced', 'path', 'size', 'embedded_track_id')
+                    if column in split_columns]
+        column_sql = ', '.join(f'"{column}"' for column in selected)
+
+        rows_by_item = {}
+        for row in connection.execute(sa.text(
+                f'SELECT "{join_column}", {column_sql} FROM {split_table} '
+                f'ORDER BY "{join_column}"')).mappings():
+            rows_by_item.setdefault(row[join_column], []).append(row)
+
+        item_ids = [row[0] for row in connection.execute(
+            sa.text(f'SELECT "{join_column}" FROM {item_table}'))]
+
+        for item_id in item_ids:
+            connection.execute(
+                sa.text(f'UPDATE {item_table} SET subtitles = :subtitles '
+                        f'WHERE "{join_column}" = :item_id'),
+                {'subtitles': legacy_subtitle_value(rows_by_item.get(item_id, [])),
+                 'item_id': item_id})
+
+        written.append(item_table)
+        logging.info('BAZARR folded %s rows from %s back into %s.subtitles',
+                     sum(len(v) for v in rows_by_item.values()), split_table, item_table)
+
+    return written
+
+
+def stamped_revision(connection):
+    """The revision in ``alembic_version``, or None on a database without one."""
+    if 'alembic_version' not in sa.inspect(connection).get_table_names():
+        return None
+    return connection.execute(sa.text('SELECT version_num FROM alembic_version')).scalar()
+
+
+def adopt_upstream_database(connection):
+    """Make an upstream database one this codebase can migrate.
+
+    Returns the revision it rewrote the stamp to, or None when there was
+    nothing to adopt. Runs before Alembic, and does nothing at all to a
+    database already on one of this fork's revisions.
+    """
+    revision = stamped_revision(connection)
+    if revision not in UPSTREAM_REVISION_EQUIVALENTS:
+        return None
+
+    equivalent = UPSTREAM_REVISION_EQUIVALENTS[revision]
+    logging.warning('BAZARR this database was created by upstream Bazarr (revision %s). '
+                    'Adopting it: restoring the subtitle columns upstream dropped, then '
+                    'continuing this fork\'s migrations from %s.', revision, equivalent)
+
+    # The column has to be back before the stamp changes. A stamp this fork
+    # understands with the column still missing would start and then fail in
+    # the indexer, which is a worse failure than not starting.
+    restore_legacy_subtitle_columns(connection)
+
+    connection.execute(sa.text('UPDATE alembic_version SET version_num = :equivalent '
+                               'WHERE version_num = :revision'),
+                       {'equivalent': equivalent, 'revision': revision})
+    return equivalent
+
+
+def known_revisions(migrations_directory):
+    """Every revision id this codebase has a script for."""
+    versions = os.path.join(migrations_directory, 'versions')
+    revisions = set()
+    try:
+        names = os.listdir(versions)
+    except OSError:
+        return revisions
+    for name in names:
+        if not name.endswith('.py'):
+            continue
+        try:
+            with open(os.path.join(versions, name), encoding='utf-8') as handle:
+                source = handle.read()
+        except OSError:
+            continue
+        match = _REVISION_ASSIGNMENT.search(source)
+        if match:
+            revisions.add(match.group(1))
+    return revisions
+
+
+def explain_unknown_revision(revision):
+    """What to tell a user whose database Alembic is about to refuse.
+
+    Alembic says only "Can't locate revision identified by X" and exits, which
+    gives no clue that the database came from somewhere this fork cannot follow.
+    """
+    return (
+        f'This database is stamped with migration revision {revision}, which Bazarr+ has no '
+        'script for. That normally means it was created by a newer upstream Bazarr than this '
+        'fork has adopted, and Bazarr+ cannot migrate it safely without knowing what that '
+        'revision changed. Please report it at https://github.com/LavX/bazarr/issues quoting '
+        f'revision {revision}, and keep a backup of the database file.'
+    )
+
+
+__all__ = [
+    'UPSTREAM_REVISION_EQUIVALENTS',
+    'adopt_upstream_database',
+    'explain_unknown_revision',
+    'known_revisions',
+    'legacy_subtitle_value',
+    'restore_legacy_subtitle_columns',
+    'stamped_revision',
+]

--- a/tests/bazarr/test_upstream_db_adoption.py
+++ b/tests/bazarr/test_upstream_db_adoption.py
@@ -97,26 +97,42 @@ def test_forced_wins_over_hearing_impaired_the_way_the_indexer_decides_it():
     ]) == str([['en:forced', '/m/a.srt', 1]])
 
 
-def test_a_row_without_a_file_is_not_an_external_subtitle():
+def test_a_row_with_no_file_is_an_embedded_track():
+    """The fork's indexer records an in-container track as [language, None,
+    None] and its file checks short-circuit on the falsy path. Upstream keeps
+    those tracks in the same table with no path, so dropping them would make
+    migrated media look as if it had lost its embedded languages and set off
+    searches for subtitles that are already in the file."""
     from app.upstream_adoption import legacy_subtitle_value
 
     assert legacy_subtitle_value([
         {'language': 'en', 'hi': False, 'forced': False, 'path': None, 'size': None},
-        {'language': 'en', 'hi': False, 'forced': False, 'path': '', 'size': None},
-    ]) == str([])
+        {'language': 'de', 'hi': False, 'forced': False, 'path': '', 'size': None},
+    ]) == str([['en', None, None], ['de', None, None]])
 
 
-def test_an_embedded_track_is_not_an_external_subtitle():
-    """Upstream keeps in-container tracks in the same table. The fork's legacy
-    column only ever held files on disk, so an embedded row must not appear in
-    it or the indexer would report a file that does not exist."""
+def test_a_row_carrying_a_track_id_is_embedded_whatever_its_path_says():
     from app.upstream_adoption import legacy_subtitle_value
 
     assert legacy_subtitle_value([
         {'language': 'en', 'hi': False, 'forced': False, 'path': '/m/video.mkv',
          'size': None, 'embedded_track_id': '3'},
         {'language': 'fr', 'hi': False, 'forced': False, 'path': '/m/a.fr.srt', 'size': 7},
-    ]) == str([['fr', '/m/a.fr.srt', 7]])
+    ]) == str([['en', None, None], ['fr', '/m/a.fr.srt', 7]])
+
+
+def test_an_embedded_track_uses_the_variant_order_the_embedded_indexer_writes():
+    """The two paths disagree and both are load-bearing. store_subtitles picks
+    one suffix, forced first. normalize_subtitle_language_variant, which the
+    embedded pass uses, emits hi first and can emit both."""
+    from app.upstream_adoption import legacy_subtitle_value
+
+    assert legacy_subtitle_value([
+        {'language': 'en', 'hi': True, 'forced': True, 'path': None, 'size': None},
+        {'language': 'fr', 'hi': True, 'forced': False, 'path': None, 'size': None},
+        {'language': 'de', 'hi': False, 'forced': True, 'path': None, 'size': None},
+    ]) == str([['en:hi:forced', None, None], ['fr:hi', None, None],
+               ['de:forced', None, None]])
 
 
 def test_a_missing_size_becomes_zero_rather_than_none():

--- a/tests/bazarr/test_upstream_db_adoption.py
+++ b/tests/bazarr/test_upstream_db_adoption.py
@@ -1,0 +1,454 @@
+# coding=utf-8
+"""Adopting a database created by upstream Bazarr (inbound LavX/bazarr#302).
+
+Upstream's chain runs ``... 309dc062d2e4 -> 7e9a2b1c4d5f -> 0124f9e278fb``. The
+fork re-parented ``7e9a2b1c4d5f`` behind its own work and never adopted
+``0124f9e278fb``, so an upstream database is stamped with a revision this
+codebase has no script for and Alembic refuses to start. That revision also
+moves the per-item subtitle list out of ``table_episodes.subtitles`` into a
+``table_episodes_subtitles`` table the fork does not model, and drops the
+column the fork's indexer reads.
+
+These build a faithful upstream-shaped database and assert both halves of the
+adoption: the list is folded back into the legacy column, and the stamp is
+rewritten to the newest fork revision whose ancestors that database has
+provably applied.
+"""
+import sqlalchemy as sa
+
+import pytest
+
+
+def _upstream_database(engine, *, stamp='0124f9e278fb', with_embedded_column=True):
+    """A database shaped the way upstream leaves one at ``0124f9e278fb``.
+
+    The ``subtitles`` columns are gone, the split tables hold the rows, and
+    alembic_version carries a revision this codebase has no script for.
+    """
+    embedded = ', embedded_track_id TEXT' if with_embedded_column else ''
+    with engine.begin() as connection:
+        connection.execute(sa.text(
+            'CREATE TABLE table_episodes ('
+            '"sonarrEpisodeId" INTEGER PRIMARY KEY, "sonarrSeriesId" INTEGER, path TEXT)'))
+        connection.execute(sa.text(
+            'CREATE TABLE table_movies ("radarrId" INTEGER PRIMARY KEY, path TEXT)'))
+        connection.execute(sa.text(
+            'CREATE TABLE table_episodes_subtitles ('
+            'id INTEGER PRIMARY KEY, "sonarrEpisodeId" INTEGER, "sonarrSeriesId" INTEGER, '
+            f'language TEXT, hi BOOLEAN, forced BOOLEAN, path TEXT, size INTEGER{embedded})'))
+        connection.execute(sa.text(
+            'CREATE TABLE table_movies_subtitles ('
+            'id INTEGER PRIMARY KEY, "radarrId" INTEGER, '
+            f'language TEXT, hi BOOLEAN, forced BOOLEAN, path TEXT, size INTEGER{embedded})'))
+        connection.execute(sa.text('CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)'))
+        connection.execute(sa.text('INSERT INTO alembic_version (version_num) VALUES (:v)'),
+                           {'v': stamp})
+    return engine
+
+
+@pytest.fixture
+def upstream_engine(tmp_path):
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'bazarr.db'}")
+    try:
+        yield _upstream_database(engine)
+    finally:
+        engine.dispose()
+
+
+def _stamp(engine):
+    with engine.connect() as connection:
+        return connection.execute(sa.text('SELECT version_num FROM alembic_version')).scalar()
+
+
+def _subtitles_of(engine, episode_id):
+    with engine.connect() as connection:
+        return connection.execute(
+            sa.text('SELECT subtitles FROM table_episodes WHERE "sonarrEpisodeId" = :i'),
+            {'i': episode_id}).scalar()
+
+
+# --- the language string the indexer writes -------------------------------
+
+def test_a_plain_language_is_carried_across_unchanged():
+    from app.upstream_adoption import legacy_subtitle_value
+
+    assert legacy_subtitle_value([
+        {'language': 'en', 'hi': False, 'forced': False, 'path': '/m/a.en.srt', 'size': 42},
+    ]) == str([['en', '/m/a.en.srt', 42]])
+
+
+def test_hearing_impaired_and_forced_carry_the_suffix_the_indexer_writes():
+    from app.upstream_adoption import legacy_subtitle_value
+
+    value = legacy_subtitle_value([
+        {'language': 'en', 'hi': True, 'forced': False, 'path': '/m/a.en.hi.srt', 'size': 1},
+        {'language': 'fr', 'hi': False, 'forced': True, 'path': '/m/a.fr.forced.srt', 'size': 2},
+    ])
+
+    assert value == str([['en:hi', '/m/a.en.hi.srt', 1], ['fr:forced', '/m/a.fr.forced.srt', 2]])
+
+
+def test_forced_wins_over_hearing_impaired_the_way_the_indexer_decides_it():
+    """store_subtitles tests ``forced`` first, so a row flagged both is forced."""
+    from app.upstream_adoption import legacy_subtitle_value
+
+    assert legacy_subtitle_value([
+        {'language': 'en', 'hi': True, 'forced': True, 'path': '/m/a.srt', 'size': 1},
+    ]) == str([['en:forced', '/m/a.srt', 1]])
+
+
+def test_a_row_without_a_file_is_not_an_external_subtitle():
+    from app.upstream_adoption import legacy_subtitle_value
+
+    assert legacy_subtitle_value([
+        {'language': 'en', 'hi': False, 'forced': False, 'path': None, 'size': None},
+        {'language': 'en', 'hi': False, 'forced': False, 'path': '', 'size': None},
+    ]) == str([])
+
+
+def test_an_embedded_track_is_not_an_external_subtitle():
+    """Upstream keeps in-container tracks in the same table. The fork's legacy
+    column only ever held files on disk, so an embedded row must not appear in
+    it or the indexer would report a file that does not exist."""
+    from app.upstream_adoption import legacy_subtitle_value
+
+    assert legacy_subtitle_value([
+        {'language': 'en', 'hi': False, 'forced': False, 'path': '/m/video.mkv',
+         'size': None, 'embedded_track_id': '3'},
+        {'language': 'fr', 'hi': False, 'forced': False, 'path': '/m/a.fr.srt', 'size': 7},
+    ]) == str([['fr', '/m/a.fr.srt', 7]])
+
+
+def test_a_missing_size_becomes_zero_rather_than_none():
+    """The indexer compares the stored size against os.stat().st_size. None
+    would raise there; zero simply never matches and the file is re-indexed."""
+    from app.upstream_adoption import legacy_subtitle_value
+
+    assert legacy_subtitle_value([
+        {'language': 'en', 'hi': False, 'forced': False, 'path': '/m/a.srt', 'size': None},
+    ]) == str([['en', '/m/a.srt', 0]])
+
+
+# --- restoring the column -------------------------------------------------
+
+def test_the_dropped_subtitles_column_is_restored(upstream_engine):
+    from app.upstream_adoption import restore_legacy_subtitle_columns
+
+    with upstream_engine.begin() as connection:
+        restore_legacy_subtitle_columns(connection)
+
+    columns = {c['name'] for c in sa.inspect(upstream_engine).get_columns('table_episodes')}
+    assert 'subtitles' in columns
+    columns = {c['name'] for c in sa.inspect(upstream_engine).get_columns('table_movies')}
+    assert 'subtitles' in columns
+
+
+def test_the_split_rows_are_folded_back_into_the_restored_column(upstream_engine):
+    from app.upstream_adoption import restore_legacy_subtitle_columns
+
+    with upstream_engine.begin() as connection:
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes ("sonarrEpisodeId", "sonarrSeriesId", path) '
+            'VALUES (11, 1, \'/m/s01e01.mkv\')'))
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes_subtitles '
+            '("sonarrEpisodeId", "sonarrSeriesId", language, hi, forced, path, size) '
+            'VALUES (11, 1, \'en\', 0, 0, \'/m/s01e01.en.srt\', 120)'))
+        connection.execute(sa.text(
+            'INSERT INTO table_movies ("radarrId", path) VALUES (5, \'/m/movie.mkv\')'))
+        connection.execute(sa.text(
+            'INSERT INTO table_movies_subtitles '
+            '("radarrId", language, hi, forced, path, size) '
+            'VALUES (5, \'fr\', 0, 1, \'/m/movie.fr.srt\', 30)'))
+
+    with upstream_engine.begin() as connection:
+        restore_legacy_subtitle_columns(connection)
+
+    assert _subtitles_of(upstream_engine, 11) == str([['en', '/m/s01e01.en.srt', 120]])
+    with upstream_engine.connect() as connection:
+        assert connection.execute(
+            sa.text('SELECT subtitles FROM table_movies WHERE "radarrId" = 5')).scalar() == \
+            str([['fr:forced', '/m/movie.fr.srt', 30]])
+
+
+def test_an_item_with_no_subtitle_rows_gets_an_empty_list_not_null(upstream_engine):
+    """``ast.literal_eval`` is only reached when the column is truthy, but the
+    API serialises the raw value; an empty list is what the indexer writes for
+    an item it found nothing for."""
+    from app.upstream_adoption import restore_legacy_subtitle_columns
+
+    with upstream_engine.begin() as connection:
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes ("sonarrEpisodeId", "sonarrSeriesId", path) '
+            'VALUES (12, 1, \'/m/s01e02.mkv\')'))
+
+    with upstream_engine.begin() as connection:
+        restore_legacy_subtitle_columns(connection)
+
+    assert _subtitles_of(upstream_engine, 12) == str([])
+
+
+def test_restoring_twice_leaves_the_same_value(upstream_engine):
+    from app.upstream_adoption import restore_legacy_subtitle_columns
+
+    with upstream_engine.begin() as connection:
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes ("sonarrEpisodeId", "sonarrSeriesId", path) '
+            'VALUES (13, 1, \'/m/s01e03.mkv\')'))
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes_subtitles '
+            '("sonarrEpisodeId", "sonarrSeriesId", language, hi, forced, path, size) '
+            'VALUES (13, 1, \'en\', 1, 0, \'/m/s01e03.en.hi.srt\', 9)'))
+
+    for _ in range(2):
+        with upstream_engine.begin() as connection:
+            restore_legacy_subtitle_columns(connection)
+
+    assert _subtitles_of(upstream_engine, 13) == str([['en:hi', '/m/s01e03.en.hi.srt', 9]])
+
+
+def test_an_upstream_build_without_the_embedded_column_still_restores(tmp_path):
+    """The embedded column arrived later than the split. Inspecting for it
+    rather than selecting it blind keeps older upstream databases working."""
+    from app.upstream_adoption import restore_legacy_subtitle_columns
+
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'old.db'}")
+    _upstream_database(engine, with_embedded_column=False)
+    try:
+        with engine.begin() as connection:
+            connection.execute(sa.text(
+                'INSERT INTO table_episodes ("sonarrEpisodeId", "sonarrSeriesId", path) '
+                'VALUES (14, 1, \'/m/x.mkv\')'))
+            connection.execute(sa.text(
+                'INSERT INTO table_episodes_subtitles '
+                '("sonarrEpisodeId", "sonarrSeriesId", language, hi, forced, path, size) '
+                'VALUES (14, 1, \'de\', 0, 0, \'/m/x.de.srt\', 4)'))
+
+        with engine.begin() as connection:
+            restore_legacy_subtitle_columns(connection)
+
+        assert _subtitles_of(engine, 14) == str([['de', '/m/x.de.srt', 4]])
+    finally:
+        engine.dispose()
+
+
+def test_a_fork_database_is_left_completely_alone(tmp_path):
+    """The fork's own schema already has the column and no split tables. The
+    restore must not touch a value the indexer wrote."""
+    from app.upstream_adoption import restore_legacy_subtitle_columns
+
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'fork.db'}")
+    try:
+        with engine.begin() as connection:
+            connection.execute(sa.text(
+                'CREATE TABLE table_episodes ("sonarrEpisodeId" INTEGER PRIMARY KEY, '
+                '"sonarrSeriesId" INTEGER, path TEXT, subtitles TEXT)'))
+            connection.execute(sa.text(
+                'CREATE TABLE table_movies ("radarrId" INTEGER PRIMARY KEY, path TEXT, subtitles TEXT)'))
+            connection.execute(sa.text(
+                'INSERT INTO table_episodes VALUES (1, 1, \'/m/a.mkv\', :s)'),
+                {'s': str([['en', '/m/a.en.srt', 5]])})
+
+        with engine.begin() as connection:
+            restore_legacy_subtitle_columns(connection)
+
+        assert _subtitles_of(engine, 1) == str([['en', '/m/a.en.srt', 5]])
+    finally:
+        engine.dispose()
+
+
+# --- rewriting the stamp --------------------------------------------------
+
+def test_the_upstream_revision_is_rewritten_to_the_shared_ancestor(upstream_engine):
+    """309dc062d2e4, not 7e9a2b1c4d5f. Both are in upstream's chain, but in the
+    fork's chain 7e9a2b1c4d5f sits behind two fork revisions this database has
+    never run, and claiming it would skip them."""
+    from app.upstream_adoption import adopt_upstream_database
+
+    with upstream_engine.begin() as connection:
+        assert adopt_upstream_database(connection) == '309dc062d2e4'
+
+    assert _stamp(upstream_engine) == '309dc062d2e4'
+
+
+def test_a_database_already_on_a_fork_revision_is_not_rewritten(tmp_path):
+    from app.upstream_adoption import adopt_upstream_database
+
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'ours.db'}")
+    _upstream_database(engine, stamp='e7f4c9d80abc')
+    try:
+        with engine.begin() as connection:
+            assert adopt_upstream_database(connection) is None
+        assert _stamp(engine) == 'e7f4c9d80abc'
+    finally:
+        engine.dispose()
+
+
+def test_an_empty_database_is_not_rewritten(tmp_path):
+    """A first run has no alembic_version table at all."""
+    from app.upstream_adoption import adopt_upstream_database
+
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'fresh.db'}")
+    try:
+        with engine.begin() as connection:
+            assert adopt_upstream_database(connection) is None
+    finally:
+        engine.dispose()
+
+
+def test_adopting_twice_is_a_no_op_the_second_time(upstream_engine):
+    from app.upstream_adoption import adopt_upstream_database
+
+    with upstream_engine.begin() as connection:
+        assert adopt_upstream_database(connection) == '309dc062d2e4'
+    with upstream_engine.begin() as connection:
+        assert adopt_upstream_database(connection) is None
+    assert _stamp(upstream_engine) == '309dc062d2e4'
+
+
+def test_adoption_restores_the_column_before_it_rewrites_the_stamp(upstream_engine):
+    """The two halves have to happen together: a stamp the fork understands
+    with the column still missing would start and then fail in the indexer."""
+    from app.upstream_adoption import adopt_upstream_database
+
+    with upstream_engine.begin() as connection:
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes ("sonarrEpisodeId", "sonarrSeriesId", path) '
+            'VALUES (21, 2, \'/m/y.mkv\')'))
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes_subtitles '
+            '("sonarrEpisodeId", "sonarrSeriesId", language, hi, forced, path, size) '
+            'VALUES (21, 2, \'es\', 0, 0, \'/m/y.es.srt\', 88)'))
+
+    with upstream_engine.begin() as connection:
+        adopt_upstream_database(connection)
+
+    assert _stamp(upstream_engine) == '309dc062d2e4'
+    assert _subtitles_of(upstream_engine, 21) == str([['es', '/m/y.es.srt', 88]])
+
+
+def test_an_unrecognised_revision_is_named_in_the_explanation():
+    """Alembic's own failure says only "Can't locate revision identified by X",
+    which tells a user nothing about where their database came from."""
+    from app.upstream_adoption import explain_unknown_revision
+
+    message = explain_unknown_revision('ffffffffffff')
+
+    assert 'ffffffffffff' in message
+    assert 'upstream' in message.lower()
+
+
+def test_every_revision_in_the_chain_is_recognised():
+    """The check that decides whether to print that explanation reads the
+    scripts on disk, so it has to actually find them."""
+    from app.database import migrations_directory
+    from app.upstream_adoption import known_revisions
+
+    revisions = known_revisions(migrations_directory)
+
+    assert '309dc062d2e4' in revisions
+    assert _chain_head() in revisions
+    assert '0124f9e278fb' not in revisions
+
+
+def test_a_directory_without_scripts_yields_nothing_rather_than_raising(tmp_path):
+    from app.upstream_adoption import known_revisions
+
+    assert known_revisions(str(tmp_path)) == set()
+
+
+# --- the whole way through startup ----------------------------------------
+
+def _chain_head():
+    """The single head of this fork's migration chain, read from the scripts."""
+    import os
+    import re
+
+    from app.database import migrations_directory
+
+    versions = os.path.join(migrations_directory, 'versions')
+    revisions, parents = set(), set()
+    for name in os.listdir(versions):
+        if not name.endswith('.py'):
+            continue
+        with open(os.path.join(versions, name), encoding='utf-8') as handle:
+            source = handle.read()
+        revision = re.search(r"^revision = ['\"]([^'\"]+)['\"]", source, re.M)
+        parent = re.search(r"^down_revision = ['\"]([^'\"]+)['\"]", source, re.M)
+        if revision:
+            revisions.add(revision.group(1))
+        if parent:
+            parents.add(parent.group(1))
+    heads = revisions - parents
+    assert len(heads) == 1, f'expected a single head, found {sorted(heads)}'
+    return heads.pop()
+
+
+def _looks_like_upstream(engine):
+    """Turn a fork-shaped database into the shape upstream leaves at 0124f9e278fb.
+
+    Upstream's migration moves the subtitle lists into their own tables and
+    drops the source columns, so that is what this does, and then stamps the
+    revision this codebase has no script for.
+    """
+    with engine.begin() as connection:
+        for item_table in ('table_episodes', 'table_movies'):
+            connection.execute(sa.text(f'ALTER TABLE {item_table} DROP COLUMN subtitles'))
+        connection.execute(sa.text(
+            'CREATE TABLE table_episodes_subtitles (id INTEGER PRIMARY KEY, '
+            '"sonarrEpisodeId" INTEGER, "sonarrSeriesId" INTEGER, language TEXT, '
+            'hi BOOLEAN, forced BOOLEAN, path TEXT, size INTEGER, embedded_track_id TEXT)'))
+        connection.execute(sa.text(
+            'CREATE TABLE table_movies_subtitles (id INTEGER PRIMARY KEY, '
+            '"radarrId" INTEGER, language TEXT, hi BOOLEAN, forced BOOLEAN, '
+            'path TEXT, size INTEGER, embedded_track_id TEXT)'))
+        connection.execute(sa.text('DELETE FROM alembic_version'))
+        connection.execute(sa.text(
+            "INSERT INTO alembic_version (version_num) VALUES ('0124f9e278fb')"))
+
+
+def test_an_upstream_database_migrates_to_the_fork_head_through_startup(tmp_path, monkeypatch):
+    """The failure a user reported is a crash-loop at startup, so the assertion
+    that matters is that startup completes. This drives migrate_db, the same
+    call main.py makes, against a database shaped the way upstream leaves one."""
+    import sqlite3
+
+    from flask import Flask
+    from sqlalchemy.orm import scoped_session, sessionmaker
+
+    import app.database as db_module
+
+    if sqlite3.sqlite_version_info < (3, 35, 0):
+        pytest.skip('DROP COLUMN needs SQLite 3.35; cannot build the upstream shape')
+
+    db_path = tmp_path / 'bazarr.db'
+    engine = sa.create_engine(f'sqlite:///{db_path}')
+    db_module.Base.metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(sa.text('CREATE TABLE IF NOT EXISTS alembic_version '
+                                   '(version_num VARCHAR(32) NOT NULL)'))
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes ("sonarrEpisodeId", "sonarrSeriesId", title, path, '
+            'season, episode) VALUES (31, 3, \'Ozymandias\', \'/m/s05e14.mkv\', 5, 14)'))
+
+    _looks_like_upstream(engine)
+
+    with engine.begin() as connection:
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes_subtitles '
+            '("sonarrEpisodeId", "sonarrSeriesId", language, hi, forced, path, size) '
+            'VALUES (31, 3, \'en\', 0, 0, \'/m/s05e14.en.srt\', 31613)'))
+
+    monkeypatch.setattr(db_module, 'engine', engine)
+    monkeypatch.setattr(db_module, 'url', f'sqlite:///{db_path}')
+    monkeypatch.setattr(db_module, 'database', scoped_session(sessionmaker(bind=engine)))
+
+    application = Flask(__name__)
+    application.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db_module.migrate_db(application)
+
+    assert _stamp(engine) == _chain_head()
+    assert _subtitles_of(engine, 31) == str([['en', '/m/s05e14.en.srt', 31613]])
+
+    engine.dispose()

--- a/tests/bazarr/test_upstream_db_adoption_pg.py
+++ b/tests/bazarr/test_upstream_db_adoption_pg.py
@@ -1,0 +1,132 @@
+# coding=utf-8
+"""Native PostgreSQL path of the upstream database adoption (inbound LavX/bazarr#302).
+
+The second reporter on that issue hit it on PostgreSQL, after loading an
+upstream SQLite database into Postgres with pgloader: the alembic_version row
+comes across with everything else. PostgreSQL is a first-class backend here, so
+the adoption is exercised against a real server rather than assumed to follow
+from the SQLite run.
+
+Skips when no Postgres is reachable (set BAZARR_PG_TEST_URL, default the
+docker-compose/dev container on 55432). CI provides a postgres service so this
+does NOT skip there.
+"""
+import os
+
+import pytest
+import sqlalchemy as sa
+
+_PG_URL = os.environ.get(
+    "BAZARR_PG_TEST_URL",
+    "postgresql+psycopg://postgres:test@127.0.0.1:55432/bazarr")
+
+
+@pytest.fixture
+def pg_engine():
+    try:
+        engine = sa.create_engine(_PG_URL)
+        with engine.connect() as connection:
+            connection.execute(sa.text("SELECT 1"))
+    except Exception as exc:  # driver missing or server unreachable
+        pytest.skip(f"no PostgreSQL at {_PG_URL}: {exc}")
+
+    with engine.begin() as connection:
+        connection.execute(sa.text('DROP SCHEMA IF EXISTS upstream_adoption CASCADE'))
+        connection.execute(sa.text('CREATE SCHEMA upstream_adoption'))
+    engine.dispose()
+
+    engine = sa.create_engine(_PG_URL,
+                              connect_args={"options": "-csearch_path=upstream_adoption"})
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+        cleanup = sa.create_engine(_PG_URL)
+        with cleanup.begin() as connection:
+            connection.execute(sa.text('DROP SCHEMA IF EXISTS upstream_adoption CASCADE'))
+        cleanup.dispose()
+
+
+def _upstream_shape(engine):
+    """A PostgreSQL database in the shape upstream leaves one at 0124f9e278fb."""
+    with engine.begin() as connection:
+        connection.execute(sa.text(
+            'CREATE TABLE table_episodes ("sonarrEpisodeId" INTEGER PRIMARY KEY, '
+            '"sonarrSeriesId" INTEGER, path TEXT)'))
+        connection.execute(sa.text(
+            'CREATE TABLE table_movies ("radarrId" INTEGER PRIMARY KEY, path TEXT)'))
+        connection.execute(sa.text(
+            'CREATE TABLE table_episodes_subtitles (id SERIAL PRIMARY KEY, '
+            '"sonarrEpisodeId" INTEGER, "sonarrSeriesId" INTEGER, language TEXT, '
+            'hi BOOLEAN, forced BOOLEAN, path TEXT, size INTEGER, embedded_track_id TEXT)'))
+        connection.execute(sa.text(
+            'CREATE TABLE table_movies_subtitles (id SERIAL PRIMARY KEY, '
+            '"radarrId" INTEGER, language TEXT, hi BOOLEAN, forced BOOLEAN, '
+            'path TEXT, size INTEGER, embedded_track_id TEXT)'))
+        connection.execute(sa.text(
+            'CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)'))
+        connection.execute(sa.text(
+            "INSERT INTO alembic_version (version_num) VALUES ('0124f9e278fb')"))
+
+
+def test_a_postgres_database_from_upstream_is_adopted(pg_engine):
+    from app.upstream_adoption import adopt_upstream_database
+
+    _upstream_shape(pg_engine)
+    with pg_engine.begin() as connection:
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes ("sonarrEpisodeId", "sonarrSeriesId", path) '
+            "VALUES (41, 4, '/m/e.mkv')"))
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes_subtitles '
+            '("sonarrEpisodeId", "sonarrSeriesId", language, hi, forced, path, size) '
+            "VALUES (41, 4, 'en', true, false, '/m/e.en.hi.srt', 500)"))
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes_subtitles '
+            '("sonarrEpisodeId", "sonarrSeriesId", language, hi, forced, path, '
+            'size, embedded_track_id) '
+            "VALUES (41, 4, 'fr', false, false, '/m/e.mkv', NULL, '2')"))
+        connection.execute(sa.text(
+            'INSERT INTO table_movies ("radarrId", path) VALUES (7, \'/m/m.mkv\')'))
+        connection.execute(sa.text(
+            'INSERT INTO table_movies_subtitles '
+            '("radarrId", language, hi, forced, path, size) '
+            "VALUES (7, 'es', false, true, '/m/m.es.forced.srt', 12)"))
+
+    with pg_engine.begin() as connection:
+        assert adopt_upstream_database(connection) == '309dc062d2e4'
+
+    with pg_engine.connect() as connection:
+        assert connection.execute(
+            sa.text('SELECT version_num FROM alembic_version')).scalar() == '309dc062d2e4'
+        # The boolean columns are real booleans here, not the 0/1 SQLite stores.
+        assert connection.execute(sa.text(
+            'SELECT subtitles FROM table_episodes WHERE "sonarrEpisodeId" = 41')).scalar() == \
+            str([['en:hi', '/m/e.en.hi.srt', 500]])
+        assert connection.execute(sa.text(
+            'SELECT subtitles FROM table_movies WHERE "radarrId" = 7')).scalar() == \
+            str([['es:forced', '/m/m.es.forced.srt', 12]])
+
+
+def test_adopting_a_postgres_database_twice_changes_nothing(pg_engine):
+    from app.upstream_adoption import adopt_upstream_database
+
+    _upstream_shape(pg_engine)
+    with pg_engine.begin() as connection:
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes ("sonarrEpisodeId", "sonarrSeriesId", path) '
+            "VALUES (42, 4, '/m/f.mkv')"))
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes_subtitles '
+            '("sonarrEpisodeId", "sonarrSeriesId", language, hi, forced, path, size) '
+            "VALUES (42, 4, 'de', false, false, '/m/f.de.srt', 3)"))
+
+    with pg_engine.begin() as connection:
+        assert adopt_upstream_database(connection) == '309dc062d2e4'
+    with pg_engine.begin() as connection:
+        assert adopt_upstream_database(connection) is None
+
+    with pg_engine.connect() as connection:
+        assert connection.execute(sa.text(
+            'SELECT subtitles FROM table_episodes WHERE "sonarrEpisodeId" = 42')).scalar() == \
+            str([['de', '/m/f.de.srt', 3]])

--- a/tests/bazarr/test_upstream_db_adoption_pg.py
+++ b/tests/bazarr/test_upstream_db_adoption_pg.py
@@ -85,7 +85,7 @@ def test_a_postgres_database_from_upstream_is_adopted(pg_engine):
             'INSERT INTO table_episodes_subtitles '
             '("sonarrEpisodeId", "sonarrSeriesId", language, hi, forced, path, '
             'size, embedded_track_id) '
-            "VALUES (41, 4, 'fr', false, false, '/m/e.mkv', NULL, '2')"))
+            "VALUES (41, 4, 'fr', false, true, NULL, NULL, '2')"))
         connection.execute(sa.text(
             'INSERT INTO table_movies ("radarrId", path) VALUES (7, \'/m/m.mkv\')'))
         connection.execute(sa.text(
@@ -99,10 +99,11 @@ def test_a_postgres_database_from_upstream_is_adopted(pg_engine):
     with pg_engine.connect() as connection:
         assert connection.execute(
             sa.text('SELECT version_num FROM alembic_version')).scalar() == '309dc062d2e4'
-        # The boolean columns are real booleans here, not the 0/1 SQLite stores.
+        # The boolean columns are real booleans here, not the 0/1 SQLite stores,
+        # and the embedded track survives the conversion alongside the file.
         assert connection.execute(sa.text(
             'SELECT subtitles FROM table_episodes WHERE "sonarrEpisodeId" = 41')).scalar() == \
-            str([['en:hi', '/m/e.en.hi.srt', 500]])
+            str([['en:hi', '/m/e.en.hi.srt', 500], ['fr:forced', None, None]])
         assert connection.execute(sa.text(
             'SELECT subtitles FROM table_movies WHERE "radarrId" = 7')).scalar() == \
             str([['es:forced', '/m/m.es.forced.srt', 12]])


### PR DESCRIPTION
## The failure

Bazarr+ crash-loops on startup against a database from a current upstream Bazarr:

```
flask_migrate ERROR (__init__:113) - Error: Can't locate revision identified by '0124f9e278fb'
Bazarr child process has stopped unexpectedly. Shutting down...
```

Two users reported it on the same thread, one on SQLite migrating across, one on PostgreSQL after pgloader carried the `alembic_version` row over with everything else.

## Root cause

Upstream's chain runs `... c00d40af333c -> 309dc062d2e4 -> 7e9a2b1c4d5f -> 0124f9e278fb`. This fork re-parented `7e9a2b1c4d5f` behind its own work and never adopted `0124f9e278fb`, so an upstream database is stamped with a revision this codebase has no script for.

The stamp is only half of it. `0124f9e278fb` also moves the per-item subtitle list out of `table_episodes.subtitles` / `table_movies.subtitles` into new `table_episodes_subtitles` / `table_movies_subtitles` tables and then drops the source columns. This fork never took that split: it still models `subtitles` as Text and the indexer reads it everywhere. `create_all()` does not add a column to a table that already exists, so correcting the stamp alone would produce an install that boots and then falls over the first time it indexes anything.

## The fix

A `bazarr/app/upstream_adoption.py` step that runs before Alembic, in this order:

1. Restore the `subtitles` column where it is missing.
2. Fold the split rows back into it in the shape `store_subtitles` writes, `[[language, path, size], ...]`, with the `:hi` / `:forced` suffixes and `forced` winning where a row is flagged both. Rows describing an in-container track are left out: the legacy column only ever held files on disk and the indexer stats every path in it. A missing size becomes `0` rather than `None`, which would raise in that comparison.
3. Rewrite the stamp to `309dc062d2e4`.

Not to `7e9a2b1c4d5f`. An upstream database has run that revision, but in this fork's chain it sits behind `4bb94a033f93` and `f2f74f2d6d0a`, which that database has never seen; Alembic walks a line rather than a set, so claiming it would silently claim those two as well. `309dc062d2e4` is the newest revision in this chain all of whose ancestors the database has provably applied. Everything from there on is guarded for the fresh-install path already, so it re-runs cleanly.

A revision that is neither ours nor mapped still fails, but the log now names it and points at the issue tracker instead of leaving the user with Alembic's one line and an immediate exit.

## Tests

`tests/bazarr/test_upstream_db_adoption.py` (21) covers the language string, the embedded-row and empty-path exclusions, the missing size, restoring and backfilling, idempotence, an older upstream build without the embedded column, and a fork database being left untouched. The last one drives `migrate_db` itself against an upstream-shaped database and asserts it reaches the chain head with the subtitle intact; before this change that test fails with the exact error from the report.

`tests/bazarr/test_upstream_db_adoption_pg.py` (2) runs the adoption against a real PostgreSQL, where `hi` / `forced` are real booleans rather than the 0/1 SQLite stores. Verified against a throwaway `postgres:16-alpine`. Both files are added to the isolated CI list.

Full local run: ruff clean, 1860 backend tests pass, the isolated per-file list passes, the main unit list passes.

Fixes https://github.com/LavX/bazarr/issues/302