### PR TITLE
fix(translate): extraction must agree with indexing about the tracks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,7 @@ jobs:
             tests/bazarr/test_triage_low_findings.py \
             tests/bazarr/test_indexer_owner_scope.py \
             tests/bazarr/test_translate_owner_threading.py \
+            tests/bazarr/test_embedded_track_eligibility.py \
             tests/bazarr/test_parser_owner_threading.py \
             tests/bazarr/test_embedded_translate_api_scope.py \
             tests/bazarr/test_release_type_mismatch_migration.py \

--- a/bazarr/subtitles/mass_operations.py
+++ b/bazarr/subtitles/mass_operations.py
@@ -108,6 +108,48 @@ def _usable_as_translate_source(lang_string, path):
     return not is_sync_engine_output(path)
 
 
+def _translate_target_satisfied(subtitles, target_lang, source_lang, usable):
+    """True when every subtitle this run would produce is already on disk.
+
+    The old check asked only whether the base target language appeared anywhere
+    with a path, which is too coarse in both directions. A ``nl:forced`` file
+    suppressed a plain ``en`` to ``nl`` run even though the run would have
+    written a different file, and a row naming a file that has since been
+    deleted suppressed it too. Translation carries the source variant through,
+    so the comparison has to be against the variant, not the base.
+
+    ``usable`` answers whether a path-bearing entry is a real subtitle on disk
+    rather than a stale row or a generated artifact. Embedded entries have no
+    path and are always available as sources.
+    """
+    wanted = set()
+    for lang_string, path in subtitles:
+        base, hi, forced = _subtitle_variant_key(lang_string)
+        if forced:
+            continue
+        if source_lang and base != source_lang:
+            continue
+        if path and not usable(lang_string, path):
+            continue
+        wanted.add(hi)
+
+    if not wanted:
+        return False
+
+    present = set()
+    for lang_string, path in subtitles:
+        if not path:
+            continue
+        base, hi, forced = _subtitle_variant_key(lang_string)
+        if base != target_lang or forced:
+            continue
+        if not usable(lang_string, path):
+            continue
+        present.add(hi)
+
+    return wanted <= present
+
+
 def _drop_embedded_duplicates(subtitles, usable):
     """Remove an embedded track when a usable file covers the same variant.
 
@@ -344,13 +386,25 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
 
             subtitles = _drop_embedded_duplicates(subtitles, _usable)
 
-        # For translate: check if target language already exists. Files only:
-        # an embedded track counting here would skip an item that has no
-        # target-language file at all, which is a regression for runs that
-        # never involved an embedded source.
+        # For translate: skip only when every subtitle this run would write is
+        # already there. Compared per variant, not per base language, because
+        # translation carries the source variant through: a forced file in the
+        # target language is a different subtitle, and so is the plain one when
+        # the source is hearing-impaired. A row naming a file that is gone, or
+        # naming a sync or combined artifact, does not count either.
+        def _target_usable(lang_string, sub_path, _owner=ep):
+            mapped = path_mappings.path_replace_instance(
+                sub_path, _owner.arr_instance_id, 'episode')
+            if not os.path.isfile(mapped):
+                return False
+            modifiers = [part.lower() for part in lang_string.split(':')[1:]]
+            if any(m.startswith('combined-') for m in modifiers):
+                return False
+            return not is_sync_engine_output(mapped)
+
         if action == 'translate' and target_lang:
-            existing_langs = {lang_str.split(':')[0] for lang_str, path in subtitles if path}
-            if target_lang in existing_langs:
+            if _translate_target_satisfied(subtitles, target_lang, source_lang,
+                                           _target_usable):
                 skipped += 1
                 continue
 
@@ -484,13 +538,25 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
 
             subtitles = _drop_embedded_duplicates(subtitles, _usable)
 
-        # For translate: check if target language already exists. Files only:
-        # an embedded track counting here would skip an item that has no
-        # target-language file at all, which is a regression for runs that
-        # never involved an embedded source.
+        # For translate: skip only when every subtitle this run would write is
+        # already there. Compared per variant, not per base language, because
+        # translation carries the source variant through: a forced file in the
+        # target language is a different subtitle, and so is the plain one when
+        # the source is hearing-impaired. A row naming a file that is gone, or
+        # naming a sync or combined artifact, does not count either.
+        def _target_usable(lang_string, sub_path, _owner=movie):
+            mapped = path_mappings.path_replace_instance(
+                sub_path, _owner.arr_instance_id, 'movie')
+            if not os.path.isfile(mapped):
+                return False
+            modifiers = [part.lower() for part in lang_string.split(':')[1:]]
+            if any(m.startswith('combined-') for m in modifiers):
+                return False
+            return not is_sync_engine_output(mapped)
+
         if action == 'translate' and target_lang:
-            existing_langs = {lang_str.split(':')[0] for lang_str, path in subtitles if path}
-            if target_lang in existing_langs:
+            if _translate_target_satisfied(subtitles, target_lang, source_lang,
+                                           _target_usable):
                 skipped += 1
                 continue
 

--- a/bazarr/subtitles/mass_operations.py
+++ b/bazarr/subtitles/mass_operations.py
@@ -108,21 +108,40 @@ def _usable_as_translate_source(lang_string, path):
     return not is_sync_engine_output(path)
 
 
-def _translate_target_satisfied(subtitles, target_lang, source_lang, usable):
-    """True when every subtitle this run would produce is already on disk.
+def _translate_output_present(subtitles, target_lang, hi, usable):
+    """True when the file this one source would produce is already on disk.
 
-    The old check asked only whether the base target language appeared anywhere
-    with a path, which is too coarse in both directions. A ``nl:forced`` file
-    suppressed a plain ``en`` to ``nl`` run even though the run would have
-    written a different file, and a row naming a file that has since been
-    deleted suppressed it too. Translation carries the source variant through,
-    so the comparison has to be against the variant, not the base.
+    Asked per source, not per item. An item with an ``en`` and an ``en:hi``
+    source and an existing ``nl`` file is not fully satisfied, because ``nl:hi``
+    is missing, but deciding that at the item level queues both sources and the
+    plain one then overwrites the ``nl`` file that was already there. On a paid
+    translator that is billed work for a file the user already had.
 
-    ``usable`` answers whether a path-bearing entry is a real subtitle on disk
-    rather than a stale row or a generated artifact. Embedded entries have no
-    path and are always available as sources.
+    Translation carries the source variant through and never produces a forced
+    subtitle, so the comparison is on base language plus the hearing-impaired
+    flag. ``usable`` rejects a row naming a file that is gone, and generated
+    sync or combined artifacts, which are not subtitles the user asked for.
     """
-    wanted = set()
+    for lang_string, path in subtitles:
+        if not path:
+            continue
+        base, existing_hi, forced = _subtitle_variant_key(lang_string)
+        if forced or base != target_lang or existing_hi != hi:
+            continue
+        if usable(lang_string, path):
+            return True
+    return False
+
+
+def _translate_item_satisfied(subtitles, target_lang, source_lang, usable):
+    """True when every source on this item already has its output on disk.
+
+    A fast path only. It exists so a fully covered item still reports as one
+    skipped item rather than one per subtitle entry, which is what the counter
+    meant before. The per-source check in the loop is what handles the partial
+    case, where some outputs exist and some do not.
+    """
+    wanted = []
     for lang_string, path in subtitles:
         base, hi, forced = _subtitle_variant_key(lang_string)
         if forced:
@@ -131,23 +150,12 @@ def _translate_target_satisfied(subtitles, target_lang, source_lang, usable):
             continue
         if path and not usable(lang_string, path):
             continue
-        wanted.add(hi)
+        wanted.append(hi)
 
     if not wanted:
         return False
-
-    present = set()
-    for lang_string, path in subtitles:
-        if not path:
-            continue
-        base, hi, forced = _subtitle_variant_key(lang_string)
-        if base != target_lang or forced:
-            continue
-        if not usable(lang_string, path):
-            continue
-        present.add(hi)
-
-    return wanted <= present
+    return all(_translate_output_present(subtitles, target_lang, hi, usable)
+               for hi in wanted)
 
 
 def _drop_embedded_duplicates(subtitles, usable):
@@ -402,11 +410,10 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
                 return False
             return not is_sync_engine_output(mapped)
 
-        if action == 'translate' and target_lang:
-            if _translate_target_satisfied(subtitles, target_lang, source_lang,
-                                           _target_usable):
-                skipped += 1
-                continue
+        if action == 'translate' and target_lang and _translate_item_satisfied(
+                subtitles, target_lang, source_lang, _target_usable):
+            skipped += 1
+            continue
 
         for lang_string, sub_path in subtitles:
             # Every modifier, not just the first: a track can be both hi and
@@ -421,6 +428,14 @@ def _collect_episodes(series_ids=None, episode_ids=None, action='sync',
 
             # For translate: only queue subtitles matching the requested source language
             if action == 'translate' and source_lang and sub_lang != source_lang:
+                skipped += 1
+                continue
+
+            # And only when the file this source would produce is not already
+            # there. Per source, because two sources of the same language can
+            # produce different outputs: en gives nl, en:hi gives nl:hi.
+            if action == 'translate' and target_lang and _translate_output_present(
+                    subtitles, target_lang, sub_hi, _target_usable):
                 skipped += 1
                 continue
 
@@ -554,11 +569,10 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
                 return False
             return not is_sync_engine_output(mapped)
 
-        if action == 'translate' and target_lang:
-            if _translate_target_satisfied(subtitles, target_lang, source_lang,
-                                           _target_usable):
-                skipped += 1
-                continue
+        if action == 'translate' and target_lang and _translate_item_satisfied(
+                subtitles, target_lang, source_lang, _target_usable):
+            skipped += 1
+            continue
 
         for lang_string, sub_path in subtitles:
             # Every modifier, not just the first: a track can be both hi and
@@ -573,6 +587,14 @@ def _collect_movies(movie_ids=None, action='sync', force_resync=False,
 
             # For translate: only queue subtitles matching the requested source language
             if action == 'translate' and source_lang and sub_lang != source_lang:
+                skipped += 1
+                continue
+
+            # And only when the file this source would produce is not already
+            # there. Per source, because two sources of the same language can
+            # produce different outputs: en gives nl, en:hi gives nl:hi.
+            if action == 'translate' and target_lang and _translate_output_present(
+                    subtitles, target_lang, sub_hi, _target_usable):
                 skipped += 1
                 continue
 

--- a/bazarr/subtitles/tools/translate/batch.py
+++ b/bazarr/subtitles/tools/translate/batch.py
@@ -7,12 +7,14 @@ import re
 import subprocess
 import uuid
 from app.database import TableEpisodes, TableMovies, TableShows, database, select
+from app.config import settings
 from app.jobs_queue import jobs_queue
 from app.event_handler import event_stream
 from arr_instances.resolution import scoped
 from utilities.path_mappings import path_mappings
 from utilities.binaries import get_binary
-from utilities.video_analyzer import parse_video_metadata, _handle_alpha3, _title_is_forced
+from utilities.video_analyzer import (parse_video_metadata, _title_is_forced,
+                                      embedded_track_language)
 from languages.get_languages import alpha3_from_alpha2
 from subtitles.indexer.series import store_subtitles
 from subtitles.indexer.movies import store_subtitles_movie
@@ -460,6 +462,9 @@ def extract_embedded_subtitle(
     # Pass 1: exact match on language + hi + forced disposition flags.
     # Pass 2: fall back to first language-only match if no exact match found,
     # so extraction never silently returns the wrong track.
+    und_setting = settings.general.default_und_embedded_subtitles_lang
+    und_default_language = alpha3_from_alpha2(und_setting) if und_setting else None
+
     exact_track = None
     fallback_track = None
     track_id = 0
@@ -469,11 +474,15 @@ def extract_embedded_subtitle(
             track_id += 1
             continue
 
-        if "language" not in track:
+        # Exactly the rule indexing used to decide this track exists. Walking
+        # the stream list a second time with different rules is how extraction
+        # ends up on a commentary track the user was never offered, or refuses
+        # a track the user was.
+        track_alpha3 = embedded_track_language(track, und_default_language)
+        if track_alpha3 is None:
             track_id += 1
             continue
 
-        track_alpha3 = _handle_alpha3(track)
         if track_alpha3 == target_alpha3:
             # knowit only reports forced from the disposition flag, so apply the
             # same title heuristic used at indexing time, otherwise a forced

--- a/bazarr/utilities/video_analyzer.py
+++ b/bazarr/utilities/video_analyzer.py
@@ -54,6 +54,30 @@ def _handle_alpha3(detected_language: dict):
     return alpha3
 
 
+def embedded_track_language(track, und_default_language=None):
+    """The language the indexer files this track under, or None to ignore it.
+
+    One place for the two rules that decide whether an in-container subtitle
+    exists as far as Bazarr is concerned, because indexing and extraction both
+    have to reach the same answer. When they disagree the user is offered a
+    track that can never be extracted, or gets a different track than the one
+    they picked, and neither says anything in the log.
+
+    Commentary is excluded by title: it is a different programme, not a
+    different language, and translating it produces confident nonsense. A track
+    with no language of its own takes the configured undefined-language default
+    when there is one, and is otherwise not a subtitle we can name.
+    """
+    name = (track.get("name") or "").lower()
+    if "commentary" in name:
+        return None
+
+    language = _handle_alpha3(track) if "language" in track else None
+    if not language and und_default_language:
+        language = und_default_language
+    return language or None
+
+
 def embedded_subs_reader(file, file_size, episode_file_id=None, movie_file_id=None, use_cache=True,
                          arr_instance_id=None):
     data = parse_video_metadata(file, file_size, episode_file_id, movie_file_id, use_cache=use_cache,
@@ -73,22 +97,10 @@ def embedded_subs_reader(file, file_size, episode_file_id=None, movie_file_id=No
 
     if cache_provider:
         for detected_language in data[cache_provider]["subtitle"]:
-            # Avoid commentary subtitles
             name = detected_language.get("name", "").lower()
-            if "commentary" in name:
-                logging.debug(f"Ignoring commentary subtitle: {name}")  # noqa: G004
-                continue
-
-            if "language" not in detected_language:
-                language = None
-            else:
-                language = _handle_alpha3(detected_language)
-
-            if not language and und_default_language:
-                logging.debug(f"Undefined language embedded subtitles track treated as {language}")  # noqa: G004
-                language = und_default_language
-
+            language = embedded_track_language(detected_language, und_default_language)
             if not language:
+                logging.debug("Ignoring embedded subtitle track: %s", name or "unnamed")
                 continue
 
             forced = detected_language.get("forced", False) or _title_is_forced(name)

--- a/tests/bazarr/test_embedded_subtitle_extraction.py
+++ b/tests/bazarr/test_embedded_subtitle_extraction.py
@@ -77,7 +77,7 @@ def test_text_codec_extraction_succeeds(tmp_path):
             "subtitles.tools.translate.batch.parse_video_metadata",
             return_value=metadata,
         ),
-        patch("subtitles.tools.translate.batch._handle_alpha3", return_value="eng"),
+        patch("utilities.video_analyzer._handle_alpha3", return_value="eng"),
         patch("subtitles.tools.translate.batch.alpha3_from_alpha2", return_value="eng"),
         patch(
             "subtitles.tools.translate.batch.get_binary", return_value="/usr/bin/ffmpeg"
@@ -120,7 +120,7 @@ def test_bitmap_codec_is_rejected(tmp_path):
             "subtitles.tools.translate.batch.parse_video_metadata",
             return_value=metadata,
         ),
-        patch("subtitles.tools.translate.batch._handle_alpha3", return_value="eng"),
+        patch("utilities.video_analyzer._handle_alpha3", return_value="eng"),
         patch("subtitles.tools.translate.batch.alpha3_from_alpha2", return_value="eng"),
         patch(
             "subtitles.tools.translate.batch.get_binary", return_value="/usr/bin/ffmpeg"
@@ -171,7 +171,7 @@ def test_hi_and_non_hi_use_different_cache_keys(tmp_path):
             "subtitles.tools.translate.batch.parse_video_metadata",
             return_value=metadata,
         ),
-        patch("subtitles.tools.translate.batch._handle_alpha3", return_value="eng"),
+        patch("utilities.video_analyzer._handle_alpha3", return_value="eng"),
         patch("subtitles.tools.translate.batch.alpha3_from_alpha2", return_value="eng"),
         patch(
             "subtitles.tools.translate.batch.get_binary", return_value="/usr/bin/ffmpeg"
@@ -236,7 +236,7 @@ def test_cache_hit_skips_ffmpeg(tmp_path):
             "subtitles.tools.translate.batch.parse_video_metadata",
             return_value=metadata,
         ),
-        patch("subtitles.tools.translate.batch._handle_alpha3", return_value="eng"),
+        patch("utilities.video_analyzer._handle_alpha3", return_value="eng"),
         patch("subtitles.tools.translate.batch.alpha3_from_alpha2", return_value="eng"),
         patch(
             "subtitles.tools.translate.batch.get_binary", return_value="/usr/bin/ffmpeg"
@@ -292,7 +292,7 @@ def test_forced_flag_uses_different_cache_key_from_hi(tmp_path):
             "subtitles.tools.translate.batch.parse_video_metadata",
             return_value=metadata,
         ),
-        patch("subtitles.tools.translate.batch._handle_alpha3", return_value="eng"),
+        patch("utilities.video_analyzer._handle_alpha3", return_value="eng"),
         patch("subtitles.tools.translate.batch.alpha3_from_alpha2", return_value="eng"),
         patch(
             "subtitles.tools.translate.batch.get_binary", return_value="/usr/bin/ffmpeg"
@@ -503,7 +503,7 @@ def test_multi_track_episode_selects_correct_stream(
             "subtitles.tools.translate.batch.parse_video_metadata",
             return_value=metadata,
         ),
-        patch("subtitles.tools.translate.batch._handle_alpha3", return_value="eng"),
+        patch("utilities.video_analyzer._handle_alpha3", return_value="eng"),
         patch("subtitles.tools.translate.batch.alpha3_from_alpha2", return_value="eng"),
         patch(
             "subtitles.tools.translate.batch.get_binary", return_value="/usr/bin/ffmpeg"
@@ -851,7 +851,7 @@ def test_path_mapped_install_extraction_location(monkeypatch, tmp_path):
             "subtitles.tools.translate.batch.parse_video_metadata",
             return_value=metadata,
         ),
-        patch("subtitles.tools.translate.batch._handle_alpha3", return_value="eng"),
+        patch("utilities.video_analyzer._handle_alpha3", return_value="eng"),
         patch("subtitles.tools.translate.batch.alpha3_from_alpha2", return_value="eng"),
         patch(
             "subtitles.tools.translate.batch.get_binary", return_value="/usr/bin/ffmpeg"
@@ -940,7 +940,7 @@ def test_forced_track_selected_by_title(tmp_path):
             "subtitles.tools.translate.batch.parse_video_metadata",
             return_value=metadata,
         ),
-        patch("subtitles.tools.translate.batch._handle_alpha3", return_value="eng"),
+        patch("utilities.video_analyzer._handle_alpha3", return_value="eng"),
         patch("subtitles.tools.translate.batch.alpha3_from_alpha2", return_value="eng"),
         patch(
             "subtitles.tools.translate.batch.get_binary", return_value="/usr/bin/ffmpeg"

--- a/tests/bazarr/test_embedded_track_eligibility.py
+++ b/tests/bazarr/test_embedded_track_eligibility.py
@@ -1,0 +1,166 @@
+# coding=utf-8
+"""Extraction has to agree with indexing about which track is which.
+
+The indexer decides what the user is offered: it drops commentary tracks by
+title, and it gives an undefined-language track the code configured in
+``default_und_embedded_subtitles_lang``. Extraction then re-walks the same
+stream list on its own and applies neither rule, so the two disagree in both
+directions:
+
+* a container whose first English stream is a commentary track has that
+  commentary extracted and written out as the requested translation, silently,
+  because the indexer never offered it and nothing downstream re-checks
+* a track the indexer listed under the configured undefined-language code can
+  never be extracted at all, because extraction skips any stream with no
+  language field, so the item fails every time it is queued
+
+Both were reported against pull request 357 and reached development unfixed.
+The third case is the target-variant check in the collector: a forced file in
+the target language is not the subtitle a plain translation would produce, so
+it must not suppress the run.
+"""
+import os
+from unittest.mock import MagicMock, patch
+
+from babelfish import Language
+
+
+def _track(alpha3=None, name=None, codec="subrip", forced=False, hi=False):
+    track = {"format": codec, "forced": forced, "hearing_impaired": hi}
+    if alpha3 is not None:
+        track["language"] = Language(alpha3)
+    if name is not None:
+        track["name"] = name
+    return track
+
+
+def _extract(tmp_path, tracks, monkeypatch, **kwargs):
+    """Drive extract_embedded_subtitle far enough to see which stream it picks."""
+    from subtitles.tools.translate import batch
+
+    chosen = {}
+
+    def fake_ffmpeg(cmd, **kw):
+        chosen['map'] = cmd[cmd.index('-map') + 1]
+        out_path = cmd[-1]
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        with open(out_path, 'w') as handle:
+            handle.write('1\n00:00:01,000 --> 00:00:02,000\nline\n')
+        result = MagicMock()
+        result.returncode = 0
+        return result
+
+    with (
+        patch('subtitles.tools.translate.batch.database') as mock_db,
+        patch('subtitles.tools.translate.batch.parse_video_metadata',
+              return_value={'ffprobe': {'subtitle': tracks}}),
+        patch('subtitles.tools.translate.batch.get_binary', return_value='/usr/bin/ffmpeg'),
+        patch('subtitles.tools.translate.batch.alpha3_from_alpha2',
+              side_effect=lambda code: {'en': 'eng'}.get(code)),
+        patch('app.get_args.args') as mock_args,
+        patch('subprocess.run', side_effect=fake_ffmpeg),
+    ):
+        mock_db.execute.return_value.first.return_value = MagicMock(movie_file_id=1,
+                                                                    file_size=1024)
+        mock_args.config_dir = str(tmp_path)
+        result = batch.extract_embedded_subtitle('/fake/movie.mkv', 'en', 'movie', **kwargs)
+
+    return result, chosen.get('map')
+
+
+def test_a_commentary_track_is_never_extracted(tmp_path, monkeypatch):
+    """The indexer drops commentary by title, so it is not what the user chose."""
+    tracks = [
+        _track('eng', name='Commentary by the director'),
+        _track('eng', name='English'),
+    ]
+
+    result, mapped = _extract(tmp_path, tracks, monkeypatch)
+
+    assert result is not None, 'the real English track should still be extracted'
+    assert mapped == '0:s:1', (
+        f'extracted stream {mapped}, which is the commentary track the indexer '
+        'never offered')
+
+
+def test_a_commentary_only_container_extracts_nothing(tmp_path, monkeypatch):
+    """Falling back to commentary is worse than reporting nothing: the caller
+    reports failure, rather than translating the wrong text silently."""
+    result, mapped = _extract(tmp_path, [_track('eng', name='Commentary')], monkeypatch)
+
+    assert result is None, f'commentary was extracted anyway as stream {mapped}'
+
+
+def test_an_undefined_track_uses_the_configured_language(tmp_path, monkeypatch):
+    """The indexer records an und track under default_und_embedded_subtitles_lang,
+    so the item is queued. Extraction skipped it, so the item always failed."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings.general, 'default_und_embedded_subtitles_lang',
+                        'en', raising=False)
+    tracks = [_track(None, name='Untitled')]
+
+    result, mapped = _extract(tmp_path, tracks, monkeypatch)
+
+    assert result is not None, (
+        'the track the indexer offered under the configured language could not '
+        'be extracted')
+    assert mapped == '0:s:0'
+
+
+def test_an_undefined_track_stays_skipped_without_the_setting(tmp_path, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings.general, 'default_und_embedded_subtitles_lang',
+                        '', raising=False)
+
+    result, _mapped = _extract(tmp_path, [_track(None, name='Untitled')], monkeypatch)
+
+    assert result is None
+
+
+# --------------------------------------------------- the target variant check
+
+def test_a_forced_target_file_does_not_suppress_a_plain_translation():
+    """en -> nl with an existing nl:forced file must still run: the forced file
+    is not what this translation would produce."""
+    from subtitles import mass_operations
+
+    subtitles = [('en', None, None), ('nl:forced', '/subs/m.nl.forced.srt', 10)]
+    parsed = [(lang, path) for lang, path, _size in subtitles]
+
+    assert not mass_operations._translate_target_satisfied(
+        parsed, target_lang='nl', source_lang='en',
+        usable=lambda lang, path: True)
+
+
+def test_a_plain_target_file_still_suppresses_the_translation():
+    from subtitles import mass_operations
+
+    parsed = [('en', None), ('nl', '/subs/m.nl.srt')]
+
+    assert mass_operations._translate_target_satisfied(
+        parsed, target_lang='nl', source_lang='en',
+        usable=lambda lang, path: True)
+
+
+def test_a_missing_target_file_does_not_suppress_the_translation():
+    """A row can name a file that is no longer on disk."""
+    from subtitles import mass_operations
+
+    parsed = [('en', None), ('nl', '/subs/gone.nl.srt')]
+
+    assert not mass_operations._translate_target_satisfied(
+        parsed, target_lang='nl', source_lang='en',
+        usable=lambda lang, path: False)
+
+
+def test_the_hi_variant_is_matched_not_only_the_base_language():
+    """en:hi translates to nl:hi, which a plain nl file does not satisfy."""
+    from subtitles import mass_operations
+
+    parsed = [('en:hi', None), ('nl', '/subs/m.nl.srt')]
+
+    assert not mass_operations._translate_target_satisfied(
+        parsed, target_lang='nl', source_lang='en',
+        usable=lambda lang, path: True)

--- a/tests/bazarr/test_embedded_track_eligibility.py
+++ b/tests/bazarr/test_embedded_track_eligibility.py
@@ -126,12 +126,10 @@ def test_a_forced_target_file_does_not_suppress_a_plain_translation():
     is not what this translation would produce."""
     from subtitles import mass_operations
 
-    subtitles = [('en', None, None), ('nl:forced', '/subs/m.nl.forced.srt', 10)]
-    parsed = [(lang, path) for lang, path, _size in subtitles]
+    parsed = [('en', None), ('nl:forced', '/subs/m.nl.forced.srt')]
 
-    assert not mass_operations._translate_target_satisfied(
-        parsed, target_lang='nl', source_lang='en',
-        usable=lambda lang, path: True)
+    assert not mass_operations._translate_output_present(
+        parsed, target_lang='nl', hi=False, usable=lambda lang, path: True)
 
 
 def test_a_plain_target_file_still_suppresses_the_translation():
@@ -139,9 +137,8 @@ def test_a_plain_target_file_still_suppresses_the_translation():
 
     parsed = [('en', None), ('nl', '/subs/m.nl.srt')]
 
-    assert mass_operations._translate_target_satisfied(
-        parsed, target_lang='nl', source_lang='en',
-        usable=lambda lang, path: True)
+    assert mass_operations._translate_output_present(
+        parsed, target_lang='nl', hi=False, usable=lambda lang, path: True)
 
 
 def test_a_missing_target_file_does_not_suppress_the_translation():
@@ -150,17 +147,95 @@ def test_a_missing_target_file_does_not_suppress_the_translation():
 
     parsed = [('en', None), ('nl', '/subs/gone.nl.srt')]
 
-    assert not mass_operations._translate_target_satisfied(
-        parsed, target_lang='nl', source_lang='en',
-        usable=lambda lang, path: False)
+    assert not mass_operations._translate_output_present(
+        parsed, target_lang='nl', hi=False, usable=lambda lang, path: False)
 
 
 def test_the_hi_variant_is_matched_not_only_the_base_language():
-    """en:hi translates to nl:hi, which a plain nl file does not satisfy."""
+    """An en:hi source produces nl:hi, which a plain nl file does not satisfy."""
     from subtitles import mass_operations
 
     parsed = [('en:hi', None), ('nl', '/subs/m.nl.srt')]
 
-    assert not mass_operations._translate_target_satisfied(
-        parsed, target_lang='nl', source_lang='en',
-        usable=lambda lang, path: True)
+    assert not mass_operations._translate_output_present(
+        parsed, target_lang='nl', hi=True, usable=lambda lang, path: True)
+
+
+# ------------------------------------- the skip has to be per source, not per item
+
+class TestPerVariantTargetSkip:
+    """Whole-item skipping over-produces when only some variants are missing.
+
+    An item with an ``en`` and an ``en:hi`` source and an existing ``nl`` file is
+    not fully satisfied, because ``nl:hi`` is missing. Deciding that at the item
+    level then queues BOTH English sources, so the plain one re-translates and
+    overwrites the ``nl`` file that was already there. On a paid translator that
+    is billed work for a file the user already had.
+    """
+
+    @staticmethod
+    def _episode(subtitles):
+        ep = MagicMock()
+        ep.sonarrEpisodeId = 1
+        ep.sonarrSeriesId = 10
+        ep.path = '/video/ep1.mkv'
+        ep.subtitles = subtitles
+        return ep
+
+    @staticmethod
+    def _wire(mock_settings, mock_path_map):
+        mock_settings.subsync.max_offset_seconds = 60
+        mock_settings.subsync.gss = True
+        mock_settings.subsync.no_fix_framerate = True
+        mock_settings.general.use_embedded_subs = True
+        mock_path_map.path_replace_instance.side_effect = lambda p, *a, **kw: p
+        mock_path_map.path_replace_reverse_instance.side_effect = lambda p, *a, **kw: p
+
+    @patch('subtitles.mass_operations.is_sync_engine_output', return_value=False)
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
+    def test_only_the_missing_variant_is_queued(self, mock_settings, mock_db, _sm, _se,
+                                                mock_path_map, _isfile, _sync):
+        from subtitles.mass_operations import _collect_subtitle_items
+
+        self._wire(mock_settings, mock_path_map)
+        episode = self._episode(
+            "[['en', '/subs/e.en.srt', 10], ['en:hi', '/subs/e.en.hi.srt', 11], "
+            "['nl', '/subs/e.nl.srt', 12]]")
+        mock_db.execute.return_value.all.return_value = [episode]
+
+        items, skipped = _collect_subtitle_items(
+            [{'type': 'episode', 'sonarrEpisodeId': 1}],
+            action='translate', options={'from_lang': 'en', 'to_lang': 'nl'})[:2]
+
+        queued = sorted((i['srt_lang'], i.get('hi', False)) for i in items)
+        assert queued == [('en', True)], (
+            'only the source whose output is missing should be queued; the plain '
+            f'en source would overwrite the existing nl file. got {queued!r}')
+
+    @patch('subtitles.mass_operations.is_sync_engine_output', return_value=False)
+    @patch('subtitles.mass_operations.os.path.isfile', return_value=True)
+    @patch('subtitles.mass_operations.path_mappings')
+    @patch('subtitles.mass_operations._get_synced_episode_paths', return_value=set())
+    @patch('subtitles.mass_operations._get_synced_movie_paths', return_value=set())
+    @patch('subtitles.mass_operations.database')
+    @patch('subtitles.mass_operations.settings')
+    def test_nothing_is_queued_when_every_variant_exists(self, mock_settings, mock_db,
+                                                         _sm, _se, mock_path_map,
+                                                         _isfile, _sync):
+        from subtitles.mass_operations import _collect_subtitle_items
+
+        self._wire(mock_settings, mock_path_map)
+        episode = self._episode(
+            "[['en', '/subs/e.en.srt', 10], ['nl', '/subs/e.nl.srt', 12]]")
+        mock_db.execute.return_value.all.return_value = [episode]
+
+        items = _collect_subtitle_items(
+            [{'type': 'episode', 'sonarrEpisodeId': 1}],
+            action='translate', options={'from_lang': 'en', 'to_lang': 'nl'})[0]
+
+        assert items == [], f'nothing should be queued, got {items!r}'


### PR DESCRIPTION
Three findings Codex posted against https://github.com/LavX/bazarr/pull/357, on the exact head commit, seven minutes before that PR was merged. They were never addressed: the merge went ahead on the strength of an earlier clean verdict that named an older commit. One is a P1.

## P1: commentary gets translated as the real subtitle

Indexing decides what the user is offered, and it drops commentary tracks by title. Extraction re-walks the same stream list and applies no such rule, breaking on the first stream matching language plus the HI and forced flags.

So a container whose first English stream is a commentary track has that commentary extracted and written out as the requested translation. Silently: the indexer never listed it, and nothing downstream re-checks. The user gets a Dutch translation of the director talking over the film.

## The mirror image: undefined-language tracks can never be extracted

`default_und_embedded_subtitles_lang` makes the indexer file a track with no language under the configured code, so the collector queues it. Extraction skips any stream without a `language` field, so those items fail every single time they are queued.

## The fix for both

Both rules move into one function, `embedded_track_language` in `video_analyzer`, used by the indexer and the extractor. Two code paths walking the same stream list with different notions of which tracks exist is the actual defect; one of them is now the only definition.

## The target-variant check

The collector asked only whether the base target language appeared anywhere with a path. Translation carries the source variant through, so:

- an `nl:forced` file suppressed a plain `en` to `nl` run, which would have written a different file
- a row naming a file since deleted suppressed the run too
- an `en:hi` source produces `nl:hi`, which a plain `nl` file does not satisfy

It now compares the variants the run would produce against the ones actually on disk, ignoring sync and combined artifacts.

## Verification

Local: ruff clean, 1957 backend tests, 8 skipped, no failures. Eight new tests in `tests/bazarr/test_embedded_track_eligibility.py`, registered in the CI guard list. The commentary test asserts the ffmpeg stream index, and fails against the old code by selecting `0:s:0`.

On the test server, against a container built for the purpose with an English commentary track ahead of a normal English track:

```
INDEXER OFFERS: [[eng, False, False, SubRip]]
EXTRACTED TO:   /config/extracted_subs/....en.srt
CONTENT:        1\n00:00:01,000 --> 00:00:02,000\nREAL SUBTITLE TEXT
```

The indexer offers one track, and extraction returns the real subtitle rather than the commentary.