### PR TITLE
fix(metadata): key the ffprobe cache by the owning instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,8 @@ jobs:
             tests/bazarr/test_mass_operations.py \
             tests/bazarr/test_embedded_extraction_instance_scope.py \
             tests/bazarr/test_ffprobe_cache_instance_scope.py \
+            tests/bazarr/test_parser_owner_threading.py \
+            tests/bazarr/test_embedded_translate_api_scope.py \
             tests/bazarr/test_release_type_mismatch_migration.py \
             tests/bazarr/test_upstream_db_adoption.py \
             tests/bazarr/test_upstream_db_adoption_pg.py ; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,7 @@ jobs:
             tests/bazarr/test_threading_followup.py \
             tests/bazarr/test_mass_operations.py \
             tests/bazarr/test_embedded_extraction_instance_scope.py \
+            tests/bazarr/test_ffprobe_cache_instance_scope.py \
             tests/bazarr/test_release_type_mismatch_migration.py \
             tests/bazarr/test_upstream_db_adoption.py \
             tests/bazarr/test_upstream_db_adoption_pg.py ; do

--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -275,7 +275,11 @@ class Subtitles(Resource):
                 ep_meta = database.execute(ep_stmt).first()
                 if not ep_meta:
                     return "Episode not found", 404
-                embedded_video_path = path_mappings.path_replace(ep_meta.path)
+                # The owning instance's mapping, not the global one: extraction
+                # reverses this path with path_replace_reverse_instance, and the
+                # two only round-trip when the same mapping made both.
+                embedded_video_path = path_mappings.path_replace_instance(
+                    ep_meta.path, arr_instance_id, 'episode')
             else:
                 mv_stmt = scoped(
                     select(TableMovies.path).where(TableMovies.radarrId == id),
@@ -285,7 +289,8 @@ class Subtitles(Resource):
                 mv_meta = database.execute(mv_stmt).first()
                 if not mv_meta:
                     return "Movie not found", 404
-                embedded_video_path = path_mappings.path_replace_movie(mv_meta.path)
+                embedded_video_path = path_mappings.path_replace_instance(
+                    mv_meta.path, arr_instance_id, 'movie')
 
             extracted = extract_embedded_subtitle(
                 embedded_video_path,
@@ -293,6 +298,7 @@ class Subtitles(Resource):
                 media_type,
                 hi=source_hi,
                 forced=source_forced,
+                arr_instance_id=arr_instance_id,
             )
             if not extracted:
                 return (

--- a/bazarr/radarr/sync/movies.py
+++ b/bazarr/radarr/sync/movies.py
@@ -282,7 +282,8 @@ def update_movies(job_id=None, wait_for_completion=False, arr_instance_id=None, 
                                                            tags_dict=tagsDict,
                                                            language_profiles=language_profiles,
                                                            movie_default_profile=movie_default_profile,
-                                                           audio_profiles=audio_profiles)
+                                                           audio_profiles=audio_profiles,
+                                                           arr_instance_id=instance_id)
                                 cached_db_row = current_movies_in_db_dict[movie['id']]
                                 if not (parsed_movie.items() <= cached_db_row.items()):
                                     # Stamp AFTER the subset-diff so the added
@@ -295,7 +296,8 @@ def update_movies(job_id=None, wait_for_completion=False, arr_instance_id=None, 
                                                            tags_dict=tagsDict,
                                                            language_profiles=language_profiles,
                                                            movie_default_profile=movie_default_profile,
-                                                           audio_profiles=audio_profiles)
+                                                           audio_profiles=audio_profiles,
+                                                           arr_instance_id=instance_id)
                                 stamp_owner(parsed_movie, instance_id)
                                 add_movie(parsed_movie)
                                 movies_added.append(parsed_movie['title'])
@@ -401,10 +403,12 @@ def update_one_movie(movie_id, action, defer_search=False, is_signalr=False,
         else:
             if action == 'updated' and existing_movie:
                 movie = movieParser(movie_data, action='update', tags_dict=tagsDict, language_profiles=language_profiles,
-                                    movie_default_profile=movie_default_profile, audio_profiles=audio_profiles)
+                                    movie_default_profile=movie_default_profile, audio_profiles=audio_profiles,
+                                    arr_instance_id=arr_instance_id)
             elif action == 'updated' and not existing_movie:
                 movie = movieParser(movie_data, action='insert', tags_dict=tagsDict, language_profiles=language_profiles,
-                                    movie_default_profile=movie_default_profile, audio_profiles=audio_profiles)
+                                    movie_default_profile=movie_default_profile, audio_profiles=audio_profiles,
+                                    arr_instance_id=arr_instance_id)
     except Exception:
         logging.exception('BAZARR cannot get movie returned by SignalR feed from Radarr API.')
         return

--- a/bazarr/radarr/sync/movies.py
+++ b/bazarr/radarr/sync/movies.py
@@ -404,11 +404,11 @@ def update_one_movie(movie_id, action, defer_search=False, is_signalr=False,
             if action == 'updated' and existing_movie:
                 movie = movieParser(movie_data, action='update', tags_dict=tagsDict, language_profiles=language_profiles,
                                     movie_default_profile=movie_default_profile, audio_profiles=audio_profiles,
-                                    arr_instance_id=arr_instance_id)
+                                    arr_instance_id=instance_id)
             elif action == 'updated' and not existing_movie:
                 movie = movieParser(movie_data, action='insert', tags_dict=tagsDict, language_profiles=language_profiles,
                                     movie_default_profile=movie_default_profile, audio_profiles=audio_profiles,
-                                    arr_instance_id=arr_instance_id)
+                                    arr_instance_id=instance_id)
     except Exception:
         logging.exception('BAZARR cannot get movie returned by SignalR feed from Radarr API.')
         return

--- a/bazarr/radarr/sync/parser.py
+++ b/bazarr/radarr/sync/parser.py
@@ -21,7 +21,8 @@ def get_matching_profile(tags, language_profiles):
     return matching_profile
 
 
-def movieParser(movie, action, tags_dict, language_profiles, movie_default_profile, audio_profiles):
+def movieParser(movie, action, tags_dict, language_profiles, movie_default_profile, audio_profiles,
+                arr_instance_id=None):
     if 'movieFile' in movie:
         try:
             overview = str(movie['overview'])
@@ -100,7 +101,8 @@ def movieParser(movie, action, tags_dict, language_profiles, movie_default_profi
             audio_language = embedded_audio_reader(path_mappings.path_replace_movie(movie['movieFile']['path']),
                                                    file_size=movie['movieFile']['size'],
                                                    movie_file_id=movie['movieFile']['id'],
-                                                   use_cache=True)
+                                                   use_cache=True,
+                                                   arr_instance_id=arr_instance_id)
         else:
             audio_language = []
             if get_radarr_info.is_legacy():

--- a/bazarr/sonarr/sync/episodes.py
+++ b/bazarr/sonarr/sync/episodes.py
@@ -141,6 +141,18 @@ def sync_episodes(series_id, defer_search=False, is_signalr=False, episodes_data
     else:
         episodes = episodes_data
     if episodes:
+        # Episodes inherit their owning instance (and local series ref) from
+        # their parent series. Resolved BEFORE parsing, not after: episodeParser
+        # reads the embedded audio track, and that metadata cache is keyed by
+        # the owning instance, so handing it the requested scope (None on every
+        # default-instance path) would leave the cache query unscoped. Falls
+        # back to the default instance when the parent is unstamped; leaves both
+        # unset for a pre-backfill install. When this sync is instance-scoped,
+        # the explicit instance owns the episodes.
+        owner_instance_id, parent_local_id = sonarr_series_owner(database, series_id, arr_instance_id)
+        if arr_instance_id is not None:
+            owner_instance_id = arr_instance_id
+
         sonarr_version = get_sonarr_info.semver()
         if sonarr_version and sonarr_version >= semver.Version(*(4, 0, 9, 2421)):
             # We skip this if the episodes already contain an episodeFile structure (added with Sonarr v4.0.9.2421)
@@ -191,11 +203,11 @@ def sync_episodes(series_id, defer_search=False, is_signalr=False, episodes_data
 
                     # Parse episode data
                     if episode['id'] in current_episodes_in_db_row_as_dict:
-                        parsed_episode = episodeParser(episode, arr_instance_id=arr_instance_id)
+                        parsed_episode = episodeParser(episode, arr_instance_id=owner_instance_id)
                         if not set(parsed_episode.items()).issubset(set(current_episodes_in_db_row_as_dict[episode['id']].items())):
                             episodes_to_update.append(parsed_episode)
                     else:
-                        episodes_to_add.append(episodeParser(episode, arr_instance_id=arr_instance_id))
+                        episodes_to_add.append(episodeParser(episode, arr_instance_id=owner_instance_id))
     else:
         return
 
@@ -209,14 +221,6 @@ def sync_episodes(series_id, defer_search=False, is_signalr=False, episodes_data
     episodes_to_delete = list(set(current_episodes_id_db_list) - set(current_episodes_sonarr))
 
     rows_changed = False
-
-    # Episodes inherit their owning instance (and local series ref) from their
-    # parent series, resolved once here. Falls back to the default instance when
-    # the parent is unstamped; leaves both unset for a pre-backfill install. When
-    # this sync is instance-scoped, the explicit instance owns the episodes.
-    owner_instance_id, parent_local_id = sonarr_series_owner(database, series_id, arr_instance_id)
-    if arr_instance_id is not None:
-        owner_instance_id = arr_instance_id
 
     if len(episodes_to_delete):
         # Before the row goes: the mismatch record points at the local id with
@@ -394,7 +398,23 @@ def sync_one_episode(episode_id, defer_search=False, is_signalr=False,
                     get_episodesFiles_from_sonarr_api(apikey_sonarr=apikey_sonarr,
                                                       episode_file_id=episode_data['episodeFileId'],
                                                       arr_client=arr_client)
-            episode = episodeParser(episode_data, arr_instance_id=arr_instance_id)
+            # Resolve the owning instance (and local series ref) from the parent
+            # series BEFORE parsing. episodeParser reads the embedded audio
+            # track, and that metadata cache is keyed by the owning instance, so
+            # the requested scope (None on every default/legacy entry point)
+            # would leave the cache query unscoped. The upstream payload's
+            # seriesId is what the parser itself stores as sonarrSeriesId.
+            # seriesId is read defensively: a payload without it cannot be
+            # parsed into a writable episode anyway, and the delete path used to
+            # reach the parser without resolving an owner at all. Raising here
+            # would land in the except below and abort the sync silently.
+            owner_instance_id = parent_local_id = None
+            if episode_data.get('seriesId') is not None:
+                owner_instance_id, parent_local_id = sonarr_series_owner(
+                    database, episode_data['seriesId'], arr_instance_id)
+                if arr_instance_id is not None:
+                    owner_instance_id = arr_instance_id
+            episode = episodeParser(episode_data, arr_instance_id=owner_instance_id)
     except Exception:
         logging.exception('BAZARR cannot get episode returned by SignalR feed from Sonarr API.')
         return
@@ -402,15 +422,6 @@ def sync_one_episode(episode_id, defer_search=False, is_signalr=False,
     # Drop useless events
     if not episode and not existing_episode:
         return
-
-    # Resolve the owning instance + local series ref from the parent series for
-    # the write branches below (episode is None only on the delete path, which
-    # needs neither). Guarded so a pre-backfill install stays NULL.
-    owner_instance_id = parent_local_id = None
-    if episode:
-        owner_instance_id, parent_local_id = sonarr_series_owner(database, episode['sonarrSeriesId'], arr_instance_id)
-        if arr_instance_id is not None:
-            owner_instance_id = arr_instance_id
 
     # Remove episode from DB
     if not episode and existing_episode:

--- a/bazarr/sonarr/sync/parser.py
+++ b/bazarr/sonarr/sync/parser.py
@@ -111,7 +111,8 @@ def episodeParser(episode, arr_instance_id=None):
                                                                                           ['path']),
                                                                file_size=episode['episodeFile']['size'],
                                                                episode_file_id=episode['episodeFile']['id'],
-                                                               use_cache=True)
+                                                               use_cache=True,
+                                                               arr_instance_id=arr_instance_id)
                     else:
                         audio_language = []
                         if 'language' in episode['episodeFile'] and len(episode['episodeFile']['language']):

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -64,7 +64,8 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
                     subtitle_languages = embedded_subs_reader(reversed_path,
                                                               file_size=item.file_size,
                                                               movie_file_id=item.movie_file_id,
-                                                              use_cache=use_cache)
+                                                              use_cache=use_cache,
+                                                              arr_instance_id=owner_instance_id)
                     for subtitle_language, subtitle_forced, subtitle_hi, subtitle_codec in subtitle_languages:
                         try:
                             if (settings.general.ignore_pgs_subs and subtitle_codec.lower() == "pgs") or \

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -65,7 +65,8 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
                     subtitle_languages = embedded_subs_reader(reversed_path,
                                                               file_size=item.file_size,
                                                               episode_file_id=item.episode_file_id,
-                                                              use_cache=use_cache)
+                                                              use_cache=use_cache,
+                                                              arr_instance_id=owner_instance_id)
                     for subtitle_language, subtitle_forced, subtitle_hi, subtitle_codec in subtitle_languages:
                         try:
                             if (settings.general.ignore_pgs_subs and subtitle_codec.lower() == "pgs") or \

--- a/bazarr/subtitles/refiners/ffprobe.py
+++ b/bazarr/subtitles/refiners/ffprobe.py
@@ -9,19 +9,30 @@ from guessit.jsonutils import GuessitEncoder
 
 from utilities.path_mappings import path_mappings
 from app.database import TableEpisodes, TableMovies, database, select
+from arr_instances.resolution import scoped
 from utilities.video_analyzer import parse_video_metadata
 
 
 def refine_from_ffprobe(path, video):
+    # The owning instance (#156), set on the video by the database layer. Two
+    # instances can index the same path and hand out the same file id, so both
+    # the row lookup and the metadata cache underneath it have to be scoped or
+    # this reads the other instance's streams.
+    arr_instance_id = getattr(video, 'arr_instance_id', None)
+
     if isinstance(video, Movie):
         file_id = database.execute(
-            select(TableMovies.movie_file_id, TableMovies.file_size)
-            .where(TableMovies.path == path_mappings.path_replace_reverse_movie(path))) \
+            scoped(
+                select(TableMovies.movie_file_id, TableMovies.file_size)
+                .where(TableMovies.path == path_mappings.path_replace_reverse_movie(path)),
+                TableMovies.arr_instance_id, arr_instance_id)) \
             .first()
     else:
         file_id = database.execute(
-            select(TableEpisodes.episode_file_id, TableEpisodes.file_size)
-            .where(TableEpisodes.path == path_mappings.path_replace_reverse(path)))\
+            scoped(
+                select(TableEpisodes.episode_file_id, TableEpisodes.file_size)
+                .where(TableEpisodes.path == path_mappings.path_replace_reverse(path)),
+                TableEpisodes.arr_instance_id, arr_instance_id))\
             .first()
 
     if not file_id:
@@ -29,10 +40,12 @@ def refine_from_ffprobe(path, video):
 
     if isinstance(video, Movie):
         data = parse_video_metadata(file=path, file_size=file_id.file_size,
-                                    movie_file_id=file_id.movie_file_id)
+                                    movie_file_id=file_id.movie_file_id,
+                                    arr_instance_id=arr_instance_id)
     else:
         data = parse_video_metadata(file=path, file_size=file_id.file_size,
-                                    episode_file_id=file_id.episode_file_id)
+                                    episode_file_id=file_id.episode_file_id,
+                                    arr_instance_id=arr_instance_id)
 
     if not data or ('ffprobe' not in data and 'mediainfo' not in data):
         logging.debug(f"No cache available for this file: {path}")  # noqa: G004

--- a/bazarr/subtitles/tools/translate/batch.py
+++ b/bazarr/subtitles/tools/translate/batch.py
@@ -391,7 +391,8 @@ def extract_embedded_subtitle(
         if not media:
             return None
         data = parse_video_metadata(
-            video_path, media.file_size, episode_file_id=media.episode_file_id
+            video_path, media.file_size, episode_file_id=media.episode_file_id,
+            arr_instance_id=arr_instance_id
         )
     else:
         db_path = path_mappings.path_replace_reverse_instance(
@@ -408,7 +409,8 @@ def extract_embedded_subtitle(
         if not media:
             return None
         data = parse_video_metadata(
-            video_path, media.file_size, movie_file_id=media.movie_file_id
+            video_path, media.file_size, movie_file_id=media.movie_file_id,
+            arr_instance_id=arr_instance_id
         )
 
     if not data:

--- a/bazarr/utilities/video_analyzer.py
+++ b/bazarr/utilities/video_analyzer.py
@@ -54,8 +54,10 @@ def _handle_alpha3(detected_language: dict):
     return alpha3
 
 
-def embedded_subs_reader(file, file_size, episode_file_id=None, movie_file_id=None, use_cache=True):
-    data = parse_video_metadata(file, file_size, episode_file_id, movie_file_id, use_cache=use_cache)
+def embedded_subs_reader(file, file_size, episode_file_id=None, movie_file_id=None, use_cache=True,
+                         arr_instance_id=None):
+    data = parse_video_metadata(file, file_size, episode_file_id, movie_file_id, use_cache=use_cache,
+                                arr_instance_id=arr_instance_id)
     und_default_language = alpha3_from_alpha2(settings.general.default_und_embedded_subtitles_lang)
 
     subtitles_list = []
@@ -97,8 +99,10 @@ def embedded_subs_reader(file, file_size, episode_file_id=None, movie_file_id=No
     return subtitles_list
 
 
-def embedded_audio_reader(file, file_size, episode_file_id=None, movie_file_id=None, use_cache=True):
-    data = parse_video_metadata(file, file_size, episode_file_id, movie_file_id, use_cache=use_cache)
+def embedded_audio_reader(file, file_size, episode_file_id=None, movie_file_id=None, use_cache=True,
+                          arr_instance_id=None):
+    data = parse_video_metadata(file, file_size, episode_file_id, movie_file_id, use_cache=use_cache,
+                                arr_instance_id=arr_instance_id)
 
     audio_list = []
 
@@ -150,7 +154,7 @@ def subtitles_sync_references(subtitles_path, sonarr_episode_id=None, radarr_mov
         mapped_path = path_mappings.path_replace(media_data.path)
 
         data = parse_video_metadata(mapped_path, media_data.file_size, media_data.episode_file_id, None,
-                                    use_cache=True)
+                                    use_cache=True, arr_instance_id=arr_instance_id)
     elif radarr_movie_id:
         media_data = database.execute(
             scoped(
@@ -165,7 +169,7 @@ def subtitles_sync_references(subtitles_path, sonarr_episode_id=None, radarr_mov
         mapped_path = path_mappings.path_replace_movie(media_data.path)
 
         data = parse_video_metadata(mapped_path, media_data.file_size, None, media_data.movie_file_id,
-                                    use_cache=True)
+                                    use_cache=True, arr_instance_id=arr_instance_id)
 
     if not data:
         return references_dict
@@ -244,7 +248,8 @@ def subtitles_sync_references(subtitles_path, sonarr_episode_id=None, radarr_mov
     return references_dict
 
 
-def parse_video_metadata(file, file_size, episode_file_id=None, movie_file_id=None, use_cache=True):
+def parse_video_metadata(file, file_size, episode_file_id=None, movie_file_id=None, use_cache=True,
+                         arr_instance_id=None):
     """
     This function return the video file properties as parsed by knowit using ffprobe or mediainfo using the cached
     value by default.
@@ -259,6 +264,11 @@ def parse_video_metadata(file, file_size, episode_file_id=None, movie_file_id=No
     @param movie_file_id: movie ID of the video file from Radarr (or None if it's an episode)
     @type use_cache: bool
     @param use_cache:
+    @type arr_instance_id: int or None
+    @param arr_instance_id: the instance that owns the media (#156). The file ids come from
+        the arr server, so two instances can hand out the same one for different files; without
+        this the cache read can return the other instance's stream list and the write can
+        overwrite its row. None means no filter, which is what a single-instance install passes.
 
     @rtype: dict or None
     @return: return a dictionary including the video file properties as parsed by ffprobe or mediainfo
@@ -278,13 +288,17 @@ def parse_video_metadata(file, file_size, episode_file_id=None, movie_file_id=No
         # Get the actual cache value form database
         if episode_file_id:
             cache_key = database.execute(
-                select(TableEpisodes.ffprobe_cache)
-                .where(TableEpisodes.episode_file_id == episode_file_id)) \
+                scoped(
+                    select(TableEpisodes.ffprobe_cache)
+                    .where(TableEpisodes.episode_file_id == episode_file_id),
+                    TableEpisodes.arr_instance_id, arr_instance_id)) \
                 .first()
         elif movie_file_id:
             cache_key = database.execute(
-                select(TableMovies.ffprobe_cache)
-                .where(TableMovies.movie_file_id == movie_file_id)) \
+                scoped(
+                    select(TableMovies.ffprobe_cache)
+                    .where(TableMovies.movie_file_id == movie_file_id),
+                    TableMovies.arr_instance_id, arr_instance_id)) \
                 .first()
         else:
             cache_key = None
@@ -357,14 +371,18 @@ def parse_video_metadata(file, file_size, episode_file_id=None, movie_file_id=No
     # we write to db the result and return the newly cached ffprobe dict
     if episode_file_id:
         database.execute(
-            update(TableEpisodes)
-            .values(ffprobe_cache=pickle.dumps(data, pickle.HIGHEST_PROTOCOL))
-            .where(TableEpisodes.episode_file_id == episode_file_id))
+            scoped(
+                update(TableEpisodes)
+                .values(ffprobe_cache=pickle.dumps(data, pickle.HIGHEST_PROTOCOL))
+                .where(TableEpisodes.episode_file_id == episode_file_id),
+                TableEpisodes.arr_instance_id, arr_instance_id))
     elif movie_file_id:
         database.execute(
-            update(TableMovies)
-            .values(ffprobe_cache=pickle.dumps(data, pickle.HIGHEST_PROTOCOL))
-            .where(TableMovies.movie_file_id == movie_file_id))
+            scoped(
+                update(TableMovies)
+                .values(ffprobe_cache=pickle.dumps(data, pickle.HIGHEST_PROTOCOL))
+                .where(TableMovies.movie_file_id == movie_file_id),
+                TableMovies.arr_instance_id, arr_instance_id))
     return data
 
 

--- a/tests/bazarr/test_arr_media_defaults.py
+++ b/tests/bazarr/test_arr_media_defaults.py
@@ -299,7 +299,7 @@ def _series_parser_stub(show, action, tags_dict, language_profiles,
 
 
 def _movie_parser_stub(movie, action, tags_dict, language_profiles,
-                       movie_default_profile, audio_profiles):
+                       movie_default_profile, audio_profiles, arr_instance_id=None):
     parsed = {"radarrId": int(movie["id"]), "path": f"/m/{movie['id']}",
               "title": "M", "tmdbId": f"t{movie['id']}", "year": "2020"}
     if action == "insert":

--- a/tests/bazarr/test_embedded_translate_api_scope.py
+++ b/tests/bazarr/test_embedded_translate_api_scope.py
@@ -1,0 +1,115 @@
+# coding=utf-8
+"""The manual embedded-translate endpoint has to stay on the owning instance (#156).
+
+The endpoint already scopes its media lookup by ``arr_instance_id``, then threw
+that away for the two things that matter downstream: it mapped the video path
+with the GLOBAL mapping and called ``extract_embedded_subtitle`` without the
+owner.
+
+Extraction reverses the path with ``path_replace_reverse_instance`` and looks the
+row up scoped. Forward-global plus reverse-per-instance do not round-trip on any
+secondary instance that has its own path mappings, so the row lookup misses and
+the user is told the track is an unsupported bitmap codec. Where the mappings do
+agree, the unscoped metadata cache can still hand back a sibling instance's
+stream list and extract the wrong track.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from app.database import TableEpisodes, TableMovies, TableShows
+
+
+@pytest.fixture
+def endpoint(schema_session, monkeypatch):
+    from api.subtitles import subtitles as api_mod
+
+    monkeypatch.setattr(api_mod, 'database', schema_session)
+    monkeypatch.setattr(api_mod, 'alpha3_from_alpha2', lambda code: 'eng')
+
+    recorded = {'mapped': [], 'extracted': None}
+
+    def _map_instance(path, arr_instance_id, media_type):
+        recorded['mapped'].append((path, arr_instance_id, media_type))
+        return f'/mapped{path}'
+
+    def _map_global(path):
+        recorded['mapped'].append((path, 'GLOBAL', 'episode'))
+        return f'/mapped{path}'
+
+    def _map_global_movie(path):
+        recorded['mapped'].append((path, 'GLOBAL', 'movie'))
+        return f'/mapped{path}'
+
+    monkeypatch.setattr(api_mod.path_mappings, 'path_replace_instance', _map_instance)
+    monkeypatch.setattr(api_mod.path_mappings, 'path_replace', _map_global)
+    monkeypatch.setattr(api_mod.path_mappings, 'path_replace_movie', _map_global_movie)
+
+    def _extract(video_path, language_code2, media_type, hi=False, forced=False,
+                 arr_instance_id=None):
+        recorded['extracted'] = {
+            'video_path': video_path, 'media_type': media_type,
+            'arr_instance_id': arr_instance_id,
+        }
+        return None  # short-circuits the handler right after the call
+
+    monkeypatch.setattr(api_mod, 'extract_embedded_subtitle', _extract)
+
+    def _call(**overrides):
+        args = {
+            'action': 'translate', 'language': 'nl', 'path': '', 'type': 'episode',
+            'id': 42, 'arr_instance_id': 2, 'from_language': 'en',
+            'forced': 'False', 'hi': 'False',
+        }
+        args.update(overrides)
+        stub_self = SimpleNamespace(
+            patch_request_parser=SimpleNamespace(parse_args=lambda: args))
+        return api_mod.Subtitles.patch.__wrapped__(stub_self)
+
+    return _call, recorded
+
+
+def test_the_episode_video_path_is_mapped_for_the_owning_instance(schema_session, endpoint):
+    call, recorded = endpoint
+    schema_session.add(TableShows(id=1, arr_instance_id=2, sonarrSeriesId=7,
+                                  title='S', path='/tv/s', profileId=None))
+    schema_session.flush()
+    schema_session.add(TableEpisodes(id=1, arr_instance_id=2, series_id=1, sonarrSeriesId=7,
+                                     sonarrEpisodeId=42, title='E', path='/tv/s/e.mkv',
+                                     season=1, episode=1))
+    schema_session.commit()
+
+    call()
+
+    assert recorded['mapped'] == [('/tv/s/e.mkv', 2, 'episode')], (
+        'the video path must be mapped with the owning instance mapping, because '
+        f'extraction reverses it with that same one; got {recorded["mapped"]!r}')
+
+
+def test_the_owner_reaches_episode_extraction(schema_session, endpoint):
+    call, recorded = endpoint
+    schema_session.add(TableShows(id=1, arr_instance_id=2, sonarrSeriesId=7,
+                                  title='S', path='/tv/s', profileId=None))
+    schema_session.flush()
+    schema_session.add(TableEpisodes(id=1, arr_instance_id=2, series_id=1, sonarrSeriesId=7,
+                                     sonarrEpisodeId=42, title='E', path='/tv/s/e.mkv',
+                                     season=1, episode=1))
+    schema_session.commit()
+
+    call()
+
+    assert recorded['extracted']['arr_instance_id'] == 2, (
+        'extraction was handed no owner, so its row lookup and metadata cache '
+        'run unscoped')
+
+
+def test_the_owner_reaches_movie_extraction(schema_session, endpoint):
+    call, recorded = endpoint
+    schema_session.add(TableMovies(id=1, arr_instance_id=3, radarrId=9, title='M',
+                                   path='/movies/m.mkv', tmdbId='1'))
+    schema_session.commit()
+
+    call(type='movie', id=9, arr_instance_id=3)
+
+    assert recorded['mapped'] == [('/movies/m.mkv', 3, 'movie')]
+    assert recorded['extracted']['arr_instance_id'] == 3

--- a/tests/bazarr/test_ffprobe_cache_instance_scope.py
+++ b/tests/bazarr/test_ffprobe_cache_instance_scope.py
@@ -1,0 +1,130 @@
+# coding=utf-8
+"""The ffprobe metadata cache has to belong to one instance (#156).
+
+``parse_video_metadata`` cached the parsed stream list against
+``episode_file_id`` or ``movie_file_id`` alone. Those ids come from the arr
+server, so two Sonarr or Radarr instances can hand out the same one for
+different files. When they do, one instance reads the other's cached stream
+list, and probing on either side overwrites the other's row.
+
+Embedded-subtitle extraction picks a stream index out of that list, so a
+collision selects the wrong track and translates a different subtitle than the
+one asked for, with nothing in the log to say so.
+"""
+import pickle
+
+import pytest
+from sqlalchemy import select
+
+from app.database import TableEpisodes, TableMovies, TableShows
+
+
+def _cached(file_id, file_size, parser='ffprobe'):
+    return pickle.dumps({
+        'ffprobe': {'subtitle': [{'name': f'stream-for-{file_id}'}]},
+        'mediainfo': {},
+        'file_id': file_id,
+        'file_size': file_size,
+    }, pickle.HIGHEST_PROTOCOL)
+
+
+@pytest.fixture
+def two_instances(schema_session, monkeypatch):
+    """Two episodes on different instances sharing one episode_file_id."""
+    from app import database as db_module
+
+    monkeypatch.setattr(db_module, 'database', schema_session)
+    import utilities.video_analyzer as va
+    monkeypatch.setattr(va, 'database', schema_session)
+    monkeypatch.setattr(va.settings.general, 'embedded_subtitles_parser', 'ffprobe',
+                        raising=False)
+
+    schema_session.add_all([
+        TableShows(id=1, arr_instance_id=1, sonarrSeriesId=1, title='S', path='/a', profileId=None),
+        TableShows(id=2, arr_instance_id=2, sonarrSeriesId=1, title='S', path='/b', profileId=None),
+    ])
+    schema_session.flush()
+    schema_session.add_all([
+        TableEpisodes(id=1, arr_instance_id=1, series_id=1, sonarrSeriesId=1,
+                      sonarrEpisodeId=1, title='E', path='/a/e.mkv', season=1, episode=1,
+                      episode_file_id=500, file_size=111,
+                      ffprobe_cache=_cached(500, 111)),
+        TableEpisodes(id=2, arr_instance_id=2, series_id=2, sonarrSeriesId=1,
+                      sonarrEpisodeId=1, title='E', path='/b/e.mkv', season=1, episode=1,
+                      episode_file_id=500, file_size=111,
+                      ffprobe_cache=_cached(500, 111)),
+    ])
+    schema_session.commit()
+    return schema_session
+
+
+def test_the_cache_read_is_scoped_to_the_owning_instance(two_instances, monkeypatch):
+    """Without scoping, first() returns whichever row the database felt like."""
+    import utilities.video_analyzer as va
+
+    # Give the two rows distinguishable cached payloads.
+    two_instances.execute(
+        TableEpisodes.__table__.update()
+        .where(TableEpisodes.id == 2)
+        .values(ffprobe_cache=pickle.dumps({
+            'ffprobe': {'subtitle': [{'name': 'second-instance'}]},
+            'mediainfo': {}, 'file_id': 500, 'file_size': 111,
+        }, pickle.HIGHEST_PROTOCOL)))
+    two_instances.commit()
+
+    data = va.parse_video_metadata('/b/e.mkv', 111, episode_file_id=500,
+                                   arr_instance_id=2, use_cache=True)
+
+    assert data['ffprobe']['subtitle'][0]['name'] == 'second-instance'
+
+
+def test_probing_one_instance_leaves_the_other_cache_alone(two_instances, monkeypatch):
+    import utilities.video_analyzer as va
+
+    monkeypatch.setattr(va, 'know', lambda *a, **kw: {'subtitle': [{'name': 'freshly-probed'}]})
+    monkeypatch.setattr(va, 'get_binary', lambda name: '/usr/bin/ffprobe', raising=False)
+
+    va.parse_video_metadata('/a/e.mkv', 999, episode_file_id=500,
+                            arr_instance_id=1, use_cache=False)
+
+    untouched = two_instances.execute(
+        select(TableEpisodes.ffprobe_cache).where(TableEpisodes.id == 2)).scalar()
+    assert pickle.loads(untouched)['file_size'] == 111, \
+        "the other instance's cached metadata was overwritten"
+
+
+def test_without_an_instance_the_behaviour_is_unchanged(two_instances, monkeypatch):
+    """A single-instance install passes None and must read exactly as before."""
+    import utilities.video_analyzer as va
+
+    data = va.parse_video_metadata('/a/e.mkv', 111, episode_file_id=500, use_cache=True)
+
+    assert data is not None
+    assert data['file_id'] == 500
+
+
+def test_the_movie_cache_is_scoped_too(schema_session, monkeypatch):
+    import utilities.video_analyzer as va
+
+    monkeypatch.setattr(va, 'database', schema_session)
+    monkeypatch.setattr(va.settings.general, 'embedded_subtitles_parser', 'ffprobe',
+                        raising=False)
+
+    schema_session.add_all([
+        TableMovies(id=1, arr_instance_id=1, radarrId=1, title='M', path='/a/m.mkv',
+                    tmdbId='1', movie_file_id=700, file_size=222,
+                    ffprobe_cache=pickle.dumps({
+                        'ffprobe': {'subtitle': [{'name': 'first'}]}, 'mediainfo': {},
+                        'file_id': 700, 'file_size': 222}, pickle.HIGHEST_PROTOCOL)),
+        TableMovies(id=2, arr_instance_id=2, radarrId=1, title='M', path='/b/m.mkv',
+                    tmdbId='2', movie_file_id=700, file_size=222,
+                    ffprobe_cache=pickle.dumps({
+                        'ffprobe': {'subtitle': [{'name': 'second'}]}, 'mediainfo': {},
+                        'file_id': 700, 'file_size': 222}, pickle.HIGHEST_PROTOCOL)),
+    ])
+    schema_session.commit()
+
+    data = va.parse_video_metadata('/b/m.mkv', 222, movie_file_id=700,
+                                   arr_instance_id=2, use_cache=True)
+
+    assert data['ffprobe']['subtitle'][0]['name'] == 'second'

--- a/tests/bazarr/test_ffprobe_cache_instance_scope.py
+++ b/tests/bazarr/test_ffprobe_cache_instance_scope.py
@@ -78,14 +78,34 @@ def test_the_cache_read_is_scoped_to_the_owning_instance(two_instances, monkeypa
     assert data['ffprobe']['subtitle'][0]['name'] == 'second-instance'
 
 
-def test_probing_one_instance_leaves_the_other_cache_alone(two_instances, monkeypatch):
+def test_probing_one_instance_leaves_the_other_cache_alone(two_instances, monkeypatch,
+                                                          tmp_path):
+    """The write half of the scoping, which is the half that corrupts data.
+
+    Two things this test has to get right or it asserts nothing at all.
+    ``get_binary`` is imported INSIDE ``parse_video_metadata``, so patching the
+    name on ``video_analyzer`` has no effect; it has to be patched on
+    ``utilities.binaries``. And the function returns early when the video file
+    does not exist, before it ever probes or writes. Miss either and the
+    "other instance untouched" assertion passes because nothing was written to
+    anything, which is why the probed row is asserted too.
+    """
+    import utilities.binaries as binaries
     import utilities.video_analyzer as va
 
-    monkeypatch.setattr(va, 'know', lambda *a, **kw: {'subtitle': [{'name': 'freshly-probed'}]})
-    monkeypatch.setattr(va, 'get_binary', lambda name: '/usr/bin/ffprobe', raising=False)
+    video = tmp_path / 'e.mkv'
+    video.write_bytes(b'stand-in, knowit is stubbed out')
 
-    va.parse_video_metadata('/a/e.mkv', 999, episode_file_id=500,
+    monkeypatch.setattr(va, 'know', lambda *a, **kw: {'subtitle': [{'name': 'freshly-probed'}]})
+    monkeypatch.setattr(binaries, 'get_binary', lambda name: '/usr/bin/ffprobe')
+
+    va.parse_video_metadata(str(video), 999, episode_file_id=500,
                             arr_instance_id=1, use_cache=False)
+
+    probed = two_instances.execute(
+        select(TableEpisodes.ffprobe_cache).where(TableEpisodes.id == 1)).scalar()
+    assert pickle.loads(probed)['ffprobe']['subtitle'][0]['name'] == 'freshly-probed', \
+        'the probe never reached the cache write, so this test proves nothing'
 
     untouched = two_instances.execute(
         select(TableEpisodes.ffprobe_cache).where(TableEpisodes.id == 2)).scalar()

--- a/tests/bazarr/test_parser_owner_threading.py
+++ b/tests/bazarr/test_parser_owner_threading.py
@@ -1,0 +1,159 @@
+# coding=utf-8
+"""The parsers must be handed the RESOLVED owner, not the requested scope (#156).
+
+``movieParser`` and ``episodeParser`` read embedded audio, which now keys the
+ffprobe metadata cache by ``arr_instance_id``. The sync orchestrators resolve
+the real owning instance, but the legacy and SignalR entry points reach the
+parser before that resolution happens and pass the REQUESTED scope, which is
+``None`` on every default-instance path.
+
+``scoped(..., None)`` applies no filter at all, so on a multi-instance install
+with colliding upstream file ids the default instance still reads and
+overwrites a sibling instance's cached stream list. Threading the cache through
+the parser is only worth anything if the value threaded is the owner.
+"""
+import semver
+
+from sqlalchemy import insert
+
+from app.database import TableShows
+
+
+def _noop(*args, **kwargs):
+    return None
+
+
+def _seed_default(session, kind):
+    from arr_instances.repository import ArrInstanceRepository
+
+    inst = ArrInstanceRepository(session).create(kind, kind.capitalize())
+    session.flush()
+    return inst.id
+
+
+class _SonarrInfoStub:
+    def semver(self):
+        return semver.Version(4, 0, 10, 0)
+
+
+class _DummyJobs:
+    def update_job_progress(self, *a, **k):
+        return None
+
+    def update_job_name(self, *a, **k):
+        return None
+
+
+# ------------------------------------------------------------------ radarr
+
+def test_update_one_movie_hands_the_parser_the_resolved_owner(schema_session, monkeypatch):
+    """The legacy/SignalR movie path resolves ``instance_id`` and then passed the
+    unresolved ``arr_instance_id``, leaving the cache query unscoped."""
+    import radarr.sync.movies as mv_mod
+
+    inst = _seed_default(schema_session, "radarr")
+    seen = {}
+
+    monkeypatch.setattr(mv_mod, "database", schema_session)
+    monkeypatch.setattr(mv_mod, "event_stream", _noop)
+    monkeypatch.setattr(mv_mod, "store_subtitles_movie", _noop)
+    monkeypatch.setattr(mv_mod, "get_profile_list", lambda *a, **k: [])
+    monkeypatch.setattr(mv_mod, "get_tags", lambda *a, **k: [])
+    monkeypatch.setattr(mv_mod, "get_language_profiles", lambda *a, **k: [])
+    monkeypatch.setattr(mv_mod, "get_movies_from_radarr_api", lambda *a, **k: {"id": 10})
+
+    def _parser(*a, **k):
+        seen["arr_instance_id"] = k.get("arr_instance_id")
+        return {"radarrId": 10, "title": "M", "path": "/m", "tmdbId": "t10"}
+
+    monkeypatch.setattr(mv_mod, "movieParser", _parser)
+
+    mv_mod.update_one_movie(10, action="updated", defer_search=True)
+
+    assert seen["arr_instance_id"] == inst, (
+        "movieParser must receive the resolved default instance, not None; got "
+        f"{seen['arr_instance_id']!r}")
+
+
+# ------------------------------------------------------------------ sonarr
+
+def _episodes_payload():
+    return [{"id": 100, "hasFile": True, "monitored": True, "episodeFileId": 100,
+             "episodeFile": {"size": 999999, "path": "/tv/s/e"}}]
+
+
+def _parsed_episode():
+    return {"sonarrSeriesId": 5, "sonarrEpisodeId": 100, "path": "/tv/s/e",
+            "season": 1, "episode": 1, "title": "E", "monitored": "True"}
+
+
+def _patch_episode_sync(monkeypatch, session, seen):
+    import sonarr.sync.episodes as ep_mod
+
+    monkeypatch.setattr(ep_mod, "database", session)
+    monkeypatch.setattr(ep_mod, "store_subtitles", _noop)
+    monkeypatch.setattr(ep_mod, "event_stream", _noop)
+    monkeypatch.setattr(ep_mod, "get_sonarr_info", _SonarrInfoStub())
+
+    def _parser(episode, **kwargs):
+        seen.append(kwargs.get("arr_instance_id"))
+        return _parsed_episode()
+
+    monkeypatch.setattr(ep_mod, "episodeParser", _parser)
+    return ep_mod
+
+
+def test_sync_episodes_hands_the_parser_the_parent_owner(schema_session, monkeypatch):
+    """The default bulk path passed None even though the parent series resolves
+    to the default instance a line later."""
+    inst = _seed_default(schema_session, "sonarr")
+    schema_session.execute(insert(TableShows).values(
+        sonarrSeriesId=5, id=5, arr_instance_id=inst, path="/tv/s", title="S",
+        audio_language="[]"))
+    seen = []
+    ep_mod = _patch_episode_sync(monkeypatch, schema_session, seen)
+
+    ep_mod.sync_episodes(series_id=5, episodes_data=_episodes_payload(), defer_search=True)
+
+    assert seen == [inst], (
+        f"episodeParser must be given the parent's owning instance; got {seen!r}")
+
+
+def test_sync_episodes_hands_the_parser_a_nondefault_parent_owner(schema_session, monkeypatch):
+    """A series owned by a secondary instance must not have its episodes parsed
+    against the default instance's cache."""
+    _seed_default(schema_session, "sonarr")
+    schema_session.execute(insert(TableShows).values(
+        sonarrSeriesId=5, id=77, arr_instance_id=2, path="/tv/s", title="S",
+        audio_language="[]"))
+    seen = []
+    ep_mod = _patch_episode_sync(monkeypatch, schema_session, seen)
+
+    ep_mod.sync_episodes(series_id=5, episodes_data=_episodes_payload(), defer_search=True)
+
+    assert seen == [2], (
+        f"episodeParser must inherit the parent series' instance; got {seen!r}")
+
+
+def test_sync_one_episode_hands_the_parser_the_parent_owner(schema_session, monkeypatch):
+    """The SignalR/webhook single-episode path resolves the owner only after
+    parsing, so the parser saw None."""
+    inst = _seed_default(schema_session, "sonarr")
+    schema_session.execute(insert(TableShows).values(
+        sonarrSeriesId=5, id=5, arr_instance_id=inst, path="/tv/s", title="S",
+        audio_language="[]"))
+    seen = []
+    ep_mod = _patch_episode_sync(monkeypatch, schema_session, seen)
+    monkeypatch.setattr(ep_mod, "jobs_queue", _DummyJobs(), raising=False)
+    monkeypatch.setattr(
+        ep_mod, "get_episodes_from_sonarr_api",
+        lambda *a, **k: {"id": 100, "seriesId": 5, "hasFile": True,
+                         "episodeFileId": 100,
+                         "episodeFile": {"size": 999999, "path": "/tv/s/e"}})
+    monkeypatch.setattr(ep_mod, "get_episodesFiles_from_sonarr_api",
+                        lambda *a, **k: {"size": 999999, "path": "/tv/s/e"})
+
+    ep_mod.sync_one_episode(episode_id=100, defer_search=True)
+
+    assert seen == [inst], (
+        f"episodeParser must be given the parent's owning instance; got {seen!r}")


### PR DESCRIPTION
## The problem

`parse_video_metadata` cached the parsed stream list against `episode_file_id` or `movie_file_id` alone. Those ids come from the arr server, so two Sonarr or Radarr instances can hand out the same one for different files. When they do, one instance reads the other's cached stream list, and probing on either side overwrites the other's row.

The consequences are quiet ones. Embedded-subtitle extraction picks a stream index out of that list, so a collision selects the wrong track and translates a different subtitle than the one asked for, with nothing in the log to say so. The indexers read the same list to decide which languages a file already carries, so a collision can make Bazarr believe a language is present when it is not, or the reverse.

Surfaced while reviewing the embedded mass-translate work, which scoped the outer row lookup in `extract_embedded_subtitle` but could not fix the cache underneath it without widening that change.

## What changed

- `parse_video_metadata` takes `arr_instance_id` and applies it to both the cache read and the cache write.
- The owning instance is threaded from every caller that already knew it: the series and movie indexers, the Sonarr and Radarr sync parsers, `subtitles_sync_references`, embedded extraction, and the ffprobe refiner.
- `refine_from_ffprobe`'s own row lookup was unscoped too, and it is what chooses the file id the cache is keyed on, so that is scoped as well. It takes the instance off the video, where the database layer already puts it.
- `movieParser` gained the parameter its Sonarr counterpart already had; the instance was in scope at all four call sites.

`None` means no filter, so a single-instance install behaves exactly as it did.

## Tests

`tests/bazarr/test_ffprobe_cache_instance_scope.py` seeds two episodes on different instances sharing one `episode_file_id` and asserts: the cache read returns the owning instance's payload, probing one instance leaves the other's cached row untouched, a `None` instance reads as before, and the movie side is scoped the same way.

Local: ruff clean, 1923 backend tests pass, the isolated per-file list passes, `tests/subliminal_patch` unchanged from development (the same 2 failures and 13 errors, all network or credential dependent and not in the CI list).

Closes the follow-up filed against the embedded mass-translate work.