### PR TITLE
fix(github): let people file a feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📗 Wiki
-    url: https://wiki.bazarr.media
-    about: The Bazarr wiki should help guide you through installation and setup as well as help resolve common problems and answer frequently asked questions.
-  - name: 🚀 Feature suggestions
-    url: https://github.com/LavX/bazarr/issues
-    about: Share your suggestions or ideas to make Bazarr+ better!
+    url: https://lavx.github.io/bazarr/guides/
+    about: Installation, setup and the guides for each feature.
+  - name: 💬 Discord
+    url: https://discord.gg/fpp5JXmB8f
+    about: Questions, help with a setup, and anything that is not yet a bug or a request.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: "\U0001F680 Feature request"
+about: Suggest an idea for Bazarr+
+
+---
+
+**What are you trying to do?**
+Describe the situation you are in and what you end up doing today. What you are working around tells us more than a description of the feature does.
+
+**What would you like Bazarr+ to do instead?**
+A clear description of the behaviour you want.
+
+**Alternatives you have considered**
+Other ways of getting there, including anything you already tried, and why they fall short.
+
+**Software (if it is relevant):**
+ - Bazarr+: [e.g. v2.5.2]
+ - Sonarr version [e.g. 4.0.19]
+ - Radarr version [e.g. 6.3.0]
+ - OS: [e.g. Docker on Debian 12]
+
+**Additional context**
+Anything else worth knowing: links to a provider's API, screenshots, a related issue.


### PR DESCRIPTION
## The report

Four of the currently open issues are feature requests filed as bug reports. Three of them open with an apology and the same explanation:

> Apologies for setting this up in a bug Report instead of a Feature Request, but I was unable to open a Feature Request ticket.

> Sorry for filing this as a bug report. I couldn't get to the Feature Request page, it keeps redirecting me to the Issues page.

They are describing something real.

## The cause

`.github/ISSUE_TEMPLATE/` holds exactly one template, `bug_report.md`, and `config.yml` sets `blank_issues_enabled: false`. The only other entry on the chooser is a contact link:

```yaml
  - name: 🚀 Feature suggestions
    url: https://github.com/LavX/bazarr/issues
```

That URL is the issue list. Clicking the feature option returned the user to the page they had just come from, and the bug report form was the only thing on the chooser that led anywhere.

## The fix

- Adds `feature_request.md`, so there is a form to fill in. It asks what the reporter is doing today and working around, which is the part that tends to be missing when a request arrives as a bug.
- Points the Wiki contact link at this fork's wiki, `https://lavx.github.io/bazarr/guides/`, instead of upstream's `wiki.bazarr.media`.
- Replaces the self-referential feature link with Discord, for the things that are not yet either kind of issue.

Front matter and `config.yml` parse as valid YAML with the keys GitHub requires.

Relates to https://github.com/LavX/bazarr/issues/296, https://github.com/LavX/bazarr/issues/297, https://github.com/LavX/bazarr/issues/303