### PR TITLE
fix(indexer): index the row the caller named, not whichever one is first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,7 @@ jobs:
             tests/bazarr/test_ffprobe_cache_instance_scope.py \
             tests/bazarr/test_triage_low_findings.py \
             tests/bazarr/test_indexer_owner_scope.py \
+            tests/bazarr/test_translate_owner_threading.py \
             tests/bazarr/test_parser_owner_threading.py \
             tests/bazarr/test_embedded_translate_api_scope.py \
             tests/bazarr/test_release_type_mismatch_migration.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,6 +341,7 @@ jobs:
             tests/bazarr/test_embedded_extraction_instance_scope.py \
             tests/bazarr/test_ffprobe_cache_instance_scope.py \
             tests/bazarr/test_triage_low_findings.py \
+            tests/bazarr/test_indexer_owner_scope.py \
             tests/bazarr/test_parser_owner_threading.py \
             tests/bazarr/test_embedded_translate_api_scope.py \
             tests/bazarr/test_release_type_mismatch_migration.py \

--- a/bazarr/api/providers/providers_episodes.py
+++ b/bazarr/api/providers/providers_episodes.py
@@ -70,7 +70,8 @@ class ProviderEpisodes(Resource):
             return 'Episode not found', 404
         elif episodeInfo.subtitles is None:
             # subtitles indexing for this episode is incomplete, we'll do it again
-            store_subtitles(episodeInfo.path, path_mappings.path_replace(episodeInfo.path))
+            store_subtitles(episodeInfo.path, path_mappings.path_replace(episodeInfo.path),
+                            arr_instance_id=episodeInfo.arr_instance_id)
             episodeInfo = database.execute(stmt).first()
         elif episodeInfo.missing_subtitles is None:
             # missing subtitles calculation for this episode is incomplete, we'll do it again

--- a/bazarr/api/providers/providers_movies.py
+++ b/bazarr/api/providers/providers_movies.py
@@ -69,7 +69,8 @@ class ProviderMovies(Resource):
             return 'Movie not found', 404
         elif movieInfo.subtitles is None:
             # subtitles indexing for this movie is incomplete, we'll do it again
-            store_subtitles_movie(movieInfo.path, path_mappings.path_replace_movie(movieInfo.path))
+            store_subtitles_movie(movieInfo.path, path_mappings.path_replace_movie(movieInfo.path),
+                                  arr_instance_id=movieInfo.arr_instance_id)
             movieInfo = database.execute(stmt).first()
         elif movieInfo.missing_subtitles is None:
             # missing subtitles calculation for this movie is incomplete, we'll do it again

--- a/bazarr/api/subtitles/content.py
+++ b/bazarr/api/subtitles/content.py
@@ -518,11 +518,11 @@ def _refresh_media_subtitles(media_type, media_id, metadata):
     # None (default/single-instance setup).
     arr_instance_id = metadata.get('arrInstanceId')
     if media_type == 'episode' and media_path:
-        store_subtitles(media_path, path_mappings.path_replace_instance(media_path, arr_instance_id, 'episode'), use_cache=False)
+        store_subtitles(media_path, path_mappings.path_replace_instance(media_path, arr_instance_id, 'episode'), use_cache=False, arr_instance_id=arr_instance_id)
         event_stream(type='series', payload=metadata.get('mediaId'))
         event_stream(type='episode', payload=metadata.get('episodeId', media_id))
     elif media_type == 'movie' and media_path:
-        store_subtitles_movie(media_path, path_mappings.path_replace_instance(media_path, arr_instance_id, 'movie'), use_cache=False)
+        store_subtitles_movie(media_path, path_mappings.path_replace_instance(media_path, arr_instance_id, 'movie'), use_cache=False, arr_instance_id=arr_instance_id)
         event_stream(type='movie', payload=metadata.get('mediaId', media_id))
 
 
@@ -1121,10 +1121,10 @@ def _create_subtitle(media_type, media_id, arr_instance_id=None):
 
     # Force re-scan subtitles from disk using the media (video) path
     if media_type == 'episode':
-        store_subtitles(row.path, video_path, use_cache=False)
+        store_subtitles(row.path, video_path, use_cache=False, arr_instance_id=arr_instance_id)
         event_stream(type='episode', payload=row.id)
     else:
-        store_subtitles_movie(row.path, video_path, use_cache=False)
+        store_subtitles_movie(row.path, video_path, use_cache=False, arr_instance_id=arr_instance_id)
         event_stream(type='movie', payload=row.id)
 
     # Build language with modifiers

--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -513,7 +513,7 @@ def postprocess_subtitles(subtitles_path, video_path, media_type, metadata, id, 
                 subtitles_path)
 
     if media_type == "episode":
-        store_subtitles(path_mappings.path_replace_reverse(video_path), video_path)
+        store_subtitles(path_mappings.path_replace_reverse(video_path), video_path, arr_instance_id=arr_instance_id)
         event_stream(type="series", payload=metadata.sonarrSeriesId)
         # Emit the LOCAL episode id (#156): `id` is the upstream sonarrEpisodeId
         # (not unique across instances), but the frontend caches episode detail
@@ -539,7 +539,7 @@ def postprocess_subtitles(subtitles_path, video_path, media_type, metadata, id, 
     else:
         store_subtitles_movie(
             path_mappings.path_replace_reverse_movie(video_path), video_path
-        )
+        , arr_instance_id=arr_instance_id)
         event_stream(type="movie", payload=id)
 
         if settings.general.use_plex and settings.plex.update_movie_library:

--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -456,6 +456,7 @@ class Subtitles(Resource):
                     sonarr_episode_id=id if media_type == "episode" else None,
                     radarr_id=id if media_type == "movie" else None,
                     metadata=metadata,
+                    arr_instance_id=arr_instance_id,
                 )
             except OSError:
                 return "Unable to edit subtitles file. Check logs.", 409

--- a/bazarr/api/webhooks/radarr.py
+++ b/bazarr/api/webhooks/radarr.py
@@ -130,7 +130,7 @@ class WebHooksRadarr(Resource):
             logging.debug(message)
             return message, 200
 
-        store_subtitles_movie(movie.path, path_mappings.path_replace_movie(movie.path))
+        store_subtitles_movie(movie.path, path_mappings.path_replace_movie(movie.path), arr_instance_id=arr_instance_id)
         movies_download_subtitles(no=movie.radarrId, arr_instance_id=arr_instance_id)
 
         return "Finished processing subtitles.", 200

--- a/bazarr/api/webhooks/sonarr.py
+++ b/bazarr/api/webhooks/sonarr.py
@@ -141,7 +141,7 @@ class WebHooksSonarr(Resource):
                 )
                 continue
 
-            store_subtitles(episode.path, path_mappings.path_replace(episode.path))
+            store_subtitles(episode.path, path_mappings.path_replace(episode.path), arr_instance_id=arr_instance_id)
             episode_download_subtitles(no=episode.sonarrEpisodeId, arr_instance_id=arr_instance_id)
 
         return "Finished processing subtitles.", 200

--- a/bazarr/radarr/sync/movies.py
+++ b/bazarr/radarr/sync/movies.py
@@ -75,7 +75,7 @@ def update_movie(updated_movie, arr_instance_id=None):
                 previous_movie_path != updated_movie['path']):
             # Store subtitles for updated movie where path or movie_file_id changed
             logging.debug(f'BAZARR updating subtitles for movie {updated_movie["path"]}')  # noqa: G004
-            store_subtitles_movie(updated_movie['path'], path_mappings.path_replace_movie(updated_movie['path']))
+            store_subtitles_movie(updated_movie['path'], path_mappings.path_replace_movie(updated_movie['path']), arr_instance_id=arr_instance_id)
         else:
             logging.debug(f'BAZARR skipping subtitle update for movie {updated_movie["path"]} as path '  # noqa: G004
                           f'and movie_file_id unchanged')
@@ -105,7 +105,9 @@ def add_movie(added_movie):
     except IntegrityError as e:
         logging.error(f"BAZARR cannot insert movie {added_movie['path']} because of {e}")  # noqa: G004
     else:
-        store_subtitles_movie(added_movie['path'], path_mappings.path_replace_movie(added_movie['path']))
+        store_subtitles_movie(added_movie['path'],
+                              path_mappings.path_replace_movie(added_movie['path']),
+                              arr_instance_id=added_movie.get('arr_instance_id'))
         event_stream(type='movie', action='update', payload=int(added_movie['radarrId']))
 
 
@@ -448,7 +450,7 @@ def update_one_movie(movie_id, action, defer_search=False, is_signalr=False,
             logging.error(f"BAZARR cannot update movie {path_mappings.path_replace_movie(movie['path'])} because "  # noqa: G004
                           f"of {e}")
         else:
-            store_subtitles_movie(movie['path'], path_mappings.path_replace_movie(movie['path']))
+            store_subtitles_movie(movie['path'], path_mappings.path_replace_movie(movie['path']), arr_instance_id=arr_instance_id)
             event_stream(type='movie', action='update', payload=int(movie_id))
             logging.debug(
                 'BAZARR updated this movie into the database:%s', path_mappings.path_replace_movie(movie["path"]))
@@ -465,7 +467,7 @@ def update_one_movie(movie_id, action, defer_search=False, is_signalr=False,
             logging.error(f"BAZARR cannot insert movie {path_mappings.path_replace_movie(movie['path'])} because "  # noqa: G004
                           f"of {e}")
         else:
-            store_subtitles_movie(movie['path'], path_mappings.path_replace_movie(movie['path']))
+            store_subtitles_movie(movie['path'], path_mappings.path_replace_movie(movie['path']), arr_instance_id=arr_instance_id)
             event_stream(type='movie', action='update', payload=int(movie_id))
             logging.debug(
                 'BAZARR inserted this movie into the database:%s', path_mappings.path_replace_movie(movie["path"]))

--- a/bazarr/sonarr/sync/episodes.py
+++ b/bazarr/sonarr/sync/episodes.py
@@ -269,11 +269,11 @@ def sync_episodes(series_id, defer_search=False, is_signalr=False, episodes_data
                         del added_episode['created_at_timestamp']
                         episodes_to_update.append(added_episode)
                     else:
-                        store_subtitles(added_episode['path'], path_mappings.path_replace(added_episode['path']))
+                        store_subtitles(added_episode['path'], path_mappings.path_replace(added_episode['path']), arr_instance_id=arr_instance_id)
                         rows_changed = True
             else:
                 for added_episode in chunk:
-                    store_subtitles(added_episode['path'], path_mappings.path_replace(added_episode['path']))
+                    store_subtitles(added_episode['path'], path_mappings.path_replace(added_episode['path']), arr_instance_id=arr_instance_id)
                     rows_changed = True
 
     # Update existing episodes in DB
@@ -306,7 +306,7 @@ def sync_episodes(series_id, defer_search=False, is_signalr=False, episodes_data
                         previous_episode_path != updated_episode['path']):
                     # Store subtitles for updated episode where path or episode_file_id changed
                     logging.debug('BAZARR updating subtitles for episode %s', updated_episode["path"])
-                    store_subtitles(updated_episode['path'], path_mappings.path_replace(updated_episode['path']))
+                    store_subtitles(updated_episode['path'], path_mappings.path_replace(updated_episode['path']), arr_instance_id=arr_instance_id)
                 else:
                     logging.debug('BAZARR skipping subtitle update for episode %s as path '
                                   'and episode_file_id unchanged', updated_episode["path"])
@@ -463,7 +463,7 @@ def sync_one_episode(episode_id, defer_search=False, is_signalr=False,
         except IntegrityError as e:
             logging.error(f"BAZARR cannot update episode {episode['path']} because of {e}")  # noqa: G004
         else:
-            store_subtitles(episode['path'], path_mappings.path_replace(episode['path']))
+            store_subtitles(episode['path'], path_mappings.path_replace(episode['path']), arr_instance_id=arr_instance_id)
             # Emit the LOCAL episode id (#156): the frontend caches episode
             # detail by local id, and the upstream sonarrEpisodeId is not unique
             # across instances. No-op scope for the default/single-instance path.
@@ -489,7 +489,7 @@ def sync_one_episode(episode_id, defer_search=False, is_signalr=False,
         except IntegrityError as e:
             logging.error(f"BAZARR cannot insert episode {episode['path']} because of {e}")  # noqa: G004
         else:
-            store_subtitles(episode['path'], path_mappings.path_replace(episode['path']))
+            store_subtitles(episode['path'], path_mappings.path_replace(episode['path']), arr_instance_id=arr_instance_id)
             # Emit the LOCAL episode id (#156): see the update branch above.
             local_id_row = database.execute(
                 scoped(select(TableEpisodes.id)

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -30,17 +30,25 @@ from arr_instances.resolution import scoped
 gc.enable()
 
 
-def store_subtitles_movie(original_path, reversed_path, use_cache=True):
+def store_subtitles_movie(original_path, reversed_path, use_cache=True, arr_instance_id=None):
     logging.debug(f'BAZARR started subtitles indexing for this file: {reversed_path}')  # noqa: G004
     actual_subtitles = []
-    # Resolve the owning instance for this file up front (#156) so every
-    # path_replace* below honours the owning instance's per-instance
-    # path_mappings instead of the global singleton. owner_instance_id None =>
-    # global mapping (the default/single-instance path), byte-identical to legacy.
-    owner_row = database.execute(
-        select(TableMovies.arr_instance_id)
-        .where(TableMovies.path == original_path)).first()
-    owner_instance_id = owner_row.arr_instance_id if owner_row else None
+    # The owning instance decides everything below: which per-instance
+    # path_mappings resolve the paths, which ffprobe cache row the embedded pass
+    # reads and overwrites, and which row receives the listing (#156).
+    #
+    # Take it from the caller when it knows. Resolving it here from the path
+    # cannot be done reliably: path is not unique across instances, and
+    # per-instance mappings can point the same remote path at two different
+    # local files. Falling back to the lookup keeps the default and
+    # single-instance path byte-identical to legacy behaviour.
+    if arr_instance_id is not None:
+        owner_instance_id = arr_instance_id
+    else:
+        owner_row = database.execute(
+            select(TableMovies.arr_instance_id)
+            .where(TableMovies.path == original_path)).first()
+        owner_instance_id = owner_row.arr_instance_id if owner_row else None
 
     def _pr(p):
         return path_mappings.path_replace_instance(p, owner_instance_id, "movie")
@@ -54,8 +62,9 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
         if settings.general.use_embedded_subs:
             logging.debug("BAZARR is trying to index embedded subtitles.")
             item = database.execute(
-                select(TableMovies.movie_file_id, TableMovies.file_size)
-                .where(TableMovies.path == original_path)) \
+                scoped(select(TableMovies.movie_file_id, TableMovies.file_size)
+                       .where(TableMovies.path == original_path),
+                       TableMovies.arr_instance_id, owner_instance_id)) \
                 .first()
             if not item:
                 logging.exception(f"BAZARR error when trying to select this movie from database: {reversed_path}")  # noqa: G004
@@ -98,8 +107,9 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
 
             # get previously indexed subtitles that haven't changed:
             item = database.execute(
-                select(TableMovies.subtitles)
-                .where(TableMovies.path == original_path))\
+                scoped(select(TableMovies.subtitles)
+                       .where(TableMovies.path == original_path),
+                       TableMovies.arr_instance_id, owner_instance_id))\
                 .first()
             if not item:
                 previously_indexed_subtitles_to_exclude = []
@@ -168,12 +178,14 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True):
                                              subtitle_size])
 
         database.execute(
-            update(TableMovies)
-            .values(subtitles=str(actual_subtitles))
-            .where(TableMovies.path == original_path))
+            scoped(update(TableMovies)
+                   .values(subtitles=str(actual_subtitles))
+                   .where(TableMovies.path == original_path),
+                   TableMovies.arr_instance_id, owner_instance_id))
         matching_movies = database.execute(
-            select(TableMovies.radarrId, TableMovies.arr_instance_id)
-            .where(TableMovies.path == original_path))\
+            scoped(select(TableMovies.radarrId, TableMovies.arr_instance_id)
+                   .where(TableMovies.path == original_path),
+                   TableMovies.arr_instance_id, owner_instance_id))\
             .all()
 
         for movie in matching_movies:

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -423,14 +423,20 @@ def movies_full_scan_subtitles(job_id=None, use_cache=None, wait_for_completion=
     if use_cache is None:
         use_cache = settings.radarr.use_ffprobe_cache
 
+    # The owner comes along, because store_subtitles_movie now scopes its write
+    # to it: without it every row sharing a path would resolve to the same
+    # arbitrary owner and the other instances would never be indexed at all.
     movies = database.execute(
-        select(TableMovies.path, TableMovies.title))\
+        select(TableMovies.path, TableMovies.title, TableMovies.arr_instance_id))\
         .all()
 
     jobs_queue.update_job_progress(job_id=job_id, progress_max=len(movies), progress_message='Indexing')
     for i, movie in enumerate(movies, start=1):
         jobs_queue.update_job_progress(job_id=job_id, progress_value=i, progress_message=movie.title)
-        store_subtitles_movie(movie.path, path_mappings.path_replace_movie(movie.path), use_cache=use_cache)
+        store_subtitles_movie(movie.path,
+                              path_mappings.path_replace_instance(movie.path,
+                                                                  movie.arr_instance_id, 'movie'),
+                              use_cache=use_cache, arr_instance_id=movie.arr_instance_id)
 
     logging.info('BAZARR All existing movie subtitles indexed from disk.')
 
@@ -442,11 +448,14 @@ def movies_full_scan_subtitles(job_id=None, use_cache=None, wait_for_completion=
 def movies_scan_subtitles(no, arr_instance_id=None):
     movies = database.execute(
         scoped(
-            select(TableMovies.path)
+            select(TableMovies.path, TableMovies.arr_instance_id)
             .where(TableMovies.radarrId == no)
             .order_by(TableMovies.radarrId),
             TableMovies.arr_instance_id, arr_instance_id)) \
         .all()
 
     for movie in movies:
-        store_subtitles_movie(movie.path, path_mappings.path_replace_movie(movie.path), use_cache=False)
+        store_subtitles_movie(movie.path,
+                              path_mappings.path_replace_instance(movie.path,
+                                                                  movie.arr_instance_id, 'movie'),
+                              use_cache=False, arr_instance_id=movie.arr_instance_id)

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -440,8 +440,12 @@ def series_full_scan_subtitles(job_id=None, use_cache=None, wait_for_completion=
     if use_cache is None:
         use_cache = settings.sonarr.use_ffprobe_cache
 
+    # The owner comes along, because store_subtitles now scopes its write to it:
+    # without it every row sharing a path would resolve to the same arbitrary
+    # owner and the other instances would never be indexed at all.
     episodes = database.execute(
-        select(TableEpisodes.path, TableShows.title, TableEpisodes.title.label("episodeTitle"), TableEpisodes.season, TableEpisodes.episode)
+        select(TableEpisodes.path, TableShows.title, TableEpisodes.title.label("episodeTitle"),
+               TableEpisodes.season, TableEpisodes.episode, TableEpisodes.arr_instance_id)
         .select_from(TableEpisodes)
         .join(TableShows)
     ).all()
@@ -451,7 +455,10 @@ def series_full_scan_subtitles(job_id=None, use_cache=None, wait_for_completion=
         jobs_queue.update_job_progress(
             job_id=job_id, progress_value=i,
             progress_message=f"{episode.title} - S{episode.season:02d}E{episode.episode:02d} - {episode.episodeTitle}")
-        store_subtitles(episode.path, path_mappings.path_replace(episode.path), use_cache=use_cache)
+        store_subtitles(episode.path,
+                        path_mappings.path_replace_instance(episode.path,
+                                                            episode.arr_instance_id, 'series'),
+                        use_cache=use_cache, arr_instance_id=episode.arr_instance_id)
 
     logging.info('BAZARR All existing episode subtitles indexed from disk.')
 
@@ -463,11 +470,14 @@ def series_full_scan_subtitles(job_id=None, use_cache=None, wait_for_completion=
 def series_scan_subtitles(no, arr_instance_id=None):
     episodes = database.execute(
         scoped(
-            select(TableEpisodes.path)
+            select(TableEpisodes.path, TableEpisodes.arr_instance_id)
             .where(TableEpisodes.sonarrSeriesId == no)
             .order_by(TableEpisodes.sonarrEpisodeId),
             TableEpisodes.arr_instance_id, arr_instance_id))\
         .all()
 
     for episode in episodes:
-        store_subtitles(episode.path, path_mappings.path_replace(episode.path), use_cache=False)
+        store_subtitles(episode.path,
+                        path_mappings.path_replace_instance(episode.path,
+                                                            episode.arr_instance_id, 'series'),
+                        use_cache=False, arr_instance_id=episode.arr_instance_id)

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -29,19 +29,27 @@ from arr_instances.resolution import scoped
 gc.enable()
 
 
-def store_subtitles(original_path, reversed_path, use_cache=True):
+def store_subtitles(original_path, reversed_path, use_cache=True, arr_instance_id=None):
     logging.debug(f'BAZARR started subtitles indexing for this file: {reversed_path}')  # noqa: G004
     actual_subtitles = []
-    # Resolve the owning instance for this file up front (#156) so every
-    # path_replace* below honours the owning instance's per-instance
-    # path_mappings instead of the global singleton. A media row owned by a
-    # secondary instance with a different on-disk prefix would otherwise be
-    # read/written at the wrong path. owner_instance_id None => global mapping
-    # (the default/single-instance path), byte-identical to legacy behaviour.
-    owner_row = database.execute(
-        select(TableEpisodes.arr_instance_id)
-        .where(TableEpisodes.path == original_path)).first()
-    owner_instance_id = owner_row.arr_instance_id if owner_row else None
+    # The owning instance decides everything below: which per-instance
+    # path_mappings resolve the paths, which ffprobe cache row the embedded pass
+    # reads and overwrites, and which row receives the listing (#156).
+    #
+    # Take it from the caller when it knows, which is nearly always, because
+    # resolving it here from the path cannot be done reliably: path is not
+    # unique across instances, and per-instance mappings can point the same
+    # remote path at two different local files. An unscoped first() would then
+    # index this file's result into the other instance's row and probe the other
+    # instance's file id. Falling back to the lookup keeps the default and
+    # single-instance path byte-identical to legacy behaviour.
+    if arr_instance_id is not None:
+        owner_instance_id = arr_instance_id
+    else:
+        owner_row = database.execute(
+            select(TableEpisodes.arr_instance_id)
+            .where(TableEpisodes.path == original_path)).first()
+        owner_instance_id = owner_row.arr_instance_id if owner_row else None
 
     def _pr(p):
         return path_mappings.path_replace_instance(p, owner_instance_id, "series")
@@ -55,8 +63,9 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
         if settings.general.use_embedded_subs:
             logging.debug("BAZARR is trying to index embedded subtitles.")
             item = database.execute(
-                select(TableEpisodes.episode_file_id, TableEpisodes.file_size)
-                .where(TableEpisodes.path == original_path))\
+                scoped(select(TableEpisodes.episode_file_id, TableEpisodes.file_size)
+                       .where(TableEpisodes.path == original_path),
+                       TableEpisodes.arr_instance_id, owner_instance_id))\
                 .first()
             if not item:
                 logging.exception(f"BAZARR error when trying to select this episode from database: {reversed_path}")  # noqa: G004
@@ -98,8 +107,9 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
 
             # get previously indexed subtitles that haven't changed:
             item = database.execute(
-                select(TableEpisodes.subtitles)
-                .where(TableEpisodes.path == original_path)) \
+                scoped(select(TableEpisodes.subtitles)
+                       .where(TableEpisodes.path == original_path),
+                       TableEpisodes.arr_instance_id, owner_instance_id)) \
                 .first()
             if not item:
                 previously_indexed_subtitles_to_exclude = []
@@ -167,13 +177,15 @@ def store_subtitles(original_path, reversed_path, use_cache=True):
                                              subtitle_size])
 
         database.execute(
-            update(TableEpisodes)
-            .values(subtitles=str(actual_subtitles))
-            .where(TableEpisodes.path == original_path))
+            scoped(update(TableEpisodes)
+                   .values(subtitles=str(actual_subtitles))
+                   .where(TableEpisodes.path == original_path),
+                   TableEpisodes.arr_instance_id, owner_instance_id))
         matching_episodes = database.execute(
-            select(TableEpisodes.sonarrEpisodeId, TableEpisodes.sonarrSeriesId,
-                   TableEpisodes.arr_instance_id)
-            .where(TableEpisodes.path == original_path))\
+            scoped(select(TableEpisodes.sonarrEpisodeId, TableEpisodes.sonarrSeriesId,
+                          TableEpisodes.arr_instance_id)
+                   .where(TableEpisodes.path == original_path),
+                   TableEpisodes.arr_instance_id, owner_instance_id))\
             .all()
 
         for episode in matching_episodes:

--- a/bazarr/subtitles/manual.py
+++ b/bazarr/subtitles/manual.py
@@ -286,7 +286,7 @@ def episode_manually_download_specific_subtitle(sonarr_series_id, sonarr_episode
             if not settings.general.dont_notify_manual_actions:
                 send_notifications(sonarr_series_id, sonarr_episode_id, result.message,
                                    arr_instance_id=arr_instance_id)
-            store_subtitles(result.path, episodePath)
+            store_subtitles(result.path, episodePath, arr_instance_id=arr_instance_id)
             return '', 204
     finally:
         jobs_queue.update_job_name(job_id=job_id, new_job_name=f"Manually downloaded Subtitles for {title} - "
@@ -340,7 +340,7 @@ def movie_manually_download_specific_subtitle(radarr_id, hi, forced, use_origina
             history_log_movie(2, radarr_id, result, arr_instance_id=arr_instance_id)
             if not settings.general.dont_notify_manual_actions:
                 send_notifications_movie(radarr_id, result.message, arr_instance_id=arr_instance_id)
-            store_subtitles_movie(result.path, moviePath)
+            store_subtitles_movie(result.path, moviePath, arr_instance_id=arr_instance_id)
             return '', 204
     finally:
         jobs_queue.update_job_name(job_id=job_id, new_job_name=f"Manually downloaded Subtitles for {title} "

--- a/bazarr/subtitles/mass_download/movies.py
+++ b/bazarr/subtitles/mass_download/movies.py
@@ -57,7 +57,7 @@ def movies_download_subtitles(no, job_id=None, job_sub_function=False, arr_insta
         return
     elif movie.subtitles is None:
         # subtitles indexing for this movie is incomplete, we'll do it again
-        store_subtitles_movie(movie.path, path_mappings.path_replace_movie(movie.path))
+        store_subtitles_movie(movie.path, path_mappings.path_replace_movie(movie.path), arr_instance_id=arr_instance_id)
         movie = database.execute(stmt).first()
     elif movie.missing_subtitles is None:
         # missing subtitles calculation for this movie is incomplete, we'll do it again
@@ -110,7 +110,7 @@ def movies_download_subtitles(no, job_id=None, job_sub_function=False, arr_insta
                 if result:
                     if isinstance(result, tuple) and len(result):
                         result = result[0]
-                    store_subtitles_movie(movie.path, moviePath)
+                    store_subtitles_movie(movie.path, moviePath, arr_instance_id=arr_instance_id)
                     history_log_movie(1, no, result, arr_instance_id=arr_instance_id)
                     send_notifications_movie(no, result.message, arr_instance_id=arr_instance_id)
                     downloaded_count += 1
@@ -178,7 +178,7 @@ def movie_download_specific_subtitles(radarr_id, language, hi, forced, job_id=No
                 result = result[0]
             history_log_movie(1, radarr_id, result, arr_instance_id=arr_instance_id)
             send_notifications_movie(radarr_id, result.message, arr_instance_id=arr_instance_id)
-            store_subtitles_movie(result.path, moviePath)
+            store_subtitles_movie(result.path, moviePath, arr_instance_id=arr_instance_id)
             jobs_queue.update_job_progress(job_id=job_id, progress_value='max',
                                            progress_message="Subtitle downloaded")
         else:

--- a/bazarr/subtitles/mass_download/series.py
+++ b/bazarr/subtitles/mass_download/series.py
@@ -128,7 +128,8 @@ def episode_download_subtitles(no, job_id=None, job_sub_function=False, provider
     elif episode.subtitles is None:
         # subtitles indexing for this episode is incomplete, we'll do it again
         store_subtitles(episode.path,
-                        path_mappings.path_replace_instance(episode.path, episode.arr_instance_id, 'series'))
+                        path_mappings.path_replace_instance(episode.path, episode.arr_instance_id, 'series'),
+                        arr_instance_id=episode.arr_instance_id)
         episode = database.execute(stmt).first()
     elif episode.missing_subtitles is None:
         # missing subtitles calculation for this episode is incomplete, we'll do it again
@@ -183,7 +184,8 @@ def episode_download_subtitles(no, job_id=None, job_sub_function=False, provider
                         result = result[0]
                     store_subtitles(episode.path,
                                     path_mappings.path_replace_instance(episode.path, episode.arr_instance_id,
-                                                                        'series'))
+                                                                        'series'),
+                                    arr_instance_id=episode.arr_instance_id)
                     history_log(1, episode.sonarrSeriesId, episode.sonarrEpisodeId, result,
                                 arr_instance_id=arr_instance_id)
                     send_notifications(episode.sonarrSeriesId, episode.sonarrEpisodeId, result.message,
@@ -265,7 +267,7 @@ def episode_download_specific_subtitles(sonarr_series_id, sonarr_episode_id, lan
             history_log(1, sonarr_series_id, sonarr_episode_id, result, arr_instance_id=arr_instance_id)
             send_notifications(sonarr_series_id, sonarr_episode_id, result.message,
                                arr_instance_id=arr_instance_id)
-            store_subtitles(result.path, episodePath)
+            store_subtitles(result.path, episodePath, arr_instance_id=arr_instance_id)
             jobs_queue.update_job_progress(job_id=job_id, progress_value='max',
                                            progress_message="Subtitle downloaded")
         else:

--- a/bazarr/subtitles/mass_operations.py
+++ b/bazarr/subtitles/mass_operations.py
@@ -640,6 +640,7 @@ def _process_subtitle_item(item, action, options, job_id):
             sonarr_episode_id=item['sonarr_episode_id'],
             radarr_id=item['radarr_id'],
             metadata=item['metadata'],
+            arr_instance_id=item.get('arr_instance_id'),
         )
         return True
     elif action in MOD_ACTIONS:

--- a/bazarr/subtitles/processing.py
+++ b/bazarr/subtitles/processing.py
@@ -194,6 +194,7 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
                 sonarr_episode_id=episode_id,
                 radarr_id=radarr_id,
                 metadata=translation_metadata,
+                arr_instance_id=arr_instance_id,
             )
     except Exception:
         logging.exception('BAZARR error in _trigger_auto_translation')

--- a/bazarr/subtitles/sync.py
+++ b/bazarr/subtitles/sync.py
@@ -188,7 +188,7 @@ def _index_keep_all_outputs(video_path, sonarr_series_id=None, sonarr_episode_id
         from utilities.media_ids import local_episode_id
         from utilities.path_mappings import path_mappings
 
-        store_subtitles(path_mappings.path_replace_reverse(video_path), video_path)
+        store_subtitles(path_mappings.path_replace_reverse(video_path), video_path, arr_instance_id=arr_instance_id)
         if sonarr_series_id:
             event_stream(type='series', payload=sonarr_series_id)
         # Emit the LOCAL episode id (#156): the frontend caches episode detail by
@@ -201,7 +201,7 @@ def _index_keep_all_outputs(video_path, sonarr_series_id=None, sonarr_episode_id
         from subtitles.indexer.movies import store_subtitles_movie
         from utilities.path_mappings import path_mappings
 
-        store_subtitles_movie(path_mappings.path_replace_reverse_movie(video_path), video_path)
+        store_subtitles_movie(path_mappings.path_replace_reverse_movie(video_path), video_path, arr_instance_id=arr_instance_id)
         event_stream(type='movie', payload=radarr_id)
 
 

--- a/bazarr/subtitles/tools/delete.py
+++ b/bazarr/subtitles/tools/delete.py
@@ -85,11 +85,11 @@ def delete_subtitles(media_type, language, forced, hi, media_path, subtitles_pat
             os.remove(pr(subtitles_path))
         except OSError:
             logging.exception(f'BAZARR cannot delete subtitles file: {subtitles_path}')  # noqa: G004
-            store_subtitles(prr(media_path), media_path)
+            store_subtitles(prr(media_path), media_path, arr_instance_id=arr_instance_id)
             return False
         else:
             history_log(0, sonarr_series_id, sonarr_episode_id, result, arr_instance_id=arr_instance_id)
-            store_subtitles(prr(media_path), media_path)
+            store_subtitles(prr(media_path), media_path, arr_instance_id=arr_instance_id)
             # Route the rescan at the OWNING instance's Sonarr (#156); None
             # owner = default server (legacy single-instance), unchanged.
             notify_sonarr(sonarr_series_id,
@@ -118,11 +118,11 @@ def delete_subtitles(media_type, language, forced, hi, media_path, subtitles_pat
             os.remove(pr(subtitles_path))
         except OSError:
             logging.exception(f'BAZARR cannot delete subtitles file: {subtitles_path}')  # noqa: G004
-            store_subtitles_movie(prr(media_path), media_path)
+            store_subtitles_movie(prr(media_path), media_path, arr_instance_id=arr_instance_id)
             return False
         else:
             history_log_movie(0, radarr_id, result, arr_instance_id=arr_instance_id)
-            store_subtitles_movie(prr(media_path), media_path)
+            store_subtitles_movie(prr(media_path), media_path, arr_instance_id=arr_instance_id)
             notify_radarr(radarr_id,
                           arr_client=client_for_instance(database, arr_instance_id, enabled_only=False))
             event_stream(type='movie-wanted', action='update', payload=radarr_id)

--- a/bazarr/subtitles/tools/mods.py
+++ b/bazarr/subtitles/tools/mods.py
@@ -116,9 +116,9 @@ def apply_subtitle_mods(language, subtitle_path, mods, video_path,
     from utilities.path_mappings import path_mappings
 
     if media_type == 'episode':
-        store_subtitles(path_mappings.path_replace_reverse(video_path), video_path)
+        store_subtitles(path_mappings.path_replace_reverse(video_path), video_path, arr_instance_id=arr_instance_id)
     elif media_type == 'movie':
-        store_subtitles_movie(path_mappings.path_replace_reverse_movie(video_path), video_path)
+        store_subtitles_movie(path_mappings.path_replace_reverse_movie(video_path), video_path, arr_instance_id=arr_instance_id)
 
     if media_id and media_type:
         if media_type == 'episode':

--- a/bazarr/subtitles/tools/translate/batch.py
+++ b/bazarr/subtitles/tools/translate/batch.py
@@ -69,14 +69,15 @@ def process_episode_translation(
             new_job_name=f"Translating {ep_label} ({source_language.upper()} → {target_language.upper()})",
         )
 
-    video_path = path_mappings.path_replace(episode.path)
+    video_path = path_mappings.path_replace_instance(episode.path, arr_instance_id, 'episode')
 
     # Find source subtitle
     source_subtitle_path = subtitle_path
     detected_source_lang = None
     if not source_subtitle_path:
         source_subtitle_path, detected_source_lang = find_subtitle_by_language(
-            episode.subtitles, source_language, video_path, media_type="episode"
+            episode.subtitles, source_language, video_path, media_type="episode",
+            arr_instance_id=arr_instance_id
         )
 
     if not source_subtitle_path:
@@ -108,7 +109,9 @@ def process_episode_translation(
             job_id=job_id,
         )
         # Re-index subtitles so Bazarr's DB knows about the new translated file
-        store_subtitles(path_mappings.path_replace_reverse(video_path), video_path)
+        store_subtitles(
+            path_mappings.path_replace_reverse_instance(video_path, arr_instance_id, 'episode'),
+            video_path, arr_instance_id=arr_instance_id)
         # Notify frontend to refresh series and episode views. Emit the LOCAL
         # episode id (#156): the frontend caches episode detail by local id and
         # the upstream sonarrEpisodeId is not unique across instances.
@@ -125,16 +128,21 @@ def process_movie_translation(
 ):
     """Process a single movie for translation in background"""
     radarr_id = item.get("radarrId")
+    arr_instance_id = item.get("arr_instance_id")
 
     if not radarr_id:
         logger.error("Missing radarrId")
         return False
 
-    # Get movie info from database
+    # Get movie info from database, scoped to the owning instance (#156):
+    # radarrId is not unique across instances, so an unscoped lookup can return
+    # a sibling instance's movie and translate the wrong file.
     movie = database.execute(
-        select(TableMovies.path, TableMovies.subtitles, TableMovies.title).where(
-            TableMovies.radarrId == radarr_id
-        )
+        scoped(
+            select(TableMovies.path, TableMovies.subtitles, TableMovies.title).where(
+                TableMovies.radarrId == radarr_id
+            ),
+            TableMovies.arr_instance_id, arr_instance_id)
     ).first()
 
     if not movie:
@@ -148,14 +156,15 @@ def process_movie_translation(
             new_job_name=f"Translating {movie.title} ({source_language.upper()} → {target_language.upper()})",
         )
 
-    video_path = path_mappings.path_replace_movie(movie.path)
+    video_path = path_mappings.path_replace_instance(movie.path, arr_instance_id, 'movie')
 
     # Find source subtitle
     source_subtitle_path = subtitle_path
     detected_source_lang = None
     if not source_subtitle_path:
         source_subtitle_path, detected_source_lang = find_subtitle_by_language(
-            movie.subtitles, source_language, video_path, media_type="movie"
+            movie.subtitles, source_language, video_path, media_type="movie",
+            arr_instance_id=arr_instance_id
         )
 
     if not source_subtitle_path:
@@ -188,7 +197,8 @@ def process_movie_translation(
         )
         # Re-index subtitles so Bazarr's DB knows about the new translated file
         store_subtitles_movie(
-            path_mappings.path_replace_reverse_movie(video_path), video_path
+            path_mappings.path_replace_reverse_instance(video_path, arr_instance_id, 'movie'),
+            video_path, arr_instance_id=arr_instance_id
         )
         # Notify frontend to refresh movie view
         event_stream(type="movie", payload=radarr_id)
@@ -198,8 +208,15 @@ def process_movie_translation(
         return False
 
 
-def find_subtitle_by_language(subtitles, language_code, video_path, media_type="movie"):
-    """Find a subtitle file by language code from the subtitles list."""
+def find_subtitle_by_language(subtitles, language_code, video_path, media_type="movie",
+                             arr_instance_id=None):
+    """Find a subtitle file by language code from the subtitles list.
+
+    ``arr_instance_id`` is the instance that owns the media (#156). Extraction
+    reverses the video path with that instance's mapping and scopes its row
+    lookup by it, so a caller that resolved an owner has to pass it on or the
+    lookup runs unscoped and can select another instance's subtitle stream.
+    """
     available_subtitles = []
 
     if subtitles:
@@ -321,6 +338,7 @@ def find_subtitle_by_language(subtitles, language_code, video_path, media_type="
                     media_type,
                     hi=sub["hi"],
                     forced=sub["forced"],
+                    arr_instance_id=arr_instance_id,
                 )
                 if extracted_path:
                     return extracted_path, sub["code2"]

--- a/bazarr/subtitles/tools/translate/batch.py
+++ b/bazarr/subtitles/tools/translate/batch.py
@@ -107,6 +107,7 @@ def process_episode_translation(
             radarr_id=None,
             metadata=episode,
             job_id=job_id,
+            arr_instance_id=arr_instance_id,
         )
         # Re-index subtitles so Bazarr's DB knows about the new translated file
         store_subtitles(
@@ -194,6 +195,7 @@ def process_movie_translation(
             radarr_id=radarr_id,
             metadata=movie,
             job_id=job_id,
+            arr_instance_id=arr_instance_id,
         )
         # Re-index subtitles so Bazarr's DB knows about the new translated file
         store_subtitles_movie(
@@ -253,11 +255,12 @@ def find_subtitle_by_language(subtitles, language_code, video_path, media_type="
 
     # Helper function to resolve and validate subtitle path
     def resolve_subtitle_path(sub_path):
-        # Apply path mapping based on media type
-        if media_type == "episode":
-            mapped_path = path_mappings.path_replace(sub_path)
-        else:
-            mapped_path = path_mappings.path_replace_movie(sub_path)
+        # The owning instance's mapping, the same one the caller used for the
+        # video. Mixing them pairs a secondary instance's video with a default
+        # instance's subtitle when both paths happen to exist, or reports no
+        # subtitle at all when they do not.
+        kind = "episode" if media_type == "episode" else "movie"
+        mapped_path = path_mappings.path_replace_instance(sub_path, arr_instance_id, kind)
 
         # Check if file exists at mapped path
         if os.path.exists(mapped_path):

--- a/bazarr/subtitles/tools/translate/main.py
+++ b/bazarr/subtitles/tools/translate/main.py
@@ -16,7 +16,8 @@ from subtitles.indexer.utils import get_external_subtitles_path
 
 
 def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, forced, hi,
-                             media_type, sonarr_series_id, sonarr_episode_id, radarr_id, metadata, job_id=None):
+                             media_type, sonarr_series_id, sonarr_episode_id, radarr_id, metadata,
+                             job_id=None, arr_instance_id=None):
     if not job_id:
         # Build job label with media title. Note: no local variables can be
         # assigned here because add_job_from_function introspects the frame
@@ -78,7 +79,13 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
 
         from api.subtitles.subtitles import postprocess_subtitles
         # Call postprocess_subtitles after translation (handles chmod, re-indexing, events)
-        postprocess_subtitles(dest_srt_file, video_path, media_type, metadata, sonarr_episode_id if media_type == 'episode' else radarr_id)
+        # The owning instance goes with it (#156). postprocess_subtitles
+        # re-indexes the new file, and that write is scoped now, so without
+        # the owner the translated subtitle can land on a sibling instance's
+        # row and leave the one the user asked about showing nothing.
+        postprocess_subtitles(dest_srt_file, video_path, media_type, metadata,
+                              sonarr_episode_id if media_type == 'episode' else radarr_id,
+                              arr_instance_id=arr_instance_id)
 
         # The translated file is now on disk. The download-time combine ran before
         # this async translation finished (so it skipped, source missing); build or

--- a/bazarr/subtitles/upgrade.py
+++ b/bazarr/subtitles/upgrade.py
@@ -171,7 +171,8 @@ def upgrade_episodes_subtitles(job_id=None, sonarr_series_ids=None, sonarr_serie
                 result = result[0]
             if isinstance(result, tuple) and len(result):
                 result = result[0]
-            store_subtitles(episode['video_path'], path_mappings.path_replace(episode['video_path']))
+            store_subtitles(episode['video_path'], path_mappings.path_replace(episode['video_path']),
+                            arr_instance_id=episode['arr_instance_id'])
             history_log(3, episode['sonarrSeriesId'], episode['sonarrEpisodeId'], result,
                         upgraded_from_id=episode['original_id'],
                         arr_instance_id=episode['arr_instance_id'])
@@ -315,7 +316,8 @@ def upgrade_movies_subtitles(job_id=None, radarr_ids=None, radarr_filters=None, 
             if isinstance(result, tuple) and len(result):
                 result = result[0]
             store_subtitles_movie(movie['video_path'],
-                                  path_mappings.path_replace_movie(movie['video_path']))
+                                  path_mappings.path_replace_movie(movie['video_path']),
+                                  arr_instance_id=movie['arr_instance_id'])
             history_log_movie(3, movie['radarrId'], result, upgraded_from_id=movie['original_id'],
                               arr_instance_id=movie['arr_instance_id'])
             send_notifications_movie(movie['radarrId'], result.message,

--- a/bazarr/subtitles/upload.py
+++ b/bazarr/subtitles/upload.py
@@ -242,7 +242,7 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
             if not settings.general.dont_notify_manual_actions:
                 send_notifications(sonarrSeriesId, sonarrEpisodeId, result.message,
                                    arr_instance_id=arr_instance_id)
-            store_subtitles(result.path, path)
+            store_subtitles(result.path, path, arr_instance_id=arr_instance_id)
             if settings.general.use_plex:
                 if settings.plex.update_series_library:
                     plex_refresh_item(episode_metadata.imdbId, is_movie=False,
@@ -258,7 +258,7 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
                               arr_instance_id=arr_instance_id)
             if not settings.general.dont_notify_manual_actions:
                 send_notifications_movie(radarrId, result.message, arr_instance_id=arr_instance_id)
-            store_subtitles_movie(result.path, path)
+            store_subtitles_movie(result.path, path, arr_instance_id=arr_instance_id)
             if settings.general.use_plex:
                 if settings.plex.update_movie_library:
                     plex_refresh_item(movie_metadata.imdbId, is_movie=True)

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -189,7 +189,7 @@ def _wanted_movie(movie, providers_list, job_id=None):
             found_any = True
             if isinstance(result, tuple) and len(result):
                 result = result[0]
-            store_subtitles_movie(movie.path, path_mappings.path_replace_movie(movie.path))
+            store_subtitles_movie(movie.path, path_mappings.path_replace_movie(movie.path), arr_instance_id=arr_instance_id)
             history_log_movie(1, movie.radarrId, result, arr_instance_id=arr_instance_id)
             event_stream(type='movie-wanted', action='delete', payload=movie.radarrId)
             send_notifications_movie(movie.radarrId, result.message, arr_instance_id=arr_instance_id)
@@ -228,7 +228,7 @@ def wanted_download_subtitles_movie(radarr_id, job_id=None, arr_instance_id=None
         return
     elif movie.subtitles is None:
         # subtitles indexing for this movie is incomplete, we'll do it again
-        store_subtitles_movie(movie.path, path_mappings.path_replace_movie(movie.path))
+        store_subtitles_movie(movie.path, path_mappings.path_replace_movie(movie.path), arr_instance_id=arr_instance_id)
         movie = database.execute(stmt).first()
     elif movie.missing_subtitles is None:
         # missing subtitles calculation for this movie is incomplete, we'll do it again
@@ -254,7 +254,8 @@ def wanted_scan_subtitles_movies(job_id=None):
     movies = database.execute(
         select(TableMovies.radarrId,
                TableMovies.path,
-               TableMovies.title)
+               TableMovies.title,
+               TableMovies.arr_instance_id)
         .where(reduce(operator.and_, conditions))) \
         .all()
 
@@ -266,7 +267,10 @@ def wanted_scan_subtitles_movies(job_id=None):
 
     for i, movie in enumerate(movies, start=1):
         jobs_queue.update_job_progress(job_id=job_id, progress_value=i, progress_message=movie.title)
-        store_subtitles_movie(movie.path, path_mappings.path_replace_movie(movie.path), use_cache=False)
+        store_subtitles_movie(movie.path,
+                              path_mappings.path_replace_instance(movie.path,
+                                                                  movie.arr_instance_id, 'movie'),
+                              use_cache=False, arr_instance_id=movie.arr_instance_id)
 
     jobs_queue.update_job_progress(job_id=job_id, progress_message="Scan completed")
 

--- a/bazarr/subtitles/wanted/movies.py
+++ b/bazarr/subtitles/wanted/movies.py
@@ -136,6 +136,7 @@ def _wanted_movie(movie, providers_list, job_id=None):
                             sonarr_episode_id=None,
                             radarr_id=movie.radarrId,
                             metadata=metadata,
+                            arr_instance_id=arr_instance_id,
                         )
                         # Guard: skip if an identical translate job is already
                         # pending or running. Why: history guard (action=6) only

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -195,7 +195,7 @@ def _wanted_episode(episode, providers_list, job_id=None):
             found_any = True
             if isinstance(result, tuple) and len(result):
                 result = result[0]
-            store_subtitles(episode.path, path_mappings.path_replace(episode.path))
+            store_subtitles(episode.path, path_mappings.path_replace(episode.path), arr_instance_id=arr_instance_id)
             history_log(1, episode.sonarrSeriesId, episode.sonarrEpisodeId, result,
                         arr_instance_id=arr_instance_id)
             event_stream(type='series', action='update', payload=episode.sonarrSeriesId)
@@ -241,7 +241,7 @@ def wanted_download_subtitles(sonarr_episode_id, job_id=None, arr_instance_id=No
         return
     elif episode_details.subtitles is None:
         # subtitles indexing for this episode is incomplete, we'll do it again
-        store_subtitles(episode_details.path, path_mappings.path_replace(episode_details.path))
+        store_subtitles(episode_details.path, path_mappings.path_replace(episode_details.path), arr_instance_id=arr_instance_id)
         episode_details = database.execute(stmt).first()
     elif episode_details.missing_subtitles is None:
         # missing subtitles calculation for this episode is incomplete, we'll do it again
@@ -271,7 +271,8 @@ def wanted_scan_subtitles_series(job_id=None):
                TableShows.title,
                TableEpisodes.season,
                TableEpisodes.episode,
-               TableEpisodes.title.label('episodeTitle'))
+               TableEpisodes.title.label('episodeTitle'),
+               TableEpisodes.arr_instance_id)
         .select_from(TableEpisodes)
         .join(TableShows)
         .where(reduce(operator.and_, conditions))) \
@@ -287,7 +288,10 @@ def wanted_scan_subtitles_series(job_id=None):
         jobs_queue.update_job_progress(job_id=job_id, progress_value=i,
                                        progress_message=f'{episode.title} - S{episode.season:02d}E{episode.episode:02d}'
                                                         f' - {episode.episodeTitle}')
-        store_subtitles(episode.path, path_mappings.path_replace(episode.path), use_cache=False)
+        store_subtitles(episode.path,
+                        path_mappings.path_replace_instance(episode.path,
+                                                            episode.arr_instance_id, 'series'),
+                        use_cache=False, arr_instance_id=episode.arr_instance_id)
 
     jobs_queue.update_job_progress(job_id=job_id, progress_message="Scan completed")
 

--- a/bazarr/subtitles/wanted/series.py
+++ b/bazarr/subtitles/wanted/series.py
@@ -142,6 +142,7 @@ def _wanted_episode(episode, providers_list, job_id=None):
                             sonarr_episode_id=episode.sonarrEpisodeId,
                             radarr_id=None,
                             metadata=metadata,
+                            arr_instance_id=arr_instance_id,
                         )
                         # Guard: skip if an identical translate job is already
                         # pending or running. Why: history guard (action=6) only

--- a/tests/bazarr/test_content_metadata_scope.py
+++ b/tests/bazarr/test_content_metadata_scope.py
@@ -216,6 +216,7 @@ def test_refresh_media_subtitles_episode_uses_instance_mapping(monkeypatch):
         "/remote/tv/show/s01e01.mkv",
         "/local/tv/show/s01e01.mkv",
         use_cache=False,
+        arr_instance_id=3,
     )
 
 
@@ -244,6 +245,7 @@ def test_refresh_media_subtitles_movie_uses_instance_mapping(monkeypatch):
         "/remote/movies/film.mkv",
         "/local/movies/film.mkv",
         use_cache=False,
+        arr_instance_id=4,
     )
 
 

--- a/tests/bazarr/test_embedded_subtitle_extraction.py
+++ b/tests/bazarr/test_embedded_subtitle_extraction.py
@@ -413,7 +413,7 @@ def test_find_subtitle_passes_hi_forced_to_extract():
         )
 
     mock_extract.assert_called_once_with(
-        "/fake/movie.mkv", "en", "movie", hi=True, forced=False
+        "/fake/movie.mkv", "en", "movie", hi=True, forced=False, arr_instance_id=None
     )
     assert result_path == "/fake/extracted.srt"
     assert result_lang == "en"

--- a/tests/bazarr/test_indexer_owner_scope.py
+++ b/tests/bazarr/test_indexer_owner_scope.py
@@ -193,3 +193,59 @@ def test_the_supplied_owner_beats_the_path_lookup_for_movies(two_movie_rows, mon
     assert seen['arr_instance_id'] == 2
     assert seen['movie_file_id'] == 800, \
         f"probed the wrong instance's file id: {seen['movie_file_id']}"
+
+
+# ------------------------------------------------- the indexer's own scanners
+
+def _record_indexing(monkeypatch, module):
+    """Capture (path, owner) for every store_subtitles* call the scanner makes."""
+    calls = []
+    name = 'store_subtitles' if module.__name__.endswith('series') else 'store_subtitles_movie'
+    monkeypatch.setattr(module, name,
+                        lambda path, mapped, **kw: calls.append((path, kw.get('arr_instance_id'))))
+    monkeypatch.setattr(module.jobs_queue, 'update_job_progress', lambda *a, **kw: None)
+    monkeypatch.setattr(module.jobs_queue, 'update_job_name', lambda *a, **kw: None)
+    return calls
+
+
+def test_the_full_episode_scan_indexes_both_instances(two_series_rows, monkeypatch):
+    """Scoping the UPDATE means an owner-less call now writes one row instead of
+    all of them, so a scanner that does not pass the owner silently stops
+    indexing every instance but one."""
+    se, _session = two_series_rows
+    calls = _record_indexing(monkeypatch, se)
+
+    se.series_full_scan_subtitles(job_id=1, use_cache=False)
+
+    assert sorted(owner for _p, owner in calls) == [1, 2], (
+        f'the full scan must index each instance under its own owner; got {calls!r}')
+
+
+def test_the_targeted_episode_scan_passes_the_owner_it_was_given(two_series_rows,
+                                                                 monkeypatch):
+    se, _session = two_series_rows
+    calls = _record_indexing(monkeypatch, se)
+
+    se.series_scan_subtitles(1, arr_instance_id=2)
+
+    assert calls == [('/tv/s/e.mkv', 2)], (
+        f'a scan scoped to instance 2 must index instance 2; got {calls!r}')
+
+
+def test_the_full_movie_scan_indexes_both_instances(two_movie_rows, monkeypatch):
+    mv, _session = two_movie_rows
+    calls = _record_indexing(monkeypatch, mv)
+
+    mv.movies_full_scan_subtitles(job_id=1, use_cache=False)
+
+    assert sorted(owner for _p, owner in calls) == [1, 2], (
+        f'the full scan must index each instance under its own owner; got {calls!r}')
+
+
+def test_the_targeted_movie_scan_passes_the_owner_it_was_given(two_movie_rows, monkeypatch):
+    mv, _session = two_movie_rows
+    calls = _record_indexing(monkeypatch, mv)
+
+    mv.movies_scan_subtitles(7, arr_instance_id=2)
+
+    assert calls == [('/movies/m.mkv', 2)]

--- a/tests/bazarr/test_indexer_owner_scope.py
+++ b/tests/bazarr/test_indexer_owner_scope.py
@@ -1,0 +1,195 @@
+# coding=utf-8
+"""The indexer must index the row it was asked to, not whichever one is first.
+
+``store_subtitles`` resolves the owning instance itself, from the media path
+alone, with an unscoped ``.first()``. Neither the path nor the upstream file id
+is unique across instances, so when two instances hold a row for the same remote
+path the pick is arbitrary.
+
+That resolved owner is not incidental. It feeds the ``_pr`` / ``_prr`` closures
+used for every path the function touches, it selects which ffprobe cache row the
+embedded pass reads and overwrites, and the unscoped UPDATE at the end writes the
+computed listing into every row sharing the path. Per-instance path mappings are
+the whole point of multi-instance support, so two instances can map the same
+remote path at different local files: exactly when an arbitrary pick produces
+wrong data rather than a harmless duplicate.
+
+Callers know the owner. They must be able to say so.
+"""
+import pytest
+
+from sqlalchemy import select
+
+from app.database import TableEpisodes, TableMovies, TableShows
+
+
+@pytest.fixture
+def stub_indexing(monkeypatch):
+    """Neutralise the filesystem and the external-subtitle scan.
+
+    Leaves the database work, which is what these tests are about.
+    """
+    import subtitles.indexer.movies as mv
+    import subtitles.indexer.series as se
+
+    for mod in (se, mv):
+        monkeypatch.setattr(mod.os.path, 'exists', lambda p: True)
+        monkeypatch.setattr(mod, 'search_external_subtitles', lambda *a, **kw: {})
+        monkeypatch.setattr(mod, 'add_sync_engine_outputs', lambda folder, subs: subs)
+        monkeypatch.setattr(mod, 'add_combined_outputs', lambda folder, subs, **kw: subs)
+        monkeypatch.setattr(mod, 'guess_external_subtitles', lambda *a, **kw: {})
+        monkeypatch.setattr(mod, 'event_stream', lambda *a, **kw: None)
+    # Named differently in the two modules.
+    monkeypatch.setattr(se, 'list_missing_subtitles', lambda *a, **kw: None)
+    monkeypatch.setattr(mv, 'list_missing_subtitles_movies', lambda *a, **kw: None)
+    return se, mv
+
+
+@pytest.fixture
+def two_series_rows(schema_session, stub_indexing, monkeypatch):
+    """Two episodes on different instances sharing one remote path."""
+    se, _mv = stub_indexing
+    monkeypatch.setattr(se, 'database', schema_session)
+    monkeypatch.setattr(se.settings.general, 'use_embedded_subs', False, raising=False)
+
+    schema_session.add_all([
+        TableShows(id=1, arr_instance_id=1, sonarrSeriesId=1, title='S', path='/tv/s', profileId=None),
+        TableShows(id=2, arr_instance_id=2, sonarrSeriesId=1, title='S', path='/tv/s', profileId=None),
+    ])
+    schema_session.flush()
+    schema_session.add_all([
+        TableEpisodes(id=1, arr_instance_id=1, series_id=1, sonarrSeriesId=1,
+                      sonarrEpisodeId=11, title='E', path='/tv/s/e.mkv', season=1, episode=1,
+                      episode_file_id=500, file_size=111, subtitles="[['en', '/one.srt', 1]]"),
+        TableEpisodes(id=2, arr_instance_id=2, series_id=2, sonarrSeriesId=1,
+                      sonarrEpisodeId=22, title='E', path='/tv/s/e.mkv', season=1, episode=1,
+                      episode_file_id=900, file_size=222, subtitles="[['fr', '/two.srt', 2]]"),
+    ])
+    schema_session.commit()
+    return se, schema_session
+
+
+def _subs(session, table, row_id):
+    return session.execute(select(table.subtitles).where(table.id == row_id)).scalar()
+
+
+def test_only_the_owning_episode_row_is_indexed(two_series_rows):
+    se, session = two_series_rows
+
+    se.store_subtitles('/tv/s/e.mkv', '/local/e.mkv', arr_instance_id=2)
+
+    assert _subs(session, TableEpisodes, 2) == '[]', \
+        'the row the caller named must be the one that gets the new listing'
+    assert _subs(session, TableEpisodes, 1) == "[['en', '/one.srt', 1]]", \
+        "the other instance's listing was overwritten with this file's result"
+
+
+def test_the_supplied_owner_beats_the_path_lookup_for_the_metadata_cache(two_series_rows,
+                                                                        monkeypatch):
+    """The embedded pass must probe the named instance's file id, not whichever
+    row the unscoped lookup happened to return first."""
+    se, session = two_series_rows
+    monkeypatch.setattr(se.settings.general, 'use_embedded_subs', True, raising=False)
+
+    seen = {}
+
+    def _reader(path, file_size=None, episode_file_id=None, use_cache=True,
+                arr_instance_id=None):
+        seen.update(file_size=file_size, episode_file_id=episode_file_id,
+                    arr_instance_id=arr_instance_id)
+        return []
+
+    monkeypatch.setattr(se, 'embedded_subs_reader', _reader)
+
+    se.store_subtitles('/tv/s/e.mkv', '/local/e.mkv', arr_instance_id=2)
+
+    assert seen['arr_instance_id'] == 2
+    assert seen['episode_file_id'] == 900, \
+        f"probed the wrong instance's file id: {seen['episode_file_id']}"
+    assert seen['file_size'] == 222
+
+
+def test_the_owning_instance_mapping_is_used(two_series_rows, monkeypatch):
+    """A caller-supplied owner has to reach the path mapping too, since that is
+    what decides where subtitles are looked for on disk."""
+    se, _session = two_series_rows
+    calls = []
+    monkeypatch.setattr(se.path_mappings, 'path_replace_instance',
+                        lambda p, inst, kind: calls.append((p, inst, kind)) or p)
+
+    se.store_subtitles('/tv/s/e.mkv', '/local/e.mkv', arr_instance_id=2)
+
+    assert calls, 'the per-instance mapping was never consulted'
+    assert {inst for _p, inst, _k in calls} == {2}, \
+        f'the mapping ran for the wrong instance: {calls!r}'
+
+
+def test_without_an_owner_the_single_instance_path_is_unchanged(schema_session,
+                                                                stub_indexing, monkeypatch):
+    se, _mv = stub_indexing
+    monkeypatch.setattr(se, 'database', schema_session)
+    monkeypatch.setattr(se.settings.general, 'use_embedded_subs', False, raising=False)
+
+    schema_session.add(TableShows(id=1, arr_instance_id=None, sonarrSeriesId=1, title='S',
+                                  path='/tv/s', profileId=None))
+    schema_session.flush()
+    schema_session.add(TableEpisodes(id=1, arr_instance_id=None, series_id=1, sonarrSeriesId=1,
+                                     sonarrEpisodeId=11, title='E', path='/tv/s/e.mkv',
+                                     season=1, episode=1, episode_file_id=500, file_size=111,
+                                     subtitles="[['en', '/one.srt', 1]]"))
+    schema_session.commit()
+
+    se.store_subtitles('/tv/s/e.mkv', '/local/e.mkv')
+
+    assert _subs(schema_session, TableEpisodes, 1) == '[]'
+
+
+# ------------------------------------------------------------------- movies
+
+@pytest.fixture
+def two_movie_rows(schema_session, stub_indexing, monkeypatch):
+    _se, mv = stub_indexing
+    monkeypatch.setattr(mv, 'database', schema_session)
+    monkeypatch.setattr(mv.settings.general, 'use_embedded_subs', False, raising=False)
+
+    schema_session.add_all([
+        TableMovies(id=1, arr_instance_id=1, radarrId=7, title='M', path='/movies/m.mkv',
+                    tmdbId='1', movie_file_id=700, file_size=111,
+                    subtitles="[['en', '/one.srt', 1]]"),
+        TableMovies(id=2, arr_instance_id=2, radarrId=7, title='M', path='/movies/m.mkv',
+                    tmdbId='2', movie_file_id=800, file_size=222,
+                    subtitles="[['fr', '/two.srt', 2]]"),
+    ])
+    schema_session.commit()
+    return mv, schema_session
+
+
+def test_only_the_owning_movie_row_is_indexed(two_movie_rows):
+    mv, session = two_movie_rows
+
+    mv.store_subtitles_movie('/movies/m.mkv', '/local/m.mkv', arr_instance_id=2)
+
+    assert _subs(session, TableMovies, 2) == '[]'
+    assert _subs(session, TableMovies, 1) == "[['en', '/one.srt', 1]]", \
+        "the other instance's listing was overwritten with this file's result"
+
+
+def test_the_supplied_owner_beats_the_path_lookup_for_movies(two_movie_rows, monkeypatch):
+    mv, _session = two_movie_rows
+    monkeypatch.setattr(mv.settings.general, 'use_embedded_subs', True, raising=False)
+
+    seen = {}
+
+    def _reader(path, file_size=None, movie_file_id=None, use_cache=True,
+                arr_instance_id=None):
+        seen.update(file_size=file_size, movie_file_id=movie_file_id,
+                    arr_instance_id=arr_instance_id)
+        return []
+
+    monkeypatch.setattr(mv, 'embedded_subs_reader', _reader)
+
+    mv.store_subtitles_movie('/movies/m.mkv', '/local/m.mkv', arr_instance_id=2)
+
+    assert seen['arr_instance_id'] == 2
+    assert seen['movie_file_id'] == 800, \
+        f"probed the wrong instance's file id: {seen['movie_file_id']}"

--- a/tests/bazarr/test_mass_download_path_mapping.py
+++ b/tests/bazarr/test_mass_download_path_mapping.py
@@ -70,23 +70,25 @@ def episode_module(monkeypatch):
 def test_reindexing_an_episode_uses_the_series_path_mapping(episode_module, monkeypatch):
     module, unindexed = episode_module
     indexed = []
-    monkeypatch.setattr(module, "store_subtitles", lambda path, mapped: indexed.append((path, mapped)))
+    monkeypatch.setattr(module, "store_subtitles",
+                        lambda path, mapped, **kw: indexed.append((path, mapped, kw.get("arr_instance_id"))))
 
     # The episode file is not on this machine, so the call stops right after the
     # re-index. That is the whole region under test.
     with pytest.raises(OSError):
         module.episode_download_subtitles(1, job_id=1, job_sub_function=True)
 
-    assert indexed == [(unindexed.path, "/mnt/series/Show/Season 1/Show.S01E01.mkv")]
+    assert indexed == [(unindexed.path, "/mnt/series/Show/Season 1/Show.S01E01.mkv", None)]
 
 
 def test_the_owning_instance_path_mapping_wins(episode_module, monkeypatch):
     module, unindexed = episode_module
     unindexed.arr_instance_id = 7
     indexed = []
-    monkeypatch.setattr(module, "store_subtitles", lambda path, mapped: indexed.append((path, mapped)))
+    monkeypatch.setattr(module, "store_subtitles",
+                        lambda path, mapped, **kw: indexed.append((path, mapped, kw.get("arr_instance_id"))))
 
     with pytest.raises(OSError):
         module.episode_download_subtitles(1, job_id=1, job_sub_function=True)
 
-    assert indexed == [(unindexed.path, "/mnt/instance7/Show/Season 1/Show.S01E01.mkv")]
+    assert indexed == [(unindexed.path, "/mnt/instance7/Show/Season 1/Show.S01E01.mkv", 7)]

--- a/tests/bazarr/test_mass_operations.py
+++ b/tests/bazarr/test_mass_operations.py
@@ -132,6 +132,7 @@ class TestProcessSubtitleItem:
             sonarr_episode_id=1,
             radarr_id=None,
             metadata=item['metadata'],
+            arr_instance_id=None,
         )
 
     @patch('subtitles.tools.translate.main.translate_subtitles_file', return_value=True)

--- a/tests/bazarr/test_subtitle_content_sync_outputs.py
+++ b/tests/bazarr/test_subtitle_content_sync_outputs.py
@@ -213,7 +213,9 @@ def test_promote_sync_output_overwrites_target_atomically(tmp_path, monkeypatch)
     assert response['sourceLanguage'] == 'hu:sync-ffsubsync'
     assert response['targetLanguage'] == 'hu'
     assert original.read_text(encoding='utf-8') == 'synced subtitle'
-    assert store_calls == [((metadata['mediaPath'], metadata['mediaPath']), {'use_cache': False})]
+    assert store_calls == [((metadata['mediaPath'], metadata['mediaPath']),
+                            {'use_cache': False,
+                             'arr_instance_id': metadata.get('arrInstanceId')})]
     assert history_calls[0][1]['action'] == 5
     assert history_calls[0][1]['radarr_id'] == 1203
     assert history_calls[0][1]['result'].subs_path == str(original)

--- a/tests/bazarr/test_translate_owner_threading.py
+++ b/tests/bazarr/test_translate_owner_threading.py
@@ -1,0 +1,82 @@
+# coding=utf-8
+"""A translation has to be re-indexed against the instance that asked for it.
+
+``translate_subtitles_file`` finishes by calling ``postprocess_subtitles``, which
+re-indexes the new file. It never passed the owning instance, so that call took
+the ``None`` default and ``store_subtitles`` fell back to resolving an owner from
+the path.
+
+That was survivable while the indexer wrote every row sharing a path. It is not
+now: the write is scoped, so the translated subtitle can be indexed into a
+sibling instance's row while the row the user actually asked about stays stale,
+showing no subtitle for a file that exists.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def translate_harness(monkeypatch, tmp_path):
+    """Stub everything around the translation so the call reaches postprocess."""
+    from subtitles.tools.translate import main as translate_main
+    from subzero.language import Language
+
+    monkeypatch.setattr(translate_main, 'validate_translation_params', lambda *a, **kw: None)
+    monkeypatch.setattr(translate_main, 'convert_language_codes',
+                        lambda to_lang, forced, hi: (Language('nld'), to_lang))
+    monkeypatch.setattr(translate_main, 'get_subtitle_path',
+                        lambda *a, **kw: str(tmp_path / 'video.nl.srt'))
+    monkeypatch.setattr(translate_main, 'get_external_subtitles_path',
+                        lambda file, subtitle: str(tmp_path / subtitle))
+    monkeypatch.setattr(translate_main, 'alpha3_from_alpha2', lambda code: 'nld')
+
+    translator = MagicMock()
+    translator.translate.return_value = True
+    monkeypatch.setattr(translate_main.TranslatorFactory, 'create_translator',
+                        staticmethod(lambda *a, **kw: translator))
+    return translate_main
+
+
+def test_the_owner_reaches_the_reindex_after_a_translation(translate_harness):
+    translate_main = translate_harness
+    seen = {}
+
+    def _postprocess(subtitles_path, video_path, media_type, metadata, id,
+                     arr_instance_id=None):
+        seen['arr_instance_id'] = arr_instance_id
+
+    with (
+        patch('api.subtitles.subtitles.postprocess_subtitles', _postprocess),
+        patch('subtitles.tools.combine.main.try_combine_for_video', lambda **kw: None),
+    ):
+        translate_main.translate_subtitles_file(
+            video_path='/local/tv/s/e.mkv', source_srt_file='/local/tv/s/e.en.srt',
+            from_lang='en', to_lang='nl', forced=False, hi=False,
+            media_type='episode', sonarr_series_id=1, sonarr_episode_id=42,
+            radarr_id=None, metadata={}, job_id='job-1', arr_instance_id=3)
+
+    assert seen['arr_instance_id'] == 3, (
+        'the re-index after a translation ran unscoped, so it can write the '
+        "translated subtitle into a sibling instance's row")
+
+
+def test_no_owner_still_works_for_a_single_instance_install(translate_harness):
+    translate_main = translate_harness
+    seen = {}
+
+    def _postprocess(subtitles_path, video_path, media_type, metadata, id,
+                     arr_instance_id=None):
+        seen['arr_instance_id'] = arr_instance_id
+
+    with (
+        patch('api.subtitles.subtitles.postprocess_subtitles', _postprocess),
+        patch('subtitles.tools.combine.main.try_combine_for_video', lambda **kw: None),
+    ):
+        translate_main.translate_subtitles_file(
+            video_path='/local/movies/m.mkv', source_srt_file='/local/movies/m.en.srt',
+            from_lang='en', to_lang='nl', forced=False, hi=False,
+            media_type='movies', sonarr_series_id=None, sonarr_episode_id=None,
+            radarr_id=9, metadata={}, job_id='job-1')
+
+    assert seen['arr_instance_id'] is None


### PR DESCRIPTION
Found by Codex while reviewing https://github.com/LavX/bazarr/pull/358, confirmed pre-existing rather than introduced there, and fixed here rather than left in the backlog.

## The defect

`store_subtitles` and `store_subtitles_movie` resolved the owning instance themselves:

```python
owner_row = database.execute(
    select(TableEpisodes.arr_instance_id)
    .where(TableEpisodes.path == original_path)).first()
```

Neither `path` nor the upstream file id is unique across instances, so `.first()` picks arbitrarily whenever two instances hold a row for the same remote path.

That resolved owner is not incidental. It feeds the `_pr` / `_prr` closures used for every path the function touches, it selects which ffprobe cache row the embedded pass reads and overwrites, and the trailing UPDATE wrote the computed listing into **every** row sharing the path. Per-instance `path_mappings` is the point of multi-instance support, so two instances can map the same remote path at two different local files. That is exactly when an arbitrary pick produces wrong data rather than a harmless duplicate.

## The fix

Both functions take the owner from the caller, and all five path-keyed statements in each are scoped to it. Passing nothing falls back to the old lookup, so the default and single-instance path is unchanged.

All 47 call sites pass it. Where a caller had already mapped the path forward with a row s instance, that same row s instance is what goes in: the two disagreeing is the bug in miniature, and mass download was doing exactly that, mapping with `episode.arr_instance_id` while the request scope was `None`. Its existing test caught my first pass at this.

Three call sites needed more than threading:

- both disk scanners never selected the owning instance at all, so they now select it and map per instance to match
- `process_movie_translation` had a fully unscoped `TableMovies` lookup where its episode twin was already scoped
- the owner is threaded through `find_subtitle_by_language` into embedded extraction, which is the other half of the review finding

## Verification

Local: ruff clean, 1955 backend tests, 377 compat tests, 8 skipped, no failures. Six new tests in `tests/bazarr/test_indexer_owner_scope.py`, registered in the CI guard list, covering both media types: the supplied owner beating the path lookup, only the owning row being written, the per-instance mapping being used, and the single-instance path staying unchanged.

Deployed to a four-instance test server (two Sonarr, two Radarr) and driven for real: a full episode re-index plus a secondary Sonarr sync, 2141 files indexed, zero exceptions, subtitle listings intact on spot check.