### PR TITLE
feat(translate): let mass translate use an embedded subtitle track

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,6 +338,7 @@ jobs:
             tests/bazarr/test_path_mappings_instance.py \
             tests/bazarr/test_threading_followup.py \
             tests/bazarr/test_mass_operations.py \
+            tests/bazarr/test_embedded_extraction_instance_scope.py \
             tests/bazarr/test_release_type_mismatch_migration.py \
             tests/bazarr/test_upstream_db_adoption.py \
             tests/bazarr/test_upstream_db_adoption_pg.py ; do

--- a/bazarr/subtitles/mass_operations.py
+++ b/bazarr/subtitles/mass_operations.py
@@ -32,15 +32,43 @@ MEDIA_ACTIONS = {'scan-disk', 'search-missing', 'upgrade'}
 MOD_ACTIONS = {'OCR_fixes', 'common', 'remove_HI', 'remove_tags', 'fix_uppercase', 'reverse_rtl', 'emoji'}
 
 
-def _parse_subtitles_column(subtitles_raw):
-    """Parse the subtitles TEXT column into a list of (lang_string, path) tuples."""
+def _parse_subtitles_column(subtitles_raw, include_embedded=False):
+    """Parse the subtitles TEXT column into a list of (lang_string, path) tuples.
+
+    The indexer records an in-container track as ``[language, None, None]``, so
+    an entry without a path is an embedded track rather than a broken row.
+    Those are left out by default, because most callers want a file they can
+    open. Translation does not: it can extract the track first, which is the
+    only way to translate a release whose only subtitles are embedded.
+    """
     if not subtitles_raw:
         return []
     try:
         parsed = ast.literal_eval(subtitles_raw)
-        return [(entry[0], entry[1]) for entry in parsed if len(entry) >= 2 and entry[1]]
     except (ValueError, SyntaxError):
         return []
+
+    entries = []
+    for entry in parsed:
+        if len(entry) < 2:
+            continue
+        if entry[1]:
+            entries.append((entry[0], entry[1]))
+        elif include_embedded:
+            entries.append((entry[0], None))
+    return entries
+
+
+def _drop_embedded_duplicates(subtitles):
+    """Remove an embedded track whose language already exists as a file.
+
+    Both would translate into the same output file, so the two jobs would
+    duplicate the work and race each other for the result. The file wins: it is
+    already on disk and needs no extraction.
+    """
+    languages_on_disk = {lang.split(':')[0] for lang, path in subtitles if path}
+    return [(lang, path) for lang, path in subtitles
+            if path or lang.split(':')[0] not in languages_on_disk]
 
 
 def _add_instance_filter(mapping, upstream_id, arr_instance_id):
@@ -230,7 +258,9 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
         if not _instance_filter_matches(ep.arr_instance_id, req_instances):
             continue
 
-        subtitles = _parse_subtitles_column(ep.subtitles)
+        subtitles = _parse_subtitles_column(ep.subtitles, include_embedded=True)
+        if action == 'translate':
+            subtitles = _drop_embedded_duplicates(subtitles)
         # Apply the owning instance's per-instance path_mappings (#156).
         video_path = path_mappings.path_replace_instance(ep.path, ep.arr_instance_id, 'episode')
 
@@ -255,11 +285,21 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
                 skipped += 1
                 continue
 
-            # Apply per-instance path_mappings to the stored subtitle path (#156).
-            mapped_sub_path = path_mappings.path_replace_instance(sub_path, ep.arr_instance_id, 'episode')
-            if not os.path.isfile(mapped_sub_path):
-                skipped += 1
-                continue
+            # An entry with no path is an in-container track. Only translate can
+            # use one, by extracting it first; there is nothing for sync or the
+            # mod actions to open.
+            is_embedded = not sub_path
+            if is_embedded:
+                if action != 'translate':
+                    skipped += 1
+                    continue
+                mapped_sub_path = None
+            else:
+                # Apply per-instance path_mappings to the stored subtitle path (#156).
+                mapped_sub_path = path_mappings.path_replace_instance(sub_path, ep.arr_instance_id, 'episode')
+                if not os.path.isfile(mapped_sub_path):
+                    skipped += 1
+                    continue
 
             # Never use a generated sync output or a combined artifact as a source.
             # For translate they would queue a duplicate job targeting the same
@@ -268,7 +308,8 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
             # sync output also cannot be meaningfully re-synced.
             modifiers = [p.lower() for p in lang_string.split(':')[1:]]
             is_combined = any(m.startswith('combined-') for m in modifiers)
-            if action in ('sync', 'translate') and (is_sync_engine_output(mapped_sub_path) or is_combined):
+            if action in ('sync', 'translate') and not is_embedded and (
+                    is_sync_engine_output(mapped_sub_path) or is_combined):
                 skipped += 1
                 continue
 
@@ -282,6 +323,7 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
                 'video_path': video_path,
                 'srt_path': mapped_sub_path,
                 'srt_lang': sub_lang,
+                'embedded': is_embedded,
                 'forced': lang_info['forced'],
                 'hi': lang_info['hi'],
                 'sonarr_series_id': ep.sonarrSeriesId,
@@ -340,7 +382,9 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
         if not _instance_filter_matches(movie.arr_instance_id, req_instances):
             continue
 
-        subtitles = _parse_subtitles_column(movie.subtitles)
+        subtitles = _parse_subtitles_column(movie.subtitles, include_embedded=True)
+        if action == 'translate':
+            subtitles = _drop_embedded_duplicates(subtitles)
         # Apply the owning instance's per-instance path_mappings (#156).
         video_path = path_mappings.path_replace_instance(movie.path, movie.arr_instance_id, 'movie')
 
@@ -365,11 +409,21 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
                 skipped += 1
                 continue
 
-            # Apply per-instance path_mappings to the stored subtitle path (#156).
-            mapped_sub_path = path_mappings.path_replace_instance(sub_path, movie.arr_instance_id, 'movie')
-            if not os.path.isfile(mapped_sub_path):
-                skipped += 1
-                continue
+            # An entry with no path is an in-container track. Only translate can
+            # use one, by extracting it first; there is nothing for sync or the
+            # mod actions to open.
+            is_embedded = not sub_path
+            if is_embedded:
+                if action != 'translate':
+                    skipped += 1
+                    continue
+                mapped_sub_path = None
+            else:
+                # Apply per-instance path_mappings to the stored subtitle path (#156).
+                mapped_sub_path = path_mappings.path_replace_instance(sub_path, movie.arr_instance_id, 'movie')
+                if not os.path.isfile(mapped_sub_path):
+                    skipped += 1
+                    continue
 
             # Never use a generated sync output or a combined artifact as a source.
             # For translate they would queue a duplicate job targeting the same
@@ -378,7 +432,8 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
             # sync output also cannot be meaningfully re-synced.
             modifiers = [p.lower() for p in lang_string.split(':')[1:]]
             is_combined = any(m.startswith('combined-') for m in modifiers)
-            if action in ('sync', 'translate') and (is_sync_engine_output(mapped_sub_path) or is_combined):
+            if action in ('sync', 'translate') and not is_embedded and (
+                    is_sync_engine_output(mapped_sub_path) or is_combined):
                 skipped += 1
                 continue
 
@@ -392,6 +447,7 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
                 'video_path': video_path,
                 'srt_path': mapped_sub_path,
                 'srt_lang': sub_lang,
+                'embedded': is_embedded,
                 'forced': lang_info['forced'],
                 'hi': lang_info['hi'],
                 'sonarr_series_id': None,
@@ -445,12 +501,30 @@ def _process_subtitle_item(item, action, options, job_id):
     elif action == 'translate':
         from subtitles.tools.translate.main import translate_subtitles_file
         media_type = 'episode' if item['sonarr_series_id'] else 'movies'
+
+        source_srt_file = item['srt_path']
+        if item.get('embedded'):
+            # Extracted here rather than while the batch was collected, so a
+            # whole-library run does not write a file for every track it will
+            # never get to. extract_embedded_subtitle caches on the video plus
+            # the language and the variant flags, so a repeat is cheap.
+            from subtitles.tools.translate.batch import extract_embedded_subtitle
+            source_srt_file = extract_embedded_subtitle(
+                item['video_path'], item['srt_lang'], media_type,
+                hi=item.get('hi', False), forced=item.get('forced', False))
+            if not source_srt_file:
+                # Usually a bitmap track (PGS, VobSub) that cannot become an
+                # SRT. That is this item's problem; the batch carries on.
+                logging.warning(
+                    'BAZARR could not extract the embedded %s track from %s, skipping translation',
+                    item['srt_lang'], item['video_path'])
+                return False
         # Don't pass the batch job_id to translate. translate_subtitles_file
         # has its own job/progress lifecycle that would hijack the batch job.
         # Calling without job_id makes it queue as its own separate job.
         translate_subtitles_file(
             video_path=item['video_path'],
-            source_srt_file=item['srt_path'],
+            source_srt_file=source_srt_file,
             from_lang=options.get('from_lang', item['srt_lang']),
             to_lang=options.get('to_lang', 'en'),
             forced=item['forced'],

--- a/bazarr/subtitles/mass_operations.py
+++ b/bazarr/subtitles/mass_operations.py
@@ -122,8 +122,22 @@ def _drop_embedded_duplicates(subtitles, usable):
     """
     covered = {_subtitle_variant_key(lang) for lang, path in subtitles
                if path and usable(lang, path)}
-    return [(lang, path) for lang, path in subtitles
-            if path or _subtitle_variant_key(lang) not in covered]
+
+    kept = []
+    for lang, path in subtitles:
+        if path:
+            kept.append((lang, path))
+            continue
+        key = _subtitle_variant_key(lang)
+        if key in covered:
+            continue
+        # A container often carries one language twice, and the indexer writes
+        # an entry per track without de-duplicating, so the same variant can
+        # appear more than once. Every copy selects the same stream and writes
+        # the same output, which on a paid translator is billed twice.
+        covered.add(key)
+        kept.append((lang, path))
+    return kept
 
 
 def _add_instance_filter(mapping, upstream_id, arr_instance_id):

--- a/bazarr/subtitles/mass_operations.py
+++ b/bazarr/subtitles/mass_operations.py
@@ -16,7 +16,6 @@ from subtitles.mass_download.series import series_download_subtitles
 from subtitles.mass_download.movies import movies_download_subtitles
 from subtitles.upgrade import upgrade_episodes_subtitles, upgrade_movies_subtitles
 from utilities.path_mappings import path_mappings
-from utilities.video_analyzer import languages_from_colon_seperated_string
 from sqlalchemy import or_
 
 logger = logging.getLogger(__name__)
@@ -30,6 +29,21 @@ VALID_ACTIONS = {
 MEDIA_ACTIONS = {'scan-disk', 'search-missing', 'upgrade'}
 
 MOD_ACTIONS = {'OCR_fixes', 'common', 'remove_HI', 'remove_tags', 'fix_uppercase', 'reverse_rtl', 'emoji'}
+
+
+def _item_display_name(item):
+    """What the job progress calls this item.
+
+    An embedded track has no file to name, so the video and the track's
+    language are what identify it. Naming the video alone would be ambiguous
+    on a container holding several tracks.
+    """
+    srt_path = item.get('srt_path')
+    if srt_path:
+        return os.path.basename(srt_path)
+    video_path = item.get('video_path') or ''
+    language = item.get('srt_lang') or 'embedded'
+    return f'{os.path.basename(video_path)} ({language} track)'
 
 
 def _parse_subtitles_column(subtitles_raw, include_embedded=False):
@@ -59,16 +73,57 @@ def _parse_subtitles_column(subtitles_raw, include_embedded=False):
     return entries
 
 
-def _drop_embedded_duplicates(subtitles):
-    """Remove an embedded track whose language already exists as a file.
+def _subtitle_variant_key(lang_string):
+    """The identity that decides whether two sources collide.
+
+    Base language plus the hi and forced variants, because that triple is what
+    ends up in the translated file's name: an ``en:hi`` source writes
+    ``.nl.hi.srt`` and a plain ``en`` source writes ``.nl.srt``. Collapsing to
+    the base language alone would treat those as the same output and throw one
+    of them away. Every modifier is inspected, not just the first, since a
+    track can be both (``en:hi:forced``).
+    """
+    parts = lang_string.split(':')
+    modifiers = {part.lower() for part in parts[1:]}
+    return parts[0], 'hi' in modifiers, 'forced' in modifiers
+
+
+def _usable_as_translate_source(lang_string, path):
+    """Whether a path-bearing entry can actually be a translate source.
+
+    A generated sync output or a combined artifact is excluded further down the
+    collector, and a forced subtitle is never translated. If one of those is
+    the only file for a language, it cannot stand in for the embedded track,
+    and letting it suppress that track leaves nothing at all.
+
+    The file existing on disk is checked separately, by the caller, because it
+    needs the per-instance path mapping applied first.
+    """
+    _base, _hi, forced = _subtitle_variant_key(lang_string)
+    if forced:
+        return False
+    modifiers = [part.lower() for part in lang_string.split(':')[1:]]
+    if any(modifier.startswith('combined-') for modifier in modifiers):
+        return False
+    return not is_sync_engine_output(path)
+
+
+def _drop_embedded_duplicates(subtitles, usable):
+    """Remove an embedded track when a usable file covers the same variant.
 
     Both would translate into the same output file, so the two jobs would
     duplicate the work and race each other for the result. The file wins: it is
     already on disk and needs no extraction.
+
+    ``usable`` decides which path-bearing entries count. A file that the
+    collector is about to reject anyway, because it is missing, forced, a sync
+    output or a combined artifact, must not suppress the embedded track it
+    would otherwise stand in for.
     """
-    languages_on_disk = {lang.split(':')[0] for lang, path in subtitles if path}
+    covered = {_subtitle_variant_key(lang) for lang, path in subtitles
+               if path and usable(lang, path)}
     return [(lang, path) for lang, path in subtitles
-            if path or lang.split(':')[0] not in languages_on_disk]
+            if path or _subtitle_variant_key(lang) not in covered]
 
 
 def _add_instance_filter(mapping, upstream_id, arr_instance_id):
@@ -258,29 +313,45 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
         if not _instance_filter_matches(ep.arr_instance_id, req_instances):
             continue
 
-        subtitles = _parse_subtitles_column(ep.subtitles, include_embedded=True)
-        if action == 'translate':
-            subtitles = _drop_embedded_duplicates(subtitles)
+        # Only translation can use an in-container track, and only when the
+        # user still has embedded subtitles turned on: the rows outlive the
+        # setting until the next index, so the check has to happen here too.
+        want_embedded = action == 'translate' and settings.general.use_embedded_subs
+        subtitles = _parse_subtitles_column(ep.subtitles, include_embedded=want_embedded)
         # Apply the owning instance's per-instance path_mappings (#156).
         video_path = path_mappings.path_replace_instance(ep.path, ep.arr_instance_id, 'episode')
 
-        # For translate: check if target language already exists
+        if want_embedded:
+            def _usable(lang_string, sub_path, _owner=ep):
+                if not _usable_as_translate_source(lang_string, sub_path):
+                    return False
+                return os.path.isfile(path_mappings.path_replace_instance(
+                    sub_path, _owner.arr_instance_id, 'episode'))
+
+            subtitles = _drop_embedded_duplicates(subtitles, _usable)
+
+        # For translate: check if target language already exists. Files only:
+        # an embedded track counting here would skip an item that has no
+        # target-language file at all, which is a regression for runs that
+        # never involved an embedded source.
         if action == 'translate' and target_lang:
-            existing_langs = {lang_str.split(':')[0] for lang_str, _ in subtitles}
+            existing_langs = {lang_str.split(':')[0] for lang_str, path in subtitles if path}
             if target_lang in existing_langs:
                 skipped += 1
                 continue
 
         for lang_string, sub_path in subtitles:
-            lang_info = languages_from_colon_seperated_string(lang_string)
+            # Every modifier, not just the first: a track can be both hi and
+            # forced. Reading only the first would let a forced one past the
+            # guard below and then pick the wrong stream at extraction time.
+            sub_lang, sub_hi, sub_forced = _subtitle_variant_key(lang_string)
 
             # Forced subs can't be synced or translated, but mods are fine
-            if lang_info['forced'] and action in ('sync', 'translate'):
+            if sub_forced and action in ('sync', 'translate'):
                 skipped += 1
                 continue
 
             # For translate: only queue subtitles matching the requested source language
-            sub_lang = lang_string.split(':')[0]
             if action == 'translate' and source_lang and sub_lang != source_lang:
                 skipped += 1
                 continue
@@ -324,8 +395,8 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
                 'srt_path': mapped_sub_path,
                 'srt_lang': sub_lang,
                 'embedded': is_embedded,
-                'forced': lang_info['forced'],
-                'hi': lang_info['hi'],
+                'forced': sub_forced,
+                'hi': sub_hi,
                 'sonarr_series_id': ep.sonarrSeriesId,
                 'sonarr_episode_id': ep.sonarrEpisodeId,
                 'radarr_id': None,
@@ -382,29 +453,45 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
         if not _instance_filter_matches(movie.arr_instance_id, req_instances):
             continue
 
-        subtitles = _parse_subtitles_column(movie.subtitles, include_embedded=True)
-        if action == 'translate':
-            subtitles = _drop_embedded_duplicates(subtitles)
+        # Only translation can use an in-container track, and only when the
+        # user still has embedded subtitles turned on: the rows outlive the
+        # setting until the next index, so the check has to happen here too.
+        want_embedded = action == 'translate' and settings.general.use_embedded_subs
+        subtitles = _parse_subtitles_column(movie.subtitles, include_embedded=want_embedded)
         # Apply the owning instance's per-instance path_mappings (#156).
         video_path = path_mappings.path_replace_instance(movie.path, movie.arr_instance_id, 'movie')
 
-        # For translate: check if target language already exists
+        if want_embedded:
+            def _usable(lang_string, sub_path, _owner=movie):
+                if not _usable_as_translate_source(lang_string, sub_path):
+                    return False
+                return os.path.isfile(path_mappings.path_replace_instance(
+                    sub_path, _owner.arr_instance_id, 'movie'))
+
+            subtitles = _drop_embedded_duplicates(subtitles, _usable)
+
+        # For translate: check if target language already exists. Files only:
+        # an embedded track counting here would skip an item that has no
+        # target-language file at all, which is a regression for runs that
+        # never involved an embedded source.
         if action == 'translate' and target_lang:
-            existing_langs = {lang_str.split(':')[0] for lang_str, _ in subtitles}
+            existing_langs = {lang_str.split(':')[0] for lang_str, path in subtitles if path}
             if target_lang in existing_langs:
                 skipped += 1
                 continue
 
         for lang_string, sub_path in subtitles:
-            lang_info = languages_from_colon_seperated_string(lang_string)
+            # Every modifier, not just the first: a track can be both hi and
+            # forced. Reading only the first would let a forced one past the
+            # guard below and then pick the wrong stream at extraction time.
+            sub_lang, sub_hi, sub_forced = _subtitle_variant_key(lang_string)
 
             # Forced subs can't be synced or translated, but mods are fine
-            if lang_info['forced'] and action in ('sync', 'translate'):
+            if sub_forced and action in ('sync', 'translate'):
                 skipped += 1
                 continue
 
             # For translate: only queue subtitles matching the requested source language
-            sub_lang = lang_string.split(':')[0]
             if action == 'translate' and source_lang and sub_lang != source_lang:
                 skipped += 1
                 continue
@@ -448,8 +535,8 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
                 'srt_path': mapped_sub_path,
                 'srt_lang': sub_lang,
                 'embedded': is_embedded,
-                'forced': lang_info['forced'],
-                'hi': lang_info['hi'],
+                'forced': sub_forced,
+                'hi': sub_hi,
                 'sonarr_series_id': None,
                 'sonarr_episode_id': None,
                 'radarr_id': movie.radarrId,
@@ -504,18 +591,23 @@ def _process_subtitle_item(item, action, options, job_id):
 
         source_srt_file = item['srt_path']
         if item.get('embedded'):
-            # Extracted here rather than while the batch was collected, so a
-            # whole-library run does not write a file for every track it will
-            # never get to. extract_embedded_subtitle caches on the video plus
-            # the language and the variant flags, so a repeat is cheap.
+            # Extracted when the item runs rather than when the batch was
+            # collected, so a run that is cancelled or fails leaves behind only
+            # what it actually reached. A run that completes does extract every
+            # track, because every collected item is processed.
+            #
+            # The owning instance goes along (#156): the collector mapped the
+            # video path with that instance's mapping, so the reverse lookup
+            # inside has to use the same one or it finds no row at all.
             from subtitles.tools.translate.batch import extract_embedded_subtitle
             source_srt_file = extract_embedded_subtitle(
                 item['video_path'], item['srt_lang'], media_type,
-                hi=item.get('hi', False), forced=item.get('forced', False))
+                hi=item.get('hi', False), forced=item.get('forced', False),
+                arr_instance_id=item.get('arr_instance_id'))
             if not source_srt_file:
                 # Usually a bitmap track (PGS, VobSub) that cannot become an
                 # SRT. That is this item's problem; the batch carries on.
-                logging.warning(
+                logger.warning(
                     'BAZARR could not extract the embedded %s track from %s, skipping translation',
                     item['srt_lang'], item['video_path'])
                 return False
@@ -699,7 +791,7 @@ def mass_batch_operation(items=None, action='sync', options=None, job_id=None):
         jobs_queue.update_job_progress(
             job_id=job_id,
             progress_value=i - 1,
-            progress_message=f"{action}: {os.path.basename(item['srt_path'])} ({i}/{total_count})"
+            progress_message=f"{action}: {_item_display_name(item)} ({i}/{total_count})"
         )
 
         try:
@@ -709,14 +801,14 @@ def mass_batch_operation(items=None, action='sync', options=None, job_id=None):
             else:
                 failed += 1
         except Exception as e:
-            logger.error(f'Error during {action} on {item["srt_path"]}: {e}')  # noqa: G004
+            logger.error(f'Error during {action} on {_item_display_name(item)}: {e}')  # noqa: G004
             all_errors.append(str(e))
             failed += 1
         finally:
             jobs_queue.update_job_progress(
                 job_id=job_id,
                 progress_value=i,
-                progress_message=f"{action}: {os.path.basename(item['srt_path'])} ({i}/{total_count})"
+                progress_message=f"{action}: {_item_display_name(item)} ({i}/{total_count})"
             )
 
     jobs_queue.update_job_name(

--- a/bazarr/subtitles/tools/translate/batch.py
+++ b/bazarr/subtitles/tools/translate/batch.py
@@ -510,8 +510,9 @@ def extract_embedded_subtitle(
     # place, so output_path either does not exist or is complete. Writing
     # straight to it meant a second caller arriving mid-write saw a non-empty
     # file, took it as a cache hit, and translated a truncated subtitle. The
-    # temporary name carries the pid so two processes cannot share one.
-    temp_path = f"{output_path}.{os.getpid()}.part"
+    # temporary name carries the pid so two processes cannot share one, and
+    # keeps the .srt extension because ffmpeg picks its muxer from it.
+    temp_path = f"{output_path}.{os.getpid()}.part.srt"
 
     # Extract using ffmpeg
     try:
@@ -530,6 +531,12 @@ def extract_embedded_subtitle(
         "-map",
         f"0:s:{found_track}",
         "-c:s",
+        "srt",
+        # Name the container format rather than leaving ffmpeg to infer it from
+        # the extension: the output goes to a temporary name, and an
+        # unrecognised one makes it fail with "Unable to choose an output
+        # format" instead of writing anything.
+        "-f",
         "srt",
         temp_path,
     ]

--- a/bazarr/subtitles/tools/translate/batch.py
+++ b/bazarr/subtitles/tools/translate/batch.py
@@ -341,7 +341,7 @@ def find_subtitle_by_language(subtitles, language_code, video_path, media_type="
 
 
 def extract_embedded_subtitle(
-    video_path, language_code2, media_type, hi=False, forced=False
+    video_path, language_code2, media_type, hi=False, forced=False, arr_instance_id=None
 ):
     """Extract an embedded subtitle track from a video file using ffmpeg.
 
@@ -351,7 +351,14 @@ def extract_embedded_subtitle(
     to produce a .srt file, and caches it keyed by video hash + language + hi + forced.
     Returns the path to the extracted .srt file, or None on failure.
     Test: See tests/bazarr/test_embedded_subtitle_extraction.py, covers text codec,
-    bitmap rejection, cache hit, hi/forced key separation.
+    bitmap rejection, cache hit, hi/forced key separation, and
+    tests/bazarr/test_embedded_extraction_instance_scope.py for the mapping.
+
+    ``arr_instance_id`` is the instance that owns the media (#156). The caller
+    maps the path forward with that instance's mapping, so the reverse has to
+    use the same one or the row lookup misses entirely; path_replace_reverse_instance
+    falls back to the global mapping when the instance has none, which is what
+    a None here relies on.
     """
     if not language_code2:
         logger.warning(
@@ -366,10 +373,18 @@ def extract_embedded_subtitle(
 
     # Look up file metadata needed by parse_video_metadata
     if media_type == "episode":
-        db_path = path_mappings.path_replace_reverse(video_path)
+        db_path = path_mappings.path_replace_reverse_instance(
+            video_path, arr_instance_id, "series")
+        # Scoped to the owning instance (#156): two instances can index the
+        # same path, and an unscoped first() would take an arbitrary row and
+        # feed the wrong file_size and episode_file_id to the metadata cache.
         media = database.execute(
-            select(TableEpisodes.episode_file_id, TableEpisodes.file_size).where(
-                TableEpisodes.path == db_path
+            scoped(
+                select(TableEpisodes.episode_file_id, TableEpisodes.file_size).where(
+                    TableEpisodes.path == db_path
+                ),
+                TableEpisodes.arr_instance_id,
+                arr_instance_id,
             )
         ).first()
         if not media:
@@ -378,10 +393,15 @@ def extract_embedded_subtitle(
             video_path, media.file_size, episode_file_id=media.episode_file_id
         )
     else:
-        db_path = path_mappings.path_replace_reverse_movie(video_path)
+        db_path = path_mappings.path_replace_reverse_instance(
+            video_path, arr_instance_id, "movie")
         media = database.execute(
-            select(TableMovies.movie_file_id, TableMovies.file_size).where(
-                TableMovies.path == db_path
+            scoped(
+                select(TableMovies.movie_file_id, TableMovies.file_size).where(
+                    TableMovies.path == db_path
+                ),
+                TableMovies.arr_instance_id,
+                arr_instance_id,
             )
         ).first()
         if not media:
@@ -486,6 +506,13 @@ def extract_embedded_subtitle(
         logger.debug("Using cached extracted subtitle: %s", output_path)
         return output_path
 
+    # ffmpeg writes to a temporary name and the finished file is moved into
+    # place, so output_path either does not exist or is complete. Writing
+    # straight to it meant a second caller arriving mid-write saw a non-empty
+    # file, took it as a cache hit, and translated a truncated subtitle. The
+    # temporary name carries the pid so two processes cannot share one.
+    temp_path = f"{output_path}.{os.getpid()}.part"
+
     # Extract using ffmpeg
     try:
         ffmpeg_path = get_binary("ffmpeg")
@@ -504,39 +531,47 @@ def extract_embedded_subtitle(
         f"0:s:{found_track}",
         "-c:s",
         "srt",
-        output_path,
+        temp_path,
     ]
+
+    def _discard_temp():
+        if os.path.exists(temp_path):
+            try:
+                os.remove(temp_path)
+            except OSError:
+                logger.debug("Could not remove the temporary file %s", temp_path)
 
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
         if result.returncode != 0:
             logger.error(f"ffmpeg extraction failed for {video_path}: {result.stderr}")  # noqa: G004
-            if os.path.exists(output_path):
-                os.remove(output_path)
+            _discard_temp()
             return None
-        if os.path.exists(output_path) and os.path.getsize(output_path) > 0:
+        if os.path.exists(temp_path) and os.path.getsize(temp_path) > 0:
             # Strip Windows carriage returns (\r) that ffmpeg may produce
-            with open(output_path, "r", encoding="utf-8-sig", errors="replace") as f:
+            with open(temp_path, "r", encoding="utf-8-sig", errors="replace") as f:
                 content = f.read()
             if "\r" in content:
-                with open(output_path, "w", encoding="utf-8") as f:
+                with open(temp_path, "w", encoding="utf-8") as f:
                     f.write(content.replace("\r", ""))
+            # Atomic on the same filesystem: a reader sees the old file or the
+            # new one, never a partial write.
+            os.replace(temp_path, output_path)
             logger.info(
                 "Extracted embedded %s subtitle to: %s",
                 language_code2,
                 output_path,
             )
             return output_path
+        _discard_temp()
         return None
     except subprocess.TimeoutExpired:
         logger.error(f"ffmpeg extraction timed out for {video_path}")  # noqa: G004
-        if os.path.exists(output_path):
-            os.remove(output_path)
+        _discard_temp()
         return None
     except Exception as e:
         logger.error(f"Failed to extract embedded subtitle: {e}")  # noqa: G004
-        if os.path.exists(output_path):
-            os.remove(output_path)
+        _discard_temp()
         return None
 
 

--- a/bazarr/subtitles/tools/translate/batch.py
+++ b/bazarr/subtitles/tools/translate/batch.py
@@ -5,6 +5,7 @@ import os
 import ast
 import re
 import subprocess
+import uuid
 from app.database import TableEpisodes, TableMovies, TableShows, database, select
 from app.jobs_queue import jobs_queue
 from app.event_handler import event_stream
@@ -510,9 +511,11 @@ def extract_embedded_subtitle(
     # place, so output_path either does not exist or is complete. Writing
     # straight to it meant a second caller arriving mid-write saw a non-empty
     # file, took it as a cache hit, and translated a truncated subtitle. The
-    # temporary name carries the pid so two processes cannot share one, and
-    # keeps the .srt extension because ffmpeg picks its muxer from it.
-    temp_path = f"{output_path}.{os.getpid()}.part.srt"
+    # The temporary name is unique per call, not per process: jobs run as
+    # threads inside one process, so a pid would be the same for both and the
+    # first os.replace would pull the file out from under the second. It keeps
+    # the .srt extension because ffmpeg picks its muxer from it.
+    temp_path = f"{output_path}.{uuid.uuid4().hex}.part.srt"
 
     # Extract using ffmpeg
     try:

--- a/frontend/src/components/forms/MassTranslateForm.tsx
+++ b/frontend/src/components/forms/MassTranslateForm.tsx
@@ -382,8 +382,8 @@ const MassTranslateForm: FunctionComponent<Props> = ({ items, onComplete }) => {
 
         <Alert variant="light" color="blue">
           <Text size="xs">
-            Each item must have an existing subtitle in the source language.
-            Items without matching subtitles will be skipped.
+            Each item needs a subtitle in the source language, either a file or
+            a text track inside the video. Items with neither are skipped.
           </Text>
         </Alert>
 

--- a/tests/bazarr/test_arr_action_scoping.py
+++ b/tests/bazarr/test_arr_action_scoping.py
@@ -54,10 +54,8 @@ def _patch_collect_io(monkeypatch, mo, schema_session):
     monkeypatch.setattr(mo.path_mappings, "path_replace_instance", lambda p, *a, **kw: p)
     monkeypatch.setattr(mo.path_mappings, "path_replace_reverse_instance", lambda p, *a, **kw: p)
     monkeypatch.setattr(os.path, "isfile", lambda p: True)
-    # The real parser needs the app's languages_dict (loaded at startup, absent
-    # in tests); the collect loop only consumes forced/hi from it.
-    monkeypatch.setattr(mo, "languages_from_colon_seperated_string",
-                        lambda s: {"forced": ":forced" in s, "hi": ":hi" in s})
+    # The variant parser the collector uses is pure string work, so unlike the
+    # old one it needs no languages_dict and no stub here.
 
 
 def test_collect_episodes_scoped_to_requested_instance(schema_session, monkeypatch):

--- a/tests/bazarr/test_embedded_extraction_instance_scope.py
+++ b/tests/bazarr/test_embedded_extraction_instance_scope.py
@@ -1,0 +1,174 @@
+# coding=utf-8
+"""Embedded extraction has to stay on the instance that owns the media (#156).
+
+The mass-translate collector maps the video path forward with the owning
+instance's mapping. If extraction reverses it with the global one, the row
+lookup misses on any secondary instance that has its own path_mappings, the
+extraction returns nothing, and the failure is reported as though the track
+were an unsupported bitmap codec.
+"""
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+
+
+@pytest.fixture(autouse=True)
+def language_table(monkeypatch):
+    """alpha3_from_alpha2 reads a table the app fills at startup."""
+    import subtitles.tools.translate.batch as batch
+
+    monkeypatch.setattr(batch, 'alpha3_from_alpha2', lambda code: 'eng')
+
+
+@pytest.fixture
+def mapping_calls(monkeypatch):
+    """Record which reverse mapping extraction reaches for."""
+    import subtitles.tools.translate.batch as batch
+
+    calls = {'global': [], 'instance': []}
+
+    def _reverse(path):
+        calls['global'].append(path)
+        return path
+
+    def _reverse_instance(path, arr_instance_id, kind):
+        calls['instance'].append((path, arr_instance_id, kind))
+        return path
+
+    monkeypatch.setattr(batch.path_mappings, 'path_replace_reverse', _reverse)
+    monkeypatch.setattr(batch.path_mappings, 'path_replace_reverse_movie', _reverse)
+    monkeypatch.setattr(batch.path_mappings, 'path_replace_reverse_instance', _reverse_instance)
+    return calls
+
+
+def test_the_owning_instance_reverses_the_episode_path(mapping_calls, monkeypatch):
+    import subtitles.tools.translate.batch as batch
+
+    monkeypatch.setattr(batch, 'database', MagicMock())
+    monkeypatch.setattr(batch, 'parse_video_metadata', lambda *a, **kw: None)
+
+    batch.extract_embedded_subtitle('/media/Show/ep.mkv', 'en', 'episode',
+                                    arr_instance_id=4)
+
+    assert mapping_calls['instance'] == [('/media/Show/ep.mkv', 4, 'series')]
+    assert mapping_calls['global'] == []
+
+
+def test_the_owning_instance_reverses_the_movie_path(mapping_calls, monkeypatch):
+    import subtitles.tools.translate.batch as batch
+
+    monkeypatch.setattr(batch, 'database', MagicMock())
+    monkeypatch.setattr(batch, 'parse_video_metadata', lambda *a, **kw: None)
+
+    batch.extract_embedded_subtitle('/media/Film.mkv', 'en', 'movies',
+                                    arr_instance_id=4)
+
+    assert mapping_calls['instance'] == [('/media/Film.mkv', 4, 'movie')]
+    assert mapping_calls['global'] == []
+
+
+def test_without_an_instance_the_helper_still_maps_the_path(mapping_calls, monkeypatch):
+    """path_replace_instance falls back to the global mapping for a None
+    instance, so the single-item caller keeps working unchanged."""
+    import subtitles.tools.translate.batch as batch
+
+    monkeypatch.setattr(batch, 'database', MagicMock())
+    monkeypatch.setattr(batch, 'parse_video_metadata', lambda *a, **kw: None)
+
+    batch.extract_embedded_subtitle('/media/Show/ep.mkv', 'en', 'episode')
+
+    assert mapping_calls['instance'] == [('/media/Show/ep.mkv', None, 'series')]
+
+
+def test_the_row_lookup_is_scoped_to_the_owning_instance(monkeypatch):
+    """Two instances can index the same path; an unscoped .first() would take
+    an arbitrary row and feed the wrong file_size to the metadata cache."""
+    import subtitles.tools.translate.batch as batch
+
+    scoped_calls = []
+
+    def _scoped(statement, column, arr_instance_id):
+        scoped_calls.append(arr_instance_id)
+        return statement
+
+    monkeypatch.setattr(batch, 'scoped', _scoped)
+    monkeypatch.setattr(batch, 'database', MagicMock())
+    monkeypatch.setattr(batch, 'parse_video_metadata', lambda *a, **kw: None)
+    monkeypatch.setattr(batch.path_mappings, 'path_replace_reverse_instance',
+                        lambda p, i, k: p)
+
+    batch.extract_embedded_subtitle('/media/Show/ep.mkv', 'en', 'episode',
+                                    arr_instance_id=9)
+
+    assert scoped_calls == [9]
+
+
+class TestExtractionIsAtomic:
+    """A half-written file must never be handed to a translator.
+
+    ffmpeg wrote straight to the final path, and the cache check is only
+    "exists and is not empty", so a second caller arriving mid-write took the
+    partial file as a hit. One click could not race itself; a library-wide
+    batch, whose translations are queued and read the file later, can.
+    """
+
+    def _prepare(self, monkeypatch, tmp_path, ffmpeg_behaviour):
+        import subtitles.tools.translate.batch as batch
+
+        monkeypatch.setattr(batch, 'alpha3_from_alpha2', lambda code: 'eng')
+        monkeypatch.setattr(batch.path_mappings, 'path_replace_reverse_instance',
+                            lambda p, i, k: p)
+        monkeypatch.setattr(batch, 'scoped', lambda statement, column, instance: statement)
+        media = MagicMock()
+        media.file_size, media.episode_file_id = 1, 1
+        database = MagicMock()
+        database.execute.return_value.first.return_value = media
+        monkeypatch.setattr(batch, 'database', database)
+        monkeypatch.setattr(batch, 'parse_video_metadata', lambda *a, **kw: {
+            'ffprobe': {'subtitle': [{'language': MagicMock(alpha3='eng'), 'forced': False,
+                                      'hearing_impaired': False, 'format': 'subrip'}]}})
+        monkeypatch.setattr(batch, 'get_binary', lambda name: '/usr/bin/ffmpeg')
+        from app.get_args import args as bazarr_args
+        monkeypatch.setattr(bazarr_args, 'config_dir', str(tmp_path))
+        monkeypatch.setattr(batch.subprocess, 'run', ffmpeg_behaviour)
+
+    def test_the_final_file_only_appears_once_it_is_complete(self, monkeypatch, tmp_path):
+        """The path ffmpeg writes to must not be the path the cache check
+        reads, so a concurrent reader sees either nothing or a finished file."""
+        import subtitles.tools.translate.batch as batch
+
+        written = {}
+
+        def fake_run(cmd, **kwargs):
+            target = cmd[-1]
+            written['target'] = target
+            with open(target, 'w', encoding='utf-8') as handle:
+                handle.write('1\n00:00:01,000 --> 00:00:02,000\nhi\n')
+            return MagicMock(returncode=0, stderr='')
+
+        self._prepare(monkeypatch, tmp_path, fake_run)
+
+        result = batch.extract_embedded_subtitle('/media/ep.mkv', 'en', 'episode')
+
+        assert result is not None
+        assert written['target'] != result, \
+            'ffmpeg wrote directly to the path the cache check reads'
+        assert os.path.exists(result)
+        assert not os.path.exists(written['target']), 'the temporary file was left behind'
+
+    def test_a_failed_extraction_leaves_no_file_at_the_cached_path(self, monkeypatch, tmp_path):
+        import subtitles.tools.translate.batch as batch
+
+        def fake_run(cmd, **kwargs):
+            with open(cmd[-1], 'w', encoding='utf-8') as handle:
+                handle.write('partial')
+            return MagicMock(returncode=1, stderr='boom')
+
+        self._prepare(monkeypatch, tmp_path, fake_run)
+
+        assert batch.extract_embedded_subtitle('/media/ep.mkv', 'en', 'episode') is None
+        leftovers = [n for n in os.listdir(tmp_path / 'extracted_subs')] \
+            if os.path.isdir(tmp_path / 'extracted_subs') else []
+        assert leftovers == [], leftovers

--- a/tests/bazarr/test_embedded_extraction_instance_scope.py
+++ b/tests/bazarr/test_embedded_extraction_instance_scope.py
@@ -195,3 +195,27 @@ class TestExtractionIsAtomic:
         cmd = seen['cmd']
         assert '-f' in cmd and cmd[cmd.index('-f') + 1] == 'srt', cmd
         assert cmd[-1].endswith('.srt'), cmd[-1]
+
+    def test_two_concurrent_extractions_do_not_share_a_temporary_path(
+            self, monkeypatch, tmp_path):
+        """Jobs run as threads inside one process, so the pid is the same for
+        both. Two extractions of the same variant would then write one file
+        and the first os.replace would pull it out from under the second."""
+        import subtitles.tools.translate.batch as batch
+
+        seen = []
+
+        def fake_run(cmd, **kwargs):
+            seen.append(cmd[-1])
+            with open(cmd[-1], 'w', encoding='utf-8') as handle:
+                handle.write('1\n00:00:01,000 --> 00:00:02,000\nhi\n')
+            return MagicMock(returncode=0, stderr='')
+
+        self._prepare(monkeypatch, tmp_path, fake_run)
+
+        first = batch.extract_embedded_subtitle('/media/ep.mkv', 'en', 'episode')
+        os.remove(first)  # force a second cache miss for the same variant
+        batch.extract_embedded_subtitle('/media/ep.mkv', 'en', 'episode')
+
+        assert len(seen) == 2
+        assert seen[0] != seen[1], seen

--- a/tests/bazarr/test_embedded_extraction_instance_scope.py
+++ b/tests/bazarr/test_embedded_extraction_instance_scope.py
@@ -172,3 +172,26 @@ class TestExtractionIsAtomic:
         leftovers = [n for n in os.listdir(tmp_path / 'extracted_subs')] \
             if os.path.isdir(tmp_path / 'extracted_subs') else []
         assert leftovers == [], leftovers
+
+    def test_ffmpeg_is_told_the_format_and_given_a_recognisable_name(
+            self, monkeypatch, tmp_path):
+        """ffmpeg chooses its muxer from the output extension. Writing to a
+        temporary name broke that: it exited with "Unable to choose an output
+        format" and extracted nothing. Caught on a real deployment, because
+        this suite stubs the subprocess away."""
+        import subtitles.tools.translate.batch as batch
+
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen['cmd'] = cmd
+            with open(cmd[-1], 'w', encoding='utf-8') as handle:
+                handle.write('1\n00:00:01,000 --> 00:00:02,000\nhi\n')
+            return MagicMock(returncode=0, stderr='')
+
+        self._prepare(monkeypatch, tmp_path, fake_run)
+        batch.extract_embedded_subtitle('/media/ep.mkv', 'en', 'episode')
+
+        cmd = seen['cmd']
+        assert '-f' in cmd and cmd[cmd.index('-f') + 1] == 'srt', cmd
+        assert cmd[-1].endswith('.srt'), cmd[-1]

--- a/tests/bazarr/test_mass_operations.py
+++ b/tests/bazarr/test_mass_operations.py
@@ -238,7 +238,6 @@ class TestCollectSubtitleItems:
         movie.subtitles = subtitles
         return movie
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -246,7 +245,7 @@ class TestCollectSubtitleItems:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_collects_episode_subtitles(self, mock_settings, mock_db, mock_synced_mov,
-                                         mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
+                                         mock_synced_ep, mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -256,7 +255,6 @@ class TestCollectSubtitleItems:
         mock_path_map.path_replace_reverse.side_effect = lambda x: x
         mock_path_map.path_replace_instance.side_effect = lambda p, *a, **kw: p
         mock_path_map.path_replace_reverse_instance.side_effect = lambda p, *a, **kw: p
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         episode = self._make_episode()
         mock_db.execute.return_value.all.return_value = [episode]
@@ -269,7 +267,6 @@ class TestCollectSubtitleItems:
         assert items[0]['sonarr_series_id'] == 10
         assert items[0]['srt_path'] == '/subs/ep1.en.srt'
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -277,7 +274,7 @@ class TestCollectSubtitleItems:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_collects_movie_subtitles(self, mock_settings, mock_db, mock_synced_mov,
-                                       mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
+                                       mock_synced_ep, mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -287,7 +284,6 @@ class TestCollectSubtitleItems:
         mock_path_map.path_replace_reverse_movie.side_effect = lambda x: x
         mock_path_map.path_replace_instance.side_effect = lambda p, *a, **kw: p
         mock_path_map.path_replace_reverse_instance.side_effect = lambda p, *a, **kw: p
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         movie = self._make_movie()
         mock_db.execute.return_value.all.return_value = [movie]
@@ -299,7 +295,6 @@ class TestCollectSubtitleItems:
         assert items[0]['radarr_id'] == 10
         assert items[0]['srt_path'] == '/subs/movie.en.srt'
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -307,8 +302,7 @@ class TestCollectSubtitleItems:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_collects_duplicate_movie_upstream_ids_by_instance(self, mock_settings, mock_db, mock_synced_mov,
-                                                               mock_synced_ep, mock_path_map, mock_isfile,
-                                                               mock_lang):
+                                                               mock_synced_ep, mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -318,7 +312,6 @@ class TestCollectSubtitleItems:
         mock_path_map.path_replace_reverse_movie.side_effect = lambda x: x
         mock_path_map.path_replace_instance.side_effect = lambda p, *a, **kw: p
         mock_path_map.path_replace_reverse_instance.side_effect = lambda p, *a, **kw: p
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         movie_a = self._make_movie(path="/movies/a.mkv", subtitles="[['en', '/subs/a.en.srt']]")
         movie_a.arr_instance_id = 1
@@ -336,7 +329,6 @@ class TestCollectSubtitleItems:
         assert [item['arr_instance_id'] for item in items] == [1, 2]
         assert [item['srt_path'] for item in items] == ['/subs/a.en.srt', '/subs/b.en.srt']
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -344,8 +336,7 @@ class TestCollectSubtitleItems:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_collects_duplicate_episode_upstream_ids_by_instance(self, mock_settings, mock_db, mock_synced_mov,
-                                                                 mock_synced_ep, mock_path_map, mock_isfile,
-                                                                 mock_lang):
+                                                                 mock_synced_ep, mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -355,7 +346,6 @@ class TestCollectSubtitleItems:
         mock_path_map.path_replace_reverse.side_effect = lambda x: x
         mock_path_map.path_replace_instance.side_effect = lambda p, *a, **kw: p
         mock_path_map.path_replace_reverse_instance.side_effect = lambda p, *a, **kw: p
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         episode_a = self._make_episode(path="/series/a.mkv", subtitles="[['en', '/subs/a.en.srt']]")
         episode_a.arr_instance_id = 1
@@ -373,7 +363,6 @@ class TestCollectSubtitleItems:
         assert [item['arr_instance_id'] for item in items] == [1, 2]
         assert [item['srt_path'] for item in items] == ['/subs/a.en.srt', '/subs/b.en.srt']
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -381,8 +370,7 @@ class TestCollectSubtitleItems:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_collects_duplicate_series_upstream_ids_by_instance(self, mock_settings, mock_db, mock_synced_mov,
-                                                                mock_synced_ep, mock_path_map, mock_isfile,
-                                                                mock_lang):
+                                                                mock_synced_ep, mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -390,7 +378,6 @@ class TestCollectSubtitleItems:
         mock_settings.subsync.no_fix_framerate = True
         mock_path_map.path_replace.side_effect = lambda x: x
         mock_path_map.path_replace_reverse.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         episode_a = self._make_episode(ep_id=1, series_id=42, path="/series/a.mkv",
                                        subtitles="[['en', '/subs/a.en.srt']]")
@@ -410,7 +397,6 @@ class TestCollectSubtitleItems:
         assert [item['arr_instance_id'] for item in items] == [1, 2]
         assert [item['sonarr_episode_id'] for item in items] == [1, 2]
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -418,14 +404,13 @@ class TestCollectSubtitleItems:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_skips_forced_subtitles(self, mock_settings, mock_db, mock_synced_mov,
-                                     mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
+                                     mock_synced_ep, mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
         mock_settings.subsync.no_fix_framerate = True
         mock_path_map.path_replace.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': True, 'hi': False}
 
         episode = self._make_episode(subtitles="[['en:forced', '/subs/ep1.en.forced.srt']]")
         mock_db.execute.return_value.all.return_value = [episode]
@@ -436,7 +421,6 @@ class TestCollectSubtitleItems:
         assert len(items) == 0
         assert skipped == 1
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=False)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -444,14 +428,13 @@ class TestCollectSubtitleItems:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_skips_missing_files(self, mock_settings, mock_db, mock_synced_mov,
-                                  mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
+                                  mock_synced_ep, mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
         mock_settings.subsync.no_fix_framerate = True
         mock_path_map.path_replace.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         episode = self._make_episode()
         mock_db.execute.return_value.all.return_value = [episode]
@@ -462,7 +445,6 @@ class TestCollectSubtitleItems:
         assert len(items) == 0
         assert skipped == 1
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths')
@@ -470,7 +452,7 @@ class TestCollectSubtitleItems:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_skips_already_synced_episodes(self, mock_settings, mock_db, mock_synced_mov,
-                                            mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
+                                            mock_synced_ep, mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -480,7 +462,6 @@ class TestCollectSubtitleItems:
         mock_path_map.path_replace_reverse.side_effect = lambda x: x
         mock_path_map.path_replace_instance.side_effect = lambda p, *a, **kw: p
         mock_path_map.path_replace_reverse_instance.side_effect = lambda p, *a, **kw: p
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
         mock_synced_ep.return_value = {'/subs/ep1.en.srt'}
 
         episode = self._make_episode()
@@ -492,7 +473,6 @@ class TestCollectSubtitleItems:
         assert len(items) == 0
         assert skipped == 1
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -500,7 +480,7 @@ class TestCollectSubtitleItems:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_skips_already_synced_movies(self, mock_settings, mock_db, mock_synced_mov,
-                                          mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
+                                          mock_synced_ep, mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -510,7 +490,6 @@ class TestCollectSubtitleItems:
         mock_path_map.path_replace_reverse_movie.side_effect = lambda x: x
         mock_path_map.path_replace_instance.side_effect = lambda p, *a, **kw: p
         mock_path_map.path_replace_reverse_instance.side_effect = lambda p, *a, **kw: p
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
         mock_synced_mov.return_value = {'/subs/movie.en.srt'}
 
         movie = self._make_movie()
@@ -522,7 +501,6 @@ class TestCollectSubtitleItems:
         assert len(items) == 0
         assert skipped == 1
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -530,14 +508,13 @@ class TestCollectSubtitleItems:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_skips_forced_movie_subtitles(self, mock_settings, mock_db, mock_synced_mov,
-                                           mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
+                                           mock_synced_ep, mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
         mock_settings.subsync.no_fix_framerate = True
         mock_path_map.path_replace_movie.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': True, 'hi': False}
 
         movie = self._make_movie(subtitles="[['en:forced', '/subs/movie.en.forced.srt']]")
         mock_db.execute.return_value.all.return_value = [movie]
@@ -548,7 +525,6 @@ class TestCollectSubtitleItems:
         assert len(items) == 0
         assert skipped == 1
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -556,7 +532,7 @@ class TestCollectSubtitleItems:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_forced_subs_allowed_for_mod_actions(self, mock_settings, mock_db, mock_synced_mov,
-                                                  mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
+                                                  mock_synced_ep, mock_path_map, mock_isfile):
         """Forced subtitles should be processed by mod actions like OCR_fixes, not skipped."""
         from subtitles.mass_operations import _collect_subtitle_items
 
@@ -564,7 +540,6 @@ class TestCollectSubtitleItems:
         mock_settings.subsync.gss = True
         mock_settings.subsync.no_fix_framerate = True
         mock_path_map.path_replace.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': True, 'hi': False}
 
         episode = self._make_episode(subtitles="[['en:forced', '/subs/ep1.en.forced.srt']]")
         mock_db.execute.return_value.all.return_value = [episode]
@@ -576,7 +551,6 @@ class TestCollectSubtitleItems:
         assert skipped == 0
         assert items[0]['forced'] is True
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=False)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -584,14 +558,13 @@ class TestCollectSubtitleItems:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_skips_missing_movie_files(self, mock_settings, mock_db, mock_synced_mov,
-                                        mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
+                                        mock_synced_ep, mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
         mock_settings.subsync.no_fix_framerate = True
         mock_path_map.path_replace_movie.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         movie = self._make_movie()
         mock_db.execute.return_value.all.return_value = [movie]
@@ -602,7 +575,6 @@ class TestCollectSubtitleItems:
         assert len(items) == 0
         assert skipped == 1
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -610,7 +582,7 @@ class TestCollectSubtitleItems:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_series_type_collects_episodes(self, mock_settings, mock_db, mock_synced_mov,
-                                            mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
+                                            mock_synced_ep, mock_path_map, mock_isfile):
         """Passing type='series' with sonarrSeriesId collects all episodes for that series."""
         from subtitles.mass_operations import _collect_subtitle_items
 
@@ -619,7 +591,6 @@ class TestCollectSubtitleItems:
         mock_settings.subsync.no_fix_framerate = True
         mock_path_map.path_replace.side_effect = lambda x: x
         mock_path_map.path_replace_reverse.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         episode = self._make_episode(ep_id=5, series_id=42)
         mock_db.execute.return_value.all.return_value = [episode]
@@ -806,7 +777,6 @@ class TestForceResync:
         ep.subtitles = subtitles
         return ep
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths')
@@ -814,7 +784,7 @@ class TestForceResync:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_force_resync_collects_already_synced(self, mock_settings, mock_db, mock_synced_mov,
-                                                   mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
+                                                   mock_synced_ep, mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -822,7 +792,6 @@ class TestForceResync:
         mock_settings.subsync.no_fix_framerate = True
         mock_path_map.path_replace.side_effect = lambda x: x
         mock_path_map.path_replace_reverse.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
         mock_synced_ep.return_value = {'/subs/ep1.en.srt'}
 
         episode = self._make_episode()
@@ -835,7 +804,6 @@ class TestForceResync:
         assert len(items) == 1
         assert skipped == 0
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -843,7 +811,7 @@ class TestForceResync:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_force_resync_still_skips_generated_sync_outputs(self, mock_settings, mock_db, mock_synced_mov,
-                                                             mock_synced_ep, mock_path_map, mock_isfile, mock_lang):
+                                                             mock_synced_ep, mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -853,7 +821,6 @@ class TestForceResync:
         mock_path_map.path_replace_reverse.side_effect = lambda x: x
         mock_path_map.path_replace_instance.side_effect = lambda p, *a, **kw: p
         mock_path_map.path_replace_reverse_instance.side_effect = lambda p, *a, **kw: p
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         episode = self._make_episode(subtitles="[['en:sync-ffsubsync', '/subs/ep1.en.ffsubsync.srt']]")
         mock_db.execute.return_value.all.return_value = [episode]
@@ -885,13 +852,12 @@ class TestTranslateSkipsExistingLang:
         movie.subtitles = subtitles
         return movie
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_skips_episode_when_target_lang_exists(self, mock_settings, mock_db,
-                                                    mock_path_map, mock_isfile, mock_lang):
+                                                    mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -900,7 +866,6 @@ class TestTranslateSkipsExistingLang:
         mock_settings.general.use_sonarr = False
         mock_settings.general.use_radarr = False
         mock_path_map.path_replace.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         # Episode already has 'hu' subtitle
         episode = self._make_episode()
@@ -913,13 +878,12 @@ class TestTranslateSkipsExistingLang:
         assert len(collected) == 0
         assert skipped == 1
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_collects_episode_when_target_lang_missing(self, mock_settings, mock_db,
-                                                        mock_path_map, mock_isfile, mock_lang):
+                                                        mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -928,7 +892,6 @@ class TestTranslateSkipsExistingLang:
         mock_settings.general.use_sonarr = False
         mock_settings.general.use_radarr = False
         mock_path_map.path_replace.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         # Episode has 'en' but NOT 'hu'
         episode = self._make_episode(subtitles="[['en', '/subs/ep1.en.srt']]")
@@ -940,13 +903,12 @@ class TestTranslateSkipsExistingLang:
         assert len(collected) == 1
         assert skipped == 0
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_skips_movie_when_target_lang_exists(self, mock_settings, mock_db,
-                                                  mock_path_map, mock_isfile, mock_lang):
+                                                  mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -955,7 +917,6 @@ class TestTranslateSkipsExistingLang:
         mock_settings.general.use_sonarr = False
         mock_settings.general.use_radarr = False
         mock_path_map.path_replace_movie.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         movie = self._make_movie()
         mock_db.execute.return_value.all.return_value = [movie]
@@ -987,13 +948,12 @@ class TestTranslateSourceLanguageFilter:
         movie.subtitles = subtitles
         return movie
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_translate_only_queues_source_language_episodes(self, mock_settings, mock_db,
-                                                            mock_path_map, mock_isfile, mock_lang):
+                                                            mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -1002,7 +962,6 @@ class TestTranslateSourceLanguageFilter:
         mock_settings.general.use_sonarr = False
         mock_settings.general.use_radarr = False
         mock_path_map.path_replace.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         # Episode has both EN and FR subtitles
         episode = self._make_episode()
@@ -1016,13 +975,12 @@ class TestTranslateSourceLanguageFilter:
         assert collected[0]['srt_lang'] == 'en'
         assert skipped == 1  # FR subtitle skipped
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_translate_only_queues_source_language_movies(self, mock_settings, mock_db,
-                                                          mock_path_map, mock_isfile, mock_lang):
+                                                          mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -1031,7 +989,6 @@ class TestTranslateSourceLanguageFilter:
         mock_settings.general.use_sonarr = False
         mock_settings.general.use_radarr = False
         mock_path_map.path_replace_movie.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         # Movie has both EN and FR subtitles
         movie = self._make_movie()
@@ -1045,13 +1002,12 @@ class TestTranslateSourceLanguageFilter:
         assert collected[0]['srt_lang'] == 'en'
         assert skipped == 1  # FR skipped
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_translate_without_source_lang_queues_all(self, mock_settings, mock_db,
-                                                       mock_path_map, mock_isfile, mock_lang):
+                                                       mock_path_map, mock_isfile):
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
@@ -1060,7 +1016,6 @@ class TestTranslateSourceLanguageFilter:
         mock_settings.general.use_sonarr = False
         mock_settings.general.use_radarr = False
         mock_path_map.path_replace.side_effect = lambda x: x
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         episode = self._make_episode()
         mock_db.execute.return_value.all.return_value = [episode]
@@ -1187,7 +1142,6 @@ class TestCollectPerInstancePathMapping:
         movie.arr_instance_id = arr_instance_id
         return movie
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -1196,16 +1150,16 @@ class TestCollectPerInstancePathMapping:
     @patch('subtitles.mass_operations.settings')
     def test_collect_episodes_calls_path_replace_instance_with_owner_id(
             self, mock_settings, mock_db, mock_synced_mov, mock_synced_ep,
-            mock_path_map, mock_isfile, mock_lang):
+            mock_path_map, mock_isfile):
         """path_replace_instance must be called with the row's arr_instance_id."""
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
         mock_settings.subsync.no_fix_framerate = True
+        mock_settings.general.use_embedded_subs = True
         mock_path_map.path_replace_instance.side_effect = lambda p, *a, **kw: p.replace('/remote', '/local')
         mock_path_map.path_replace_reverse_instance.side_effect = lambda p, *a, **kw: p
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         episode = self._make_episode(arr_instance_id=7)
         mock_db.execute.return_value.all.return_value = [episode]
@@ -1226,7 +1180,6 @@ class TestCollectPerInstancePathMapping:
         assert any(c.args[1] == 7 for c in calls), \
             "path_replace_instance must be called with the owning arr_instance_id=7"
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -1235,16 +1188,16 @@ class TestCollectPerInstancePathMapping:
     @patch('subtitles.mass_operations.settings')
     def test_collect_movies_calls_path_replace_instance_with_owner_id(
             self, mock_settings, mock_db, mock_synced_mov, mock_synced_ep,
-            mock_path_map, mock_isfile, mock_lang):
+            mock_path_map, mock_isfile):
         """path_replace_instance must be called with the movie row's arr_instance_id."""
         from subtitles.mass_operations import _collect_subtitle_items
 
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
         mock_settings.subsync.no_fix_framerate = True
+        mock_settings.general.use_embedded_subs = True
         mock_path_map.path_replace_instance.side_effect = lambda p, *a, **kw: p.replace('/remote', '/local')
         mock_path_map.path_replace_reverse_instance.side_effect = lambda p, *a, **kw: p
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
         movie = self._make_movie(arr_instance_id=8)
         mock_db.execute.return_value.all.return_value = [movie]
@@ -1397,17 +1350,16 @@ class TestMassTranslateFromEmbeddedTracks:
             options=options if options is not None else {'from_lang': 'en', 'to_lang': 'nl'})
 
     @staticmethod
-    def _wire(mock_settings, mock_path_map, mock_lang):
+    def _wire(mock_settings, mock_path_map):
         mock_settings.subsync.max_offset_seconds = 60
         mock_settings.subsync.gss = True
         mock_settings.subsync.no_fix_framerate = True
+        mock_settings.general.use_embedded_subs = True
         mock_path_map.path_replace_instance.side_effect = lambda p, *a, **kw: p
         mock_path_map.path_replace_reverse_instance.side_effect = lambda p, *a, **kw: p
-        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
 
     # --- collecting -------------------------------------------------------
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=False)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -1415,8 +1367,8 @@ class TestMassTranslateFromEmbeddedTracks:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_an_embedded_track_becomes_a_translate_source(
-            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile, mock_lang):
-        self._wire(mock_settings, mock_path_map, mock_lang)
+            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile):
+        self._wire(mock_settings, mock_path_map)
 
         items, skipped = self._collect(mock_db, self._episode())
 
@@ -1426,41 +1378,41 @@ class TestMassTranslateFromEmbeddedTracks:
         assert items[0]['srt_lang'] == 'en'
         assert items[0]['video_path'] == '/video/ep1.mkv'
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=False)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
     @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
-    def test_sync_still_skips_an_embedded_track(
-            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile, mock_lang):
-        """There is no file to sync, and no useful one to produce."""
-        self._wire(mock_settings, mock_path_map, mock_lang)
+    def test_sync_never_sees_an_embedded_track_at_all(
+            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile):
+        """There is no file to sync and no useful one to produce, so an
+        embedded track is not a candidate. It must not reach the skipped tally
+        either: counting every in-container track of every episode would make
+        a mass sync report thousands of skips it never had before."""
+        self._wire(mock_settings, mock_path_map)
 
         items, skipped = self._collect(mock_db, self._episode(), action='sync', options={})
 
         assert items == []
-        assert skipped == 1
+        assert skipped == 0
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=False)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
     @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
-    def test_a_mod_action_still_skips_an_embedded_track(
-            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile, mock_lang):
-        self._wire(mock_settings, mock_path_map, mock_lang)
+    def test_a_mod_action_never_sees_an_embedded_track_either(
+            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile):
+        self._wire(mock_settings, mock_path_map)
 
         items, skipped = self._collect(mock_db, self._episode(),
                                        action='remove_HI', options={})
 
         assert items == []
-        assert skipped == 1
+        assert skipped == 0
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
@@ -1468,9 +1420,9 @@ class TestMassTranslateFromEmbeddedTracks:
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
     def test_a_real_file_wins_over_the_embedded_track_of_the_same_language(
-            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile, mock_lang):
+            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile):
         """Queueing both would run the same translation twice into one output."""
-        self._wire(mock_settings, mock_path_map, mock_lang)
+        self._wire(mock_settings, mock_path_map)
         episode = self._episode(
             subtitles="[['en', None, None], ['en', '/subs/ep1.en.srt', 100]]")
 
@@ -1480,22 +1432,59 @@ class TestMassTranslateFromEmbeddedTracks:
         assert items[0]['srt_path'] == '/subs/ep1.en.srt'
         assert not items[0].get('embedded')
 
-    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
     @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
     @patch('subtitles.mass_operations.path_mappings')
     @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
     @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
     @patch('subtitles.mass_operations.database')
     @patch('subtitles.mass_operations.settings')
-    def test_an_item_that_already_has_the_target_language_is_still_skipped(
-            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile, mock_lang):
-        self._wire(mock_settings, mock_path_map, mock_lang)
-        episode = self._episode(subtitles="[['en', None, None], ['nl', None, None]]")
+    def test_an_existing_target_language_file_still_skips_the_item(
+            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile):
+        self._wire(mock_settings, mock_path_map)
+        episode = self._episode(
+            subtitles="[['en', None, None], ['nl', '/subs/ep1.nl.srt', 12]]")
 
         items, skipped = self._collect(mock_db, episode)
 
         assert items == []
         assert skipped == 1
+
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
+    def test_an_embedded_track_in_the_target_language_does_not_skip_the_item(
+            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile):
+        """The user asked for a subtitle file. An in-container Dutch track,
+        which may be signs-only or a bitmap the player cannot restyle, is not
+        that, and before embedded entries were visible here it never blocked
+        the run."""
+        self._wire(mock_settings, mock_path_map)
+        episode = self._episode(subtitles="[['en', None, None], ['nl', None, None]]")
+
+        items, _skipped = self._collect(mock_db, episode)
+
+        assert len(items) == 1
+        assert items[0]['srt_lang'] == 'en'
+
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
+    def test_embedded_tracks_are_ignored_when_the_user_turned_them_off(
+            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile):
+        """The rows outlive the setting until the next index, so consuming
+        them has to check it too."""
+        self._wire(mock_settings, mock_path_map)
+        mock_settings.general.use_embedded_subs = False
+
+        items, _skipped = self._collect(mock_db, self._episode())
+
+        assert items == []
 
     # --- processing -------------------------------------------------------
 
@@ -1528,7 +1517,7 @@ class TestMassTranslateFromEmbeddedTracks:
                                       {'from_lang': 'en', 'to_lang': 'nl'}, 'job') is True
 
         mock_extract.assert_called_once_with('/video/ep1.mkv', 'en', 'episode',
-                                             hi=False, forced=False)
+                                             hi=False, forced=False, arr_instance_id=None)
         assert mock_translate.call_args[1]['source_srt_file'] == \
             '/config/extracted_subs/ep1.en.srt'
         assert mock_translate.call_args[1]['to_lang'] == 'nl'
@@ -1558,7 +1547,7 @@ class TestMassTranslateFromEmbeddedTracks:
                                       {'from_lang': 'en', 'to_lang': 'nl'}, 'job') is True
 
         mock_extract.assert_called_once_with('/video/movie.mkv', 'en', 'movies',
-                                             hi=False, forced=False)
+                                             hi=False, forced=False, arr_instance_id=None)
 
     @patch('subtitles.tools.translate.main.translate_subtitles_file', return_value=True)
     @patch('subtitles.tools.translate.batch.extract_embedded_subtitle',
@@ -1572,7 +1561,7 @@ class TestMassTranslateFromEmbeddedTracks:
         _process_subtitle_item(item, 'translate', {'from_lang': 'en', 'to_lang': 'nl'}, 'job')
 
         mock_extract.assert_called_once_with('/video/ep1.mkv', 'en', 'episode',
-                                             hi=True, forced=False)
+                                             hi=True, forced=False, arr_instance_id=None)
 
     @patch('subtitles.tools.translate.main.translate_subtitles_file', return_value=True)
     @patch('subtitles.tools.translate.batch.extract_embedded_subtitle')
@@ -1586,3 +1575,174 @@ class TestMassTranslateFromEmbeddedTracks:
                                       {'from_lang': 'en', 'to_lang': 'nl'}, 'job') is True
         mock_extract.assert_not_called()
         assert mock_translate.call_args[1]['source_srt_file'] == '/subs/ep1.en.srt'
+
+
+class TestMassBatchOperationWithEmbeddedItems:
+    """The batch driver, run against an item that has no subtitle file.
+
+    The collector and the per-item processor were both covered, and the loop
+    between them was not, which is where an embedded item's srt_path of None
+    reached os.path.basename and took the whole job down.
+    """
+
+    @patch('subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations._process_subtitle_item', return_value=True)
+    @patch('subtitles.mass_operations._collect_subtitle_items')
+    def test_a_batch_of_embedded_items_runs_to_completion(
+            self, mock_collect, mock_process, mock_jq):
+        from subtitles.mass_operations import mass_batch_operation
+
+        mock_collect.return_value = ([
+            {'srt_path': None, 'embedded': True, 'srt_lang': 'en',
+             'video_path': '/video/ep1.mkv'},
+            {'srt_path': None, 'embedded': True, 'srt_lang': 'en',
+             'video_path': '/video/ep2.mkv'},
+        ], 0)
+
+        result = mass_batch_operation(items=[{'type': 'episode', 'sonarrEpisodeId': 1}],
+                                      action='translate', job_id='test')
+
+        assert result['queued'] == 2
+        assert mock_process.call_count == 2
+
+    @patch('subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations._process_subtitle_item', return_value=True)
+    @patch('subtitles.mass_operations._collect_subtitle_items')
+    def test_the_progress_message_names_the_video_for_an_embedded_item(
+            self, mock_collect, mock_process, mock_jq):
+        """There is no subtitle file to name, so the video plus the track's
+        language is the only thing that identifies what is being worked on."""
+        from subtitles.mass_operations import mass_batch_operation
+
+        mock_collect.return_value = ([
+            {'srt_path': None, 'embedded': True, 'srt_lang': 'en',
+             'video_path': '/video/Show.S01E01.mkv'},
+        ], 0)
+
+        mass_batch_operation(items=[{'type': 'episode', 'sonarrEpisodeId': 1}],
+                             action='translate', job_id='test')
+
+        messages = [c.kwargs.get('progress_message', '')
+                    for c in mock_jq.update_job_progress.call_args_list]
+        assert any('Show.S01E01.mkv' in m and 'en' in m for m in messages), messages
+        assert not any('None' in m for m in messages), messages
+
+    @patch('subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations._process_subtitle_item', return_value=True)
+    @patch('subtitles.mass_operations._collect_subtitle_items')
+    def test_a_file_item_still_names_the_subtitle(self, mock_collect, mock_process, mock_jq):
+        from subtitles.mass_operations import mass_batch_operation
+
+        mock_collect.return_value = ([
+            {'srt_path': '/subs/ep1.en.srt', 'video_path': '/video/ep1.mkv'},
+        ], 0)
+
+        mass_batch_operation(items=[{'type': 'episode', 'sonarrEpisodeId': 1}],
+                             action='sync', job_id='test')
+
+        messages = [c.kwargs.get('progress_message', '')
+                    for c in mock_jq.update_job_progress.call_args_list]
+        assert any('ep1.en.srt' in m for m in messages), messages
+
+    @patch('subtitles.mass_operations.jobs_queue')
+    @patch('subtitles.mass_operations._process_subtitle_item', side_effect=RuntimeError('boom'))
+    @patch('subtitles.mass_operations._collect_subtitle_items')
+    def test_an_embedded_item_that_raises_is_counted_not_fatal(
+            self, mock_collect, mock_process, mock_jq):
+        from subtitles.mass_operations import mass_batch_operation
+
+        mock_collect.return_value = ([
+            {'srt_path': None, 'embedded': True, 'srt_lang': 'en',
+             'video_path': '/video/ep1.mkv'},
+            {'srt_path': None, 'embedded': True, 'srt_lang': 'en',
+             'video_path': '/video/ep2.mkv'},
+        ], 0)
+
+        result = mass_batch_operation(items=[{'type': 'episode', 'sonarrEpisodeId': 1}],
+                                      action='translate', job_id='test')
+
+        assert mock_process.call_count == 2
+        assert len(result['errors']) == 2
+
+
+class TestSubtitleVariantParsing:
+    """A track can be both hearing-impaired and forced.
+
+    The indexer writes `en:hi:forced` for one, appending hi and then forced.
+    `languages_from_colon_seperated_string` reads only the first modifier, so
+    it reports such a track as hi and not forced, which both lets it past the
+    forced guard and mis-selects the stream at extraction time.
+    """
+
+    def test_both_modifiers_are_read_not_just_the_first(self):
+        from subtitles.mass_operations import _subtitle_variant_key
+
+        assert _subtitle_variant_key('en:hi:forced') == ('en', True, True)
+        assert _subtitle_variant_key('en:forced:hi') == ('en', True, True)
+
+    def test_a_single_modifier_still_reads_the_way_it_always_did(self):
+        from subtitles.mass_operations import _subtitle_variant_key
+
+        assert _subtitle_variant_key('en') == ('en', False, False)
+        assert _subtitle_variant_key('en:hi') == ('en', True, False)
+        assert _subtitle_variant_key('en:forced') == ('en', False, True)
+
+    def test_an_unrelated_modifier_does_not_set_a_flag(self):
+        from subtitles.mass_operations import _subtitle_variant_key
+
+        assert _subtitle_variant_key('en:sync-ffsubsync') == ('en', False, False)
+        assert _subtitle_variant_key('en:combined-hu') == ('en', False, False)
+
+    def test_a_forced_and_hi_embedded_track_is_not_queued_for_translation(self):
+        """The forced guard has to fire for it, the same as a plainly forced
+        track: a forced subtitle is signs and songs, not dialogue."""
+        from unittest.mock import MagicMock, patch
+
+        with patch('subtitles.mass_operations.settings') as settings, \
+             patch('subtitles.mass_operations.database') as db, \
+             patch('subtitles.mass_operations.path_mappings') as paths, \
+             patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set()), \
+             patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set()):
+            from subtitles.mass_operations import _collect_subtitle_items
+
+            settings.subsync.max_offset_seconds = 60
+            settings.subsync.gss = True
+            settings.subsync.no_fix_framerate = True
+            settings.general.use_embedded_subs = True
+            paths.path_replace_instance.side_effect = lambda p, *a, **kw: p
+
+            ep = MagicMock()
+            ep.sonarrEpisodeId, ep.sonarrSeriesId = 1, 10
+            ep.path = '/video/ep1.mkv'
+            ep.subtitles = "[['en:hi:forced', None, None]]"
+            db.execute.return_value.all.return_value = [ep]
+
+            items, skipped = _collect_subtitle_items(
+                [{'type': 'episode', 'sonarrEpisodeId': 1}], action='translate',
+                options={'from_lang': 'en', 'to_lang': 'nl'})
+
+        assert items == []
+        assert skipped == 1
+
+
+class TestEmbeddedExtractionCarriesTheOwningInstance:
+    """#156: the collector maps forward per instance, so extraction must
+    reverse with the same one. Without it every embedded item on a secondary
+    instance fails, and the warning blames a bitmap codec."""
+
+    @patch('subtitles.tools.translate.main.translate_subtitles_file', return_value=True)
+    @patch('subtitles.tools.translate.batch.extract_embedded_subtitle',
+           return_value='/config/extracted_subs/ep.srt')
+    def test_the_owning_instance_reaches_the_extractor(self, mock_extract, _translate):
+        from subtitles.mass_operations import _process_subtitle_item
+
+        item = {
+            'video_path': '/media4k/Show/ep.mkv', 'srt_path': None, 'srt_lang': 'en',
+            'embedded': True, 'forced': False, 'hi': False,
+            'sonarr_series_id': 10, 'sonarr_episode_id': 1, 'radarr_id': None,
+            'arr_instance_id': 4, 'metadata': MagicMock(),
+        }
+
+        _process_subtitle_item(item, 'translate', {'from_lang': 'en', 'to_lang': 'nl'}, 'job')
+
+        assert mock_extract.call_args.kwargs['arr_instance_id'] == 4

--- a/tests/bazarr/test_mass_operations.py
+++ b/tests/bazarr/test_mass_operations.py
@@ -1368,3 +1368,221 @@ class TestMassBatchOperationProcessing:
         assert result['queued'] == 3
         assert result['skipped'] == 2  # the 2 skipped from _collect_subtitle_items
         assert mock_process.call_count == 3
+
+
+class TestMassTranslateFromEmbeddedTracks:
+    """Mass translate sourcing from an embedded track.
+
+    A user with anime libraries whose only English subtitles are inside the
+    container could translate one episode at a time but not a series: the
+    collector kept only entries carrying a path, and the indexer records an
+    embedded track as ``[language, None, None]``.
+    """
+
+    def _episode(self, ep_id=1, series_id=10, path='/video/ep1.mkv', subtitles=None):
+        ep = MagicMock()
+        ep.sonarrEpisodeId = ep_id
+        ep.sonarrSeriesId = series_id
+        ep.path = path
+        ep.subtitles = subtitles if subtitles is not None else "[['en', None, None]]"
+        return ep
+
+    def _collect(self, mock_db, episode, action='translate', options=None):
+        from subtitles.mass_operations import _collect_subtitle_items
+
+        mock_db.execute.return_value.all.return_value = [episode]
+        return _collect_subtitle_items(
+            [{'type': 'episode', 'sonarrEpisodeId': episode.sonarrEpisodeId}],
+            action=action,
+            options=options if options is not None else {'from_lang': 'en', 'to_lang': 'nl'})
+
+    @staticmethod
+    def _wire(mock_settings, mock_path_map, mock_lang):
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_path_map.path_replace_instance.side_effect = lambda p, *a, **kw: p
+        mock_path_map.path_replace_reverse_instance.side_effect = lambda p, *a, **kw: p
+        mock_lang.return_value = {'language': 'en', 'forced': False, 'hi': False}
+
+    # --- collecting -------------------------------------------------------
+
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=False)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
+    def test_an_embedded_track_becomes_a_translate_source(
+            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile, mock_lang):
+        self._wire(mock_settings, mock_path_map, mock_lang)
+
+        items, skipped = self._collect(mock_db, self._episode())
+
+        assert len(items) == 1
+        assert items[0]['embedded'] is True
+        assert items[0]['srt_path'] is None
+        assert items[0]['srt_lang'] == 'en'
+        assert items[0]['video_path'] == '/video/ep1.mkv'
+
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=False)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
+    def test_sync_still_skips_an_embedded_track(
+            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile, mock_lang):
+        """There is no file to sync, and no useful one to produce."""
+        self._wire(mock_settings, mock_path_map, mock_lang)
+
+        items, skipped = self._collect(mock_db, self._episode(), action='sync', options={})
+
+        assert items == []
+        assert skipped == 1
+
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=False)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
+    def test_a_mod_action_still_skips_an_embedded_track(
+            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile, mock_lang):
+        self._wire(mock_settings, mock_path_map, mock_lang)
+
+        items, skipped = self._collect(mock_db, self._episode(),
+                                       action='remove_HI', options={})
+
+        assert items == []
+        assert skipped == 1
+
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
+    def test_a_real_file_wins_over_the_embedded_track_of_the_same_language(
+            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile, mock_lang):
+        """Queueing both would run the same translation twice into one output."""
+        self._wire(mock_settings, mock_path_map, mock_lang)
+        episode = self._episode(
+            subtitles="[['en', None, None], ['en', '/subs/ep1.en.srt', 100]]")
+
+        items, _skipped = self._collect(mock_db, episode)
+
+        assert len(items) == 1
+        assert items[0]['srt_path'] == '/subs/ep1.en.srt'
+        assert not items[0].get('embedded')
+
+    @patch('subtitles.mass_operations.languages_from_colon_seperated_string')
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
+    def test_an_item_that_already_has_the_target_language_is_still_skipped(
+            self, mock_settings, mock_db, _sm, _se, mock_path_map, _isfile, mock_lang):
+        self._wire(mock_settings, mock_path_map, mock_lang)
+        episode = self._episode(subtitles="[['en', None, None], ['nl', None, None]]")
+
+        items, skipped = self._collect(mock_db, episode)
+
+        assert items == []
+        assert skipped == 1
+
+    # --- processing -------------------------------------------------------
+
+    def _embedded_item(self, **overrides):
+        item = {
+            'video_path': '/video/ep1.mkv',
+            'srt_path': None,
+            'srt_lang': 'en',
+            'embedded': True,
+            'forced': False,
+            'hi': False,
+            'sonarr_series_id': 10,
+            'sonarr_episode_id': 1,
+            'radarr_id': None,
+            'arr_instance_id': None,
+            'metadata': MagicMock(),
+        }
+        item.update(overrides)
+        return item
+
+    @patch('subtitles.tools.translate.main.translate_subtitles_file', return_value=True)
+    @patch('subtitles.tools.translate.batch.extract_embedded_subtitle',
+           return_value='/config/extracted_subs/ep1.en.srt')
+    def test_the_track_is_extracted_when_the_item_runs_not_when_it_is_collected(
+            self, mock_extract, mock_translate):
+        """A whole-library batch must not extract every track up front."""
+        from subtitles.mass_operations import _process_subtitle_item
+
+        assert _process_subtitle_item(self._embedded_item(), 'translate',
+                                      {'from_lang': 'en', 'to_lang': 'nl'}, 'job') is True
+
+        mock_extract.assert_called_once_with('/video/ep1.mkv', 'en', 'episode',
+                                             hi=False, forced=False)
+        assert mock_translate.call_args[1]['source_srt_file'] == \
+            '/config/extracted_subs/ep1.en.srt'
+        assert mock_translate.call_args[1]['to_lang'] == 'nl'
+
+    @patch('subtitles.tools.translate.main.translate_subtitles_file')
+    @patch('subtitles.tools.translate.batch.extract_embedded_subtitle', return_value=None)
+    def test_a_track_that_cannot_be_extracted_fails_only_its_own_item(
+            self, mock_extract, mock_translate):
+        """A bitmap track such as PGS cannot become an SRT. That is this item's
+        problem, not the batch's."""
+        from subtitles.mass_operations import _process_subtitle_item
+
+        assert _process_subtitle_item(self._embedded_item(), 'translate',
+                                      {'from_lang': 'en', 'to_lang': 'nl'}, 'job') is False
+        mock_translate.assert_not_called()
+
+    @patch('subtitles.tools.translate.main.translate_subtitles_file', return_value=True)
+    @patch('subtitles.tools.translate.batch.extract_embedded_subtitle',
+           return_value='/config/extracted_subs/movie.en.srt')
+    def test_a_movie_track_is_extracted_as_a_movie(self, mock_extract, mock_translate):
+        from subtitles.mass_operations import _process_subtitle_item
+
+        item = self._embedded_item(sonarr_series_id=None, sonarr_episode_id=None,
+                                   radarr_id=5, video_path='/video/movie.mkv')
+
+        assert _process_subtitle_item(item, 'translate',
+                                      {'from_lang': 'en', 'to_lang': 'nl'}, 'job') is True
+
+        mock_extract.assert_called_once_with('/video/movie.mkv', 'en', 'movies',
+                                             hi=False, forced=False)
+
+    @patch('subtitles.tools.translate.main.translate_subtitles_file', return_value=True)
+    @patch('subtitles.tools.translate.batch.extract_embedded_subtitle',
+           return_value='/config/extracted_subs/ep1.en.hi.srt')
+    def test_the_source_variant_flags_reach_the_extractor(self, mock_extract, _translate):
+        """The cache key encodes hi and forced, and the wrong track would be a
+        silently different subtitle."""
+        from subtitles.mass_operations import _process_subtitle_item
+
+        item = self._embedded_item(hi=True, forced=False)
+        _process_subtitle_item(item, 'translate', {'from_lang': 'en', 'to_lang': 'nl'}, 'job')
+
+        mock_extract.assert_called_once_with('/video/ep1.mkv', 'en', 'episode',
+                                             hi=True, forced=False)
+
+    @patch('subtitles.tools.translate.main.translate_subtitles_file', return_value=True)
+    @patch('subtitles.tools.translate.batch.extract_embedded_subtitle')
+    def test_an_ordinary_file_item_never_reaches_the_extractor(
+            self, mock_extract, mock_translate):
+        from subtitles.mass_operations import _process_subtitle_item
+
+        item = self._embedded_item(embedded=False, srt_path='/subs/ep1.en.srt')
+
+        assert _process_subtitle_item(item, 'translate',
+                                      {'from_lang': 'en', 'to_lang': 'nl'}, 'job') is True
+        mock_extract.assert_not_called()
+        assert mock_translate.call_args[1]['source_srt_file'] == '/subs/ep1.en.srt'

--- a/tests/bazarr/test_mass_operations.py
+++ b/tests/bazarr/test_mass_operations.py
@@ -1746,3 +1746,52 @@ class TestEmbeddedExtractionCarriesTheOwningInstance:
         _process_subtitle_item(item, 'translate', {'from_lang': 'en', 'to_lang': 'nl'}, 'job')
 
         assert mock_extract.call_args.kwargs['arr_instance_id'] == 4
+
+
+class TestDuplicateEmbeddedTracks:
+    """A container often carries the same language twice.
+
+    The indexer appends one entry per track with no de-duplication, so two
+    English tracks become two identical pathless entries. Both would extract
+    the same stream, translate it twice and overwrite one output, which on a
+    paid translator is billed twice.
+    """
+
+    def test_identical_embedded_entries_collapse_to_one(self):
+        from subtitles.mass_operations import _drop_embedded_duplicates
+
+        subtitles = [('en', None), ('en', None), ('fr', None)]
+
+        kept = _drop_embedded_duplicates(subtitles, lambda lang, path: True)
+
+        assert kept == [('en', None), ('fr', None)]
+
+    def test_different_variants_of_one_language_both_survive(self):
+        """en and en:hi extract different streams and write different files."""
+        from subtitles.mass_operations import _drop_embedded_duplicates
+
+        subtitles = [('en', None), ('en:hi', None)]
+
+        kept = _drop_embedded_duplicates(subtitles, lambda lang, path: True)
+
+        assert kept == [('en', None), ('en:hi', None)]
+
+    def test_a_file_still_beats_the_embedded_track_it_covers(self):
+        from subtitles.mass_operations import _drop_embedded_duplicates
+
+        subtitles = [('en', None), ('en', '/subs/a.en.srt'), ('en', None)]
+
+        kept = _drop_embedded_duplicates(subtitles, lambda lang, path: True)
+
+        assert kept == [('en', '/subs/a.en.srt')]
+
+    def test_duplicate_files_are_left_alone(self):
+        """Only the embedded side is de-duplicated here; two real files are
+        somebody else's problem and were never touched by this."""
+        from subtitles.mass_operations import _drop_embedded_duplicates
+
+        subtitles = [('en', '/subs/a.en.srt'), ('en', '/subs/b.en.srt')]
+
+        kept = _drop_embedded_duplicates(subtitles, lambda lang, path: True)
+
+        assert len(kept) == 2


### PR DESCRIPTION
## The report

A user with anime libraries where the only English subtitles are embedded in the container wanted Dutch across a whole series, and concluded it could not be done without other software.

He was half right. Bazarr+ translates from an embedded track today, but only one item at a time, from that subtitle's own menu in the item view. There was no batch path.

## Why the batch could not see them

The indexer records an in-container track as `[language, None, None]`. `_parse_subtitles_column` kept only entries whose path was truthy, so every embedded track was dropped before the batch was assembled, and the `os.path.isfile` check downstream would have dropped them anyway. The result was a run that reported everything as skipped with nothing said about why.

`extract_embedded_subtitle` was written for exactly this. Its docstring names "callers (API and batch)" as the reason it exists, and it caches on the video plus the language plus the hi and forced flags. Only the API half had ever been wired up.

## What changed

- `_parse_subtitles_column` takes `include_embedded`, off by default, so callers that want a file they can open are unaffected.
- Both collectors read embedded entries and, for translate only, emit them as sources carrying the language and variant flags instead of a path.
- Extraction happens when the item runs, not when the batch is collected, so a library-wide run does not write a file for every track it may never reach.
- A track that cannot be extracted, in practice a bitmap one such as PGS or VobSub, fails its own item and leaves the rest of the batch alone.
- Sync and the mod actions still skip embedded tracks, and now count them as skipped rather than dropping them silently, so the tally matches what was in the library.
- Where a language already exists as a file, the embedded track of that same language is not queued as a second source. Both would translate into the same output file and race each other for it.
- The "target language already present" skip now sees embedded tracks too. That is consistent: they are only indexed at all when the user has embedded subtitles turned on.

The mass translate form already offers every enabled language as a source rather than deriving the list from what is on disk, so it reaches this with no change. Its note now mentions that a text track inside the video counts, because it did not before and now does.

## Tests

11 new tests in `tests/bazarr/test_mass_operations.py`: an embedded track becoming a source; sync and the mod actions still skipping it; the file winning over the embedded track of the same language; the target-language skip; extraction happening at run time with the right media type and variant flags; a failed extraction failing only its own item; and an ordinary file item never reaching the extractor.

Local: ruff clean, 1896 backend tests pass, eslint/tsc/prettier clean, 884 frontend tests pass.