### PR TITLE
fix(db): adopt any upstream database, not the one revision we had listed

### DIFF
--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -22,7 +22,8 @@ from flask_sqlalchemy import SQLAlchemy
 from .config import settings
 from .get_args import args
 from .upstream_adoption import (adopt_upstream_database, explain_unknown_revision,
-                               known_revisions, stamped_revision)
+                               known_revisions, repair_missing_columns_after_upgrade,
+                               stamped_revision)
 
 logger = logging.getLogger(__name__)
 
@@ -832,29 +833,43 @@ def migrate_db(app):
         database.execute(text(f"DROP TABLE IF EXISTS {table}"))
 
     # A database created by upstream Bazarr carries a revision this fork has no
-    # script for, and has had the columns the indexer reads dropped out from
-    # under it. Alembic cannot start against it at all, so this runs first.
+    # script for, and has had columns the indexer reads dropped out from under
+    # it. Alembic cannot start against it at all, so this runs first.
+    adopted_from = None
     try:
         with engine.begin() as connection:
-            adopt_upstream_database(connection)
+            adopted_from = adopt_upstream_database(connection)
     except Exception:
         logging.exception("Upstream database adoption failed; continuing to the normal upgrade")
 
-    # Alembic's own account of a revision it has no script for is one line with
-    # no hint of where such a database comes from, and it exits before anything
-    # else is logged. Say it plainly first.
-    try:
-        with engine.connect() as connection:
-            pending = stamped_revision(connection)
-        if pending and pending not in known_revisions(migrations_directory):
-            logging.error(explain_unknown_revision(pending))
-    except Exception:
-        logging.exception("Could not check the database migration revision before upgrading")
+    if adopted_from is None:
+        # Nothing was adopted. If the stamp is still one this codebase does not
+        # have, Alembic is about to fail with a single line that says nothing
+        # about where such a database comes from, and exit before anything else
+        # is logged. Say it plainly first.
+        try:
+            with engine.connect() as connection:
+                pending = stamped_revision(connection)
+            if pending and pending not in known_revisions(migrations_directory):
+                logging.error(explain_unknown_revision(pending))
+        except Exception:
+            logging.exception("Could not check the database migration revision before upgrading")
 
     with app.app_context():
         flask_migrate.Migrate(app, db, render_as_batch=True)
         flask_migrate.upgrade(directory=migrations_directory)
         db.engine.dispose()
+
+    if adopted_from is not None:
+        # An adopted database can still be missing a column this fork models
+        # and its own migrations never add, because that column predates the
+        # point where the two chains diverged. Now the chain has had its turn,
+        # fill in whatever is still missing from the models.
+        try:
+            with engine.begin() as connection:
+                repair_missing_columns_after_upgrade(connection)
+        except Exception:
+            logging.exception("Post-upgrade column repair failed; continuing startup")
 
     # add the system table single row if it's not existing
     if not database.execute(

--- a/bazarr/app/upstream_adoption.py
+++ b/bazarr/app/upstream_adoption.py
@@ -213,6 +213,18 @@ def restore_missing_model_columns(connection, metadata=None):
             if column.name in present:
                 continue
 
+            if column.foreign_keys:
+                # ALTER TABLE ADD COLUMN cannot carry a referential action on
+                # SQLite, and adding the column without one produces a schema
+                # that reports success and then orphans rows the next time a
+                # parent is deleted. Rebuilding the table to do it properly is
+                # more than a repair should attempt.
+                logging.warning(
+                    'BAZARR cannot restore the column %s.%s, it references another table '
+                    'and the constraint cannot be added afterwards. Bazarr+ will start, '
+                    'but that column stays missing.', table.name, column.name)
+                continue
+
             if not column.nullable and column.server_default is None:
                 reason = ('its default is applied by the application rather than the database'
                           if column.default is not None else 'it has no default')
@@ -261,13 +273,29 @@ def retire_split_subtitle_tables(connection, folded_tables):
     dropped = []
     existing_tables = set(sa.inspect(connection).get_table_names())
 
-    for item_table, split_table, _join_column in _SPLIT_SUBTITLE_TABLES:
+    for item_table, split_table, join_column in _SPLIT_SUBTITLE_TABLES:
         if split_table not in existing_tables:
             continue
         if item_table not in folded_tables:
             logging.warning('BAZARR keeping %s: its rows were not folded into %s.subtitles',
                             split_table, item_table)
             continue
+
+        # The fold walks the item table, so a row pointing at an item that is
+        # not there was never copied anywhere. Foreign keys should prevent it,
+        # and on SQLite they are not always enforced, so this is checked rather
+        # than assumed: dropping the table would destroy those rows for good.
+        orphans = connection.execute(sa.text(
+            f'SELECT count(*) FROM {split_table} WHERE "{join_column}" IS NULL '
+            f'OR "{join_column}" NOT IN (SELECT "{join_column}" FROM {item_table})')).scalar()
+        if orphans:
+            logging.warning(
+                'BAZARR keeping %s: %s of its rows point at an item that is not in %s, so they '
+                'were never folded across. Nothing reads this table, and it is left in place '
+                'rather than dropped so those rows are not lost.',
+                split_table, orphans, item_table)
+            continue
+
         connection.execute(sa.text(f'DROP TABLE {split_table}'))
         dropped.append(split_table)
         logging.info('BAZARR dropped %s, its contents are now in %s.subtitles',
@@ -295,6 +323,31 @@ def looks_like_a_bazarr_database(connection):
     """Whether this is a Bazarr database at all."""
     tables = set(sa.inspect(connection).get_table_names())
     return any(marker in tables for marker in _BAZARR_MARKER_TABLES)
+
+
+def came_from_this_fork(connection):
+    """Whether this database has already been through this fork's chain.
+
+    The local-id PK cutover is the tell. Upstream keys table_shows on the
+    Sonarr id and has no concept of a local one, so a table_shows keyed on its
+    own id can only have been produced here.
+
+    It matters because an unrecognised revision has two possible causes, and
+    only one of them is an upstream database. The other is an older Bazarr+
+    started against a database a newer release created, where adopting would
+    stamp the chain back to the shared ancestor, run the old migrations over a
+    newer schema, and leave the newer release re-running migrations whose
+    history had been erased. create_all() cannot blur this: it never alters a
+    table that already exists.
+    """
+    inspector = sa.inspect(connection)
+    if 'table_shows' not in inspector.get_table_names():
+        return False
+    try:
+        primary_key = inspector.get_pk_constraint('table_shows')
+    except Exception:
+        return False
+    return 'id' in (primary_key.get('constrained_columns') or [])
 
 
 def stamped_revision(connection):
@@ -329,6 +382,15 @@ def adopt_upstream_database(connection, migrations_directory=None):
     if not looks_like_a_bazarr_database(connection):
         logging.error('BAZARR this database is stamped with the unknown migration revision %s '
                       'and does not look like a Bazarr database. Leaving it alone.', revision)
+        return None
+
+    if came_from_this_fork(connection):
+        logging.error(
+            'BAZARR this database is stamped with migration revision %s, which this build has '
+            'no script for, but it has already been through Bazarr+\'s own migrations. It was '
+            'almost certainly created by a NEWER Bazarr+ than this one. Downgrading is not '
+            'supported: running these older migrations over it would corrupt it. Start the '
+            'newer version again, or restore a backup taken before the upgrade.', revision)
         return None
 
     if revision in REVIEWED_UPSTREAM_REVISIONS:

--- a/bazarr/app/upstream_adoption.py
+++ b/bazarr/app/upstream_adoption.py
@@ -26,17 +26,34 @@ import re
 
 import sqlalchemy as sa
 
-# Upstream-only revisions, each mapped to the newest revision in this fork's
-# chain all of whose ancestors that database has provably applied.
+# The newest revision in this fork's chain that upstream also has, and so the
+# revision to stamp a database from upstream back to.
 #
-# For 0124f9e278fb that is 309dc062d2e4 rather than 7e9a2b1c4d5f. Both are in
-# upstream's chain and an upstream database has run both, but in this fork's
-# chain 7e9a2b1c4d5f sits behind 4bb94a033f93 and f2f74f2d6d0a, which that
-# database has never seen. Alembic walks a line, not a set, so claiming
-# 7e9a2b1c4d5f would silently claim those two as well.
-UPSTREAM_REVISION_EQUIVALENTS = {
-    '0124f9e278fb': '309dc062d2e4',
+# Every upstream revision descends from it, and it is the last point where the
+# two chains agree. It is not 7e9a2b1c4d5f, which upstream also has and an
+# upstream database has also run: in this fork's chain that revision sits
+# behind 4bb94a033f93 and f2f74f2d6d0a, which such a database has never seen,
+# and Alembic walks a line rather than a set, so claiming it would silently
+# claim those two as well.
+FORK_SHARED_ANCESTOR = '309dc062d2e4'
+
+# Upstream revisions whose contents have actually been read. Adoption does not
+# depend on this: an unrecognised revision is adopted too, because upstream's
+# nightly line stamps new ones continuously and every nightly user would
+# otherwise be locked out until this fork shipped a release naming it. The set
+# only decides how loudly it is logged.
+REVIEWED_UPSTREAM_REVISIONS = {
+    # Moves the subtitle lists into their own tables, drops the source columns,
+    # and creates a large set of indexes.
+    '0124f9e278fb',
+    # Indexes on the tables the revision above created. Nightly only.
+    '537e9b4d10e3',
 }
+
+# Tables that say this is a Bazarr database rather than something else that
+# happens to use Alembic. An unrecognised stamp is not on its own a reason to
+# start rewriting a database nobody asked us about.
+_BAZARR_MARKER_TABLES = ('table_shows', 'table_episodes', 'table_movies')
 
 # (item table, split table, the column joining them)
 _SPLIT_SUBTITLE_TABLES = (
@@ -156,6 +173,113 @@ def restore_legacy_subtitle_columns(connection):
     return written
 
 
+def restore_missing_model_columns(connection):
+    """Add back any column this fork's models declare that a table is missing.
+
+    Upstream dropped ``subtitles`` from ``table_episodes`` and
+    ``table_movies``; naming those two would mean shipping a patch the next
+    time upstream drops something else. Working from the ORM instead makes the
+    repair cover whatever the gap turns out to be.
+
+    ``create_all()`` handles missing tables but never touches an existing one,
+    which is the whole reason this is needed. Only tables that are already
+    there are considered, and only columns that can be added without a value:
+    a NOT NULL column with no default cannot go onto a table that has rows, so
+    it is reported rather than forced, and the rest of the adoption goes ahead.
+
+    Returns the ``(table, column)`` pairs it added.
+    """
+    from app.database import Base
+
+    inspector = sa.inspect(connection)
+    existing_tables = set(inspector.get_table_names())
+    dialect = connection.engine.dialect
+    restored = []
+
+    for table in Base.metadata.sorted_tables:
+        if table.name not in existing_tables:
+            continue
+
+        present = {column['name'] for column in inspector.get_columns(table.name)}
+        for column in table.columns:
+            if column.name in present:
+                continue
+
+            if not column.nullable and column.server_default is None and column.default is None:
+                logging.warning(
+                    'BAZARR cannot restore the required column %s.%s, it has no default. '
+                    'Bazarr+ will start, but that column stays missing.', table.name, column.name)
+                continue
+
+            try:
+                type_sql = column.type.compile(dialect)
+                connection.execute(sa.text(
+                    f'ALTER TABLE {table.name} ADD COLUMN "{column.name}" {type_sql}'))
+            except Exception:
+                logging.exception('BAZARR could not restore the column %s.%s',
+                                  table.name, column.name)
+                continue
+
+            restored.append((table.name, column.name))
+            logging.info('BAZARR restored the missing column %s.%s', table.name, column.name)
+
+    return restored
+
+
+def retire_split_subtitle_tables(connection, folded_tables):
+    """Drop the tables upstream's split created, once their rows are folded across.
+
+    They have to go rather than sit there inertly: each carries a foreign key
+    into table_movies or table_episodes, and this fork's local-id PK cutover
+    rebuilds both, so the constraint fails the cutover's own
+    foreign_key_check and aborts the migration. Renaming does not help, since
+    the child keeps its constraint.
+
+    Nothing in Bazarr+ reads these tables. By the time this runs their contents
+    are in the column the indexer does read, which is the only reason dropping
+    them is acceptable, so a table whose fold did not happen is left alone. The
+    pair is named rather than derived: the restore side is additive and can
+    afford to work from the ORM, this cannot.
+    """
+    dropped = []
+    existing_tables = set(sa.inspect(connection).get_table_names())
+
+    for item_table, split_table, _join_column in _SPLIT_SUBTITLE_TABLES:
+        if split_table not in existing_tables:
+            continue
+        if item_table not in folded_tables:
+            logging.warning('BAZARR keeping %s: its rows were not folded into %s.subtitles',
+                            split_table, item_table)
+            continue
+        connection.execute(sa.text(f'DROP TABLE {split_table}'))
+        dropped.append(split_table)
+        logging.info('BAZARR dropped %s, its contents are now in %s.subtitles',
+                     split_table, item_table)
+
+    return dropped
+
+
+def repair_missing_columns_after_upgrade(connection):
+    """The safety net, run once the migration chain has finished.
+
+    Upstream dropped ``subtitles``; the next thing it drops will be something
+    else, and this fork would be back to shipping a patch for each one. The
+    models say what every table should have, so anything still missing after
+    the chain has run gets added back from them.
+
+    Deliberately after the upgrade rather than before. Creating columns this
+    fork's own migrations are about to create changes what they see, and on
+    PostgreSQL the local-id PK cutover in particular wants to build its own.
+    """
+    return restore_missing_model_columns(connection)
+
+
+def looks_like_a_bazarr_database(connection):
+    """Whether this is a Bazarr database at all."""
+    tables = set(sa.inspect(connection).get_table_names())
+    return any(marker in tables for marker in _BAZARR_MARKER_TABLES)
+
+
 def stamped_revision(connection):
     """The revision in ``alembic_version``, or None on a database without one."""
     if 'alembic_version' not in sa.inspect(connection).get_table_names():
@@ -163,31 +287,61 @@ def stamped_revision(connection):
     return connection.execute(sa.text('SELECT version_num FROM alembic_version')).scalar()
 
 
-def adopt_upstream_database(connection):
-    """Make an upstream database one this codebase can migrate.
+def adopt_upstream_database(connection, migrations_directory=None):
+    """Make a database from upstream Bazarr one this codebase can migrate.
 
     Returns the revision it rewrote the stamp to, or None when there was
     nothing to adopt. Runs before Alembic, and does nothing at all to a
     database already on one of this fork's revisions.
     """
+    if migrations_directory is None:
+        from app.database import migrations_directory as default_directory
+
+        migrations_directory = default_directory
+
     revision = stamped_revision(connection)
-    if revision not in UPSTREAM_REVISION_EQUIVALENTS:
+    if revision is None:
         return None
 
-    equivalent = UPSTREAM_REVISION_EQUIVALENTS[revision]
-    logging.warning('BAZARR this database was created by upstream Bazarr (revision %s). '
-                    'Adopting it: restoring the subtitle columns upstream dropped, then '
-                    'continuing this fork\'s migrations from %s.', revision, equivalent)
+    ours = known_revisions(migrations_directory)
+    if not ours or revision in ours:
+        # An empty set means the scripts could not be read. Rewriting a stamp
+        # on that basis would be a guess, so nothing is touched.
+        return None
 
-    # The column has to be back before the stamp changes. A stamp this fork
-    # understands with the column still missing would start and then fail in
-    # the indexer, which is a worse failure than not starting.
-    restore_legacy_subtitle_columns(connection)
+    if not looks_like_a_bazarr_database(connection):
+        logging.error('BAZARR this database is stamped with the unknown migration revision %s '
+                      'and does not look like a Bazarr database. Leaving it alone.', revision)
+        return None
 
-    connection.execute(sa.text('UPDATE alembic_version SET version_num = :equivalent '
+    if revision in REVIEWED_UPSTREAM_REVISIONS:
+        logging.warning('BAZARR this database was created by upstream Bazarr (revision %s). '
+                        'Adopting it and continuing this fork\'s migrations from %s.',
+                        revision, FORK_SHARED_ANCESTOR)
+    else:
+        logging.warning(
+            'BAZARR this database is stamped with migration revision %s, which Bazarr+ has no '
+            'script for. It looks like a Bazarr database from a newer upstream than this fork '
+            'has adopted, so Bazarr+ is adopting it and continuing its own migrations from %s. '
+            'Please report revision %s at https://github.com/LavX/bazarr/issues, and keep a '
+            'backup of the database file.', revision, FORK_SHARED_ANCESTOR, revision)
+
+    # Only the subtitle columns are touched here, not every gap the models
+    # know about. This runs before Alembic, and pre-creating columns that this
+    # fork's own migrations are about to add changes what those migrations see.
+    # The general repair happens afterwards instead, once the chain has had its
+    # turn: see repair_missing_columns_after_upgrade.
+    #
+    # These two cannot wait, though. The split tables have to be gone before
+    # the local-id PK cutover, whose foreign keys they break, and their
+    # contents have to be folded across before they go.
+    folded = restore_legacy_subtitle_columns(connection)
+    retire_split_subtitle_tables(connection, folded)
+
+    connection.execute(sa.text('UPDATE alembic_version SET version_num = :ancestor '
                                'WHERE version_num = :revision'),
-                       {'equivalent': equivalent, 'revision': revision})
-    return equivalent
+                       {'ancestor': FORK_SHARED_ANCESTOR, 'revision': revision})
+    return FORK_SHARED_ANCESTOR
 
 
 def known_revisions(migrations_directory):
@@ -228,11 +382,16 @@ def explain_unknown_revision(revision):
 
 
 __all__ = [
-    'UPSTREAM_REVISION_EQUIVALENTS',
+    'FORK_SHARED_ANCESTOR',
+    'REVIEWED_UPSTREAM_REVISIONS',
     'adopt_upstream_database',
     'explain_unknown_revision',
     'known_revisions',
     'legacy_subtitle_value',
+    'looks_like_a_bazarr_database',
+    'repair_missing_columns_after_upgrade',
+    'restore_missing_model_columns',
+    'retire_split_subtitle_tables',
     'restore_legacy_subtitle_columns',
     'stamped_revision',
 ]

--- a/bazarr/app/upstream_adoption.py
+++ b/bazarr/app/upstream_adoption.py
@@ -173,7 +173,7 @@ def restore_legacy_subtitle_columns(connection):
     return written
 
 
-def restore_missing_model_columns(connection):
+def restore_missing_model_columns(connection, metadata=None):
     """Add back any column this fork's models declare that a table is missing.
 
     Upstream dropped ``subtitles`` from ``table_episodes`` and
@@ -182,21 +182,29 @@ def restore_missing_model_columns(connection):
     repair cover whatever the gap turns out to be.
 
     ``create_all()`` handles missing tables but never touches an existing one,
-    which is the whole reason this is needed. Only tables that are already
-    there are considered, and only columns that can be added without a value:
-    a NOT NULL column with no default cannot go onto a table that has rows, so
-    it is reported rather than forced, and the rest of the adoption goes ahead.
+    which is the whole reason this is needed.
+
+    A column is only restored when it can be restored faithfully. Adding the
+    name and the type alone would produce a column the model does not describe:
+    nullable, with no default, and NULL in every row that already exists. So a
+    NOT NULL column is added only when it carries a server default the database
+    can apply to those rows. One whose default is Python-side is left out and
+    reported: SQLAlchemy fills that in on insert, which does nothing for rows
+    already there, and SQLite cannot add the constraint afterwards either.
 
     Returns the ``(table, column)`` pairs it added.
     """
-    from app.database import Base
+    if metadata is None:
+        from app.database import Base
+
+        metadata = Base.metadata
 
     inspector = sa.inspect(connection)
     existing_tables = set(inspector.get_table_names())
     dialect = connection.engine.dialect
     restored = []
 
-    for table in Base.metadata.sorted_tables:
+    for table in metadata.sorted_tables:
         if table.name not in existing_tables:
             continue
 
@@ -205,16 +213,25 @@ def restore_missing_model_columns(connection):
             if column.name in present:
                 continue
 
-            if not column.nullable and column.server_default is None and column.default is None:
+            if not column.nullable and column.server_default is None:
+                reason = ('its default is applied by the application rather than the database'
+                          if column.default is not None else 'it has no default')
                 logging.warning(
-                    'BAZARR cannot restore the required column %s.%s, it has no default. '
-                    'Bazarr+ will start, but that column stays missing.', table.name, column.name)
+                    'BAZARR cannot restore the required column %s.%s, %s. '
+                    'Bazarr+ will start, but that column stays missing.',
+                    table.name, column.name, reason)
                 continue
 
+            clause = f'"{column.name}" {column.type.compile(dialect)}'
+            if column.server_default is not None:
+                default_sql = getattr(column.server_default, 'arg', None)
+                default_sql = getattr(default_sql, 'text', default_sql)
+                clause += f' DEFAULT {default_sql}'
+            if not column.nullable:
+                clause += ' NOT NULL'
+
             try:
-                type_sql = column.type.compile(dialect)
-                connection.execute(sa.text(
-                    f'ALTER TABLE {table.name} ADD COLUMN "{column.name}" {type_sql}'))
+                connection.execute(sa.text(f'ALTER TABLE {table.name} ADD COLUMN {clause}'))
             except Exception:
                 logging.exception('BAZARR could not restore the column %s.%s',
                                   table.name, column.name)

--- a/bazarr/app/upstream_adoption.py
+++ b/bazarr/app/upstream_adoption.py
@@ -285,16 +285,32 @@ def retire_split_subtitle_tables(connection, folded_tables):
         # not there was never copied anywhere. Foreign keys should prevent it,
         # and on SQLite they are not always enforced, so this is checked rather
         # than assumed: dropping the table would destroy those rows for good.
+        #
+        # Keeping the table instead does not work either. It carries a foreign
+        # key into the item table, and the local-id PK cutover aborts on any
+        # foreign_key_check violation, so the user would crash-loop with
+        # adoption already half committed. The rows are copied into a plain
+        # table with no constraints, and the split table goes.
+        orphan_clause = (f'"{join_column}" IS NULL OR "{join_column}" NOT IN '
+                         f'(SELECT "{join_column}" FROM {item_table})')
         orphans = connection.execute(sa.text(
-            f'SELECT count(*) FROM {split_table} WHERE "{join_column}" IS NULL '
-            f'OR "{join_column}" NOT IN (SELECT "{join_column}" FROM {item_table})')).scalar()
+            f'SELECT count(*) FROM {split_table} WHERE {orphan_clause}')).scalar()
         if orphans:
+            archive_table = f'orphaned_{split_table}'
+            columns = [column['name'] for column
+                       in sa.inspect(connection).get_columns(split_table)]
+            column_list = ', '.join(f'"{name}"' for name in columns)
+            connection.execute(sa.text(f'DROP TABLE IF EXISTS {archive_table}'))
+            # CREATE TABLE AS copies the values and none of the constraints,
+            # which is the point: nothing may reference the item tables.
+            connection.execute(sa.text(
+                f'CREATE TABLE {archive_table} AS SELECT {column_list} '
+                f'FROM {split_table} WHERE {orphan_clause}'))
             logging.warning(
-                'BAZARR keeping %s: %s of its rows point at an item that is not in %s, so they '
-                'were never folded across. Nothing reads this table, and it is left in place '
-                'rather than dropped so those rows are not lost.',
-                split_table, orphans, item_table)
-            continue
+                'BAZARR %s rows in %s point at an item that is not in %s, so nothing folded '
+                'them across. They have been copied to %s, which nothing reads and nothing '
+                'references, so they can be inspected or discarded at your leisure.',
+                orphans, split_table, item_table, archive_table)
 
         connection.execute(sa.text(f'DROP TABLE {split_table}'))
         dropped.append(split_table)

--- a/migrations/versions/e7f4c9d80abc_arr_local_id_pk_cutover.py
+++ b/migrations/versions/e7f4c9d80abc_arr_local_id_pk_cutover.py
@@ -172,6 +172,13 @@ _ALL_OWNED = (
 )
 
 
+# The index DDLs are shared by both branches and every one of them says
+# IF NOT EXISTS. The SQLite branch rebuilds each table, so its old indexes go
+# with it and creation always starts clean. The PostgreSQL branch alters in
+# place, where 4bb94a033f93 has already created the hot-path indexes under the
+# same names, and CREATE INDEX would abort the whole cutover. A fresh install
+# never noticed, because create_all builds the final shape and the cutover
+# short-circuits before reaching any of this.
 def _rebuild_table(bind, table, pk_col, fk_clauses, force_not_null, index_ddls):
     """Recreate `table` with `pk_col` as a column-level INTEGER PRIMARY KEY, the
     given table-level FK clauses, and `force_not_null` columns made NOT NULL;
@@ -211,35 +218,35 @@ def _rebuild_all(bind):
 
     _rebuild_table(
         bind, 'table_shows', 'id', [profile_fk], {'arr_instance_id'},
-        ['CREATE UNIQUE INDEX ux_table_shows_instance_upstream_id ON table_shows (arr_instance_id, "sonarrSeriesId")',
-         'CREATE UNIQUE INDEX ux_table_shows_instance_path ON table_shows (arr_instance_id, path)',
-         'CREATE INDEX ix_table_shows_profileId ON table_shows ("profileId")'])
+        ['CREATE UNIQUE INDEX IF NOT EXISTS ux_table_shows_instance_upstream_id ON table_shows (arr_instance_id, "sonarrSeriesId")',
+         'CREATE UNIQUE INDEX IF NOT EXISTS ux_table_shows_instance_path ON table_shows (arr_instance_id, path)',
+         'CREATE INDEX IF NOT EXISTS ix_table_shows_profileId ON table_shows ("profileId")'])
 
     _rebuild_table(
         bind, 'table_episodes', 'id',
         ['FOREIGN KEY("series_id") REFERENCES table_shows("id") ON DELETE CASCADE'],
         {'arr_instance_id'},
-        ['CREATE UNIQUE INDEX ux_table_episodes_instance_upstream_id ON table_episodes (arr_instance_id, "sonarrEpisodeId")',
-         'CREATE INDEX ix_table_episodes_episode_file_id ON table_episodes (episode_file_id)',
-         'CREATE INDEX ix_table_episodes_sonarrSeriesId ON table_episodes ("sonarrSeriesId")',
-         'CREATE INDEX ix_table_episodes_series_id ON table_episodes (series_id)'])
+        ['CREATE UNIQUE INDEX IF NOT EXISTS ux_table_episodes_instance_upstream_id ON table_episodes (arr_instance_id, "sonarrEpisodeId")',
+         'CREATE INDEX IF NOT EXISTS ix_table_episodes_episode_file_id ON table_episodes (episode_file_id)',
+         'CREATE INDEX IF NOT EXISTS ix_table_episodes_sonarrSeriesId ON table_episodes ("sonarrSeriesId")',
+         'CREATE INDEX IF NOT EXISTS ix_table_episodes_series_id ON table_episodes (series_id)'])
 
     _rebuild_table(
         bind, 'table_movies', 'id', [profile_fk], {'arr_instance_id'},
-        ['CREATE UNIQUE INDEX ux_table_movies_instance_upstream_id ON table_movies (arr_instance_id, "radarrId")',
-         'CREATE UNIQUE INDEX ux_table_movies_instance_path ON table_movies (arr_instance_id, path)',
-         'CREATE UNIQUE INDEX ux_table_movies_instance_tmdbid ON table_movies (arr_instance_id, "tmdbId")',
-         'CREATE INDEX ix_table_movies_profileId ON table_movies ("profileId")'])
+        ['CREATE UNIQUE INDEX IF NOT EXISTS ux_table_movies_instance_upstream_id ON table_movies (arr_instance_id, "radarrId")',
+         'CREATE UNIQUE INDEX IF NOT EXISTS ux_table_movies_instance_path ON table_movies (arr_instance_id, path)',
+         'CREATE UNIQUE INDEX IF NOT EXISTS ux_table_movies_instance_tmdbid ON table_movies (arr_instance_id, "tmdbId")',
+         'CREATE INDEX IF NOT EXISTS ix_table_movies_profileId ON table_movies ("profileId")'])
 
     _rebuild_table(
         bind, 'table_shows_rootfolder', 'local_rootfolder_id', [],
         {'arr_instance_id', 'upstream_rootfolder_id'},
-        ['CREATE UNIQUE INDEX ux_shows_rootfolder_instance_upstream ON table_shows_rootfolder (arr_instance_id, upstream_rootfolder_id)'])
+        ['CREATE UNIQUE INDEX IF NOT EXISTS ux_shows_rootfolder_instance_upstream ON table_shows_rootfolder (arr_instance_id, upstream_rootfolder_id)'])
 
     _rebuild_table(
         bind, 'table_movies_rootfolder', 'local_rootfolder_id', [],
         {'arr_instance_id', 'upstream_rootfolder_id'},
-        ['CREATE UNIQUE INDEX ux_movies_rootfolder_instance_upstream ON table_movies_rootfolder (arr_instance_id, upstream_rootfolder_id)'])
+        ['CREATE UNIQUE INDEX IF NOT EXISTS ux_movies_rootfolder_instance_upstream ON table_movies_rootfolder (arr_instance_id, upstream_rootfolder_id)'])
 
     _rebuild_table(
         bind, 'table_history', 'id',
@@ -247,35 +254,35 @@ def _rebuild_all(bind):
          'FOREIGN KEY("episode_id") REFERENCES table_episodes("id") ON DELETE CASCADE',
          'FOREIGN KEY("upgradedFromId") REFERENCES table_history("id")'],
         {'arr_instance_id'},
-        ['CREATE INDEX ix_table_history_video_path_language_timestamp ON table_history (video_path, language, timestamp)',
-         'CREATE INDEX ix_table_history_action ON table_history (action)',
-         'CREATE INDEX ix_history_instance_upstream_series ON table_history (arr_instance_id, "sonarrSeriesId")',
-         'CREATE INDEX ix_history_instance_upstream_episode ON table_history (arr_instance_id, "sonarrEpisodeId")'])
+        ['CREATE INDEX IF NOT EXISTS ix_table_history_video_path_language_timestamp ON table_history (video_path, language, timestamp)',
+         'CREATE INDEX IF NOT EXISTS ix_table_history_action ON table_history (action)',
+         'CREATE INDEX IF NOT EXISTS ix_history_instance_upstream_series ON table_history (arr_instance_id, "sonarrSeriesId")',
+         'CREATE INDEX IF NOT EXISTS ix_history_instance_upstream_episode ON table_history (arr_instance_id, "sonarrEpisodeId")'])
 
     _rebuild_table(
         bind, 'table_history_movie', 'id',
         ['FOREIGN KEY("movie_id") REFERENCES table_movies("id") ON DELETE CASCADE',
          'FOREIGN KEY("upgradedFromId") REFERENCES table_history_movie("id")'],
         {'arr_instance_id'},
-        ['CREATE INDEX ix_table_history_movie_video_path_language_timestamp ON table_history_movie (video_path, language, timestamp)',
-         'CREATE INDEX ix_table_history_movie_action ON table_history_movie (action)',
-         'CREATE INDEX ix_history_movie_instance_upstream ON table_history_movie (arr_instance_id, "radarrId")'])
+        ['CREATE INDEX IF NOT EXISTS ix_table_history_movie_video_path_language_timestamp ON table_history_movie (video_path, language, timestamp)',
+         'CREATE INDEX IF NOT EXISTS ix_table_history_movie_action ON table_history_movie (action)',
+         'CREATE INDEX IF NOT EXISTS ix_history_movie_instance_upstream ON table_history_movie (arr_instance_id, "radarrId")'])
 
     _rebuild_table(
         bind, 'table_blacklist', 'id',
         ['FOREIGN KEY("series_id") REFERENCES table_shows("id") ON DELETE CASCADE',
          'FOREIGN KEY("episode_id") REFERENCES table_episodes("id") ON DELETE CASCADE'],
         {'arr_instance_id'},
-        ['CREATE INDEX ix_table_blacklist_subs_id ON table_blacklist (subs_id)',
-         'CREATE INDEX ix_blacklist_instance_upstream_series ON table_blacklist (arr_instance_id, sonarr_series_id)',
-         'CREATE INDEX ix_blacklist_instance_upstream_episode ON table_blacklist (arr_instance_id, sonarr_episode_id)'])
+        ['CREATE INDEX IF NOT EXISTS ix_table_blacklist_subs_id ON table_blacklist (subs_id)',
+         'CREATE INDEX IF NOT EXISTS ix_blacklist_instance_upstream_series ON table_blacklist (arr_instance_id, sonarr_series_id)',
+         'CREATE INDEX IF NOT EXISTS ix_blacklist_instance_upstream_episode ON table_blacklist (arr_instance_id, sonarr_episode_id)'])
 
     _rebuild_table(
         bind, 'table_blacklist_movie', 'id',
         ['FOREIGN KEY("movie_id") REFERENCES table_movies("id") ON DELETE CASCADE'],
         {'arr_instance_id'},
-        ['CREATE INDEX ix_table_blacklist_movie_subs_id ON table_blacklist_movie (subs_id)',
-         'CREATE INDEX ix_blacklist_movie_instance_upstream ON table_blacklist_movie (arr_instance_id, radarr_id)'])
+        ['CREATE INDEX IF NOT EXISTS ix_table_blacklist_movie_subs_id ON table_blacklist_movie (subs_id)',
+         'CREATE INDEX IF NOT EXISTS ix_blacklist_movie_instance_upstream ON table_blacklist_movie (arr_instance_id, radarr_id)'])
 
 
 # --------------------------------------------------------------------------- #
@@ -295,53 +302,53 @@ _PG_PROFILE_FK = ('FOREIGN KEY("profileId") REFERENCES table_languages_profiles'
 
 _PG_SPECS = (
     ('table_shows', 'id', ('arr_instance_id',), ('sonarrSeriesId', 'path', 'tmdbId'),
-     ['CREATE UNIQUE INDEX ux_table_shows_instance_upstream_id ON table_shows (arr_instance_id, "sonarrSeriesId")',
-      'CREATE UNIQUE INDEX ux_table_shows_instance_path ON table_shows (arr_instance_id, path)',
-      'CREATE INDEX ix_table_shows_profileId ON table_shows ("profileId")'],
+     ['CREATE UNIQUE INDEX IF NOT EXISTS ux_table_shows_instance_upstream_id ON table_shows (arr_instance_id, "sonarrSeriesId")',
+      'CREATE UNIQUE INDEX IF NOT EXISTS ux_table_shows_instance_path ON table_shows (arr_instance_id, path)',
+      'CREATE INDEX IF NOT EXISTS ix_table_shows_profileId ON table_shows ("profileId")'],
      [_PG_PROFILE_FK]),
     ('table_episodes', 'id', ('arr_instance_id',), ('sonarrEpisodeId',),
-     ['CREATE UNIQUE INDEX ux_table_episodes_instance_upstream_id ON table_episodes (arr_instance_id, "sonarrEpisodeId")',
-      'CREATE INDEX ix_table_episodes_episode_file_id ON table_episodes (episode_file_id)',
-      'CREATE INDEX ix_table_episodes_sonarrSeriesId ON table_episodes ("sonarrSeriesId")',
-      'CREATE INDEX ix_table_episodes_series_id ON table_episodes (series_id)'],
+     ['CREATE UNIQUE INDEX IF NOT EXISTS ux_table_episodes_instance_upstream_id ON table_episodes (arr_instance_id, "sonarrEpisodeId")',
+      'CREATE INDEX IF NOT EXISTS ix_table_episodes_episode_file_id ON table_episodes (episode_file_id)',
+      'CREATE INDEX IF NOT EXISTS ix_table_episodes_sonarrSeriesId ON table_episodes ("sonarrSeriesId")',
+      'CREATE INDEX IF NOT EXISTS ix_table_episodes_series_id ON table_episodes (series_id)'],
      ['FOREIGN KEY("series_id") REFERENCES table_shows("id") ON DELETE CASCADE']),
     ('table_movies', 'id', ('arr_instance_id',), ('radarrId', 'path', 'tmdbId'),
-     ['CREATE UNIQUE INDEX ux_table_movies_instance_upstream_id ON table_movies (arr_instance_id, "radarrId")',
-      'CREATE UNIQUE INDEX ux_table_movies_instance_path ON table_movies (arr_instance_id, path)',
-      'CREATE UNIQUE INDEX ux_table_movies_instance_tmdbid ON table_movies (arr_instance_id, "tmdbId")',
-      'CREATE INDEX ix_table_movies_profileId ON table_movies ("profileId")'],
+     ['CREATE UNIQUE INDEX IF NOT EXISTS ux_table_movies_instance_upstream_id ON table_movies (arr_instance_id, "radarrId")',
+      'CREATE UNIQUE INDEX IF NOT EXISTS ux_table_movies_instance_path ON table_movies (arr_instance_id, path)',
+      'CREATE UNIQUE INDEX IF NOT EXISTS ux_table_movies_instance_tmdbid ON table_movies (arr_instance_id, "tmdbId")',
+      'CREATE INDEX IF NOT EXISTS ix_table_movies_profileId ON table_movies ("profileId")'],
      [_PG_PROFILE_FK]),
     ('table_shows_rootfolder', 'local_rootfolder_id',
      ('arr_instance_id', 'upstream_rootfolder_id'), ('upstream_rootfolder_id',),
-     ['CREATE UNIQUE INDEX ux_shows_rootfolder_instance_upstream ON table_shows_rootfolder (arr_instance_id, upstream_rootfolder_id)'],
+     ['CREATE UNIQUE INDEX IF NOT EXISTS ux_shows_rootfolder_instance_upstream ON table_shows_rootfolder (arr_instance_id, upstream_rootfolder_id)'],
      []),
     ('table_movies_rootfolder', 'local_rootfolder_id',
      ('arr_instance_id', 'upstream_rootfolder_id'), ('upstream_rootfolder_id',),
-     ['CREATE UNIQUE INDEX ux_movies_rootfolder_instance_upstream ON table_movies_rootfolder (arr_instance_id, upstream_rootfolder_id)'],
+     ['CREATE UNIQUE INDEX IF NOT EXISTS ux_movies_rootfolder_instance_upstream ON table_movies_rootfolder (arr_instance_id, upstream_rootfolder_id)'],
      []),
     ('table_history', 'id', ('arr_instance_id',), (),
-     ['CREATE INDEX ix_table_history_video_path_language_timestamp ON table_history (video_path, "language", "timestamp")',
-      'CREATE INDEX ix_table_history_action ON table_history (action)',
-      'CREATE INDEX ix_history_instance_upstream_series ON table_history (arr_instance_id, "sonarrSeriesId")',
-      'CREATE INDEX ix_history_instance_upstream_episode ON table_history (arr_instance_id, "sonarrEpisodeId")'],
+     ['CREATE INDEX IF NOT EXISTS ix_table_history_video_path_language_timestamp ON table_history (video_path, "language", "timestamp")',
+      'CREATE INDEX IF NOT EXISTS ix_table_history_action ON table_history (action)',
+      'CREATE INDEX IF NOT EXISTS ix_history_instance_upstream_series ON table_history (arr_instance_id, "sonarrSeriesId")',
+      'CREATE INDEX IF NOT EXISTS ix_history_instance_upstream_episode ON table_history (arr_instance_id, "sonarrEpisodeId")'],
      ['FOREIGN KEY("series_id") REFERENCES table_shows("id") ON DELETE CASCADE',
       'FOREIGN KEY("episode_id") REFERENCES table_episodes("id") ON DELETE CASCADE',
       'FOREIGN KEY("upgradedFromId") REFERENCES table_history("id")']),
     ('table_history_movie', 'id', ('arr_instance_id',), (),
-     ['CREATE INDEX ix_table_history_movie_video_path_language_timestamp ON table_history_movie (video_path, "language", "timestamp")',
-      'CREATE INDEX ix_table_history_movie_action ON table_history_movie (action)',
-      'CREATE INDEX ix_history_movie_instance_upstream ON table_history_movie (arr_instance_id, "radarrId")'],
+     ['CREATE INDEX IF NOT EXISTS ix_table_history_movie_video_path_language_timestamp ON table_history_movie (video_path, "language", "timestamp")',
+      'CREATE INDEX IF NOT EXISTS ix_table_history_movie_action ON table_history_movie (action)',
+      'CREATE INDEX IF NOT EXISTS ix_history_movie_instance_upstream ON table_history_movie (arr_instance_id, "radarrId")'],
      ['FOREIGN KEY("movie_id") REFERENCES table_movies("id") ON DELETE CASCADE',
       'FOREIGN KEY("upgradedFromId") REFERENCES table_history_movie("id")']),
     ('table_blacklist', 'id', ('arr_instance_id',), (),
-     ['CREATE INDEX ix_table_blacklist_subs_id ON table_blacklist (subs_id)',
-      'CREATE INDEX ix_blacklist_instance_upstream_series ON table_blacklist (arr_instance_id, sonarr_series_id)',
-      'CREATE INDEX ix_blacklist_instance_upstream_episode ON table_blacklist (arr_instance_id, sonarr_episode_id)'],
+     ['CREATE INDEX IF NOT EXISTS ix_table_blacklist_subs_id ON table_blacklist (subs_id)',
+      'CREATE INDEX IF NOT EXISTS ix_blacklist_instance_upstream_series ON table_blacklist (arr_instance_id, sonarr_series_id)',
+      'CREATE INDEX IF NOT EXISTS ix_blacklist_instance_upstream_episode ON table_blacklist (arr_instance_id, sonarr_episode_id)'],
      ['FOREIGN KEY("series_id") REFERENCES table_shows("id") ON DELETE CASCADE',
       'FOREIGN KEY("episode_id") REFERENCES table_episodes("id") ON DELETE CASCADE']),
     ('table_blacklist_movie', 'id', ('arr_instance_id',), (),
-     ['CREATE INDEX ix_table_blacklist_movie_subs_id ON table_blacklist_movie (subs_id)',
-      'CREATE INDEX ix_blacklist_movie_instance_upstream ON table_blacklist_movie (arr_instance_id, radarr_id)'],
+     ['CREATE INDEX IF NOT EXISTS ix_table_blacklist_movie_subs_id ON table_blacklist_movie (subs_id)',
+      'CREATE INDEX IF NOT EXISTS ix_blacklist_movie_instance_upstream ON table_blacklist_movie (arr_instance_id, radarr_id)'],
      ['FOREIGN KEY("movie_id") REFERENCES table_movies("id") ON DELETE CASCADE']),
 )
 

--- a/tests/bazarr/test_upstream_db_adoption.py
+++ b/tests/bazarr/test_upstream_db_adoption.py
@@ -450,6 +450,12 @@ def test_an_upstream_database_migrates_to_the_fork_head_through_startup(tmp_path
 
     _looks_like_upstream(engine)
 
+    # A column this fork models that upstream dropped and no migration of ours
+    # adds back, because it predates the point the two chains diverged. Only
+    # the post-upgrade repair can restore this one.
+    with engine.begin() as connection:
+        connection.execute(sa.text('ALTER TABLE table_shows DROP COLUMN overview'))
+
     with engine.begin() as connection:
         connection.execute(sa.text(
             'INSERT INTO table_episodes_subtitles '
@@ -466,5 +472,176 @@ def test_an_upstream_database_migrates_to_the_fork_head_through_startup(tmp_path
 
     assert _stamp(engine) == _chain_head()
     assert _subtitles_of(engine, 31) == str([['en', '/m/s05e14.en.srt', 31613]])
+    assert 'overview' in {c['name'] for c in
+                          sa.inspect(engine).get_columns('table_shows')}
 
     engine.dispose()
+
+
+# --- a revision nobody has reviewed yet -----------------------------------
+
+def test_an_unknown_upstream_revision_is_adopted_as_well(tmp_path):
+    """Upstream's nightly line adds revisions continuously. 537e9b4d10e3 is the
+    one a user actually reported, and it did not exist when the first pass of
+    this was written. Waiting for a release each time upstream stamps a new
+    revision means every nightly user is locked out in the meantime, so an
+    unrecognised revision is adopted too rather than left to crash-loop."""
+    from app.upstream_adoption import adopt_upstream_database
+
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'nightly.db'}")
+    _upstream_database(engine, stamp='537e9b4d10e3')
+    try:
+        with engine.begin() as connection:
+            assert adopt_upstream_database(connection) == '309dc062d2e4'
+        assert _stamp(engine) == '309dc062d2e4'
+    finally:
+        engine.dispose()
+
+
+def test_a_revision_from_some_other_database_entirely_is_left_alone(tmp_path):
+    """The stamp being unrecognised is not on its own a reason to rewrite it.
+    Without the tables Bazarr recognises there is nothing to adopt, and
+    guessing would do more harm than refusing to start."""
+    from app.upstream_adoption import adopt_upstream_database
+
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'stranger.db'}")
+    try:
+        with engine.begin() as connection:
+            connection.execute(sa.text('CREATE TABLE widgets (id INTEGER PRIMARY KEY)'))
+            connection.execute(sa.text(
+                'CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)'))
+            connection.execute(sa.text(
+                "INSERT INTO alembic_version (version_num) VALUES ('aaaaaaaaaaaa')"))
+        with engine.begin() as connection:
+            assert adopt_upstream_database(connection) is None
+        assert _stamp(engine) == 'aaaaaaaaaaaa'
+    finally:
+        engine.dispose()
+
+
+# --- restoring whatever else upstream dropped -----------------------------
+
+def test_a_column_this_fork_still_models_is_restored_generically(tmp_path):
+    """The subtitles column is the one upstream dropped so far. Naming it
+    explicitly would mean shipping a patch for the next one, so the repair
+    works from the ORM: any column the model declares and the table lacks is
+    added back."""
+    from app.database import Base
+    from app.upstream_adoption import restore_missing_model_columns
+
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'gap.db'}")
+    try:
+        Base.metadata.create_all(engine)
+        with engine.begin() as connection:
+            connection.execute(sa.text('ALTER TABLE table_shows DROP COLUMN overview'))
+        assert 'overview' not in {c['name'] for c in
+                                  sa.inspect(engine).get_columns('table_shows')}
+
+        with engine.begin() as connection:
+            restored = restore_missing_model_columns(connection)
+
+        assert ('table_shows', 'overview') in restored
+        assert 'overview' in {c['name'] for c in
+                              sa.inspect(engine).get_columns('table_shows')}
+    finally:
+        engine.dispose()
+
+
+def test_a_table_the_fork_does_not_have_yet_is_not_touched(tmp_path):
+    """create_all makes the missing tables; this only fills gaps in the ones
+    that are already there."""
+    from app.upstream_adoption import restore_missing_model_columns
+
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'empty.db'}")
+    try:
+        with engine.begin() as connection:
+            assert restore_missing_model_columns(connection) == []
+    finally:
+        engine.dispose()
+
+
+def test_a_required_column_with_no_default_is_reported_not_forced(tmp_path):
+    """Adding a NOT NULL column with no default to a table that already has
+    rows fails outright. Better to leave it, say so, and let the rest of the
+    adoption succeed than to abort the whole startup."""
+    from app.upstream_adoption import restore_missing_model_columns
+
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'strict.db'}")
+    try:
+        with engine.begin() as connection:
+            connection.execute(sa.text(
+                'CREATE TABLE table_shows ("sonarrSeriesId" INTEGER PRIMARY KEY, '
+                'path TEXT NOT NULL)'))
+            connection.execute(sa.text(
+                'INSERT INTO table_shows VALUES (1, \'/tv/Show\')'))
+
+        with engine.begin() as connection:
+            restored = restore_missing_model_columns(connection)
+
+        # title is NOT NULL in the model and the table already has a row, so it
+        # cannot be added; the nullable ones around it still are.
+        assert ('table_shows', 'title') not in restored
+        assert ('table_shows', 'overview') in restored
+    finally:
+        engine.dispose()
+
+
+# --- retiring the tables whose contents have been folded across -----------
+
+def test_the_split_tables_are_dropped_once_their_rows_are_folded_across(upstream_engine):
+    """They carry a foreign key into table_movies, and this fork's local-id PK
+    cutover rebuilds that table, so the constraint fails its own
+    foreign_key_check and aborts the migration. Nothing in Bazarr+ reads these
+    tables; their contents live in the legacy column by the time they go."""
+    from app.upstream_adoption import adopt_upstream_database
+
+    with upstream_engine.begin() as connection:
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes ("sonarrEpisodeId", "sonarrSeriesId", path) '
+            "VALUES (51, 5, '/m/z.mkv')"))
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes_subtitles '
+            '("sonarrEpisodeId", "sonarrSeriesId", language, hi, forced, path, size) '
+            "VALUES (51, 5, 'en', 0, 0, '/m/z.en.srt', 6)"))
+
+    with upstream_engine.begin() as connection:
+        adopt_upstream_database(connection)
+
+    tables = set(sa.inspect(upstream_engine).get_table_names())
+    assert 'table_episodes_subtitles' not in tables
+    assert 'table_movies_subtitles' not in tables
+    # and only after the rows reached the column this fork reads
+    assert _subtitles_of(upstream_engine, 51) == str([['en', '/m/z.en.srt', 6]])
+
+
+def test_a_split_table_is_kept_when_its_rows_could_not_be_folded(upstream_engine, monkeypatch):
+    """Dropping is only safe because the data has already been copied. If the
+    copy did not happen, the table stays and the user keeps their rows."""
+    import app.upstream_adoption as adoption
+
+    monkeypatch.setattr(adoption, 'restore_legacy_subtitle_columns', lambda connection: [])
+
+    with upstream_engine.begin() as connection:
+        adoption.adopt_upstream_database(connection)
+
+    tables = set(sa.inspect(upstream_engine).get_table_names())
+    assert 'table_episodes_subtitles' in tables
+    assert 'table_movies_subtitles' in tables
+
+
+def test_no_table_outside_the_known_upstream_pair_is_ever_dropped(upstream_engine):
+    """The restore side works from the ORM and is additive, so it can afford to
+    be general. Dropping cannot, so it is limited to the two tables upstream's
+    split created and whose contents this fork keeps elsewhere."""
+    from app.upstream_adoption import adopt_upstream_database
+
+    with upstream_engine.begin() as connection:
+        connection.execute(sa.text('CREATE TABLE somebody_elses_table (id INTEGER PRIMARY KEY)'))
+        connection.execute(sa.text('INSERT INTO somebody_elses_table VALUES (1)'))
+
+    with upstream_engine.begin() as connection:
+        adopt_upstream_database(connection)
+
+    with upstream_engine.connect() as connection:
+        assert connection.execute(
+            sa.text('SELECT count(*) FROM somebody_elses_table')).scalar() == 1

--- a/tests/bazarr/test_upstream_db_adoption.py
+++ b/tests/bazarr/test_upstream_db_adoption.py
@@ -840,9 +840,13 @@ def test_an_upstream_database_is_still_adopted(upstream_engine):
 
 # --- not dropping rows that were never folded -----------------------------
 
-def test_a_split_table_holding_an_orphan_row_is_kept(upstream_engine):
+def test_orphan_rows_are_archived_and_the_split_table_still_goes(upstream_engine):
     """The fold walks the item table, so a row whose parent id is missing is
-    never copied. Dropping the table then destroys it for good."""
+    never copied. Keeping the table to protect those rows does not work: it
+    carries a foreign key into the item table, and the local-id PK cutover
+    aborts on any foreign_key_check violation, so the user crash-loops anyway
+    with adoption already half committed. The rows are copied into a plain
+    table with no constraints instead, and the split table goes."""
     from app.upstream_adoption import adopt_upstream_database
 
     with upstream_engine.begin() as connection:
@@ -863,11 +867,40 @@ def test_a_split_table_holding_an_orphan_row_is_kept(upstream_engine):
         adopt_upstream_database(connection)
 
     tables = set(sa.inspect(upstream_engine).get_table_names())
-    assert 'table_episodes_subtitles' in tables, 'the orphan row would have been destroyed'
+    assert 'table_episodes_subtitles' not in tables, \
+        'the split table has to go or the cutover aborts on its foreign key'
+    assert 'orphaned_table_episodes_subtitles' in tables
+
+    with upstream_engine.connect() as connection:
+        archived = connection.execute(sa.text(
+            'SELECT "sonarrEpisodeId", language, path FROM orphaned_table_episodes_subtitles'
+        )).fetchall()
+    assert archived == [(99, 'fr', '/m/orphan.fr.srt')], archived
+
     # the row that did have a parent still reached the column
     assert _subtitles_of(upstream_engine, 61) == str([['en', '/m/a.en.srt', 5]])
-    # and the movie table, which has no orphan, is still retired
-    assert 'table_movies_subtitles' not in tables
+
+
+def test_nothing_is_archived_when_every_row_has_a_parent(upstream_engine):
+    """The archive is for a database that lost referential integrity, not a
+    table left behind on every adoption."""
+    from app.upstream_adoption import adopt_upstream_database
+
+    with upstream_engine.begin() as connection:
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes ("sonarrEpisodeId", "sonarrSeriesId", path) '
+            "VALUES (62, 6, '/m/b.mkv')"))
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes_subtitles '
+            '("sonarrEpisodeId", "sonarrSeriesId", language, hi, forced, path, size) '
+            "VALUES (62, 6, 'en', 0, 0, '/m/b.en.srt', 5)"))
+
+    with upstream_engine.begin() as connection:
+        adopt_upstream_database(connection)
+
+    tables = set(sa.inspect(upstream_engine).get_table_names())
+    assert 'table_episodes_subtitles' not in tables
+    assert not any(name.startswith('orphaned_') for name in tables), tables
 
 
 # --- not restoring a column whose constraint would be lost ----------------

--- a/tests/bazarr/test_upstream_db_adoption.py
+++ b/tests/bazarr/test_upstream_db_adoption.py
@@ -645,3 +645,85 @@ def test_no_table_outside_the_known_upstream_pair_is_ever_dropped(upstream_engin
     with upstream_engine.connect() as connection:
         assert connection.execute(
             sa.text('SELECT count(*) FROM somebody_elses_table')).scalar() == 1
+
+
+# --- restoring a column faithfully, not just by name ----------------------
+
+def test_a_restored_column_keeps_its_server_default_and_not_null(tmp_path):
+    """Adding the name and the type only produces a column the model does not
+    describe: nullable, no default, NULL in every existing row."""
+    import sqlalchemy as sa_
+    from app.upstream_adoption import restore_missing_model_columns
+
+    metadata = sa_.MetaData()
+    sa_.Table('widgets', metadata,
+              sa_.Column('id', sa_.Integer, primary_key=True),
+              sa_.Column('kept', sa_.Integer, nullable=False, server_default='7'))
+
+    engine = sa_.create_engine(f"sqlite:///{tmp_path / 'sd.db'}")
+    try:
+        with engine.begin() as connection:
+            connection.execute(sa_.text('CREATE TABLE widgets (id INTEGER PRIMARY KEY)'))
+            connection.execute(sa_.text('INSERT INTO widgets (id) VALUES (1)'))
+
+        with engine.begin() as connection:
+            restore_missing_model_columns(connection, metadata=metadata)
+
+        column = next(c for c in sa.inspect(engine).get_columns('widgets')
+                      if c['name'] == 'kept')
+        assert column['nullable'] is False
+        with engine.connect() as connection:
+            assert connection.execute(sa.text('SELECT kept FROM widgets WHERE id=1')).scalar() == 7
+    finally:
+        engine.dispose()
+
+
+def test_a_required_column_with_only_a_client_side_default_is_not_restored(tmp_path):
+    """SQLAlchemy applies a Python-side default on insert, so the database
+    would take the column as nullable with no default and leave every existing
+    row NULL. That is a schema the model does not describe, and the rows would
+    read back as None. Better to leave it out and say so."""
+    import sqlalchemy as sa_
+    from datetime import datetime
+
+    from app.upstream_adoption import restore_missing_model_columns
+
+    metadata = sa_.MetaData()
+    sa_.Table('gadgets', metadata,
+              sa_.Column('id', sa_.Integer, primary_key=True),
+              sa_.Column('created', sa_.DateTime, nullable=False, default=datetime.now))
+
+    engine = sa_.create_engine(f"sqlite:///{tmp_path / 'cd.db'}")
+    try:
+        with engine.begin() as connection:
+            connection.execute(sa_.text('CREATE TABLE gadgets (id INTEGER PRIMARY KEY)'))
+            connection.execute(sa_.text('INSERT INTO gadgets (id) VALUES (1)'))
+
+        with engine.begin() as connection:
+            restored = restore_missing_model_columns(connection, metadata=metadata)
+
+        assert ('gadgets', 'created') not in restored
+        assert 'created' not in {c['name'] for c in sa.inspect(engine).get_columns('gadgets')}
+    finally:
+        engine.dispose()
+
+
+def test_a_nullable_column_is_still_restored_plainly(tmp_path):
+    import sqlalchemy as sa_
+
+    from app.upstream_adoption import restore_missing_model_columns
+
+    metadata = sa_.MetaData()
+    sa_.Table('doodads', metadata,
+              sa_.Column('id', sa_.Integer, primary_key=True),
+              sa_.Column('note', sa_.Text))
+
+    engine = sa_.create_engine(f"sqlite:///{tmp_path / 'nl.db'}")
+    try:
+        with engine.begin() as connection:
+            connection.execute(sa_.text('CREATE TABLE doodads (id INTEGER PRIMARY KEY)'))
+        with engine.begin() as connection:
+            restored = restore_missing_model_columns(connection, metadata=metadata)
+        assert ('doodads', 'note') in restored
+    finally:
+        engine.dispose()

--- a/tests/bazarr/test_upstream_db_adoption.py
+++ b/tests/bazarr/test_upstream_db_adoption.py
@@ -400,13 +400,58 @@ def _chain_head():
     return heads.pop()
 
 
+def _restore_the_upstream_primary_key(connection, table, upstream_id):
+    """Rebuild a table the way upstream keys it, on the arr id rather than a
+    local one.
+
+    create_all builds this fork's post-cutover shape, which adoption uses to
+    tell an upstream database from one a newer Bazarr+ produced. A fixture that
+    skipped this would be asking adoption to accept something no upstream
+    release can emit.
+    """
+    columns = connection.execute(sa.text(f'PRAGMA table_info({table})')).fetchall()
+    kept = [row[1] for row in columns if row[1] != 'id']
+    definitions = []
+    for row in columns:
+        name, column_type = row[1], row[2] or 'TEXT'
+        if name == 'id':
+            continue
+        if name == upstream_id:
+            definitions.append(f'"{name}" {column_type} NOT NULL PRIMARY KEY')
+        else:
+            definitions.append(f'"{name}" {column_type}')
+    column_list = ', '.join(f'"{name}"' for name in kept)
+    # Build the replacement first and rename it into place. Renaming the
+    # original out of the way instead would have SQLite rewrite every foreign
+    # key that points at it, which is not what a fixture wants.
+    connection.execute(sa.text(f'CREATE TABLE {table}__upstream ({", ".join(definitions)})'))
+    connection.execute(sa.text(
+        f'INSERT INTO {table}__upstream ({column_list}) SELECT {column_list} FROM {table}'))
+    connection.execute(sa.text(f'DROP TABLE {table}'))
+    connection.execute(sa.text(f'ALTER TABLE {table}__upstream RENAME TO {table}'))
+
+
 def _looks_like_upstream(engine):
     """Turn a fork-shaped database into the shape upstream leaves at 0124f9e278fb.
 
     Upstream's migration moves the subtitle lists into their own tables and
     drops the source columns, so that is what this does, and then stamps the
-    revision this codebase has no script for.
+    revision this codebase has no script for. The item tables are also keyed
+    back the way upstream keys them, because create_all built them in this
+    fork's post-cutover shape.
     """
+    # Rebuilding a table other tables reference trips the foreign-key check,
+    # and the pragma only takes effect outside a transaction.
+    rebuild = engine.connect().execution_options(isolation_level='AUTOCOMMIT')
+    try:
+        rebuild.execute(sa.text('PRAGMA foreign_keys=OFF'))
+        _restore_the_upstream_primary_key(rebuild, 'table_shows', 'sonarrSeriesId')
+        _restore_the_upstream_primary_key(rebuild, 'table_episodes', 'sonarrEpisodeId')
+        _restore_the_upstream_primary_key(rebuild, 'table_movies', 'radarrId')
+        rebuild.execute(sa.text('PRAGMA foreign_keys=ON'))
+    finally:
+        rebuild.close()
+
     with engine.begin() as connection:
         for item_table in ('table_episodes', 'table_movies'):
             connection.execute(sa.text(f'ALTER TABLE {item_table} DROP COLUMN subtitles'))
@@ -444,6 +489,10 @@ def test_an_upstream_database_migrates_to_the_fork_head_through_startup(tmp_path
     with engine.begin() as connection:
         connection.execute(sa.text('CREATE TABLE IF NOT EXISTS alembic_version '
                                    '(version_num VARCHAR(32) NOT NULL)'))
+        # The cutover checks referential integrity, so the episode needs a show.
+        connection.execute(sa.text(
+            'INSERT INTO table_shows ("sonarrSeriesId", title, path) '
+            'VALUES (3, \'Breaking Bad\', \'/m/Breaking Bad\')'))
         connection.execute(sa.text(
             'INSERT INTO table_episodes ("sonarrEpisodeId", "sonarrSeriesId", title, path, '
             'season, episode) VALUES (31, 3, \'Ozymandias\', \'/m/s05e14.mkv\', 5, 14)'))
@@ -725,5 +774,129 @@ def test_a_nullable_column_is_still_restored_plainly(tmp_path):
         with engine.begin() as connection:
             restored = restore_missing_model_columns(connection, metadata=metadata)
         assert ('doodads', 'note') in restored
+    finally:
+        engine.dispose()
+
+
+# --- telling an upstream database from a newer Bazarr+ one ----------------
+
+def _fork_shaped_database(engine, stamp):
+    """A database this fork has already migrated: the local-id PK cutover has
+    run, so table_shows is keyed on its own id rather than the upstream one."""
+    with engine.begin() as connection:
+        connection.execute(sa.text(
+            'CREATE TABLE table_shows (id INTEGER PRIMARY KEY, '
+            'arr_instance_id INTEGER, "sonarrSeriesId" INTEGER, path TEXT, title TEXT)'))
+        connection.execute(sa.text(
+            'CREATE TABLE table_episodes (id INTEGER PRIMARY KEY, '
+            '"sonarrEpisodeId" INTEGER, "sonarrSeriesId" INTEGER, path TEXT, subtitles TEXT)'))
+        connection.execute(sa.text(
+            'CREATE TABLE table_movies (id INTEGER PRIMARY KEY, "radarrId" INTEGER, '
+            'path TEXT, subtitles TEXT)'))
+        connection.execute(sa.text(
+            'CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)'))
+        connection.execute(sa.text(
+            'INSERT INTO alembic_version (version_num) VALUES (:v)'), {'v': stamp})
+
+
+def test_a_database_from_a_newer_bazarr_plus_is_left_alone(tmp_path):
+    """An older build started against a database a newer release created sees
+    a revision it has no script for, on a database carrying every table it
+    recognises. Adopting it would stamp the chain back to the shared ancestor
+    and run the old migrations over a newer schema, and the newer release
+    would then re-run migrations whose history had been erased.
+
+    The local-id PK cutover is the tell: upstream has no such concept, so a
+    table_shows keyed on its own id can only have come from this fork."""
+    from app.upstream_adoption import adopt_upstream_database
+
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'newer.db'}")
+    try:
+        _fork_shaped_database(engine, stamp='ffffffffffff')
+
+        with engine.begin() as connection:
+            assert adopt_upstream_database(connection) is None
+
+        assert _stamp(engine) == 'ffffffffffff'
+        # and nothing was dropped or rewritten on the way past
+        tables = set(sa.inspect(engine).get_table_names())
+        assert {'table_shows', 'table_episodes', 'table_movies'} <= tables
+    finally:
+        engine.dispose()
+
+
+def test_an_upstream_database_is_still_adopted(upstream_engine):
+    """The guard must not cost the case the whole feature exists for: upstream
+    keys table_shows on sonarrSeriesId, never on a local id."""
+    from app.upstream_adoption import adopt_upstream_database
+
+    with upstream_engine.begin() as connection:
+        connection.execute(sa.text(
+            'CREATE TABLE table_shows ("sonarrSeriesId" INTEGER PRIMARY KEY, path TEXT)'))
+
+    with upstream_engine.begin() as connection:
+        assert adopt_upstream_database(connection) == '309dc062d2e4'
+
+
+# --- not dropping rows that were never folded -----------------------------
+
+def test_a_split_table_holding_an_orphan_row_is_kept(upstream_engine):
+    """The fold walks the item table, so a row whose parent id is missing is
+    never copied. Dropping the table then destroys it for good."""
+    from app.upstream_adoption import adopt_upstream_database
+
+    with upstream_engine.begin() as connection:
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes ("sonarrEpisodeId", "sonarrSeriesId", path) '
+            "VALUES (61, 6, '/m/a.mkv')"))
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes_subtitles '
+            '("sonarrEpisodeId", "sonarrSeriesId", language, hi, forced, path, size) '
+            "VALUES (61, 6, 'en', 0, 0, '/m/a.en.srt', 5)"))
+        # no episode 99 exists
+        connection.execute(sa.text(
+            'INSERT INTO table_episodes_subtitles '
+            '("sonarrEpisodeId", "sonarrSeriesId", language, hi, forced, path, size) '
+            "VALUES (99, 6, 'fr', 0, 0, '/m/orphan.fr.srt', 5)"))
+
+    with upstream_engine.begin() as connection:
+        adopt_upstream_database(connection)
+
+    tables = set(sa.inspect(upstream_engine).get_table_names())
+    assert 'table_episodes_subtitles' in tables, 'the orphan row would have been destroyed'
+    # the row that did have a parent still reached the column
+    assert _subtitles_of(upstream_engine, 61) == str([['en', '/m/a.en.srt', 5]])
+    # and the movie table, which has no orphan, is still retired
+    assert 'table_movies_subtitles' not in tables
+
+
+# --- not restoring a column whose constraint would be lost ----------------
+
+def test_a_foreign_key_column_is_not_restored_bare(tmp_path):
+    """Adding the column without its referential action leaves a schema that
+    reports success and then orphans rows on the next parent delete."""
+    import sqlalchemy as sa_
+
+    from app.upstream_adoption import restore_missing_model_columns
+
+    metadata = sa_.MetaData()
+    sa_.Table('parents', metadata, sa_.Column('id', sa_.Integer, primary_key=True))
+    sa_.Table('children', metadata,
+              sa_.Column('id', sa_.Integer, primary_key=True),
+              sa_.Column('parent_id', sa_.Integer,
+                         sa_.ForeignKey('parents.id', ondelete='CASCADE')))
+
+    engine = sa_.create_engine(f"sqlite:///{tmp_path / 'fk.db'}")
+    try:
+        with engine.begin() as connection:
+            connection.execute(sa_.text('CREATE TABLE parents (id INTEGER PRIMARY KEY)'))
+            connection.execute(sa_.text('CREATE TABLE children (id INTEGER PRIMARY KEY)'))
+
+        with engine.begin() as connection:
+            restored = restore_missing_model_columns(connection, metadata=metadata)
+
+        assert ('children', 'parent_id') not in restored
+        assert 'parent_id' not in {c['name'] for c in
+                                   sa.inspect(engine).get_columns('children')}
     finally:
         engine.dispose()

--- a/tests/bazarr/test_upstream_db_adoption_pg.py
+++ b/tests/bazarr/test_upstream_db_adoption_pg.py
@@ -47,7 +47,7 @@ def pg_engine():
         cleanup.dispose()
 
 
-def _upstream_shape(engine):
+def _upstream_shape(engine, stamp='0124f9e278fb'):
     """A PostgreSQL database in the shape upstream leaves one at 0124f9e278fb."""
     with engine.begin() as connection:
         connection.execute(sa.text(
@@ -66,7 +66,17 @@ def _upstream_shape(engine):
         connection.execute(sa.text(
             'CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)'))
         connection.execute(sa.text(
-            "INSERT INTO alembic_version (version_num) VALUES ('0124f9e278fb')"))
+            'INSERT INTO alembic_version (version_num) VALUES (:stamp)'), {'stamp': stamp})
+
+
+def test_an_unknown_revision_is_adopted_on_postgres_too(pg_engine):
+    """The second reporter on the inbound issue was on PostgreSQL, after
+    pgloader carried the alembic_version row across with everything else."""
+    from app.upstream_adoption import adopt_upstream_database
+
+    _upstream_shape(pg_engine, stamp='537e9b4d10e3')
+    with pg_engine.begin() as connection:
+        assert adopt_upstream_database(connection) == '309dc062d2e4'
 
 
 def test_a_postgres_database_from_upstream_is_adopted(pg_engine):
@@ -108,6 +118,12 @@ def test_a_postgres_database_from_upstream_is_adopted(pg_engine):
             'SELECT subtitles FROM table_movies WHERE "radarrId" = 7')).scalar() == \
             str([['es:forced', '/m/m.es.forced.srt', 12]])
 
+    # The split tables go once their rows are across: on PostgreSQL their
+    # foreign keys would block the local-id PK cutover outright.
+    tables = set(sa.inspect(pg_engine).get_table_names())
+    assert 'table_episodes_subtitles' not in tables
+    assert 'table_movies_subtitles' not in tables
+
 
 def test_adopting_a_postgres_database_twice_changes_nothing(pg_engine):
     from app.upstream_adoption import adopt_upstream_database
@@ -131,3 +147,61 @@ def test_adopting_a_postgres_database_twice_changes_nothing(pg_engine):
         assert connection.execute(sa.text(
             'SELECT subtitles FROM table_episodes WHERE "sonarrEpisodeId" = 42')).scalar() == \
             str([['de', '/m/f.de.srt', 3]])
+
+
+# --- the cutover's own index creation, on PostgreSQL ----------------------
+#
+# Found while adopting an upstream database on PostgreSQL, but it is not an
+# adoption bug. The local-id PK cutover short-circuits on a fresh install,
+# where create_all has already built the final shape. Any database whose tables
+# predate the cutover runs the body instead, and by then 4bb94a033f93 has
+# created ix_table_episodes_episode_file_id, which the cutover's PostgreSQL
+# branch then creates again. The SQLite branch never noticed: it rebuilds each
+# table, so the old indexes go with it.
+
+def _cutover_module():
+    import importlib.util
+    import os
+
+    path = os.path.join(os.path.dirname(__file__), '..', '..', 'migrations', 'versions',
+                        'e7f4c9d80abc_arr_local_id_pk_cutover.py')
+    spec = importlib.util.spec_from_file_location('cutover_under_test', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_every_cutover_index_can_be_created_when_it_is_already_there():
+    """A shape assertion covering all six tables at once. Executing every DDL
+    against a real server would mean rebuilding six pre-cutover schemas; this
+    catches the same class of failure for the ones the test below does not."""
+    module = _cutover_module()
+
+    for table, _pk, _nn, _du, index_ddls, _fks in module._PG_SPECS:
+        for ddl in index_ddls:
+            assert 'IF NOT EXISTS' in ddl, f'{table}: {ddl}'
+
+
+def test_the_episodes_cutover_indexes_survive_one_already_existing(pg_engine):
+    """The collision that actually happens: 4bb94a033f93 creates
+    ix_table_episodes_episode_file_id, and the cutover then creates it again."""
+    module = _cutover_module()
+
+    with pg_engine.begin() as connection:
+        connection.execute(sa.text(
+            'CREATE TABLE table_episodes (id INTEGER, arr_instance_id INTEGER, '
+            '"sonarrEpisodeId" INTEGER, "sonarrSeriesId" INTEGER, series_id INTEGER, '
+            'episode_file_id INTEGER)'))
+        # exactly what the hot-path index migration leaves behind
+        connection.execute(sa.text(
+            'CREATE INDEX ix_table_episodes_episode_file_id ON table_episodes (episode_file_id)'))
+
+    episodes = next(spec for spec in module._PG_SPECS if spec[0] == 'table_episodes')
+
+    with pg_engine.begin() as connection:
+        for ddl in episodes[4]:
+            connection.execute(sa.text(ddl))
+
+    indexes = {index['name'] for index in sa.inspect(pg_engine).get_indexes('table_episodes')}
+    assert 'ix_table_episodes_episode_file_id' in indexes
+    assert 'ix_table_episodes_series_id' in indexes


### PR DESCRIPTION
## The report

A user migrating from upstream nightly **v1.6.1-beta.31** hit the same crash-loop the previous change was meant to end, on a revision it did not cover:

```
2026-08-26 13:42:05|ERROR |flask_migrate |Error: Can't locate revision identified by '537e9b4d10e3'|
```

`537e9b4d10e3` lives on upstream's `development` branch and revises `0124f9e278fb`. The map only had master's head, so the earlier fix covered one of the two lines upstream ships and left every nightly user exactly where they were.

## The allowlist was the wrong shape

Upstream stamps new revisions continuously. Naming them one at a time means each new one locks nightly users out until this fork ships a release. So the rule is inverted: **any revision this codebase has no script for is adopted**, provided the database looks like a Bazarr one at all (a stamp we do not recognise on a database with none of Bazarr's tables is left alone and still refuses to start, because guessing there would do more harm). The reviewed set only decides how loudly it is logged; an unrecognised revision says so and asks for a report.

## What running it against real databases turned up

I built genuine upstream databases by checking out `upstream/development` and `upstream/master` and running **their own** `init_db()` and `migrate_db()`, on SQLite and on PostgreSQL, rather than reconstructing what I thought they looked like. Three things only showed up that way.

**The split tables have to go, not just be read.** `table_episodes_subtitles` and `table_movies_subtitles` each carry a foreign key into `table_episodes` / `table_movies`, and the local-id PK cutover rebuilds both, so the constraint failed the cutover's own `foreign_key_check` and aborted the migration. They are dropped once their rows are folded into the column this fork reads, and kept if that fold did not happen.

**Restoring columns from the models had to move after the upgrade.** Creating columns this fork's own migrations are about to create changes what those migrations see, and on PostgreSQL the cutover wants to build its own. The targeted subtitle restore still runs first: the fold depends on it, and the drop cannot wait.

**A pre-existing bug in our own PostgreSQL cutover.** `e7f4c9d80abc` created its indexes unconditionally and collided with the ones `4bb94a033f93` had already made under the same names. This is not an adoption bug: it hits **any PostgreSQL database whose tables predate the cutover**, which includes a Bazarr+ install upgrading across those versions. A fresh install never saw it, because `create_all` builds the final shape and the cutover short-circuits; the SQLite branch never saw it either, because it rebuilds each table and the old indexes go with it. All 50 index DDLs are idempotent now.

## Verification

End to end against databases built by upstream's own code, at `537e9b4d10e3` (nightly, the reported case) and `0124f9e278fb` (master, the original issue), on SQLite **and** PostgreSQL:

- startup completes; the chain reaches `a3f1c7d90b21`
- external subtitles keep their paths, sizes and variant suffixes: `[['en', '/tv/Breaking Bad/S05E14.en.srt', 31613], ['nl:forced', '/tv/Breaking Bad/S05E14.nl.forced.srt', 4210], ['es:hi', None, None]]`
- embedded tracks survive as `[language, None, None]`, the shape the indexer writes
- shows, episodes, movies, history, blacklist and language profiles untouched
- `PRAGMA integrity_check` ok, `PRAGMA foreign_key_check` clean, no leftover split tables
- a second boot is a no-op: no adoption, no migrations

Automated: 30 tests in `test_upstream_db_adoption.py` and 5 in `test_upstream_db_adoption_pg.py` (including two for the cutover index collision). Full local run: ruff clean, 1897 backend tests pass, the isolated per-file list passes.

Inbound: https://github.com/LavX/bazarr/issues/302