### PR TITLE
feat(scoring): add a per-provider score modifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,7 @@ jobs:
             tests/bazarr/test_provider_hub_install_serialization.py \
             tests/bazarr/test_provider_hub_language_fallback.py \
             tests/bazarr/test_provider_hub_release_scoring.py \
+            tests/bazarr/test_provider_score_modifier.py \
             tests/bazarr/test_scheduler_session_cleanup.py \
             tests/bazarr/test_secret_store_crypto.py \
             tests/bazarr/test_secret_store_e2e.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,7 @@ jobs:
             tests/bazarr/test_upgrade_embedded_history.py \
             tests/subliminal_patch/test_animetosho.py \
             tests/subliminal_patch/test_core.py \
+            tests/subliminal_patch/test_prioritized_satisfaction.py \
             tests/subliminal_patch/test_core_persistent.py \
             tests/subliminal_patch/test_opensubtitles_scraper.py \
             tests/subliminal_patch/test_score.py \

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -897,6 +897,7 @@ def save_settings(settings_items):
     reset_providers = False
     reset_fanout_pool = False
     reset_compat_pool = False
+    invalidate_compat_cache = False
     active_provider_hub_provider_ids = None
 
     # Subzero Mods
@@ -1079,6 +1080,12 @@ def save_settings(settings_items):
             if value != settings.subsource.apikey:
                 reset_providers = True
 
+        if key == 'settings-general-provider_score_modifiers':
+            # A cached compat envelope carries the projected scores in it, so
+            # an edited modifier would leave external clients on the old
+            # numbers until the entry expires, up to a day later.
+            invalidate_compat_cache = True
+
         if key in ('settings-general-enabled_providers',
                    'settings-general-provider_languages'):
             # Defer the reset until AFTER all values in this batch are
@@ -1187,6 +1194,15 @@ def save_settings(settings_items):
         try:
             from compat.service import reset_compat_pool as _reset_compat
             _reset_compat()
+        except Exception:
+            pass
+
+    if invalidate_compat_cache:
+        # Same reasoning: after the writes, so the next request rebuilds
+        # against the new values rather than the ones being replaced.
+        try:
+            from compat.cache import invalidate_all as _invalidate_compat_cache
+            _invalidate_compat_cache()
         except Exception:
             pass
 

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -157,6 +157,7 @@ validators = [
     Validator('general.enabled_providers', must_exist=True, default=[], is_type_of=list),
     Validator('general.provider_priorities', must_exist=True, default={}, is_type_of=dict),
     Validator('general.provider_languages', must_exist=True, default={}, is_type_of=dict),
+    Validator('general.provider_score_modifiers', must_exist=True, default={}, is_type_of=dict),
     Validator('general.use_provider_priority', must_exist=True, default=True, is_type_of=bool),
     Validator('general.enabled_integrations', must_exist=True, default=[], is_type_of=list),
     Validator('general.multithreading', must_exist=True, default=True, is_type_of=bool),
@@ -939,7 +940,8 @@ def save_settings(settings_items):
             value = False
 
         # Handle JSON strings for dict settings
-        if settings_keys[-1] in ['provider_priorities', 'provider_languages', 'tiers'] and isinstance(value, str):
+        if settings_keys[-1] in ['provider_priorities', 'provider_languages',
+                                'provider_score_modifiers', 'tiers'] and isinstance(value, str):
             try:
                 value = json.loads(value)
             except ValueError:

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -19,6 +19,7 @@ from subliminal_patch.exceptions import (TooManyRequests, APIThrottled, ParseRes
 from subliminal.exceptions import DownloadLimitExceeded, ServiceUnavailable, AuthenticationError, ConfigurationError
 from subliminal import region as subliminal_cache_region
 from subliminal_patch.extensions import provider_registry
+from subliminal_patch.score import compute_score
 
 from app.get_args import args
 from app.config import settings
@@ -303,6 +304,28 @@ def get_provider_priority(provider_name):
     """Get priority for a specific provider"""
     priorities = settings.general.provider_priorities or {}
     return priorities.get(provider_name, priorities.get('default', 100))
+
+
+def get_provider_score_modifier(provider_name):
+    """The signed percentage to add to this provider's candidate scores.
+
+    Read fresh on every scoring call rather than cached, so editing the setting
+    takes effect on the next search without a restart. The value comes back
+    from the browser as JSON, so anything that is not a number is treated as no
+    modifier at all instead of taking the search down.
+    """
+    modifiers = settings.general.provider_score_modifiers or {}
+    value = modifiers.get(provider_name, 0)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0
+    return value
+
+
+# Install the reader on the shared scorer. Every search path -- automatic
+# download, the priority-ordered listing's early-exit, manual search -- goes
+# through that one instance, so this is the only place the wiring exists and no
+# call site can be forgotten.
+compute_score.modifier = get_provider_score_modifier
 
 
 _FFPROBE_BINARY = get_binary("ffprobe")

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 
+import math
 import os
 import json
 import datetime
@@ -19,7 +20,7 @@ from subliminal_patch.exceptions import (TooManyRequests, APIThrottled, ParseRes
 from subliminal.exceptions import DownloadLimitExceeded, ServiceUnavailable, AuthenticationError, ConfigurationError
 from subliminal import region as subliminal_cache_region
 from subliminal_patch.extensions import provider_registry
-from subliminal_patch.score import compute_score
+from subliminal_patch.score import ComputeScore
 
 from app.get_args import args
 from app.config import settings
@@ -318,14 +319,19 @@ def get_provider_score_modifier(provider_name):
     value = modifiers.get(provider_name, 0)
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return 0
+    # NaN and the infinities pass the type check and then raise inside round().
+    if not math.isfinite(value):
+        return 0
     return value
 
 
-# Install the reader on the shared scorer. Every search path -- automatic
-# download, the priority-ordered listing's early-exit, manual search -- goes
-# through that one instance, so this is the only place the wiring exists and no
-# call site can be forgotten.
-compute_score.modifier = get_provider_score_modifier
+# Install the reader on the scorer class, not on the shared instance. Every
+# native search path -- automatic download, the priority-ordered listing's
+# early-exit, manual search -- goes through the shared one, but the compat
+# endpoint builds its own ComputeScore to project scores for external clients,
+# and that surface has to agree with the rest. staticmethod keeps it a plain
+# function rather than binding self over the provider name.
+ComputeScore.modifier = staticmethod(get_provider_score_modifier)
 
 
 _FFPROBE_BINARY = get_binary("ffprobe")

--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -322,7 +322,9 @@ def get_provider_score_modifier(provider_name):
     # NaN and the infinities pass the type check and then raise inside round().
     if not math.isfinite(value):
         return 0
-    return value
+    # The scale only goes to a hundred, and a finite value large enough to
+    # overflow the multiplication would raise rather than degrade.
+    return max(-100, min(100, value))
 
 
 # Install the reader on the scorer class, not on the shared instance. Every

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -541,6 +541,25 @@ class SZProviderPool(ProviderPool):
 
         return subtitles
 
+    @staticmethod
+    def _episode_candidate_is_valid(subtitle, orig_matches, matches):
+        """Whether an episode candidate identifies the episode it claims to.
+
+        download_best_subtitles refuses one that does not, so the prioritized
+        listing has to apply the same rule before it calls a language satisfied
+        and stops asking the remaining providers. Otherwise the search ends on
+        a candidate the download then throws away and nothing is downloaded.
+
+        ``orig_matches`` is the set as the provider reported it; ``matches`` is
+        what compute_score left behind, which is where the hash decision lives.
+        """
+        if not getattr(subtitle, 'hash_verifiable', False) and "hash" in matches:
+            # The provider cannot vouch for its own hash, so there is nothing
+            # to verify the episode against and the candidate is not held to it.
+            return True
+        return ({"season", "episode"}.issubset(orig_matches)
+                and ("series" in orig_matches or "imdb_id" in orig_matches))
+
     def list_subtitles_prioritized(self, video, languages, min_score=0, provider_order=None, compute_score=None,
                                    exhaustive=False):
         """List subtitles with priority-based provider search.
@@ -597,9 +616,17 @@ class SZProviderPool(ProviderPool):
                 except AttributeError:
                     logger.error("%r: Match computation failed: %s", subtitle, traceback.format_exc())
                     continue
+                orig_matches = matches.copy()
                 score, _ = compute_score(matches, subtitle, video, False)
-                if score >= min_score:
-                    satisfied_languages.add(subtitle.language.alpha3)
+                if score < min_score:
+                    continue
+                if isinstance(video, Episode) and not self._episode_candidate_is_valid(
+                        subtitle, orig_matches, matches):
+                    logger.debug("%r: Score %d clears the minimum but the candidate does not "
+                                 "identify the episode, so it does not satisfy the language",
+                                 subtitle, score)
+                    continue
+                satisfied_languages.add(subtitle.language.alpha3)
 
             all_subtitles.extend(valid_subtitles)
 
@@ -792,20 +819,10 @@ class SZProviderPool(ProviderPool):
                              score, hearing_impaired)
                 continue
 
-            if is_episode:
-                can_verify_series = True
-                if not subtitle.hash_verifiable and "hash" in matches:
-                    can_verify_series = False
-
-                matches_series = False
-                if {"season", "episode"}.issubset(orig_matches) and \
-                        ("series" in orig_matches or "imdb_id" in orig_matches):
-                    matches_series = True
-
-                if can_verify_series and not matches_series:
-                    logger.debug("%r: Skipping subtitle with score %d, because it doesn't match our series/episode",
-                                 subtitle, score)
-                    continue
+            if is_episode and not self._episode_candidate_is_valid(subtitle, orig_matches, matches):
+                logger.debug("%r: Skipping subtitle with score %d, because it doesn't match our series/episode",
+                             subtitle, score)
+                continue
 
             # make sure to preserve original subtitles format if requested
             subtitle.use_original_format = use_original_format

--- a/custom_libs/subliminal_patch/score.py
+++ b/custom_libs/subliminal_patch/score.py
@@ -64,6 +64,26 @@ MAX_SCORES = {
 }
 
 
+def apply_score_modifier(score, max_score, modifier_percent):
+    """Adjust a raw score by a signed percentage of the maximum.
+
+    The percentage is the scale the minimum-score setting uses, which is the
+    scale the user thinks in, so a modifier of 20 means "count this provider as
+    twenty points of percentage better than it scored".
+
+    The ceiling is the higher of the maximum and the score handed in. A hash
+    match scores above the maximum by design, because MAX_SCORES leaves the
+    hash out, and a modifier has no business collapsing such a score down to
+    the ceiling. What the ceiling does prevent is a positive modifier inventing
+    a score above 100% for a subtitle that did not earn one.
+    """
+    if not modifier_percent:
+        return score
+
+    adjusted = score + round(modifier_percent * max_score / 100)
+    return max(0, min(max(max_score, score), adjusted))
+
+
 def _check_hash_sum(scores: dict):
     hash_val = scores["hash"]
     rest_sum = sum(val for key, val in scores.items() if key != "hash")
@@ -72,6 +92,20 @@ def _check_hash_sum(scores: dict):
 
 
 class ComputeScore:
+    """The scorer every search path goes through.
+
+    ``modifier`` is a hook the host installs: given a provider name it returns
+    a signed percentage to apply to that provider's candidates. Applying it
+    here rather than at the call sites is deliberate. The automatic download,
+    the priority-ordered listing's early-exit and the manual search all compute
+    scores separately, and the minimum-score gate, the search listing and the
+    recorded history percentage have to agree or the interface contradicts
+    itself. subliminal_patch on its own has no such policy, so the hook stays
+    None and nothing changes.
+    """
+
+    modifier = None
+
     def __init__(self, scores=None):
         if scores:
             valid = True
@@ -168,7 +202,33 @@ class ComputeScore:
             )
         )
 
+        modifier_percent = self._modifier_for(subtitle)
+        if modifier_percent:
+            max_score = MAX_SCORES[video.__class__.__name__.lower()]
+            score = apply_score_modifier(score, max_score, modifier_percent)
+            score_without_hash = apply_score_modifier(
+                score_without_hash, max_score, modifier_percent)
+            logger.info("%r: Provider modifier %r%% applied, score is now %r",
+                        subtitle, modifier_percent, score)
+
         return score, score_without_hash
+
+    def _modifier_for(self, subtitle):
+        """The modifier for this subtitle's provider, or nothing.
+
+        The hook reads live settings, so a value the user has just broken must
+        cost them a modifier rather than every search on the instance.
+        """
+        if self.modifier is None:
+            return 0
+        provider_name = getattr(subtitle, "provider_name", None)
+        if not provider_name:
+            return 0
+        try:
+            return self.modifier(provider_name) or 0
+        except Exception:
+            logger.exception("Provider score modifier failed for %r", provider_name)
+            return 0
 
 
 def _episode_checks(video, eq_matches, matches):

--- a/custom_libs/subliminal_patch/score.py
+++ b/custom_libs/subliminal_patch/score.py
@@ -237,7 +237,10 @@ class ComputeScore:
                 or not math.isfinite(modifier):
             logger.warning("Ignoring unusable score modifier %r for %r", modifier, provider_name)
             return 0
-        return modifier
+        # A finite value can still be large enough that multiplying it by the
+        # maximum score overflows to infinity, and round() raises on that a
+        # frame above this guard. The scale only goes to a hundred either way.
+        return max(-100, min(100, modifier))
 
 
 def _episode_checks(video, eq_matches, matches):

--- a/custom_libs/subliminal_patch/score.py
+++ b/custom_libs/subliminal_patch/score.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 import logging
+import math
 
 from subliminal.video import Episode, Movie
 from subliminal.score import get_scores
@@ -225,10 +226,18 @@ class ComputeScore:
         if not provider_name:
             return 0
         try:
-            return self.modifier(provider_name) or 0
+            modifier = self.modifier(provider_name) or 0
         except Exception:
             logger.exception("Provider score modifier failed for %r", provider_name)
             return 0
+        # NaN and the infinities are floats, so a type check upstream lets them
+        # through, and round() raises on both. That would happen outside this
+        # guard and take the whole search down with it.
+        if not isinstance(modifier, (int, float)) or isinstance(modifier, bool) \
+                or not math.isfinite(modifier):
+            logger.warning("Ignoring unusable score modifier %r for %r", modifier, provider_name)
+            return 0
+        return modifier
 
 
 def _episode_checks(video, eq_matches, matches):

--- a/frontend/src/pages/Settings/Providers/__tests__/scoreModifiers.test.ts
+++ b/frontend/src/pages/Settings/Providers/__tests__/scoreModifiers.test.ts
@@ -1,0 +1,124 @@
+/* eslint-disable camelcase */
+
+import { describe, expect, it } from "vitest";
+import {
+  foldScoreModifier,
+  resolveProviderScoreModifiers,
+} from "@/pages/Settings/Providers/components";
+
+/** A saved-settings stand-in carrying only the field under test. */
+const saved = (modifiers: unknown): Settings =>
+  ({
+    general: { provider_score_modifiers: modifiers },
+  }) as unknown as Settings;
+
+describe("provider score modifiers", () => {
+  describe("reading the current values", () => {
+    it("prefers what is staged in this settings session over what is saved", () => {
+      const resolved = resolveProviderScoreModifiers(
+        {
+          "settings-general-provider_score_modifiers": JSON.stringify({
+            whisperai: 25,
+          }),
+        },
+        saved(JSON.stringify({ whisperai: 5 })),
+      );
+
+      expect(resolved).toEqual({ whisperai: 25 });
+    });
+
+    it("falls back to the saved settings when nothing is staged", () => {
+      const resolved = resolveProviderScoreModifiers(
+        {},
+        saved(JSON.stringify({ whisperai: 5 })),
+      );
+
+      expect(resolved).toEqual({ whisperai: 5 });
+    });
+
+    it("reads an object that was never serialised", () => {
+      const resolved = resolveProviderScoreModifiers(
+        {
+          "settings-general-provider_score_modifiers": { whisperai: 25 },
+        },
+        null,
+      );
+
+      expect(resolved).toEqual({ whisperai: 25 });
+    });
+
+    it("gives back nothing rather than throwing on malformed JSON", () => {
+      const resolved = resolveProviderScoreModifiers(
+        { "settings-general-provider_score_modifiers": "{not json" },
+        null,
+      );
+
+      expect(resolved).toEqual({});
+    });
+
+    it("drops an entry whose value is not a number", () => {
+      const resolved = resolveProviderScoreModifiers(
+        {
+          "settings-general-provider_score_modifiers": JSON.stringify({
+            whisperai: "quite a lot",
+            subdl: 10,
+          }),
+        },
+        null,
+      );
+
+      expect(resolved).toEqual({ subdl: 10 });
+    });
+  });
+
+  describe("writing a value back", () => {
+    it("records the modifier the user set", () => {
+      expect(foldScoreModifier({ subdl: 10 }, "whisperai", 25)).toEqual({
+        subdl: 10,
+        whisperai: 25,
+      });
+    });
+
+    it("records a negative modifier, which is the demoting case", () => {
+      expect(foldScoreModifier({}, "someprovider", -20)).toEqual({
+        someprovider: -20,
+      });
+    });
+
+    it("removes the entry when the user clears it back to zero", () => {
+      expect(
+        foldScoreModifier({ whisperai: 25, subdl: 10 }, "whisperai", 0),
+      ).toEqual({
+        subdl: 10,
+      });
+    });
+
+    it("removes the entry when the field is emptied", () => {
+      expect(foldScoreModifier({ whisperai: 25 }, "whisperai", "")).toEqual({});
+    });
+
+    it("leaves the other providers alone", () => {
+      const before = { subdl: 10, opensubtitles: -5 };
+      const after = foldScoreModifier(before, "whisperai", 25);
+
+      expect(after.subdl).toBe(10);
+      expect(after.opensubtitles).toBe(-5);
+      expect(before).toEqual({ subdl: 10, opensubtitles: -5 });
+    });
+
+    it("clamps a value beyond the percentage scale to its ends", () => {
+      expect(foldScoreModifier({}, "whisperai", 500)).toEqual({
+        whisperai: 100,
+      });
+      expect(foldScoreModifier({}, "whisperai", -500)).toEqual({
+        whisperai: -100,
+      });
+    });
+
+    it("ignores a value that is not a number", () => {
+      expect(foldScoreModifier({ whisperai: 25 }, "whisperai", "abc")).toEqual({
+        whisperai: 25,
+      });
+    });
+  });
+});

--- a/frontend/src/pages/Settings/Providers/components.tsx
+++ b/frontend/src/pages/Settings/Providers/components.tsx
@@ -15,6 +15,7 @@ import {
   Drawer,
   Group,
   MultiSelect,
+  NumberInput,
   Stack,
   Text as MantineText,
   TextInput,
@@ -172,6 +173,99 @@ const resolveProviderPriorities = (
   }
 
   return {};
+};
+
+const parseProviderScoreModifiers = (
+  value: unknown,
+): Record<string, number> | null => {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value === "string") {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parseProviderScoreModifiers(parsed);
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+
+  if (typeof value === "object" && !Array.isArray(value)) {
+    const out: Record<string, number> = {};
+    for (const [provider, modifier] of Object.entries(value)) {
+      // The value arrives as JSON from a hand-edited config as easily as from
+      // this form. An entry that is not a number is dropped rather than
+      // carried through to the scorer.
+      if (typeof modifier === "number" && Number.isFinite(modifier)) {
+        out[provider] = modifier;
+      }
+    }
+    return out;
+  }
+
+  return null;
+};
+
+/**
+ * Read the per-provider score modifiers, preferring this settings session's
+ * staged value over what is saved.
+ */
+export const resolveProviderScoreModifiers = (
+  staged: LooseObject | undefined,
+  settings: Settings | null,
+): Record<string, number> => {
+  const fromStaged = parseProviderScoreModifiers(
+    staged?.["settings-general-provider_score_modifiers"],
+  );
+  if (fromStaged) {
+    return { ...fromStaged };
+  }
+
+  const fromSettings = parseProviderScoreModifiers(
+    settings?.general?.provider_score_modifiers,
+  );
+  if (fromSettings) {
+    return { ...fromSettings };
+  }
+
+  return {};
+};
+
+/**
+ * Put one provider's modifier into the map that gets saved.
+ *
+ * Zero and an emptied field both mean "no modifier", and are stored as the
+ * absence of an entry rather than as a zero, so the saved settings only ever
+ * carry the providers the user has actually adjusted. Values are clamped to
+ * the percentage scale the minimum-score setting uses.
+ */
+export const foldScoreModifier = (
+  modifiers: Record<string, number>,
+  provider: string,
+  value: unknown,
+): Record<string, number> => {
+  const next = { ...modifiers };
+
+  if (value === "" || value === null || value === undefined) {
+    delete next[provider];
+    return next;
+  }
+
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return next;
+  }
+
+  if (value === 0) {
+    delete next[provider];
+    return next;
+  }
+
+  next[provider] = Math.max(-100, Math.min(100, Math.round(value)));
+  return next;
 };
 
 const resolveProviderLanguageExclusions = (
@@ -753,6 +847,7 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
     staged,
     settings,
   );
+  const seededScoreModifiers = resolveProviderScoreModifiers(staged, settings);
 
   const form = useForm<FormValues>({
     initialValues: {
@@ -769,6 +864,8 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
                 seededPriorities[info.key] ?? 100,
               [`settings-general-provider_languages-${info.key}`]:
                 seededProviderLanguageExclusions[info.key] ?? [],
+              [`settings-general-provider_score_modifiers-${info.key}`]:
+                seededScoreModifiers[info.key] ?? 0,
             }
           : {}),
       },
@@ -790,6 +887,11 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
       const languageValue =
         resolveProviderLanguageExclusions(staged, settings)[info.key] ?? [];
       form.setFieldValue(`settings.${languagesKey}`, languageValue);
+
+      const modifierKey = `settings-general-provider_score_modifiers-${info.key}`;
+      const modifierValue =
+        resolveProviderScoreModifiers(staged, settings)[info.key] ?? 0;
+      form.setFieldValue(`settings.${modifierKey}`, modifierValue);
     }
   }, [info?.key]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -819,6 +921,14 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
           delete nextProviderLanguageExclusions[payload.key];
           changes["settings-general-provider_languages"] = JSON.stringify(
             nextProviderLanguageExclusions,
+          );
+
+          const scoreModifiers = resolveProviderScoreModifiers(
+            staged,
+            settings,
+          );
+          changes["settings-general-provider_score_modifiers"] = JSON.stringify(
+            foldScoreModifier(scoreModifiers, payload.key, 0),
           );
         }
 
@@ -879,6 +989,19 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
           changes["settings-general-provider_languages"] = JSON.stringify(
             providerLanguageExclusions,
           );
+
+          const modifierKey = `settings-general-provider_score_modifiers-${info.key}`;
+          const scoreModifiers = resolveProviderScoreModifiers(
+            values.settings,
+            settings,
+          );
+          changes["settings-general-provider_score_modifiers"] = JSON.stringify(
+            foldScoreModifier(
+              scoreModifiers,
+              info.key,
+              values.settings[modifierKey],
+            ),
+          );
         }
 
         // The per-provider priority/language helper keys are UI-local: their
@@ -892,7 +1015,8 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
         for (const changeKey of Object.keys(changes)) {
           if (
             changeKey.startsWith("settings-general-provider_priorities-") ||
-            changeKey.startsWith("settings-general-provider_languages-")
+            changeKey.startsWith("settings-general-provider_languages-") ||
+            changeKey.startsWith("settings-general-provider_score_modifiers-")
           ) {
             delete changes[changeKey];
           }
@@ -1175,6 +1299,27 @@ const ProviderTool: FunctionComponent<ProviderToolProps> = ({
                       maxDropdownHeight={240}
                       comboboxProps={{ withinPortal: true }}
                       leftSection={<FontAwesomeIcon icon={faLanguage} />}
+                    />
+                    <NumberInput
+                      label="Score modifier"
+                      description="Percentage added to this provider's scores before the minimum-score check. Use a negative value to demote a provider, or a positive one to let a provider that structurally cannot score well through a high threshold."
+                      value={
+                        (form.values.settings[
+                          `settings-general-provider_score_modifiers-${info.key}`
+                        ] as number) ?? 0
+                      }
+                      onChange={(value) =>
+                        form.setFieldValue(
+                          `settings.settings-general-provider_score_modifiers-${info.key}`,
+                          value,
+                        )
+                      }
+                      min={-100}
+                      max={100}
+                      step={5}
+                      clampBehavior="strict"
+                      allowDecimal={false}
+                      suffix="%"
                     />
                   </Stack>
                 )}

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -87,6 +87,7 @@ declare namespace Settings {
     utf8_encode: boolean;
     provider_priorities?: string;
     provider_languages?: Record<string, string[]> | string;
+    provider_score_modifiers?: Record<string, number> | string;
     wanted_search_frequency: number;
     wanted_search_frequency_movie: number;
     use_external_webhook?: boolean;

--- a/tests/bazarr/test_config_save.py
+++ b/tests/bazarr/test_config_save.py
@@ -87,3 +87,71 @@ def test_save_settings_resets_compat_pool_for_dynamic_provider_hub_config(monkey
         assert executed
     finally:
         config.settings.unset(provider_id.upper())
+
+
+def test_save_settings_invalidates_the_compat_cache_for_a_score_modifier(monkeypatch):
+    """A cached compat envelope carries the projected scores with it, so an
+    edited modifier would leave external clients on the old numbers for the
+    rest of the cache TTL, up to a day."""
+    from app import config
+
+    executed = []
+    invalidations = []
+
+    monkeypatch.setattr(config, "write_config", lambda: None)
+    monkeypatch.setattr(config, "validate_log_regex", lambda: None)
+    monkeypatch.setattr(config.settings.validators, "validate", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "app.database",
+        SimpleNamespace(
+            database=SimpleNamespace(execute=lambda statement: executed.append(statement)),
+            update=lambda _model: _FakeUpdate(),
+            System=object,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "compat.cache",
+        SimpleNamespace(invalidate_all=lambda: invalidations.append(
+            config.settings.general.provider_score_modifiers)),
+    )
+
+    previous = config.settings.general.provider_score_modifiers
+    try:
+        config.save_settings(
+            [("settings-general-provider_score_modifiers", ['{"whisperai": 25}'])]
+        )
+
+        assert config.settings.general.provider_score_modifiers == {"whisperai": 25}
+        assert invalidations == [{"whisperai": 25}]
+    finally:
+        config.settings.general.provider_score_modifiers = previous
+
+
+def test_save_settings_leaves_the_compat_cache_alone_for_an_unrelated_setting(monkeypatch):
+    from app import config
+
+    invalidations = []
+
+    monkeypatch.setattr(config, "write_config", lambda: None)
+    monkeypatch.setattr(config, "validate_log_regex", lambda: None)
+    monkeypatch.setattr(config.settings.validators, "validate", lambda: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "app.database",
+        SimpleNamespace(
+            database=SimpleNamespace(execute=lambda _statement: None),
+            update=lambda _model: _FakeUpdate(),
+            System=object,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "compat.cache",
+        SimpleNamespace(invalidate_all=lambda: invalidations.append(True)),
+    )
+
+    config.save_settings([("settings-general-page_size", ["50"])])
+
+    assert invalidations == []

--- a/tests/bazarr/test_provider_score_modifier.py
+++ b/tests/bazarr/test_provider_score_modifier.py
@@ -1,0 +1,233 @@
+# coding=utf-8
+"""Per-provider score modifier (inbound LavX/bazarr#301).
+
+A user keeping WhisperAI as a last-resort fallback has to drop the global
+minimum score to about sixty for generated subtitles to be accepted, and that
+threshold then admits bad subtitles from every other provider. Generated
+subtitles structurally cannot score well: the plugin returns identifier matches
+and a synthetic release description, so source, resolution and release group
+are never available to the scorer.
+
+The modifier is a signed percentage, on the same scale as the minimum-score
+setting, applied to a provider's candidates before the minimum-score gate.
+"""
+import pytest
+
+
+class _Subtitle:
+    """Enough of a subtitle for ComputeScore: a provider and no hash."""
+
+    def __init__(self, provider_name, hearing_impaired=False):
+        self.provider_name = provider_name
+        self.hearing_impaired = hearing_impaired
+        self.hash_verifiable = False
+
+    def __repr__(self):
+        return f'<_Subtitle {self.provider_name}>'
+
+
+@pytest.fixture
+def episode_video():
+    from subliminal_patch.core import Episode
+
+    return Episode('/m/Show.S01E01.mkv', 'Show', 1, 1)
+
+
+@pytest.fixture
+def scorer():
+    """A ComputeScore with no modifier installed, restored afterwards."""
+    from subliminal_patch.score import ComputeScore
+
+    return ComputeScore()
+
+
+# --- the arithmetic -------------------------------------------------------
+
+def test_no_modifier_leaves_the_score_exactly_as_it_was():
+    from subliminal_patch.score import apply_score_modifier
+
+    assert apply_score_modifier(200, 358, 0) == 200
+
+
+def test_a_positive_modifier_adds_that_percentage_of_the_maximum():
+    from subliminal_patch.score import apply_score_modifier
+
+    # 10% of 358 is 35.8, rounded to 36.
+    assert apply_score_modifier(200, 358, 10) == 236
+
+
+def test_a_negative_modifier_subtracts_it():
+    from subliminal_patch.score import apply_score_modifier
+
+    assert apply_score_modifier(200, 358, -10) == 164
+
+
+def test_a_positive_modifier_cannot_push_a_score_past_the_maximum():
+    from subliminal_patch.score import apply_score_modifier
+
+    assert apply_score_modifier(350, 358, 50) == 358
+
+
+def test_a_negative_modifier_cannot_push_a_score_below_zero():
+    from subliminal_patch.score import apply_score_modifier
+
+    assert apply_score_modifier(20, 358, -50) == 0
+
+
+def test_a_hash_verified_score_above_the_maximum_is_not_dragged_down_to_it():
+    """A hash match scores above the 100% mark by design, because MAX_SCORES
+    excludes the hash. A negative modifier should move such a score by the
+    amount asked for, not collapse it to the ceiling."""
+    from subliminal_patch.score import apply_score_modifier
+
+    assert apply_score_modifier(400, 358, -10) == 364
+
+
+# --- through the scorer ---------------------------------------------------
+
+def test_a_provider_without_a_modifier_scores_exactly_as_before(scorer, episode_video):
+    subtitle = _Subtitle('opensubtitles')
+    matches = {'series', 'season', 'episode'}
+
+    before = scorer(set(matches), subtitle, episode_video)
+    scorer.modifier = lambda provider: 0
+    after = scorer(set(matches), subtitle, episode_video)
+
+    assert after == before
+
+
+def test_the_modifier_lifts_the_score_of_the_provider_it_names(scorer, episode_video):
+    from subliminal_patch.score import MAX_SCORES
+
+    subtitle = _Subtitle('whisperai')
+    matches = {'series', 'season', 'episode'}
+
+    plain, _ = scorer(set(matches), subtitle, episode_video)
+    scorer.modifier = lambda provider: 20 if provider == 'whisperai' else 0
+    lifted, _ = scorer(set(matches), subtitle, episode_video)
+
+    assert lifted == plain + round(20 * MAX_SCORES['episode'] / 100)
+
+
+def test_another_provider_is_untouched_by_that_modifier(scorer, episode_video):
+    subtitle = _Subtitle('opensubtitles')
+    matches = {'series', 'season', 'episode'}
+
+    plain, _ = scorer(set(matches), subtitle, episode_video)
+    scorer.modifier = lambda provider: 20 if provider == 'whisperai' else 0
+    after, _ = scorer(set(matches), subtitle, episode_video)
+
+    assert after == plain
+
+
+def test_the_score_without_hash_carries_the_modifier_too(scorer, episode_video):
+    """The prioritized listing and the manual search read that one, so a
+    modifier applied only to the first score would disagree with itself."""
+    subtitle = _Subtitle('whisperai')
+    matches = {'series', 'season', 'episode'}
+
+    _, plain = scorer(set(matches), subtitle, episode_video)
+    scorer.modifier = lambda provider: 20
+    _, modified = scorer(set(matches), subtitle, episode_video)
+
+    assert modified > plain
+
+
+def test_a_modifier_that_raises_does_not_take_the_search_down(scorer, episode_video):
+    """The modifier reads live settings. A broken value there must cost the
+    user a modifier, not every search on the instance."""
+    def explode(provider):
+        raise ValueError('bad setting')
+
+    subtitle = _Subtitle('whisperai')
+    matches = {'series', 'season', 'episode'}
+
+    plain = scorer(set(matches), subtitle, episode_video)
+    scorer.modifier = explode
+
+    assert scorer(set(matches), subtitle, episode_video) == plain
+
+
+def test_a_subtitle_without_a_provider_name_is_scored_unmodified(scorer, episode_video):
+    subtitle = _Subtitle('whisperai')
+    del subtitle.provider_name
+    matches = {'series', 'season', 'episode'}
+
+    scorer.modifier = lambda provider: 20
+    modified, _ = scorer(set(matches), subtitle, episode_video)
+
+    scorer.modifier = None
+    plain, _ = scorer(set(matches), subtitle, episode_video)
+
+    assert modified == plain
+
+
+# --- the setting ----------------------------------------------------------
+
+def test_the_configured_modifier_is_read_for_that_provider(monkeypatch):
+    from app.config import settings
+    from app.get_providers import get_provider_score_modifier
+
+    monkeypatch.setattr(settings.general, 'provider_score_modifiers',
+                        {'whisperai': 25}, raising=False)
+
+    assert get_provider_score_modifier('whisperai') == 25
+
+
+def test_a_provider_with_nothing_configured_gets_no_modifier(monkeypatch):
+    from app.config import settings
+    from app.get_providers import get_provider_score_modifier
+
+    monkeypatch.setattr(settings.general, 'provider_score_modifiers',
+                        {'whisperai': 25}, raising=False)
+
+    assert get_provider_score_modifier('opensubtitles') == 0
+
+
+def test_no_modifiers_at_all_is_not_an_error(monkeypatch):
+    from app.config import settings
+    from app.get_providers import get_provider_score_modifier
+
+    monkeypatch.setattr(settings.general, 'provider_score_modifiers', {}, raising=False)
+
+    assert get_provider_score_modifier('whisperai') == 0
+
+
+def test_a_value_that_is_not_a_number_is_ignored_rather_than_raising(monkeypatch):
+    """The setting arrives as JSON from the browser, so it is not guaranteed."""
+    from app.config import settings
+    from app.get_providers import get_provider_score_modifier
+
+    monkeypatch.setattr(settings.general, 'provider_score_modifiers',
+                        {'whisperai': 'quite a lot'}, raising=False)
+
+    assert get_provider_score_modifier('whisperai') == 0
+
+
+def test_a_change_to_the_setting_applies_without_reinstalling_anything(monkeypatch):
+    """The acceptance criterion is that editing the setting takes effect
+    without a restart, so the reader must not cache."""
+    from app.config import settings
+    from app.get_providers import get_provider_score_modifier
+
+    monkeypatch.setattr(settings.general, 'provider_score_modifiers',
+                        {'whisperai': 10}, raising=False)
+    assert get_provider_score_modifier('whisperai') == 10
+
+    monkeypatch.setattr(settings.general, 'provider_score_modifiers',
+                        {'whisperai': 30}, raising=False)
+    assert get_provider_score_modifier('whisperai') == 30
+
+
+def test_the_shared_scorer_asks_the_settings_for_the_modifier(monkeypatch):
+    """The wiring: the ComputeScore instance every search path uses has the
+    settings-backed reader installed, so no call site can miss it."""
+    from app.config import settings
+    from subliminal_patch.score import compute_score
+
+    monkeypatch.setattr(settings.general, 'provider_score_modifiers',
+                        {'whisperai': 15}, raising=False)
+
+    assert compute_score.modifier is not None
+    assert compute_score.modifier('whisperai') == 15
+    assert compute_score.modifier('opensubtitles') == 0

--- a/tests/bazarr/test_provider_score_modifier.py
+++ b/tests/bazarr/test_provider_score_modifier.py
@@ -231,3 +231,41 @@ def test_the_shared_scorer_asks_the_settings_for_the_modifier(monkeypatch):
     assert compute_score.modifier is not None
     assert compute_score.modifier('whisperai') == 15
     assert compute_score.modifier('opensubtitles') == 0
+
+
+# --- the hook has to reach every scorer, not just the shared one ----------
+
+def test_a_freshly_built_scorer_also_carries_the_modifier(monkeypatch):
+    """The compat endpoint builds its own ComputeScore to project scores for
+    external clients. A hook installed only on the shared instance would leave
+    that surface disagreeing with every native search path."""
+    from app.config import settings
+    import app.get_providers  # noqa: F401  installs the hook
+    from subliminal_patch.score import ComputeScore
+
+    monkeypatch.setattr(settings.general, 'provider_score_modifiers',
+                        {'whisperai': 15}, raising=False)
+
+    assert ComputeScore().modifier('whisperai') == 15
+
+
+def test_a_not_a_number_modifier_does_not_take_the_scorer_down(scorer, episode_video):
+    """NaN and the infinities are floats, so a type check lets them past, and
+    round() then raises on them outside the hook's own guard."""
+    subtitle = _Subtitle('whisperai')
+    matches = {'series', 'season', 'episode'}
+
+    plain = scorer(set(matches), subtitle, episode_video)
+    for bad in (float('nan'), float('inf'), float('-inf')):
+        scorer.modifier = lambda provider, value=bad: value
+        assert scorer(set(matches), subtitle, episode_video) == plain
+
+
+def test_the_setting_reader_rejects_a_not_a_number_value(monkeypatch):
+    from app.config import settings
+    from app.get_providers import get_provider_score_modifier
+
+    for bad in (float('nan'), float('inf'), float('-inf')):
+        monkeypatch.setattr(settings.general, 'provider_score_modifiers',
+                            {'whisperai': bad}, raising=False)
+        assert get_provider_score_modifier('whisperai') == 0

--- a/tests/bazarr/test_provider_score_modifier.py
+++ b/tests/bazarr/test_provider_score_modifier.py
@@ -35,10 +35,17 @@ def episode_video():
 
 @pytest.fixture
 def scorer():
-    """A ComputeScore with no modifier installed, restored afterwards."""
+    """A ComputeScore with no modifier on it.
+
+    The settings-backed hook lives on the class, so a bare instance would carry
+    whatever the live configuration happens to say. Shadowing it per instance
+    keeps these tests about the scorer rather than about the settings.
+    """
     from subliminal_patch.score import ComputeScore
 
-    return ComputeScore()
+    instance = ComputeScore()
+    instance.modifier = None
+    return instance
 
 
 # --- the arithmetic -------------------------------------------------------
@@ -269,3 +276,33 @@ def test_the_setting_reader_rejects_a_not_a_number_value(monkeypatch):
         monkeypatch.setattr(settings.general, 'provider_score_modifiers',
                             {'whisperai': bad}, raising=False)
         assert get_provider_score_modifier('whisperai') == 0
+
+
+def test_a_huge_but_finite_modifier_does_not_overflow_the_arithmetic(scorer, episode_video):
+    """1e306 is finite, so the non-finite guards let it past, and multiplying
+    it by the maximum score overflows to infinity inside round()."""
+    subtitle = _Subtitle('whisperai')
+    matches = {'series', 'season', 'episode'}
+
+    plain, _ = scorer(set(matches), subtitle, episode_video)
+    scorer.modifier = lambda provider: 1e306
+    huge, _ = scorer(set(matches), subtitle, episode_video)
+
+    from subliminal_patch.score import MAX_SCORES
+    # Bounded to the percentage scale, so the most it can do is reach the top.
+    assert huge == MAX_SCORES['episode']
+    assert huge > plain
+
+    scorer.modifier = lambda provider: -1e306
+    assert scorer(set(matches), subtitle, episode_video)[0] == 0
+
+
+def test_the_setting_reader_bounds_a_value_beyond_the_percentage_scale(monkeypatch):
+    from app.config import settings
+    from app.get_providers import get_provider_score_modifier
+
+    monkeypatch.setattr(settings.general, 'provider_score_modifiers',
+                        {'whisperai': 1e306, 'subdl': -400}, raising=False)
+
+    assert get_provider_score_modifier('whisperai') == 100
+    assert get_provider_score_modifier('subdl') == -100

--- a/tests/subliminal_patch/test_prioritized_satisfaction.py
+++ b/tests/subliminal_patch/test_prioritized_satisfaction.py
@@ -1,0 +1,128 @@
+# coding=utf-8
+"""The prioritized listing's early exit has to mean what the download means.
+
+``list_subtitles_prioritized`` stops querying providers once every requested
+language is "satisfied", and it decided that on score alone.
+``download_best_subtitles`` then throws out an episode candidate that does not
+carry season, episode and either series or an imdb id, so a candidate could end
+the search and be rejected straight afterwards, leaving nothing downloaded and
+the remaining providers never asked.
+
+A per-provider score modifier widens the gap between the two checks, which is
+what brought it to light.
+"""
+import pytest
+
+from subliminal_patch.core import SZProviderPool
+from subliminal_patch.score import MAX_SCORES
+
+
+class _Subtitle:
+    hash_verifiable = False
+
+    def __init__(self, provider_name, matches, language):
+        self.provider_name = provider_name
+        self._matches = matches
+        self.language = language
+        self.hearing_impaired = False
+
+    def get_matches(self, video):
+        return set(self._matches)
+
+    def __repr__(self):
+        return f'<_Subtitle {self.provider_name} {sorted(self._matches)}>'
+
+
+@pytest.fixture
+def episode():
+    from subliminal_patch.core import Episode
+
+    return Episode('/m/Show.S01E01.mkv', 'Show', 1, 1)
+
+
+@pytest.fixture
+def language():
+    from babelfish import Language
+
+    return Language('eng')
+
+
+def _pool_listing(monkeypatch, subtitles_by_provider):
+    """An SZProviderPool that hands back the given results, provider by provider.
+
+    The method is patched on the class because list_subtitles_prioritized calls
+    it unbound, so an instance attribute would never be reached.
+    """
+    monkeypatch.setattr(SZProviderPool, 'list_subtitles_provider',
+                        lambda self, name, video, languages: subtitles_by_provider.get(name, []))
+    return SZProviderPool(providers=list(subtitles_by_provider))
+
+
+def test_an_episode_candidate_missing_season_and_episode_does_not_end_the_search(
+        monkeypatch, episode, language):
+    """It scores well on series and year alone, and the download path will
+    refuse it, so it must not stop the second provider being asked."""
+    weak = _Subtitle('first', {'series', 'year'}, language)
+    good = _Subtitle('second', {'series', 'year', 'season', 'episode'}, language)
+
+    pool = _pool_listing(monkeypatch, {'first': [weak], 'second': [good]})
+
+    listed = pool.list_subtitles_prioritized(
+        episode, {language}, min_score=1, provider_order=['first', 'second'])
+
+    assert good in listed
+
+
+def test_a_complete_episode_candidate_still_ends_the_search(
+        monkeypatch, episode, language):
+    """The early exit is the point of the prioritized path; it has to survive."""
+    good = _Subtitle('first', {'series', 'year', 'season', 'episode'}, language)
+    later = _Subtitle('second', {'series', 'year', 'season', 'episode'}, language)
+
+    pool = _pool_listing(monkeypatch, {'first': [good], 'second': [later]})
+
+    listed = pool.list_subtitles_prioritized(
+        episode, {language}, min_score=1, provider_order=['first', 'second'])
+
+    assert good in listed
+    assert later not in listed
+
+
+def test_a_modifier_cannot_satisfy_a_language_with_an_invalid_candidate(
+        monkeypatch, episode, language):
+    """The case that exposed it: a positive modifier lifts a series-and-year
+    candidate over an eighty percent threshold, the search stops, and then the
+    download path rejects it."""
+    from subliminal_patch.score import compute_score
+
+    weak = _Subtitle('whisperai', {'series', 'year'}, language)
+    good = _Subtitle('second', {'series', 'year', 'season', 'episode'}, language)
+
+    pool = _pool_listing(monkeypatch, {'whisperai': [weak], 'second': [good]})
+    monkeypatch.setattr(type(compute_score), 'modifier',
+                        staticmethod(lambda provider: 20 if provider == 'whisperai' else 0))
+
+    listed = pool.list_subtitles_prioritized(
+        episode, {language},
+        min_score=round(MAX_SCORES['episode'] * 0.8),
+        provider_order=['whisperai', 'second'])
+
+    assert good in listed
+
+
+def test_a_movie_candidate_is_judged_on_score_alone(monkeypatch, language):
+    """The series/season/episode requirement is an episode rule. A movie has
+    no equivalent in the download path, so nothing extra is imposed here."""
+    from subliminal_patch.core import Movie
+
+    movie = Movie('/m/Film.2020.mkv', 'Film', year=2020)
+    candidate = _Subtitle('first', {'title', 'year'}, language)
+    later = _Subtitle('second', {'title', 'year'}, language)
+
+    pool = _pool_listing(monkeypatch, {'first': [candidate], 'second': [later]})
+
+    listed = pool.list_subtitles_prioritized(
+        movie, {language}, min_score=1, provider_order=['first', 'second'])
+
+    assert candidate in listed
+    assert later not in listed


### PR DESCRIPTION
## The problem

A user keeping the WhisperAI plugin as a last-resort fallback has to drop the global minimum score to around sixty for its generated subtitles to be accepted. That threshold then admits bad subtitles from every other provider, which is the opposite of what they want: a high bar everywhere, and one exception.

Generated subtitles structurally cannot clear a high bar. The plugin returns identifier matches and a synthetic release description, so `source`, `resolution` and `release_group` are never available to the scorer. That caps an episode at roughly sixty percent of the maximum and a movie at roughly a third, no matter how good the transcription is.

Making the plugin emit release tags it did not earn would poison history records and the match pipeline, and the reporter also asked for the general solution, so this is the general solution.

## What this adds

A signed percentage per provider, on the same scale the minimum-score setting already uses, added to that provider's candidate scores before the minimum-score comparison.

**One seam, not three.** The modifier is applied inside the shared `ComputeScore` instance rather than at the call sites. The automatic download, the priority-ordered listing's early-exit check and the manual search each compute scores separately, and the gate, the search listing and the recorded history percentage all have to agree or the interface contradicts itself. Applying it in the scorer means no call site can be forgotten, now or later. `subliminal_patch` on its own has no such policy: the hook is `None` there and its behaviour is unchanged.

**Live, not cached.** `get_provider_score_modifier` reads settings on every scoring call, so editing the value takes effect on the next search without a restart. A value that is not a number, whether from the form or a hand-edited config, is treated as no modifier rather than taking every search on the instance down.

**The clamp.** The ceiling is the higher of the maximum and the score handed in. A positive modifier cannot invent a score above 100% for a subtitle that did not earn one; a negative modifier does not collapse a hash-verified score, which sits above `MAX_SCORES` by design because that constant leaves the hash out.

**Storage and UI.** Stored as `general.provider_score_modifiers`, a global map keyed by provider, exactly as the priorities are, so it covers built-in providers as well as plugins and no manifest has to opt in. The field sits in the provider drawer beside the language exclusions. Zero and an emptied field both mean no modifier and are stored as the absence of an entry, so the saved settings only carry the providers the user actually adjusted; removing a provider drops its modifier with it.

## Tests

`tests/bazarr/test_provider_score_modifier.py` (18): the arithmetic including both clamps and the hash case; the modifier lifting the named provider and leaving the others alone; `score_without_hash` carrying it too, since that is the one the listing and the manual search read; a modifier that raises costing a modifier rather than the search; a subtitle with no provider name; the setting's reader including the non-numeric and empty cases and that a change applies without reinstalling anything; and the wiring, that the shared scorer really has the settings-backed reader on it.

`frontend/src/pages/Settings/Providers/__tests__/scoreModifiers.test.ts` (12): reading staged over saved, an unserialised object, malformed JSON, a non-numeric entry; and writing back, including the negative case, clearing to zero, emptying the field, leaving other providers untouched, and the clamp.

Local: ruff clean, 1847 backend tests pass, eslint and tsc clean, prettier clean, 884 frontend tests pass.

## Not yet verified

The ticket's end-to-end criterion, a generated-subtitle provider accepted through a high threshold on a live instance, is not done: the test server is unreachable at the moment. Everything else on the list is covered above.

Inbound: https://github.com/LavX/bazarr/issues/301