### PR TITLE
perf: cap glibc's malloc arenas in the image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,7 @@ jobs:
             tests/bazarr/test_ffprobe_cache_instance_scope.py \
             tests/bazarr/test_triage_low_findings.py \
             tests/bazarr/test_indexer_owner_scope.py \
+            tests/bazarr/test_image_memory_config.py \
             tests/bazarr/test_translate_owner_threading.py \
             tests/bazarr/test_embedded_track_eligibility.py \
             tests/bazarr/test_parser_owner_threading.py \

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,7 +128,18 @@ COPY frontend/build ./frontend/build
 # Set environment variables
 ENV HOME="/config" \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    MALLOC_ARENA_MAX=2
+
+# glibc gives every thread its own malloc arena, up to 8 per core, and each one
+# reserves address space that shows up as RSS as it is touched. The web server
+# alone parks a thread per open browser tab for its event stream, so a normal
+# session runs well over a hundred threads and pays for a heap arena on most of
+# them. Two arenas is the usual server setting: it costs a little allocator
+# contention under heavy concurrent allocation, which this workload does not do,
+# and it stops resident memory scaling with thread count.
+#
+# Override it at runtime if you are profiling and want glibc's default back.
 
 # Volume for persistent data
 VOLUME /config

--- a/tests/bazarr/test_image_memory_config.py
+++ b/tests/bazarr/test_image_memory_config.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+"""The shipped image has to cap glibc's malloc arenas.
+
+glibc gives each thread its own malloc arena, up to eight per core, and each one
+reserves address space that becomes resident as it is touched. Bazarr runs well
+over a hundred threads in normal operation, because the web server parks one per
+open browser tab for its event stream, so without a cap the process pays for a
+heap arena on most of them.
+
+Measured on a real deployment, same database and same workload: capping arenas
+at two took the container from 514 MiB to 347 MiB and the backend process from
+388 MiB to 278 MiB, with the thread count unchanged at 123. That is the whole
+of the difference, which is why the thread count itself was left alone: after
+this, threads are no longer what the memory is spent on.
+
+Asserted here because it is one environment variable in the Dockerfile with
+nothing else referring to it, so it would be removed by a tidy-up without
+anything noticing until someone measured again.
+"""
+import os
+import re
+
+DOCKERFILE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    'Dockerfile')
+
+
+def _env_values():
+    """Every KEY=VALUE the Dockerfile sets in an ENV instruction."""
+    text = open(DOCKERFILE).read()
+    # ENV blocks continue across escaped newlines
+    text = text.replace('\\\n', ' ')
+    values = {}
+    for line in text.splitlines():
+        if not line.startswith('ENV '):
+            continue
+        for key, value in re.findall(r'(\w+)=("[^"]*"|\S+)', line[4:]):
+            values[key] = value.strip('"')
+    return values
+
+
+def test_the_image_caps_the_malloc_arenas():
+    values = _env_values()
+    assert 'MALLOC_ARENA_MAX' in values, (
+        'MALLOC_ARENA_MAX is not set in the image. Without it resident memory '
+        'scales with thread count, which cost about 110 MiB when measured.')
+    assert values['MALLOC_ARENA_MAX'].isdigit(), values['MALLOC_ARENA_MAX']
+    assert 1 <= int(values['MALLOC_ARENA_MAX']) <= 4, (
+        f"MALLOC_ARENA_MAX is {values['MALLOC_ARENA_MAX']}. Two is the usual "
+        'server setting; much higher gives the saving back.')


### PR DESCRIPTION
Answers the memory report raised on Discord by **★ [GI]**: 710 MB resident for an idle install.

## What it was

glibc gives every thread its own malloc arena, up to eight per core, and each reserves address space that becomes resident as it is touched. Bazarr runs well over a hundred threads in normal operation, because the web server parks one per open browser tab for its event stream (the frontend uses `EventSource`, so a tab holds its thread for as long as it is open). The process was paying for a heap arena on most of them.

## Measured, not assumed

Same test server, same database, same workload, before and after:

| | before | after |
|---|---|---|
| container | 514.5 MiB | **347.1 MiB** |
| backend RSS | 388 MiB | **278 MiB** |
| backend threads | 123 | 123 |

167 MiB off the container, 110 MiB off the backend process, from one environment variable, with nothing else changed.

## Why the thread count is untouched

That measurement is the argument. The arenas were the cost, not the threads. Cutting the web server pool from 100 after this would trade real availability, since each open tab holds a thread for its event stream and running out means the UI stops responding, for very little memory. I would rather leave a number that is generous than cut it on the strength of it looking large.

The remaining 278 MiB is the application itself: Python, the loaded providers and their caches. Sharing one Provider Hub worker per provider instead of one per pool is still the next real term and is not in this PR.

## Verification

Local: ruff clean, 1976 backend tests, 8 skipped. Deployed to the test server and measured as above.

A test asserts the Dockerfile still sets it, because it is one variable nothing else refers to and a tidy-up would remove it without anything noticing until someone measured again.