### PR TITLE
fix: the two low findings from the pre-release triage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,7 @@ jobs:
             tests/bazarr/test_mass_operations.py \
             tests/bazarr/test_embedded_extraction_instance_scope.py \
             tests/bazarr/test_ffprobe_cache_instance_scope.py \
+            tests/bazarr/test_triage_low_findings.py \
             tests/bazarr/test_parser_owner_threading.py \
             tests/bazarr/test_embedded_translate_api_scope.py \
             tests/bazarr/test_release_type_mismatch_migration.py \

--- a/bazarr/arr_instances/service.py
+++ b/bazarr/arr_instances/service.py
@@ -16,6 +16,7 @@ from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 
 from app.database import TableLanguagesProfiles, TableMovies, TableShows
+from utilities.sql_limits import in_chunks
 
 from .media_defaults import (instance_default_profile, merge_media_defaults_into_options,
                              read_media_defaults, validate_media_defaults)
@@ -504,13 +505,17 @@ def apply_default_profile(session, instance_id):
     excluded_tags = _excluded_profile_tags(row.kind)
     upstream_ids = [t[0] for t in targets
                     if not _tags_exclude_a_profile(t[1], excluded_tags)]
-    if upstream_ids:
+    # One statement per chunk: this binds a variable per item, and SQLite built
+    # with the legacy limit rejects more than 999 in a statement. A library with
+    # that many unprofiled items is ordinary, and the failure would be the Apply
+    # button erroring with nothing updated.
+    for chunk in in_chunks(upstream_ids):
         session.execute(
             update(table)
             .values(profileId=profile)
             .where(table.arr_instance_id == instance_id,
                    table.profileId.is_(None),
-                   upstream_column.in_(upstream_ids)))
+                   upstream_column.in_(chunk)))
 
     logging.info("Assigned language profile %s to %s unprofiled %s items on instance %s",
                  profile, len(upstream_ids), row.kind, instance_id)

--- a/bazarr/subtitles/mismatch.py
+++ b/bazarr/subtitles/mismatch.py
@@ -52,6 +52,7 @@ from app.event_handler import event_stream
 from app.notifier import send_notifications, send_notifications_movie
 from arr_instances.resolution import scoped
 from utilities.path_mappings import path_mappings
+from utilities.sql_limits import MAX_IN_CLAUSE, in_chunks
 
 logger = logging.getLogger(__name__)
 
@@ -547,13 +548,10 @@ def forget_media_by_upstream(media_type, upstream_ids, arr_instance_id=None,
 
 # One page of Wanted may legitimately be 1000 rows, and SQLite builds carrying
 # the legacy limit reject a statement binding more than 999 variables with "too
-# many SQL variables". Leave room for the other bound values in the statement.
-_MAX_IN_CLAUSE = 900
-
-
-def _in_chunks(values):
-    for start in range(0, len(values), _MAX_IN_CLAUSE):
-        yield values[start:start + _MAX_IN_CLAUSE]
+# many SQL variables". The ceiling and the splitting live in utilities.sql_limits
+# so every caller that binds one variable per row respects the same number.
+_MAX_IN_CLAUSE = MAX_IN_CLAUSE
+_in_chunks = in_chunks
 
 
 def flagged_media_ids(session, media_type, media_ids):

--- a/bazarr/subtitles/tools/alass_ffprobe_shim.py
+++ b/bazarr/subtitles/tools/alass_ffprobe_shim.py
@@ -28,6 +28,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 
 # What a stream whose codec ffprobe could not identify gets called. alass only
 # needs the field to exist: it reads codec_type to pick the audio stream.
@@ -74,6 +75,11 @@ def patch_ffprobe_json(text):
 
 
 _LAUNCHER_PATH = None
+
+# Jobs are threads in one process, so two syncs starting together race here:
+# both would install, and the loser's sweep would delete the winner's
+# directory out from under an alass that is already running against it.
+_LAUNCHER_LOCK = threading.Lock()
 
 
 def launcher_script(python, shim):
@@ -131,11 +137,18 @@ def _sweep(parent):
     except OSError:
         return
 
+    # Never the one in use. It is being handed to alass, which execs it
+    # directly, and a sweep that removes it mid-sync fails that sync and spends
+    # one of the engine's three strikes on a self-inflicted error.
+    in_use = os.path.dirname(_LAUNCHER_PATH) if _LAUNCHER_PATH else None
+
     for entry in entries:
         if not entry.startswith(LAUNCHER_PREFIX):
             continue
 
         path = os.path.join(parent, entry)
+        if in_use and os.path.abspath(path) == os.path.abspath(in_use):
+            continue
         try:
             if os.stat(path).st_uid != os.getuid():
                 continue
@@ -188,21 +201,27 @@ def ensure_launcher():
     if _LAUNCHER_PATH and os.path.isfile(_LAUNCHER_PATH):
         return _LAUNCHER_PATH
 
-    content = launcher_script(sys.executable, os.path.abspath(__file__))
-    for parent in _writable_directories():
-        directory = None
-        try:
-            directory = tempfile.mkdtemp(prefix=LAUNCHER_PREFIX, dir=_ensure(parent))
-            _LAUNCHER_PATH = _install_launcher(directory, content)
-        except Exception:
-            logger.debug("Could not install the alass ffprobe shim in %s", parent, exc_info=True)
-            # Nothing remembers the failure, so every sync retries this. Each
-            # retry leaving its private directory behind would leak inodes.
-            if directory:
-                shutil.rmtree(directory, ignore_errors=True)
-            continue
+    with _LAUNCHER_LOCK:
+        # Checked again inside: the thread that held the lock may have just
+        # installed the launcher this one was about to duplicate.
+        if _LAUNCHER_PATH and os.path.isfile(_LAUNCHER_PATH):
+            return _LAUNCHER_PATH
 
-        return _LAUNCHER_PATH
+        content = launcher_script(sys.executable, os.path.abspath(__file__))
+        for parent in _writable_directories():
+            directory = None
+            try:
+                directory = tempfile.mkdtemp(prefix=LAUNCHER_PREFIX, dir=_ensure(parent))
+                _LAUNCHER_PATH = _install_launcher(directory, content)
+            except Exception:
+                logger.debug("Could not install the alass ffprobe shim in %s", parent, exc_info=True)
+                # Nothing remembers the failure, so every sync retries this. Each
+                # retry leaving its private directory behind would leak inodes.
+                if directory:
+                    shutil.rmtree(directory, ignore_errors=True)
+                continue
+
+            return _LAUNCHER_PATH
 
     return None
 

--- a/bazarr/utilities/sql_limits.py
+++ b/bazarr/utilities/sql_limits.py
@@ -1,0 +1,19 @@
+# coding=utf-8
+"""One place for the bind-parameter ceiling every IN clause has to respect.
+
+SQLite compiled with the legacy SQLITE_MAX_VARIABLE_NUMBER rejects a statement
+binding more than 999 variables with "too many SQL variables". That is still
+what ships in plenty of distributions, and a library large enough to trip it is
+ordinary rather than exotic, so any query that binds one variable per row has to
+be split. The margin below 999 leaves room for the other bound values in the
+statement.
+"""
+
+MAX_IN_CLAUSE = 900
+
+
+def in_chunks(values, size=MAX_IN_CLAUSE):
+    """Yield ``values`` in slices small enough for a single IN clause."""
+    values = list(values)
+    for start in range(0, len(values), size):
+        yield values[start:start + size]

--- a/tests/bazarr/test_triage_low_findings.py
+++ b/tests/bazarr/test_triage_low_findings.py
@@ -1,0 +1,161 @@
+# coding=utf-8
+"""Two defects the v2.6.0 pre-release triage turned up.
+
+1. ``apply_default_profile`` binds every unprofiled item id into a single IN
+   clause. SQLite built with the legacy limit rejects a statement binding more
+   than 999 variables, and the codebase already chunks at 900 elsewhere for
+   exactly that reason. A library with more than that many unprofiled items
+   would make the Apply button fail with nothing updated.
+
+2. ``ensure_launcher`` sweeps every launcher directory this user owns on each
+   install, and reads and writes the module-level path with no lock. Bazarr's
+   jobs are threads in one process, so two syncs starting together can both
+   install, and the second one's sweep can delete the directory the first is
+   about to hand to a running alass.
+"""
+import os
+import threading
+
+import pytest
+
+from sqlalchemy import select
+
+from app.database import TableLanguagesProfiles, TableShows
+
+
+# ------------------------------------------------- the unchunked IN clause
+
+def _bound_in_sizes(statement):
+    """How many values each IN clause in this statement binds."""
+    sizes = []
+    for criterion in getattr(statement, '_where_criteria', ()):
+        for element in getattr(criterion, 'get_children', lambda **kw: ())(column_collections=False):
+            expanding = getattr(element, 'expanding', False)
+            value = getattr(element, 'value', None)
+            if expanding and isinstance(value, (list, tuple)):
+                sizes.append(len(value))
+    return sizes
+
+
+@pytest.fixture
+def instance_with_many_unprofiled(schema_session, monkeypatch):
+    from arr_instances import service
+    from arr_instances.repository import ArrInstanceRepository
+
+    monkeypatch.setattr(service, '_known_profile_ids', lambda _s: {7})
+    monkeypatch.setattr(service, '_excluded_profile_tags', lambda _kind: set())
+
+    from arr_instances.media_defaults import merge_media_defaults_into_options
+
+    # profileId carries a real foreign key, so the profile has to exist.
+    schema_session.add(TableLanguagesProfiles(profileId=7, cutoff=None, originalFormat=0,
+                                              items='[]', name='Default'))
+    schema_session.flush()
+
+    repo = ArrInstanceRepository(schema_session)
+    inst = repo.create('sonarr', 'Sonarr')
+    schema_session.flush()
+    repo.update(inst.id, options=merge_media_defaults_into_options(
+        None, {'default_profile': 7, 'default_enabled': True}))
+    schema_session.flush()
+
+    schema_session.add_all([
+        TableShows(id=i, arr_instance_id=inst.id, sonarrSeriesId=1000 + i,
+                   title=f'S{i}', path=f'/tv/{i}', profileId=None, tags='[]')
+        for i in range(1, 1001)
+    ])
+    schema_session.commit()
+    return service, inst.id, schema_session
+
+
+def test_applying_a_default_profile_chunks_its_in_clause(instance_with_many_unprofiled,
+                                                         monkeypatch):
+    service, instance_id, session = instance_with_many_unprofiled
+
+    widest = []
+    real_execute = session.execute
+
+    def _spy(statement, *a, **kw):
+        widest.extend(_bound_in_sizes(statement))
+        return real_execute(statement, *a, **kw)
+
+    monkeypatch.setattr(session, 'execute', _spy)
+
+    body, status = service.apply_default_profile(session, instance_id)
+
+    assert status == 200, body
+    assert widest, 'no IN clause was bound, the test is not looking at the right thing'
+    assert max(widest) <= 900, (
+        f'one statement bound {max(widest)} values into a single IN clause; SQLite '
+        'built with the legacy limit rejects more than 999')
+
+
+def test_applying_a_default_profile_still_updates_every_row(instance_with_many_unprofiled):
+    service, instance_id, session = instance_with_many_unprofiled
+
+    body, status = service.apply_default_profile(session, instance_id)
+
+    assert status == 200
+    assert body['updated'] == 1000
+    remaining = session.execute(
+        select(TableShows.id).where(TableShows.arr_instance_id == instance_id,
+                                    TableShows.profileId.is_(None))).all()
+    assert remaining == [], f'{len(remaining)} rows were left unprofiled'
+
+
+# ------------------------------------------------------- the launcher sweep
+
+def test_the_sweep_spares_the_launcher_in_use(tmp_path, monkeypatch):
+    """A sweep that deletes the launcher a running alass is executing fails that
+    sync and records a strike against the engine."""
+    from subtitles.tools import alass_ffprobe_shim as shim
+
+    parent = tmp_path / 'cache'
+    parent.mkdir()
+    live = parent / f'{shim.LAUNCHER_PREFIX}live'
+    live.mkdir()
+    (live / 'ffprobe').write_text('#!/bin/sh\n')
+    stale = parent / f'{shim.LAUNCHER_PREFIX}stale'
+    stale.mkdir()
+
+    monkeypatch.setattr(shim, '_LAUNCHER_PATH', str(live / 'ffprobe'))
+
+    shim._sweep(str(parent))
+
+    assert live.exists(), 'the sweep deleted the launcher that is currently in use'
+    assert not stale.exists(), 'the sweep should still reclaim earlier runs'
+
+
+def test_concurrent_callers_install_one_launcher(tmp_path, monkeypatch):
+    """Jobs are threads in one process, so two syncs starting together race on
+    the module-level path and both install."""
+    from subtitles.tools import alass_ffprobe_shim as shim
+
+    monkeypatch.setattr(shim, '_LAUNCHER_PATH', None)
+    monkeypatch.setattr(shim, '_writable_directories', lambda: [str(tmp_path)])
+
+    installs = []
+    barrier = threading.Barrier(4)
+
+    def _install(directory, content):
+        installs.append(directory)
+        launcher = os.path.join(directory, 'ffprobe')
+        with open(launcher, 'w') as handle:
+            handle.write(content)
+        return launcher
+
+    monkeypatch.setattr(shim, '_install_launcher', _install)
+
+    def _run():
+        barrier.wait()
+        shim.ensure_launcher()
+
+    threads = [threading.Thread(target=_run) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(installs) == 1, (
+        f'{len(installs)} threads installed a launcher; only one should have, and '
+        'the others must reuse it')


### PR DESCRIPTION
Both surfaced by the v2.6.0 pre-release check. Low severity, fixed rather than filed.

## The unchunked IN clause

`apply_default_profile` binds one variable per item into a single `IN`. SQLite built with the legacy `SQLITE_MAX_VARIABLE_NUMBER` rejects a statement binding more than 999 with "too many SQL variables", and a library with that many unprofiled items is ordinary. The symptom would be the Apply button erroring with nothing updated.

`mismatch.py` already chunked at 900 for exactly this reason, so the ceiling and the splitting move into `utilities/sql_limits.py` and both callers share one number instead of two copies drifting apart.

The test asserts the bind count, not the outcome, deliberately: modern SQLite swallows 1000 variables happily, so an outcome-only test would pass against the unfixed code and prove nothing. The outcome is asserted too, as a separate test.

## The launcher sweep race

`ensure_launcher` swept every `bazarr-alass-shim-*` directory this user owns on each install, and read and wrote the module-level path with no lock. Jobs are threads in one process, so two syncs starting together both install, and the loser sweep can delete the directory the winner is about to hand to a running alass. alass execs that path directly, so the sync fails and spends one of the engine three strikes on a self-inflicted error.

Installs are serialised behind a lock with a re-check inside it, and the sweep skips the launcher currently in use while still reclaiming what earlier runs left behind.

## Verification

Local: ruff clean, 1953 backend tests, 8 skipped, no failures. Four new tests in `tests/bazarr/test_triage_low_findings.py`, registered in the CI guard list.

Deployed to the test server: boots healthy, the shared module and both fixes present in the image, no new errors in the log.