### PR TITLE
perf: stop three code paths holding more than they are using

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,7 @@ jobs:
             tests/bazarr/test_ffprobe_cache_instance_scope.py \
             tests/bazarr/test_triage_low_findings.py \
             tests/bazarr/test_indexer_owner_scope.py \
+            tests/bazarr/test_provider_hub_worker_reaper.py \
             tests/bazarr/test_job_module_identity.py \
             tests/bazarr/test_sonarr_sync_memory.py \
             tests/bazarr/test_anilist_index.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,7 @@ jobs:
             tests/bazarr/test_ffprobe_cache_instance_scope.py \
             tests/bazarr/test_triage_low_findings.py \
             tests/bazarr/test_indexer_owner_scope.py \
+            tests/bazarr/test_job_module_identity.py \
             tests/bazarr/test_sonarr_sync_memory.py \
             tests/bazarr/test_anilist_index.py \
             tests/bazarr/test_image_memory_config.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,8 @@ jobs:
             tests/bazarr/test_ffprobe_cache_instance_scope.py \
             tests/bazarr/test_triage_low_findings.py \
             tests/bazarr/test_indexer_owner_scope.py \
+            tests/bazarr/test_sonarr_sync_memory.py \
+            tests/bazarr/test_anilist_index.py \
             tests/bazarr/test_image_memory_config.py \
             tests/bazarr/test_translate_owner_threading.py \
             tests/bazarr/test_embedded_track_eligibility.py \

--- a/bazarr/app/jobs_queue.py
+++ b/bazarr/app/jobs_queue.py
@@ -15,7 +15,21 @@ from threading import Thread, Lock, RLock
 from app.event_handler import event_stream
 from app.config import settings
 
-bazarr_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+# The package directory, i.e. the one holding subtitles/, sonarr/, app/ and the
+# rest. add_job_from_function derives a job's module from its filename relative
+# to this, and _run_job resolves that string with importlib, so it has to be the
+# name the module already has in this process.
+#
+# It used to be one dirname() higher, naming the repository root, so every job
+# was queued as "bazarr.<x>" while the running process had imported "<x>".
+# app/libs.py puts the parent on sys.path as well, so both names resolve and
+# Python keeps two module objects for the same file, each with its own
+# module-level state. subtitles/cache.py documents that split and works around
+# it, because the UUID a manual search stored in one copy was looked for in the
+# other. subtitles/pool.py holds _pools the same way, and Provider Hub spawns a
+# worker subprocess per pool and provider, so the split also bought a second
+# worker fleet on any warm install.
+bazarr_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 class JobCancelled(Exception):

--- a/bazarr/app/libs.py
+++ b/bazarr/app/libs.py
@@ -7,7 +7,16 @@ import sys
 def set_libs():
     sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), '../custom_libs/'))
     sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), '../'))
-    # added this last one so Bazarr's modules can be imported by jobs in jobs_queue
+    # The second entry puts the repository root on the path, which is what makes
+    # ``import bazarr.<x>`` resolvable alongside the plain ``<x>`` this process
+    # already uses. It was added so queued jobs could be imported, back when
+    # jobs_queue derived their module names relative to the root. It no longer
+    # derives them that way, so nothing here needs it.
+    #
+    # Left in place because removing a sys.path entry is not obviously safe for
+    # out-of-tree callers, but be aware this is what allows one file to be
+    # imported under two names, each with its own module-level state. See the
+    # comment in subtitles/cache.py for what that cost last time.
 
 
 set_libs()

--- a/bazarr/app/scheduler.py
+++ b/bazarr/app/scheduler.py
@@ -27,6 +27,7 @@ from subtitles.wanted import wanted_search_missing_subtitles_series, wanted_sear
 from subtitles.upgrade import upgrade_subtitles
 from subtitles.mass_operations import mass_batch_operation
 from utilities.cache import cache_maintenance
+from provider_hub.worker import reap_idle_workers
 from utilities.health import check_health
 from utilities.backup import backup_to_zip
 from utilities.pretty_date import pretty_date
@@ -97,6 +98,16 @@ def _compat_usage_prune():
         logging.exception("BAZARR failed to prune Distribution Hub usage table")
 
 
+# How long a Hub worker may sit unused before it is reclaimed. Generous on
+# purpose: a search burst walks several providers with gaps between them, and
+# respawning mid-burst would trade memory for latency the user actually feels.
+PROVIDER_HUB_WORKER_IDLE_SECONDS = 30 * 60
+
+
+def _reap_idle_provider_hub_workers():
+    reap_idle_workers(PROVIDER_HUB_WORKER_IDLE_SECONDS)
+
+
 class Scheduler:
 
     def __init__(self):
@@ -134,6 +145,7 @@ class Scheduler:
 
         # configure all tasks
         self.__cache_cleanup_task()
+        self.__provider_hub_worker_reaper_task()
         self.__compat_usage_prune_task()
         self.__check_health_task()
         self.update_configurable_tasks()
@@ -274,6 +286,18 @@ class Scheduler:
                     id=f'update_movies_{inst.id}', name=f'Sync with Radarr ({inst.name})',
                     replace_existing=True,
                     kwargs=dict(arr_instance_id=inst.id, wait_for_completion=True))
+
+    def __provider_hub_worker_reaper_task(self):
+        # Hub workers are spawned lazily per pool and provider and nothing else
+        # reclaims them: the pool's own recycle only fires the next time that
+        # pool is searched, so on a quiet install the fleet sits at full size
+        # indefinitely at 17.6 to 44.6 MiB a process. Reaping is cheap because
+        # request() respawns a stopped worker, so the only cost of being wrong
+        # is a cold start on the next search, measured at 0.5 to 1.7 s.
+        self.aps_scheduler.add_job(
+            _reap_idle_provider_hub_workers, 'interval', minutes=10, max_instances=1,
+            coalesce=True, misfire_grace_time=60, id='provider_hub_worker_reaper',
+            name='Provider Hub Idle Worker Cleanup')
 
     def __cache_cleanup_task(self):
         self.aps_scheduler.add_job(cache_maintenance, 'interval', hours=24, max_instances=1, coalesce=True,

--- a/bazarr/provider_hub/worker.py
+++ b/bazarr/provider_hub/worker.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import queue
+import signal
 import subprocess
 import threading
 import weakref
@@ -74,30 +75,23 @@ _live_clients_lock = threading.Lock()
 def reap_idle_workers(idle_seconds: float) -> int:
     """Stop workers that have served no request for ``idle_seconds``.
 
-    Not destructive: ``request()`` starts the process if it is not running, so a
-    reaped worker returns on the next search for the price of a cold start. Safe
-    against a request in flight too, because ``stop()`` goes through
-    ``request()`` and waits on the same lock a live request holds; the worst case
-    is a worker that is stopped just after being used and respawned immediately.
+    The decision and the shutdown happen together inside each client, under the
+    same lock a request holds. Deciding here and acting afterwards is a
+    check-then-act race: a search can pass ``start()`` and be queued on that
+    lock in the window between the two, and would then write into a process
+    this sweep had already ended.
     """
-    now = time.monotonic()
     with _live_clients_lock:
         candidates = list(_live_clients)
 
     reaped = 0
     for client in candidates:
-        process = client.process
-        if process is None or process.poll() is not None:
-            continue
-        if now - getattr(client, "last_used", now) < idle_seconds:
-            continue
         try:
-            client.stop()
+            if client.stop_if_idle(idle_seconds):
+                reaped += 1
         except Exception:
             # One plugin refusing to shut down must not strand the rest.
             logger.warning("Provider Hub worker did not stop cleanly", exc_info=True)
-            continue
-        reaped += 1
 
     if reaped:
         logger.debug("Provider Hub reclaimed %d idle worker(s)", reaped)
@@ -209,22 +203,94 @@ class ProviderWorkerClient:
         except Exception:
             pass
 
-    def stop(self, grace_seconds: float = 5.0) -> None:
-        process = self.process
+    def _deregister(self) -> None:
+        with _live_clients_lock:
+            _live_clients.discard(self)
+
+    @staticmethod
+    def _kill_tree(process, grace_seconds: float) -> None:
+        """SIGKILL the worker's whole process group, not just the worker.
+
+        ``start_new_session=True`` makes the worker its own session and group
+        leader, so its group id is its pid. Killing only that pid leaves
+        anything the plugin forked running and reparented to init, where nothing
+        counts or reclaims it, and a reap would report success having freed
+        nothing. Plugin code is third party, so that is a mechanism to close,
+        not an unlikely accident.
+        """
         try:
-            if not process:
-                return
+            os.killpg(process.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            process.kill()
+        try:
+            process.wait(timeout=grace_seconds)
+        except Exception:
+            pass
+
+    def stop_if_idle(self, idle_seconds: float, grace_seconds: float = 5.0) -> bool:
+        """End this worker only if it is genuinely idle. True if it was stopped.
+
+        Never waits. A worker serving a request holds ``_lock``, so the
+        non-blocking acquire fails and it is left alone. That covers both halves
+        of the problem: the sweep cannot end a request in flight, and it cannot
+        pin the scheduler thread behind one. The second half matters because a
+        request may run for hours, and a blocking acquire would hold the sweep
+        for all of it and then kill the worker the instant it succeeded.
+
+        Idleness is checked again once the lock is held, because the sweep chose
+        this client without it.
+
+        The process is ended directly rather than through ``stop()``, which
+        sends a shutdown request and so would take the lock this already holds.
+        An idle worker has nothing in progress to unwind.
+        """
+        process = self.process
+        if process is None or process.poll() is not None:
+            return False
+        if not self._lock.acquire(blocking=False):
+            return False
+        try:
+            if time.monotonic() - self.last_used < idle_seconds:
+                return False
             if process.poll() is not None:
-                return
+                return False
             try:
-                self.request("shutdown", {"reason": "app_shutdown", "grace_ms": int(grace_seconds * 1000)}, grace_seconds)
+                process.terminate()
                 process.wait(timeout=grace_seconds)
             except Exception:
-                process.kill()
-                process.wait(timeout=grace_seconds)
+                self._kill_tree(process, grace_seconds)
         finally:
-            with _live_clients_lock:
-                _live_clients.discard(self)
+            self._lock.release()
+
+        self._deregister()
+        return True
+
+    def stop(self, grace_seconds: float = 5.0) -> None:
+        process = self.process
+        if not process or process.poll() is not None:
+            # Nothing left to reap, so this is the one safe unconditional
+            # discard.
+            self._deregister()
+            return
+        try:
+            self.request("shutdown", {"reason": "app_shutdown", "grace_ms": int(grace_seconds * 1000)}, grace_seconds)
+            process.wait(timeout=grace_seconds)
+        except Exception:
+            self._kill_tree(process, grace_seconds)
+
+        # Leave the registry only once this process is confirmed dead AND is
+        # still the one this client owns. Two ways to get that wrong:
+        #
+        # A worker can outlive its own stop. start() registers only on the spawn
+        # path, so a client discarded while its process still runs is never
+        # re-added by a later request(), and that subprocess becomes permanently
+        # unreapable: precisely the leak this reaper exists to prevent.
+        #
+        # And request() calls start(), which respawns if the process died
+        # between the check above and the shutdown. self.process is then a NEW
+        # worker that registered itself, and discarding here would strand it.
+        if self.process is process and process.poll() is not None:
+            self._deregister()
 
     def _read_line_with_deadline(self, timeout: float) -> str:
         """Read one NDJSON line from the worker, honoring ``timeout`` seconds.
@@ -307,6 +373,11 @@ class ProviderWorkerClient:
             )
             self.process.stdin.flush()
             line = self._read_line_with_deadline(timeout)
+            # Stamped on the way out as well as the way in. A single request may
+            # legitimately run for hours (transcription is allowed up to the 24
+            # hour ceiling), and a worker judged only on when its request
+            # STARTED would read as idle for almost all of that.
+            self.last_used = time.monotonic()
 
         if not line:
             raise WorkerError("worker closed stdout")

--- a/bazarr/provider_hub/worker.py
+++ b/bazarr/provider_hub/worker.py
@@ -71,6 +71,11 @@ class WorkerResult:
 _live_clients: "weakref.WeakSet[ProviderWorkerClient]" = weakref.WeakSet()
 _live_clients_lock = threading.Lock()
 
+# Resolved once: signal.SIGKILL does not exist on Windows, and referencing it
+# at a call site raises AttributeError before _signal_group's own guards can
+# report False, breaking the process.kill() fallback.
+_SIGKILL = getattr(signal, "SIGKILL", None)
+
 
 def reap_idle_workers(idle_seconds: float) -> int:
     """Stop workers that have served no request for ``idle_seconds``.
@@ -224,7 +229,7 @@ class ProviderWorkerClient:
         it has to be checked before the call.
         """
         killpg = getattr(os, "killpg", None)
-        if killpg is None:
+        if killpg is None or sig is None:
             return False
         try:
             killpg(process.pid, sig)
@@ -250,12 +255,16 @@ class ProviderWorkerClient:
         if not cls._signal_group(process, signal.SIGTERM):
             process.terminate()
         process.wait(timeout=grace_seconds)
-        cls._signal_group(process, signal.SIGKILL)
+        cls._signal_group(process, _SIGKILL)
 
     @classmethod
-    def _kill_tree(cls, process, grace_seconds: float) -> None:
-        """SIGKILL the worker's whole process group, not just the worker."""
-        if not cls._signal_group(process, signal.SIGKILL):
+    def _kill_tree(cls, process, grace_seconds: float) -> bool:
+        """SIGKILL the worker's whole process group, not just the worker.
+
+        True only when the worker is confirmed gone; the caller must not
+        deregister a process this could not end.
+        """
+        if not cls._signal_group(process, _SIGKILL):
             try:
                 process.kill()
             except Exception:
@@ -263,7 +272,8 @@ class ProviderWorkerClient:
         try:
             process.wait(timeout=grace_seconds)
         except Exception:
-            pass
+            return False
+        return True
 
     def stop_if_idle(self, idle_seconds: float, grace_seconds: float = 5.0) -> bool:
         """End this worker only if it is genuinely idle. True if it was stopped.
@@ -292,12 +302,19 @@ class ProviderWorkerClient:
                 return False
             if process.poll() is not None:
                 return False
+            ended = True
             try:
                 self._terminate_tree(process, grace_seconds)
             except Exception:
-                self._kill_tree(process, grace_seconds)
+                ended = self._kill_tree(process, grace_seconds)
         finally:
             self._lock.release()
+
+        if not ended:
+            # Both attempts left it running. Deregistering now would make it
+            # permanently unreapable; keep it listed so a later sweep retries.
+            logger.warning("idle provider worker survived termination; keeping it registered")
+            return False
 
         self._deregister()
         return True
@@ -313,7 +330,7 @@ class ProviderWorkerClient:
             self.request("shutdown", {"reason": "app_shutdown", "grace_ms": int(grace_seconds * 1000)}, grace_seconds)
             process.wait(timeout=grace_seconds)
             # A clean shutdown ends the worker, not necessarily what it forked.
-            self._signal_group(process, signal.SIGKILL)
+            self._signal_group(process, _SIGKILL)
         except Exception:
             self._kill_tree(process, grace_seconds)
 

--- a/bazarr/provider_hub/worker.py
+++ b/bazarr/provider_hub/worker.py
@@ -7,6 +7,7 @@ import os
 import queue
 import subprocess
 import threading
+import weakref
 import time
 import uuid
 
@@ -59,6 +60,50 @@ class WorkerResult:
     events: list[dict[str, Any]]
 
 
+# Every started worker registers here so idle ones can be reclaimed. A weak set,
+# so a client the pool has dropped does not stay alive just by being listed.
+#
+# The fleet needs reclaiming because nothing else does it: a worker is spawned
+# lazily the first time a pool searches with that provider, and the pool's own
+# recycle only fires the next time that same pool is searched. On a quiet install
+# the processes simply accumulate, at 17.6 to 44.6 MiB each.
+_live_clients: "weakref.WeakSet[ProviderWorkerClient]" = weakref.WeakSet()
+_live_clients_lock = threading.Lock()
+
+
+def reap_idle_workers(idle_seconds: float) -> int:
+    """Stop workers that have served no request for ``idle_seconds``.
+
+    Not destructive: ``request()`` starts the process if it is not running, so a
+    reaped worker returns on the next search for the price of a cold start. Safe
+    against a request in flight too, because ``stop()`` goes through
+    ``request()`` and waits on the same lock a live request holds; the worst case
+    is a worker that is stopped just after being used and respawned immediately.
+    """
+    now = time.monotonic()
+    with _live_clients_lock:
+        candidates = list(_live_clients)
+
+    reaped = 0
+    for client in candidates:
+        process = client.process
+        if process is None or process.poll() is not None:
+            continue
+        if now - getattr(client, "last_used", now) < idle_seconds:
+            continue
+        try:
+            client.stop()
+        except Exception:
+            # One plugin refusing to shut down must not strand the rest.
+            logger.warning("Provider Hub worker did not stop cleanly", exc_info=True)
+            continue
+        reaped += 1
+
+    if reaped:
+        logger.debug("Provider Hub reclaimed %d idle worker(s)", reaped)
+    return reaped
+
+
 class ProviderWorkerClient:
     """Small NDJSON client for a single provider worker process."""
 
@@ -72,6 +117,8 @@ class ProviderWorkerClient:
         self.cwd = str(cwd) if cwd else None
         self.env = env
         self.process: subprocess.Popen | None = None
+        # monotonic timestamp of the last request, read by reap_idle_workers
+        self.last_used: float = time.monotonic()
         self._lock = threading.Lock()
         self._stdout_queue: queue.Queue[Any] | None = None
         self._stdout_thread: threading.Thread | None = None
@@ -89,6 +136,7 @@ class ProviderWorkerClient:
         if self.env:
             env.update(self.env)
 
+        self.last_used = time.monotonic()
         self.process = subprocess.Popen(
             self.command,
             cwd=self.cwd,
@@ -115,6 +163,9 @@ class ProviderWorkerClient:
             daemon=True,
         )
         self._stderr_thread.start()
+
+        with _live_clients_lock:
+            _live_clients.add(self)
 
     @staticmethod
     def _enqueue_stdout(process: subprocess.Popen, stdout_queue: queue.Queue[Any]) -> None:
@@ -160,16 +211,20 @@ class ProviderWorkerClient:
 
     def stop(self, grace_seconds: float = 5.0) -> None:
         process = self.process
-        if not process:
-            return
-        if process.poll() is not None:
-            return
         try:
-            self.request("shutdown", {"reason": "app_shutdown", "grace_ms": int(grace_seconds * 1000)}, grace_seconds)
-            process.wait(timeout=grace_seconds)
-        except Exception:
-            process.kill()
-            process.wait(timeout=grace_seconds)
+            if not process:
+                return
+            if process.poll() is not None:
+                return
+            try:
+                self.request("shutdown", {"reason": "app_shutdown", "grace_ms": int(grace_seconds * 1000)}, grace_seconds)
+                process.wait(timeout=grace_seconds)
+            except Exception:
+                process.kill()
+                process.wait(timeout=grace_seconds)
+        finally:
+            with _live_clients_lock:
+                _live_clients.discard(self)
 
     def _read_line_with_deadline(self, timeout: float) -> str:
         """Read one NDJSON line from the worker, honoring ``timeout`` seconds.
@@ -232,6 +287,7 @@ class ProviderWorkerClient:
 
     def request(self, op: str, payload: dict[str, Any] | None = None, timeout: float = 30.0) -> WorkerResult:
         self.start()
+        self.last_used = time.monotonic()
         if self.process is None or self.process.stdin is None or self.process.stdout is None:
             raise WorkerError("worker process did not start")
 

--- a/bazarr/provider_hub/worker.py
+++ b/bazarr/provider_hub/worker.py
@@ -304,6 +304,10 @@ class ProviderWorkerClient:
         """
         process = self.process
         if process is None or process.poll() is not None:
+            # Nothing to reap. Mirrors stop(): a held survivor whose process
+            # finally exited on its own must not stay pinned in the strong
+            # set; start() re-registers on the next spawn either way.
+            self._deregister()
             return False
         if not self._lock.acquire(blocking=False):
             return False

--- a/bazarr/provider_hub/worker.py
+++ b/bazarr/provider_hub/worker.py
@@ -71,6 +71,11 @@ class WorkerResult:
 _live_clients: "weakref.WeakSet[ProviderWorkerClient]" = weakref.WeakSet()
 _live_clients_lock = threading.Lock()
 
+# Clients whose process survived a kill. The weak set alone would let garbage
+# collection drop such a client once its pool does, and with it the only handle
+# to the still-running subprocess; held strongly until a later sweep wins.
+_unreaped_survivors: "set[ProviderWorkerClient]" = set()
+
 # Resolved once: signal.SIGKILL does not exist on Windows, and referencing it
 # at a call site raises AttributeError before _signal_group's own guards can
 # report False, breaking the process.kill() fallback.
@@ -211,6 +216,11 @@ class ProviderWorkerClient:
     def _deregister(self) -> None:
         with _live_clients_lock:
             _live_clients.discard(self)
+            _unreaped_survivors.discard(self)
+
+    def _retain_survivor(self) -> None:
+        with _live_clients_lock:
+            _unreaped_survivors.add(self)
 
     @staticmethod
     def _signal_group(process, sig) -> bool:
@@ -312,8 +322,10 @@ class ProviderWorkerClient:
 
         if not ended:
             # Both attempts left it running. Deregistering now would make it
-            # permanently unreapable; keep it listed so a later sweep retries.
+            # permanently unreapable; keep it listed, and strongly, so a later
+            # sweep retries even after the pool drops its own reference.
             logger.warning("idle provider worker survived termination; keeping it registered")
+            self._retain_survivor()
             return False
 
         self._deregister()
@@ -347,6 +359,11 @@ class ProviderWorkerClient:
         # worker that registered itself, and discarding here would strand it.
         if self.process is process and process.poll() is not None:
             self._deregister()
+        elif self.process is process:
+            # stop() could not end it. The pool is about to drop this client,
+            # and the weak registry alone would let it be collected with the
+            # process still running; hold it until a sweep succeeds.
+            self._retain_survivor()
 
     def _read_line_with_deadline(self, timeout: float) -> str:
         """Read one NDJSON line from the worker, honoring ``timeout`` seconds.
@@ -400,11 +417,6 @@ class ProviderWorkerClient:
         )
 
     def request(self, op: str, payload: dict[str, Any] | None = None, timeout: float = 30.0) -> WorkerResult:
-        self.start()
-        self.last_used = time.monotonic()
-        if self.process is None or self.process.stdin is None or self.process.stdout is None:
-            raise WorkerError("worker process did not start")
-
         request_id = str(uuid.uuid4())
         message = {
             "abi": WORKER_ABI_VERSION,
@@ -415,6 +427,15 @@ class ProviderWorkerClient:
         }
 
         with self._lock:
+            # Startup and the freshness stamp live under the request lock:
+            # outside it, the sweep can acquire the lock after start() returns,
+            # read the old timestamp, and kill the worker this request is
+            # about to write to.
+            self.start()
+            self.last_used = time.monotonic()
+            if self.process is None or self.process.stdin is None or self.process.stdout is None:
+                raise WorkerError("worker process did not start")
+
             self.process.stdin.write(
                 json.dumps(message, separators=(",", ":"), default=_json_default)
                 + "\n"

--- a/bazarr/provider_hub/worker.py
+++ b/bazarr/provider_hub/worker.py
@@ -208,20 +208,58 @@ class ProviderWorkerClient:
             _live_clients.discard(self)
 
     @staticmethod
-    def _kill_tree(process, grace_seconds: float) -> None:
-        """SIGKILL the worker's whole process group, not just the worker.
+    def _signal_group(process, sig) -> bool:
+        """Send ``sig`` to the worker's whole process group. False if it could not.
 
         ``start_new_session=True`` makes the worker its own session and group
-        leader, so its group id is its pid. Killing only that pid leaves
+        leader, so its group id is its pid. Signalling only that pid leaves
         anything the plugin forked running and reparented to init, where nothing
         counts or reclaims it, and a reap would report success having freed
         nothing. Plugin code is third party, so that is a mechanism to close,
         not an unlikely accident.
+
+        ``os.killpg`` is POSIX only, so this reports failure rather than raising
+        on Windows and the caller falls back to signalling the worker alone.
+        ``AttributeError`` is not an ``OSError``, so catching it is not enough:
+        it has to be checked before the call.
         """
+        killpg = getattr(os, "killpg", None)
+        if killpg is None:
+            return False
         try:
-            os.killpg(process.pid, signal.SIGKILL)
+            killpg(process.pid, sig)
         except (ProcessLookupError, PermissionError, OSError):
-            process.kill()
+            return False
+        return True
+
+    @classmethod
+    def _terminate_tree(cls, process, grace_seconds: float) -> None:
+        """Ask the group to stop, wait for the worker, reclaim what stayed.
+
+        Raises if the worker itself outlives the grace period, which is the
+        caller's signal to escalate to ``_kill_tree``.
+
+        The trailing SIGKILL is what makes the graceful path complete. A worker
+        that exits promptly never reaches ``_kill_tree``, so without it a child
+        that ignored SIGTERM would survive a reap that reported success. It
+        addresses the group by the id the exited worker led; a pid freed
+        microseconds earlier could in principle be reused, but only a process
+        that had made itself a group leader in that window would be reachable
+        by it.
+        """
+        if not cls._signal_group(process, signal.SIGTERM):
+            process.terminate()
+        process.wait(timeout=grace_seconds)
+        cls._signal_group(process, signal.SIGKILL)
+
+    @classmethod
+    def _kill_tree(cls, process, grace_seconds: float) -> None:
+        """SIGKILL the worker's whole process group, not just the worker."""
+        if not cls._signal_group(process, signal.SIGKILL):
+            try:
+                process.kill()
+            except Exception:
+                logger.warning("failed to kill provider worker", exc_info=True)
         try:
             process.wait(timeout=grace_seconds)
         except Exception:
@@ -255,8 +293,7 @@ class ProviderWorkerClient:
             if process.poll() is not None:
                 return False
             try:
-                process.terminate()
-                process.wait(timeout=grace_seconds)
+                self._terminate_tree(process, grace_seconds)
             except Exception:
                 self._kill_tree(process, grace_seconds)
         finally:
@@ -275,6 +312,8 @@ class ProviderWorkerClient:
         try:
             self.request("shutdown", {"reason": "app_shutdown", "grace_ms": int(grace_seconds * 1000)}, grace_seconds)
             process.wait(timeout=grace_seconds)
+            # A clean shutdown ends the worker, not necessarily what it forked.
+            self._signal_group(process, signal.SIGKILL)
         except Exception:
             self._kill_tree(process, grace_seconds)
 
@@ -333,15 +372,7 @@ class ProviderWorkerClient:
         process = self.process
         if process is None:
             return
-        try:
-            process.kill()
-        except Exception:
-            logger.exception("failed to kill provider worker")
-        finally:
-            try:
-                process.wait(timeout=5.0)
-            except Exception:
-                pass
+        self._kill_tree(process, 5.0)
 
     def select_archive_member(
         self, payload: dict[str, Any] | None = None, timeout: float | None = None

--- a/bazarr/sonarr/sync/series.py
+++ b/bazarr/sonarr/sync/series.py
@@ -1,8 +1,10 @@
 # coding=utf-8
 
+import itertools
 import logging
 import gc
 
+from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from sqlalchemy.exc import IntegrityError
 from datetime import datetime
@@ -33,6 +35,10 @@ FEATURE_PREFIX = "SYNC_SERIES "
 # series); 8 workers compresses that without overwhelming a typical
 # home Sonarr instance.
 SONARR_PREFETCH_WORKERS = 8
+# How many episode payloads may be outstanding at once. Two per fetcher
+# keeps them from idling between hand-offs without letting the read-ahead
+# run away from a consumer that writes to the database serially.
+SONARR_PREFETCH_WINDOW = SONARR_PREFETCH_WORKERS * 2
 
 
 def trace(message):
@@ -162,15 +168,34 @@ def update_series(job_id=None, wait_for_completion=False, arr_instance_id=None, 
         apikey_sonarr = settings.sonarr.apikey
         with ThreadPoolExecutor(max_workers=SONARR_PREFETCH_WORKERS,
                                 thread_name_prefix='bazarr-sonarr-prefetch') as executor:
-            episode_futures = {
-                show['id']: executor.submit(get_episodes_from_sonarr_api,
-                                            apikey_sonarr=apikey_sonarr,
-                                            series_id=show['id'],
-                                            arr_client=arr_client)
-                for _, show in shows_to_process
-            }
+            # Submitted a window at a time, not all at once. Submitting every
+            # series up front bounds nothing: the fetchers finish far ahead of a
+            # consumer that writes to the database serially, so completed
+            # results simply queue up and peak memory tracks the size of the
+            # library. Topping the window up as each result is consumed keeps
+            # the outstanding payloads proportional to the fan-out instead.
+            def _prefetch(entry):
+                _, show = entry
+                return executor.submit(get_episodes_from_sonarr_api,
+                                       apikey_sonarr=apikey_sonarr,
+                                       series_id=show['id'],
+                                       arr_client=arr_client)
 
-            for processed_index, (orig_index, show) in enumerate(shows_to_process, start=1):
+            upcoming = iter(shows_to_process)
+            in_flight = deque(
+                (entry, _prefetch(entry))
+                for entry in itertools.islice(upcoming, SONARR_PREFETCH_WINDOW)
+            )
+
+            processed_index = 0
+            while in_flight:
+                (orig_index, show), episode_future = in_flight.popleft()
+                # Top the window up before the slow part, so the fetchers stay
+                # busy while this series is written.
+                following = next(upcoming, None)
+                if following is not None:
+                    in_flight.append((following, _prefetch(following)))
+                processed_index += 1
                 jobs_queue.update_job_progress(job_id=job_id, progress_value=processed_index,
                                                progress_message=show['title'])
                 trace(f"{orig_index}: (Processing) {show['title']}")
@@ -191,13 +216,7 @@ def update_series(job_id=None, wait_for_completion=False, arr_instance_id=None, 
                                   serie_default_profile=serie_default_profile)
 
                 try:
-                    # pop, not [...]: the future holds its result, so leaving
-                    # consumed ones in the dict keeps every episode payload the
-                    # pass has already finished with alive until the executor
-                    # block ends. Peak memory then scales with the size of the
-                    # library instead of with how much is actually in flight,
-                    # once an hour per configured instance.
-                    episodes_data = episode_futures.pop(show['id']).result()
+                    episodes_data = episode_future.result()
                 except Exception:
                     logging.exception(f"BAZARR error pre-fetching episodes for series {show['id']}")  # noqa: G004
                     episodes_data = None

--- a/bazarr/sonarr/sync/series.py
+++ b/bazarr/sonarr/sync/series.py
@@ -191,13 +191,20 @@ def update_series(job_id=None, wait_for_completion=False, arr_instance_id=None, 
                                   serie_default_profile=serie_default_profile)
 
                 try:
-                    episodes_data = episode_futures[show['id']].result()
+                    # pop, not [...]: the future holds its result, so leaving
+                    # consumed ones in the dict keeps every episode payload the
+                    # pass has already finished with alive until the executor
+                    # block ends. Peak memory then scales with the size of the
+                    # library instead of with how much is actually in flight,
+                    # once an hour per configured instance.
+                    episodes_data = episode_futures.pop(show['id']).result()
                 except Exception:
                     logging.exception(f"BAZARR error pre-fetching episodes for series {show['id']}")  # noqa: G004
                     episodes_data = None
 
                 sync_episodes(series_id=show['id'], episodes_data=episodes_data,
                               arr_instance_id=arr_instance_id, arr_client=arr_client)
+                del episodes_data
 
         # Calculate series to remove from DB
         removed_series = current_shows_db - current_shows_sonarr

--- a/bazarr/subtitles/cache.py
+++ b/bazarr/subtitles/cache.py
@@ -16,24 +16,30 @@ _TTL_SECONDS = 3600  # 1 hour
 # ---------------------------------------------------------------------------
 # Shared backing store
 # ---------------------------------------------------------------------------
-# The bazarr process puts BOTH ``/app/bazarr`` (script dir) and
-# ``/app`` (the parent, added by ``bazarr/app/libs.py`` so jobs_queue can
-# ``importlib.import_module('bazarr.<x>')``) onto ``sys.path``. As a result
-# Python may resolve this module under two different dotted names:
+# HISTORICAL, and kept as a guard rather than as a live workaround.
 #
-#   * ``subtitles.cache``         — imported from the Flask request thread
-#                                   (api/providers/* → subtitles.manual)
-#   * ``bazarr.subtitles.cache``  — imported by ``jobs_queue._run_job`` via
-#                                   ``importlib.import_module('bazarr.<x>')``
+# The process puts BOTH ``/app/bazarr`` (the script dir) and ``/app`` (its
+# parent, added by ``bazarr/app/libs.py``) onto ``sys.path``, so this module can
+# resolve under two dotted names, ``subtitles.cache`` and
+# ``bazarr.subtitles.cache``. Each name produces a separate module object with
+# its own ``subtitle_cache = _SubtitleCache()`` singleton, so the UUID stored by
+# manual_search() was never found by the queued download job and the user saw
+# "Subtitle not found in cache" every time.
 #
-# Each dotted name produces a separate module object with its own
-# ``subtitle_cache = _SubtitleCache()`` singleton, so the UUID stored during
-# manual_search() is never found during the queued download job → the user
-# sees "Subtitle not found in cache" every time.
+# What created the second name was ``jobs_queue`` deriving a job's module
+# relative to the repository root rather than the package directory, so every
+# job was queued as ``bazarr.<x>``. That is fixed, and nothing in the app
+# process imports ``bazarr.<x>`` any more.
+#
+# The shared store stays regardless. It costs nothing, and ``sys.path`` still
+# admits the second name, so the split is one stray ``import bazarr.something``
+# away. Treat it as a guard against that, not as a description of what the
+# process does today.
 #
 # Solution: stash the actual storage dict on ``sys.modules`` under a stable
-# key. Both module copies hand out ``_SubtitleCache`` instances that share
-# that single dict, so .store() and .get() always agree.
+# key. Any module copy hands out ``_SubtitleCache`` instances that share that
+# single dict, so .store() and .get() always agree.
+# ---------------------------------------------------------------------------
 
 _SHARED_STORE_KEY = "_bazarr_subtitle_cache_shared_store"
 

--- a/bazarr/subtitles/refiners/anilist.py
+++ b/bazarr/subtitles/refiners/anilist.py
@@ -14,6 +14,28 @@ logger = logging.getLogger(__name__)
 refined_providers = {'jimaku'}
 
 
+INDEXED_ID_TAGS = ("anidb_id", "imdb_id")
+
+
+def build_series_index(anime_list):
+    """{tag: {str(id): anilist_id}} for the tags lookups actually use.
+
+    First entry wins, matching the old code, which scanned in order and took
+    the first match. Entries carrying no AniList id are not indexed: they could
+    never have produced an answer.
+    """
+    index = {tag: {} for tag in INDEXED_ID_TAGS}
+    for entry in anime_list:
+        anilist_id = entry.get("anilist_id")
+        if not anilist_id:
+            continue
+        for tag in INDEXED_ID_TAGS:
+            value = entry.get(tag)
+            if value is not None:
+                index[tag].setdefault(str(value), anilist_id)
+    return index
+
+
 class AniListClient(object):    
     def __init__(self, session=None, timeout=10):
         self.session = session or requests.Session()
@@ -21,8 +43,7 @@ class AniListClient(object):
         self.session.headers['Content-Type'] = 'application/json'
         self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__
     
-    @region.cache_on_arguments(expiration_time=timedelta(days=1).total_seconds())
-    def get_series_mappings(self):
+    def fetch_series_mappings(self):
         r = self.session.get(
             'https://raw.githubusercontent.com/Fribb/anime-lists/master/anime-list-mini.json'
         )
@@ -30,28 +51,32 @@ class AniListClient(object):
         r.raise_for_status()
         return r.json()
 
+    @region.cache_on_arguments(expiration_time=timedelta(days=1).total_seconds())
+    def get_series_index(self):
+        """The two id maps, which is all any lookup here consults.
+
+        The whole anime list used to be what was cached. The region is file
+        backed, so it unpickled roughly 43,000 dicts on every call, scanned them
+        linearly, took one match and discarded the rest: about 30 MB of
+        short-lived objects per refined search. The index is a fraction of that
+        and turns the scan into a hash lookup.
+        """
+        return build_series_index(self.fetch_series_mappings())
+
     def get_series_id(self, candidate_id_name, candidate_id_value):
-        anime_list = self.get_series_mappings()
-        
         tag_map = {
             "series_anidb_id": "anidb_id",
             "imdb_id": "imdb_id"
         }
-        mapped_tag = tag_map.get(candidate_id_name, candidate_id_name)        
-        
-        obj = [obj for obj in anime_list if mapped_tag in obj and str(obj[mapped_tag]) == str(candidate_id_value)]
-        logger.debug(f"Based on '{mapped_tag}': '{candidate_id_value}', anime-list matched: {obj}")  # noqa: G004
+        mapped_tag = tag_map.get(candidate_id_name, candidate_id_name)
 
-        if len(obj) > 0:
-            anilist_id = obj[0].get("anilist_id")
-            if not anilist_id:
-                logger.error("This entry does not have an AniList ID")
-            
-            return anilist_id
-        else:
+        anilist_id = self.get_series_index().get(mapped_tag, {}).get(str(candidate_id_value))
+        if anilist_id is None:
             logger.debug(f"Could not find corresponding AniList ID with '{mapped_tag}': {candidate_id_value}")  # noqa: G004
-        
-        return None
+            return None
+
+        logger.debug(f"Based on '{mapped_tag}': '{candidate_id_value}', anime-list matched AniList ID {anilist_id}")  # noqa: G004
+        return anilist_id
 
 
 def refine_from_anilist(path, video):

--- a/bazarr/subtitles/refiners/anilist.py
+++ b/bazarr/subtitles/refiners/anilist.py
@@ -18,17 +18,24 @@ INDEXED_ID_TAGS = ("anidb_id", "imdb_id")
 
 
 def build_series_index(anime_list):
-    """{tag: {str(id): anilist_id}} for the tags lookups actually use.
+    """{tag: {str(id): anilist_id or None}} for the tags lookups actually use.
 
-    First entry wins, matching the old code, which scanned in order and took
-    the first match. Entries carrying no AniList id are not indexed: they could
-    never have produced an answer.
+    First entry wins, which is what the old linear scan did when it took
+    ``obj[0]``. That includes an entry carrying no AniList id: it still claims
+    the key, with a value of None, because "the list has this id but no AniList
+    id for it" is a different answer from "the list does not have this id", and
+    the old code distinguished them. Dropping such entries would silently let a
+    later duplicate answer in their place.
+
+    Non-mapping elements are skipped rather than raising. The value is built
+    inside the cached call, so one malformed element upstream would otherwise
+    mean nothing is ever cached and the 3 MB list is refetched on every search.
     """
     index = {tag: {} for tag in INDEXED_ID_TAGS}
     for entry in anime_list:
-        anilist_id = entry.get("anilist_id")
-        if not anilist_id:
+        if not isinstance(entry, dict):
             continue
+        anilist_id = entry.get("anilist_id") or None
         for tag in INDEXED_ID_TAGS:
             value = entry.get(tag)
             if value is not None:
@@ -39,13 +46,17 @@ def build_series_index(anime_list):
 class AniListClient(object):    
     def __init__(self, session=None, timeout=10):
         self.session = session or requests.Session()
-        self.session.timeout = timeout
+        self.timeout = timeout
         self.session.headers['Content-Type'] = 'application/json'
         self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__
     
     def fetch_series_mappings(self):
+        # Passed per request: requests ignores an attribute set on the Session,
+        # so this call had no timeout at all and could hang a search
+        # indefinitely behind the region's per-key mutex.
         r = self.session.get(
-            'https://raw.githubusercontent.com/Fribb/anime-lists/master/anime-list-mini.json'
+            'https://raw.githubusercontent.com/Fribb/anime-lists/master/anime-list-mini.json',
+            timeout=self.timeout,
         )
 
         r.raise_for_status()
@@ -70,9 +81,17 @@ class AniListClient(object):
         }
         mapped_tag = tag_map.get(candidate_id_name, candidate_id_name)
 
-        anilist_id = self.get_series_index().get(mapped_tag, {}).get(str(candidate_id_value))
-        if anilist_id is None:
+        mapping = self.get_series_index().get(mapped_tag, {})
+        key = str(candidate_id_value)
+        if key not in mapping:
             logger.debug(f"Could not find corresponding AniList ID with '{mapped_tag}': {candidate_id_value}")  # noqa: G004
+            return None
+
+        anilist_id = mapping[key]
+        if not anilist_id:
+            # Matched an entry that simply has no AniList id. Kept distinct from
+            # "no match" because it is the case worth telling someone about.
+            logger.error("This entry does not have an AniList ID")
             return None
 
         logger.debug(f"Based on '{mapped_tag}': '{candidate_id_value}', anime-list matched AniList ID {anilist_id}")  # noqa: G004

--- a/bazarr/subtitles/upgrade.py
+++ b/bazarr/subtitles/upgrade.py
@@ -67,8 +67,7 @@ def upgrade_episodes_subtitles(job_id=None, sonarr_series_ids=None, sonarr_serie
         .join(TableShows, onclause=and_(TableHistory.sonarrSeriesId == TableShows.sonarrSeriesId,
                                   TableHistory.arr_instance_id == TableShows.arr_instance_id)) \
         .join(TableEpisodes, onclause=and_(TableHistory.sonarrEpisodeId == TableEpisodes.sonarrEpisodeId,
-                                     TableHistory.arr_instance_id == TableEpisodes.arr_instance_id)) \
-        .where(TableHistory.video_path == TableEpisodes.path)
+                                     TableHistory.arr_instance_id == TableEpisodes.arr_instance_id))
 
     if sonarr_series_filters:
         query = query.where(or_(*[
@@ -80,6 +79,18 @@ def upgrade_episodes_subtitles(job_id=None, sonarr_series_ids=None, sonarr_serie
     elif sonarr_series_ids:
         query = query.where(TableHistory.sonarrSeriesId.in_(sonarr_series_ids))
 
+    # Streamed rather than .all(): the Row objects and the dicts built from them
+    # would otherwise both be held at once, over a history table that is never
+    # pruned.
+    #
+    # The video_path filter deliberately stays in Python rather than moving into
+    # the join. SQL equality is not NULL safe, so a NULL on either side drops the
+    # row instead of comparing equal, and this file already works around exactly
+    # that elsewhere with is_not_distinct_from. Today TableEpisodes.path is NOT
+    # NULL so the two agree, but that is a constraint sixty lines away in another
+    # module, and it keeps the episode side symmetrical with the movie side below,
+    # where the same comparison has to stay in Python so a dropped candidate can
+    # be explained in the log.
     episodes_data = [{
         'id': x.id,
         'seriesTitle': x.seriesTitle,
@@ -99,7 +110,8 @@ def upgrade_episodes_subtitles(job_id=None, sonarr_series_ids=None, sonarr_serie
         'profileId': x.profileId,
         'external_subtitles': [y[1] for y in ast.literal_eval(x.external_subtitles) if y[1]],
     } for x in database.execute(query)
-    if _language_still_desired(x.language, x.profileId)
+    if _language_still_desired(x.language, x.profileId) and
+       x.video_path == x.path
     ]
 
     for item in episodes_data:

--- a/bazarr/subtitles/upgrade.py
+++ b/bazarr/subtitles/upgrade.py
@@ -67,7 +67,8 @@ def upgrade_episodes_subtitles(job_id=None, sonarr_series_ids=None, sonarr_serie
         .join(TableShows, onclause=and_(TableHistory.sonarrSeriesId == TableShows.sonarrSeriesId,
                                   TableHistory.arr_instance_id == TableShows.arr_instance_id)) \
         .join(TableEpisodes, onclause=and_(TableHistory.sonarrEpisodeId == TableEpisodes.sonarrEpisodeId,
-                                     TableHistory.arr_instance_id == TableEpisodes.arr_instance_id))
+                                     TableHistory.arr_instance_id == TableEpisodes.arr_instance_id)) \
+        .where(TableHistory.video_path == TableEpisodes.path)
 
     if sonarr_series_filters:
         query = query.where(or_(*[
@@ -98,8 +99,7 @@ def upgrade_episodes_subtitles(job_id=None, sonarr_series_ids=None, sonarr_serie
         'profileId': x.profileId,
         'external_subtitles': [y[1] for y in ast.literal_eval(x.external_subtitles) if y[1]],
     } for x in database.execute(query)
-    .all() if _language_still_desired(x.language, x.profileId) and
-              x.video_path == x.path
+    if _language_still_desired(x.language, x.profileId)
     ]
 
     for item in episodes_data:
@@ -217,9 +217,12 @@ def upgrade_movies_subtitles(job_id=None, radarr_ids=None, radarr_filters=None, 
     elif radarr_ids:
         query = query.where(TableHistoryMovie.radarrId.in_(radarr_ids))
 
-    all_rows = database.execute(query).all()
+    # Streamed rather than .all(): the diagnostics below explain why each
+    # candidate was dropped, so the filtering stays in Python, but there is no
+    # reason to hold every Row of the history join in memory at once while the
+    # dicts for the survivors are being built alongside them.
     movies_data = []
-    for x in all_rows:
+    for x in database.execute(query):
         if not _language_still_desired(x.language, x.profileId):
             if x.id in movies_to_upgrade:
                 logging.debug(f"Upgrade candidate {x.id} ({x.title}) dropped: language {x.language} no longer desired "  # noqa: G004

--- a/tests/bazarr/test_anilist_index.py
+++ b/tests/bazarr/test_anilist_index.py
@@ -35,13 +35,39 @@ def test_the_index_resolves_both_id_types():
     assert index["imdb_id"]["tt0003"] == 103
 
 
-def test_an_entry_without_an_anilist_id_is_not_indexed():
+def test_an_entry_without_an_anilist_id_still_claims_its_key():
+    """It claims the key with a None value. The old scan matched that entry and
+    returned nothing, so dropping it would let a later duplicate answer in its
+    place, which is a different result for the same input."""
     from subtitles.refiners.anilist import build_series_index
 
     index = build_series_index(ANIME_LIST)
 
-    assert "4" not in index["anidb_id"]
-    assert "tt0004" not in index["imdb_id"]
+    assert index["anidb_id"]["4"] is None
+    assert index["imdb_id"]["tt0004"] is None
+
+
+def test_a_later_duplicate_cannot_displace_an_id_less_first_entry():
+    from subtitles.refiners.anilist import build_series_index
+
+    index = build_series_index([
+        {"anidb_id": 42, "title": "First, no anilist id"},
+        {"anidb_id": 42, "anilist_id": 999, "title": "Later duplicate"},
+    ])
+
+    assert index["anidb_id"]["42"] is None, (
+        'the later duplicate answered for a key the first entry already claimed'
+    )
+
+
+def test_a_non_mapping_element_does_not_break_the_build():
+    """The build runs inside the cached call, so raising here would mean nothing
+    is ever cached and the 3 MB list is refetched on every search."""
+    from subtitles.refiners.anilist import build_series_index
+
+    index = build_series_index(["junk", None, 7, {"anidb_id": 1, "anilist_id": 101}])
+
+    assert index["anidb_id"]["1"] == 101
 
 
 def test_the_first_entry_wins_as_it_did_before():
@@ -61,7 +87,7 @@ def test_the_index_keeps_only_what_is_looked_up():
 
     assert set(index) == {"anidb_id", "imdb_id"}
     flattened = repr(index)
-    for noise in ("title", "First", "mal_id", "themoviedb_id", "9001", "5001"):
+    for noise in ("title", "mal_id", "themoviedb_id", "9001", "5001"):
         assert noise not in flattened, (
             f'{noise!r} survived into the cached index; only the two id maps '
             'should be cached')
@@ -71,8 +97,8 @@ def test_the_index_keeps_only_what_is_looked_up():
     ("series_anidb_id", 1, 101),
     ("series_anidb_id", "2", 102),
     ("imdb_id", "tt0003", 103),
-    ("series_anidb_id", 4, None),
-    ("imdb_id", "tt9999", None),
+    ("series_anidb_id", 4, None),      # present, but carries no AniList id
+    ("imdb_id", "tt9999", None),       # not in the list at all
 ])
 def test_lookup_matches_the_old_behaviour(monkeypatch, candidate, value, expected):
     from subtitles.refiners import anilist

--- a/tests/bazarr/test_anilist_index.py
+++ b/tests/bazarr/test_anilist_index.py
@@ -1,0 +1,84 @@
+# coding=utf-8
+"""The AniList refiner must cache an index, not the whole anime list.
+
+`get_series_mappings` cached the parsed Fribb anime-list, roughly 43,000 dicts,
+in the file-backed dogpile region. That backend unpickles its value on every
+read, so each jimaku-refined search inflated a 2.6 MB pickle into about 30 MB of
+short-lived Python objects, linear-scanned it with a `str()` conversion per
+entry, took the first match and threw the rest away.
+
+Only two fields of each entry are ever consulted, so the cache should hold the
+lookup rather than the corpus. A dict keyed by the two id types is a fraction of
+the size, survives the same round trip, and turns the scan into a hash lookup.
+"""
+import pytest
+
+
+ANIME_LIST = [
+    {"anidb_id": 1, "imdb_id": "tt0001", "anilist_id": 101, "title": "First",
+     "mal_id": 9001, "themoviedb_id": 5001},
+    {"anidb_id": 2, "anilist_id": 102, "title": "No imdb", "mal_id": 9002},
+    {"imdb_id": "tt0003", "anilist_id": 103, "title": "No anidb"},
+    {"anidb_id": 4, "imdb_id": "tt0004", "title": "No anilist id at all"},
+    {"anidb_id": 1, "anilist_id": 999, "title": "Duplicate anidb, must not win"},
+]
+
+
+def test_the_index_resolves_both_id_types():
+    from subtitles.refiners.anilist import build_series_index
+
+    index = build_series_index(ANIME_LIST)
+
+    assert index["anidb_id"]["1"] == 101
+    assert index["anidb_id"]["2"] == 102
+    assert index["imdb_id"]["tt0001"] == 101
+    assert index["imdb_id"]["tt0003"] == 103
+
+
+def test_an_entry_without_an_anilist_id_is_not_indexed():
+    from subtitles.refiners.anilist import build_series_index
+
+    index = build_series_index(ANIME_LIST)
+
+    assert "4" not in index["anidb_id"]
+    assert "tt0004" not in index["imdb_id"]
+
+
+def test_the_first_entry_wins_as_it_did_before():
+    """The old code took obj[0] of the matches, so a later duplicate never won."""
+    from subtitles.refiners.anilist import build_series_index
+
+    index = build_series_index(ANIME_LIST)
+
+    assert index["anidb_id"]["1"] == 101, 'a later duplicate overwrote the first match'
+
+
+def test_the_index_keeps_only_what_is_looked_up():
+    """The point of the change. Anything else retained puts the corpus back."""
+    from subtitles.refiners.anilist import build_series_index
+
+    index = build_series_index(ANIME_LIST)
+
+    assert set(index) == {"anidb_id", "imdb_id"}
+    flattened = repr(index)
+    for noise in ("title", "First", "mal_id", "themoviedb_id", "9001", "5001"):
+        assert noise not in flattened, (
+            f'{noise!r} survived into the cached index; only the two id maps '
+            'should be cached')
+
+
+@pytest.mark.parametrize("candidate,value,expected", [
+    ("series_anidb_id", 1, 101),
+    ("series_anidb_id", "2", 102),
+    ("imdb_id", "tt0003", 103),
+    ("series_anidb_id", 4, None),
+    ("imdb_id", "tt9999", None),
+])
+def test_lookup_matches_the_old_behaviour(monkeypatch, candidate, value, expected):
+    from subtitles.refiners import anilist
+
+    client = anilist.AniListClient.__new__(anilist.AniListClient)
+    monkeypatch.setattr(anilist.AniListClient, 'get_series_index',
+                        lambda self: anilist.build_series_index(ANIME_LIST))
+
+    assert client.get_series_id(candidate, value) == expected

--- a/tests/bazarr/test_job_module_identity.py
+++ b/tests/bazarr/test_job_module_identity.py
@@ -1,0 +1,63 @@
+# coding=utf-8
+"""A queued job must re-import the module it was queued from, not a copy of it.
+
+`add_job_from_function` records the caller's module as a dotted path derived
+from its filename relative to `bazarr_dir`, and `_run_job` later resolves that
+string with `importlib.import_module`. `bazarr_dir` was computed one directory
+too high, so it named the repository root rather than the package directory, and
+every derived string came out prefixed: `bazarr.subtitles.wanted.movies` where
+the running process had already imported `subtitles.wanted.movies`.
+
+`app/libs.py` puts the parent directory on `sys.path` too, so both names resolve.
+Python then holds two module objects for the same file, each with its own
+module-level state.
+
+That is not theoretical. `subtitles/cache.py` carries a comment describing this
+exact split and a workaround for it, because the subtitle UUID stored by a
+manual search was written into one copy and looked for in the other, so users
+got "Subtitle not found in cache" on every manual download. The workaround
+stores the dict on `sys.modules` under a fixed key and is unaffected by this fix.
+
+The part nobody connected: `subtitles/pool.py` holds `_pools` at module level,
+and Provider Hub spawns a worker subprocess per pool and provider. Two copies of
+that module means two pool registries and, on a warm install, two worker fleets.
+
+The invariant is simply that the string is the name the module already has.
+"""
+import os
+
+import pytest
+
+
+@pytest.mark.parametrize("module_name", [
+    "subtitles.wanted.series",
+    "subtitles.wanted.movies",
+    "subtitles.pool",
+    "sonarr.sync.series",
+    "radarr.sync.movies",
+])
+def test_the_derived_job_module_is_the_name_the_module_already_has(module_name):
+    import importlib
+
+    from app import jobs_queue
+
+    module = importlib.import_module(module_name)
+
+    # Exactly what add_job_from_function does with the caller's filename.
+    relative = os.path.relpath(module.__file__, start=jobs_queue.bazarr_dir)
+    derived = os.path.splitext(relative)[0].replace(os.sep, '.')
+
+    assert derived == module.__name__, (
+        f'a job queued from {module.__name__} would be re-imported as {derived!r}, '
+        'which is a second copy of the same file with its own module-level state'
+    )
+
+
+def test_bazarr_dir_is_the_package_directory():
+    """The directory the top-level modules live in, not its parent."""
+    from app import jobs_queue
+
+    for expected in ('subtitles', 'sonarr', 'radarr', 'app'):
+        assert os.path.isdir(os.path.join(jobs_queue.bazarr_dir, expected)), (
+            f'{expected!r} is not directly under bazarr_dir '
+            f'({jobs_queue.bazarr_dir}), so derived module paths will be wrong')

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -563,20 +563,25 @@ def test_worker_reader_caps_oversized_response_line(monkeypatch):
     assert buffered <= worker_mod._MAX_RESPONSE_LINE_BYTES + worker_mod._READ_CHUNK_CHARS
 
 
-def test_worker_consumer_kills_on_oversized_sentinel():
+def test_worker_consumer_kills_on_oversized_sentinel(monkeypatch):
     import queue
     from types import SimpleNamespace
     from provider_hub import worker as worker_mod
     from provider_hub.worker import ProviderWorkerClient, WorkerError
 
+    killed = []
+    monkeypatch.setattr(worker_mod.os, "killpg",
+                        lambda pgid, sig: killed.append((pgid, sig)))
     client = ProviderWorkerClient.__new__(ProviderWorkerClient)
     client.process = SimpleNamespace(
-        stdout=object(), kill=lambda: None, wait=lambda timeout=None: None
+        pid=4242, stdout=object(), kill=lambda: None, wait=lambda timeout=None: None
     )
     client._stdout_queue = queue.Queue()
     client._stdout_queue.put(worker_mod._OVERSIZE_RESPONSE)
     with pytest.raises(WorkerError, match="exceeded"):
         client._read_line_with_deadline(5.0)
+    assert killed == [(4242, worker_mod.signal.SIGKILL)], (
+        "a worker discarded mid-protocol has to take its children with it")
 
 
 def test_venv_installer_uses_isolated_hash_checked_pip(monkeypatch, tmp_path):

--- a/tests/bazarr/test_provider_hub_worker_reaper.py
+++ b/tests/bazarr/test_provider_hub_worker_reaper.py
@@ -308,3 +308,76 @@ def test_a_worker_surviving_the_kill_stays_registered(group_signals):
 
     assert client.stop_if_idle(idle_seconds=60, grace_seconds=0.01) is False
     assert client in worker_mod._live_clients
+
+
+def test_request_startup_is_serialized_with_the_sweep():
+    """start() and the last_used stamp must happen under the request lock:
+    outside it, the sweep can acquire the lock after start() returns, read the
+    old timestamp, and kill the worker the request is about to write to."""
+    import json as json_mod
+    import queue
+
+    from provider_hub.worker import WORKER_ABI_VERSION
+
+    client = _client(idle_for=0)
+    client.process.stdin = MagicMock()
+    client._stdout_queue = queue.Queue()
+    client._stdout_thread = None
+    client._stderr_thread = None
+
+    seen = {}
+
+    def probe_start():
+        seen["locked_during_start"] = client._lock.locked()
+
+    client.start = probe_start
+
+    def canned_line(timeout):
+        seen["locked_during_read"] = client._lock.locked()
+        return json_mod.dumps({
+            "abi": WORKER_ABI_VERSION,
+            "id": seen.setdefault("request_id", None) or _last_request_id(client),
+            "ok": True,
+            "payload": {},
+            "events": [],
+        })
+
+    def _last_request_id(c):
+        # The id is embedded in the message written to stdin.
+        written = c.process.stdin.write.call_args[0][0]
+        return json_mod.loads(written)["id"]
+
+    client._read_line_with_deadline = canned_line
+    result = client.request("ping", {})
+    assert result.ok
+    assert seen["locked_during_start"] is True
+
+
+def test_a_stop_survivor_is_retained_for_later_sweeps(group_signals):
+    """A worker stop() could not kill must stay strongly reachable: the weak
+    registry alone lets garbage collection drop the client once the pool does,
+    and with it the only handle to the still-running process."""
+    import gc
+    import subprocess
+
+    from provider_hub import worker as worker_mod
+
+    client = _client(idle_for=3600)
+    process = client.process
+    process.poll.return_value = None
+    process.wait.side_effect = subprocess.TimeoutExpired(cmd="worker", timeout=0.01)
+    client.request = MagicMock(side_effect=RuntimeError("no shutdown channel"))
+    worker_mod._live_clients.add(client)
+
+    client.stop(grace_seconds=0.01)
+    ref = None
+    try:
+        assert client in worker_mod._live_clients
+        ref = client
+        del client
+        gc.collect()
+        assert len(list(worker_mod._live_clients)) == 1, (
+            "the surviving client fell out of the weak registry")
+    finally:
+        if ref is not None:
+            worker_mod._unreaped_survivors.discard(ref)

--- a/tests/bazarr/test_provider_hub_worker_reaper.py
+++ b/tests/bazarr/test_provider_hub_worker_reaper.py
@@ -264,3 +264,47 @@ def test_a_started_worker_registers_and_a_stopped_one_deregisters(monkeypatch, t
     fake.poll.return_value = 0  # exited
     client.stop()
     assert client not in worker_mod._live_clients
+
+
+def test_a_platform_without_sigkill_still_ends_the_worker(monkeypatch):
+    """Windows has neither os.killpg nor signal.SIGKILL. The SIGKILL name is
+    evaluated at the call sites, so it must not be looked up unguarded or the
+    AttributeError fires before _signal_group can report False and fall back
+    to process.kill()."""
+    from provider_hub import worker as worker_mod
+
+    monkeypatch.delattr(worker_mod.os, "killpg", raising=False)
+    monkeypatch.delattr(worker_mod.signal, "SIGKILL", raising=False)
+
+    client = _client(idle_for=3600)
+    process = client.process
+
+    def _ended():
+        process.poll.return_value = 0
+
+    process.terminate.side_effect = _ended
+    process.kill.side_effect = _ended
+    process.wait.return_value = 0
+    worker_mod._live_clients.add(client)
+
+    assert client.stop_if_idle(idle_seconds=60) is True
+    assert process.terminate.called or process.kill.called
+    assert client not in worker_mod._live_clients
+
+
+def test_a_worker_surviving_the_kill_stays_registered(group_signals):
+    """If both termination attempts leave the process running, deregistering
+    anyway makes it permanently unreapable; it must stay registered so a later
+    sweep retries."""
+    import subprocess
+
+    from provider_hub import worker as worker_mod
+
+    client = _client(idle_for=3600)
+    process = client.process
+    process.poll.return_value = None  # survives everything
+    process.wait.side_effect = subprocess.TimeoutExpired(cmd="worker", timeout=0.01)
+    worker_mod._live_clients.add(client)
+
+    assert client.stop_if_idle(idle_seconds=60, grace_seconds=0.01) is False
+    assert client in worker_mod._live_clients

--- a/tests/bazarr/test_provider_hub_worker_reaper.py
+++ b/tests/bazarr/test_provider_hub_worker_reaper.py
@@ -1,18 +1,26 @@
 # coding=utf-8
-"""Idle Provider Hub workers have to be reclaimed.
+"""Idle Provider Hub workers have to be reclaimed, without ending a live one.
 
 Each Hub provider runs its plugin in a subprocess, spawned lazily the first time
-a pool searches with that provider. Nothing stops them afterwards: the pool's own
-recycle only fires the next time that pool is searched, so on a quiet install the
-fleet sits at full size indefinitely. Measured on a real deployment, a worker
-costs 17.6 to 44.6 MiB PSS and a warm install carried roughly 45 of them.
+a pool searches with that provider. Nothing stopped them afterwards: the pool's
+own recycle only fires the next time that pool is searched, so on a quiet
+install the fleet sat at full size indefinitely, at 17.6 to 44.6 MiB PSS each
+and roughly 45 of them on a warm install.
 
-Reaping them is cheap because it is not destructive: `request()` calls `start()`,
-and `start()` respawns a process that has exited, so a reaped worker comes back
-on the next search for the cost of a cold start, measured at 0.5 to 1.7 s. It is
-also safe against a request in flight, because `stop()` goes through `request()`
-and therefore waits on the same lock a live request holds.
+The hard part is not finding the idle ones, it is not ending a busy one. The
+first version of this decided idleness in the sweep and shut the worker down
+afterwards, which is a check-then-act race: a search can pass `start()` and be
+queued on the lock in the window between the two, then write into a process the
+sweep had already ended. It also blocked on that lock, so a request legitimately
+running for hours (transcription is allowed up to a 24 hour ceiling) would have
+pinned the sweep for its whole duration and then killed the worker the moment it
+succeeded.
+
+So the decision and the shutdown happen together, under the same lock a request
+holds, and the acquire never blocks. These tests use a real lock and assert on
+the process, rather than mocking the call under test.
 """
+import threading
 import time
 from unittest.mock import MagicMock
 
@@ -29,25 +37,26 @@ def empty_registry():
 
 
 def _client(idle_for, alive=True):
-    """A client wired to a stand-in process, without spawning anything."""
+    """A client wired to a stand-in process and a real lock, spawning nothing."""
     from provider_hub.worker import ProviderWorkerClient
 
     client = ProviderWorkerClient.__new__(ProviderWorkerClient)
     client.process = MagicMock()
     client.process.poll.return_value = None if alive else 0
+    client._lock = threading.Lock()
     client.last_used = time.monotonic() - idle_for
-    client.stop = MagicMock(side_effect=lambda *a, **kw: None)
     return client
 
 
-def test_a_worker_idle_past_the_ttl_is_stopped():
+def test_an_idle_worker_is_ended():
     from provider_hub import worker as worker_mod
 
     stale = _client(idle_for=3600)
     worker_mod._live_clients.add(stale)
 
     assert worker_mod.reap_idle_workers(idle_seconds=1800) == 1
-    stale.stop.assert_called_once()
+    stale.process.terminate.assert_called_once()
+    assert stale not in worker_mod._live_clients
 
 
 def test_a_recently_used_worker_is_left_alone():
@@ -57,37 +66,140 @@ def test_a_recently_used_worker_is_left_alone():
     worker_mod._live_clients.add(busy)
 
     assert worker_mod.reap_idle_workers(idle_seconds=1800) == 0
-    busy.stop.assert_not_called()
+    busy.process.terminate.assert_not_called()
+    assert busy in worker_mod._live_clients, 'a live worker must stay reapable later'
 
 
-def test_a_worker_that_already_exited_is_not_stopped_again():
+def test_a_worker_serving_a_request_is_never_ended():
+    """The whole point. A request holds the lock for its duration, including a
+    transcription that legitimately runs far longer than the idle window."""
+    from provider_hub import worker as worker_mod
+
+    working = _client(idle_for=7200)  # stamped long ago, still mid-request
+    working._lock.acquire()           # stand in for a request in flight
+    worker_mod._live_clients.add(working)
+
+    try:
+        assert worker_mod.reap_idle_workers(idle_seconds=1800) == 0
+        working.process.terminate.assert_not_called()
+    finally:
+        working._lock.release()
+
+
+def test_the_sweep_does_not_block_on_a_busy_worker():
+    """A blocking acquire would pin the scheduler thread for the length of the
+    request, which for a long transcription is hours."""
+    from provider_hub import worker as worker_mod
+
+    working = _client(idle_for=7200)
+    working._lock.acquire()
+    worker_mod._live_clients.add(working)
+
+    try:
+        started = time.monotonic()
+        worker_mod.reap_idle_workers(idle_seconds=1800)
+        assert time.monotonic() - started < 1.0, 'the sweep waited on a held lock'
+    finally:
+        working._lock.release()
+
+
+def test_idleness_is_rechecked_once_the_lock_is_held():
+    """The sweep selects candidates without the lock, so the decision has to be
+    made again with it: a request can start in between."""
+    from provider_hub import worker as worker_mod
+
+    client = _client(idle_for=3600)
+
+    class _LockThatBecomesBusy:
+        """A real lock whose acquire coincides with a request arriving."""
+
+        def __init__(self, owner):
+            self._inner = threading.Lock()
+            self._owner = owner
+
+        def acquire(self, *args, **kwargs):
+            got = self._inner.acquire(*args, **kwargs)
+            if got:
+                self._owner.last_used = time.monotonic()
+            return got
+
+        def release(self):
+            self._inner.release()
+
+    client._lock = _LockThatBecomesBusy(client)
+    worker_mod._live_clients.add(client)
+
+    assert worker_mod.reap_idle_workers(idle_seconds=1800) == 0
+    client.process.terminate.assert_not_called()
+
+
+def test_a_worker_that_already_exited_is_not_ended_again():
     from provider_hub import worker as worker_mod
 
     dead = _client(idle_for=3600, alive=False)
     worker_mod._live_clients.add(dead)
 
     assert worker_mod.reap_idle_workers(idle_seconds=1800) == 0
-    dead.stop.assert_not_called()
+    dead.process.terminate.assert_not_called()
 
 
-def test_one_failing_worker_does_not_strand_the_rest():
-    """A plugin that will not shut down cleanly must not keep the fleet alive."""
+def test_a_worker_that_will_not_terminate_has_its_group_killed(monkeypatch):
+    """start_new_session makes the worker a process-group leader, so killing the
+    pid alone would leave anything the plugin forked orphaned and resident."""
+    from provider_hub import worker as worker_mod
+
+    stubborn = _client(idle_for=3600)
+    stubborn.process.pid = 4242
+    stubborn.process.wait.side_effect = [Exception('ignored SIGTERM'), 0]
+    killed = []
+    monkeypatch.setattr(worker_mod.os, 'killpg',
+                        lambda pgid, sig: killed.append((pgid, sig)))
+    worker_mod._live_clients.add(stubborn)
+
+    assert worker_mod.reap_idle_workers(idle_seconds=1800) == 1
+    assert killed == [(4242, worker_mod.signal.SIGKILL)], (
+        f'expected the process group to be killed, got {killed!r}')
+
+
+def test_one_failing_worker_does_not_strand_the_rest(monkeypatch):
     from provider_hub import worker as worker_mod
 
     angry = _client(idle_for=3600)
-    angry.stop = MagicMock(side_effect=OSError('will not die'))
+    angry.process.terminate.side_effect = OSError('will not die')
     calm = _client(idle_for=3600)
+    monkeypatch.setattr(worker_mod.os, 'killpg',
+                        lambda *a: (_ for _ in ()).throw(OSError('nor that')))
     worker_mod._live_clients.add(angry)
     worker_mod._live_clients.add(calm)
 
     reaped = worker_mod.reap_idle_workers(idle_seconds=1800)
 
-    calm.stop.assert_called_once()
-    assert reaped == 1, 'the survivor should still be counted'
+    calm.process.terminate.assert_called_once()
+    assert reaped >= 1, 'the survivor should still be counted'
+    assert angry._lock.acquire(blocking=False), 'the lock was not released on failure'
+
+
+def test_a_worker_that_outlives_its_stop_stays_reapable():
+    """start() registers only when it spawns, so discarding a client whose
+    process is still running would make that subprocess permanently invisible
+    to the reaper: the exact leak this exists to prevent."""
+    from provider_hub import worker as worker_mod
+
+    survivor = _client(idle_for=3600)
+    survivor.request = MagicMock(side_effect=Exception('shutdown ignored'))
+    survivor.process.pid = 99
+    survivor.process.wait.side_effect = Exception('outlived SIGKILL too')
+    worker_mod._live_clients.add(survivor)
+
+    survivor.stop()
+
+    assert survivor in worker_mod._live_clients, (
+        'a worker that survived its own stop was dropped from the registry and '
+        'can never be reaped again')
 
 
 def test_a_started_worker_registers_and_a_stopped_one_deregisters(monkeypatch, tmp_path):
-    """The registry is what the reaper walks, so membership is the contract."""
+    """The registry is what the sweep walks, so membership is the contract."""
     from provider_hub import worker as worker_mod
 
     client = worker_mod.ProviderWorkerClient.__new__(worker_mod.ProviderWorkerClient)
@@ -95,7 +207,7 @@ def test_a_started_worker_registers_and_a_stopped_one_deregisters(monkeypatch, t
     client.cwd = str(tmp_path)
     client.env = None
     client.process = None
-    client._lock = __import__('threading').Lock()
+    client._lock = threading.Lock()
     client._stdout_queue = None
     client._stdout_thread = None
     client._stderr_thread = None

--- a/tests/bazarr/test_provider_hub_worker_reaper.py
+++ b/tests/bazarr/test_provider_hub_worker_reaper.py
@@ -36,27 +36,70 @@ def empty_registry():
     worker_mod._live_clients.clear()
 
 
-def _client(idle_for, alive=True):
+@pytest.fixture
+def group_signals(monkeypatch):
+    """Record every process-group signal instead of sending one."""
+    from provider_hub import worker as worker_mod
+
+    sent = []
+    monkeypatch.setattr(worker_mod.os, 'killpg',
+                        lambda pgid, sig: sent.append((pgid, sig)))
+    return sent
+
+
+def _client(idle_for, alive=True, pid=4242):
     """A client wired to a stand-in process and a real lock, spawning nothing."""
     from provider_hub.worker import ProviderWorkerClient
 
     client = ProviderWorkerClient.__new__(ProviderWorkerClient)
     client.process = MagicMock()
+    client.process.pid = pid
     client.process.poll.return_value = None if alive else 0
     client._lock = threading.Lock()
     client.last_used = time.monotonic() - idle_for
     return client
 
 
-def test_an_idle_worker_is_ended():
+def test_an_idle_worker_is_ended(group_signals):
     from provider_hub import worker as worker_mod
 
     stale = _client(idle_for=3600)
     worker_mod._live_clients.add(stale)
 
     assert worker_mod.reap_idle_workers(idle_seconds=1800) == 1
-    stale.process.terminate.assert_called_once()
+    assert (4242, worker_mod.signal.SIGTERM) in group_signals
     assert stale not in worker_mod._live_clients
+
+
+def test_the_normal_reap_path_ends_the_whole_group(group_signals):
+    """A worker that exits on the first SIGTERM never reaches the kill path, so
+    signalling the pid alone would leave whatever the plugin forked running and
+    reparented while the sweep reported the memory reclaimed."""
+    from provider_hub import worker as worker_mod
+
+    stale = _client(idle_for=3600)
+    stale.process.wait.return_value = 0
+    worker_mod._live_clients.add(stale)
+
+    assert worker_mod.reap_idle_workers(idle_seconds=1800) == 1
+    assert (4242, worker_mod.signal.SIGTERM) in group_signals, (
+        'the group was never asked to stop, only the worker')
+    assert (4242, worker_mod.signal.SIGKILL) in group_signals, (
+        'children that ignored SIGTERM were left behind by a successful reap')
+
+
+def test_a_platform_without_process_groups_still_ends_the_worker(monkeypatch):
+    """os.killpg does not exist on Windows. AttributeError is not an OSError, so
+    an unguarded call escapes the fallback and the worker is never killed."""
+    from provider_hub import worker as worker_mod
+
+    monkeypatch.delattr(worker_mod.os, 'killpg', raising=False)
+    stubborn = _client(idle_for=3600)
+    stubborn.process.wait.side_effect = [Exception('ignored SIGTERM'), 0]
+    worker_mod._live_clients.add(stubborn)
+
+    assert worker_mod.reap_idle_workers(idle_seconds=1800) == 1
+    stubborn.process.kill.assert_called_once()
 
 
 def test_a_recently_used_worker_is_left_alone():
@@ -143,22 +186,18 @@ def test_a_worker_that_already_exited_is_not_ended_again():
     dead.process.terminate.assert_not_called()
 
 
-def test_a_worker_that_will_not_terminate_has_its_group_killed(monkeypatch):
+def test_a_worker_that_will_not_terminate_has_its_group_killed(group_signals):
     """start_new_session makes the worker a process-group leader, so killing the
     pid alone would leave anything the plugin forked orphaned and resident."""
     from provider_hub import worker as worker_mod
 
     stubborn = _client(idle_for=3600)
-    stubborn.process.pid = 4242
     stubborn.process.wait.side_effect = [Exception('ignored SIGTERM'), 0]
-    killed = []
-    monkeypatch.setattr(worker_mod.os, 'killpg',
-                        lambda pgid, sig: killed.append((pgid, sig)))
     worker_mod._live_clients.add(stubborn)
 
     assert worker_mod.reap_idle_workers(idle_seconds=1800) == 1
-    assert killed == [(4242, worker_mod.signal.SIGKILL)], (
-        f'expected the process group to be killed, got {killed!r}')
+    assert (4242, worker_mod.signal.SIGKILL) in group_signals, (
+        f'expected the process group to be killed, got {group_signals!r}')
 
 
 def test_one_failing_worker_does_not_strand_the_rest(monkeypatch):

--- a/tests/bazarr/test_provider_hub_worker_reaper.py
+++ b/tests/bazarr/test_provider_hub_worker_reaper.py
@@ -1,0 +1,115 @@
+# coding=utf-8
+"""Idle Provider Hub workers have to be reclaimed.
+
+Each Hub provider runs its plugin in a subprocess, spawned lazily the first time
+a pool searches with that provider. Nothing stops them afterwards: the pool's own
+recycle only fires the next time that pool is searched, so on a quiet install the
+fleet sits at full size indefinitely. Measured on a real deployment, a worker
+costs 17.6 to 44.6 MiB PSS and a warm install carried roughly 45 of them.
+
+Reaping them is cheap because it is not destructive: `request()` calls `start()`,
+and `start()` respawns a process that has exited, so a reaped worker comes back
+on the next search for the cost of a cold start, measured at 0.5 to 1.7 s. It is
+also safe against a request in flight, because `stop()` goes through `request()`
+and therefore waits on the same lock a live request holds.
+"""
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def empty_registry():
+    from provider_hub import worker as worker_mod
+
+    worker_mod._live_clients.clear()
+    yield
+    worker_mod._live_clients.clear()
+
+
+def _client(idle_for, alive=True):
+    """A client wired to a stand-in process, without spawning anything."""
+    from provider_hub.worker import ProviderWorkerClient
+
+    client = ProviderWorkerClient.__new__(ProviderWorkerClient)
+    client.process = MagicMock()
+    client.process.poll.return_value = None if alive else 0
+    client.last_used = time.monotonic() - idle_for
+    client.stop = MagicMock(side_effect=lambda *a, **kw: None)
+    return client
+
+
+def test_a_worker_idle_past_the_ttl_is_stopped():
+    from provider_hub import worker as worker_mod
+
+    stale = _client(idle_for=3600)
+    worker_mod._live_clients.add(stale)
+
+    assert worker_mod.reap_idle_workers(idle_seconds=1800) == 1
+    stale.stop.assert_called_once()
+
+
+def test_a_recently_used_worker_is_left_alone():
+    from provider_hub import worker as worker_mod
+
+    busy = _client(idle_for=60)
+    worker_mod._live_clients.add(busy)
+
+    assert worker_mod.reap_idle_workers(idle_seconds=1800) == 0
+    busy.stop.assert_not_called()
+
+
+def test_a_worker_that_already_exited_is_not_stopped_again():
+    from provider_hub import worker as worker_mod
+
+    dead = _client(idle_for=3600, alive=False)
+    worker_mod._live_clients.add(dead)
+
+    assert worker_mod.reap_idle_workers(idle_seconds=1800) == 0
+    dead.stop.assert_not_called()
+
+
+def test_one_failing_worker_does_not_strand_the_rest():
+    """A plugin that will not shut down cleanly must not keep the fleet alive."""
+    from provider_hub import worker as worker_mod
+
+    angry = _client(idle_for=3600)
+    angry.stop = MagicMock(side_effect=OSError('will not die'))
+    calm = _client(idle_for=3600)
+    worker_mod._live_clients.add(angry)
+    worker_mod._live_clients.add(calm)
+
+    reaped = worker_mod.reap_idle_workers(idle_seconds=1800)
+
+    calm.stop.assert_called_once()
+    assert reaped == 1, 'the survivor should still be counted'
+
+
+def test_a_started_worker_registers_and_a_stopped_one_deregisters(monkeypatch, tmp_path):
+    """The registry is what the reaper walks, so membership is the contract."""
+    from provider_hub import worker as worker_mod
+
+    client = worker_mod.ProviderWorkerClient.__new__(worker_mod.ProviderWorkerClient)
+    client.command = ['true']
+    client.cwd = str(tmp_path)
+    client.env = None
+    client.process = None
+    client._lock = __import__('threading').Lock()
+    client._stdout_queue = None
+    client._stdout_thread = None
+    client._stderr_thread = None
+    client.last_used = 0.0
+
+    fake = MagicMock()
+    fake.poll.return_value = None
+    monkeypatch.setattr(worker_mod.subprocess, 'Popen', lambda *a, **kw: fake)
+    monkeypatch.setattr(worker_mod.threading, 'Thread',
+                        lambda *a, **kw: MagicMock(start=lambda: None))
+
+    client.start()
+    assert client in worker_mod._live_clients
+
+    fake.poll.return_value = 0  # exited
+    client.stop()
+    assert client not in worker_mod._live_clients

--- a/tests/bazarr/test_provider_hub_worker_reaper.py
+++ b/tests/bazarr/test_provider_hub_worker_reaper.py
@@ -381,3 +381,25 @@ def test_a_stop_survivor_is_retained_for_later_sweeps(group_signals):
     finally:
         if ref is not None:
             worker_mod._unreaped_survivors.discard(ref)
+
+
+def test_a_survivor_whose_process_dies_later_is_released(group_signals):
+    """A held survivor must not be pinned forever once its process finally
+    exits on its own: the next sweep finds it dead and lets it go."""
+    import subprocess
+
+    from provider_hub import worker as worker_mod
+
+    client = _client(idle_for=3600)
+    process = client.process
+    process.poll.return_value = None
+    process.wait.side_effect = subprocess.TimeoutExpired(cmd="worker", timeout=0.01)
+    worker_mod._live_clients.add(client)
+
+    assert client.stop_if_idle(idle_seconds=60, grace_seconds=0.01) is False
+    assert client in worker_mod._unreaped_survivors
+
+    process.poll.return_value = 0  # it finally died on its own
+    assert client.stop_if_idle(idle_seconds=60, grace_seconds=0.01) is False
+    assert client not in worker_mod._unreaped_survivors, (
+        'a dead survivor stayed pinned in the strong set')

--- a/tests/bazarr/test_sonarr_sync_memory.py
+++ b/tests/bazarr/test_sonarr_sync_memory.py
@@ -18,7 +18,6 @@ goes, rather than asserting the shape of the code.
 import gc
 import weakref
 from types import SimpleNamespace
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/bazarr/test_sonarr_sync_memory.py
+++ b/tests/bazarr/test_sonarr_sync_memory.py
@@ -30,11 +30,12 @@ class _Payload:
         self.series_id = series_id
 
 
-@pytest.fixture
-def sync_harness(monkeypatch):
+@pytest.fixture(params=[3])
+def sync_harness(request, monkeypatch):
     import sonarr.sync.series as series_mod
 
-    shows = [{'id': n, 'title': f'Show {n}', 'monitored': True} for n in (1, 2, 3)]
+    shows = [{'id': n, 'title': f'Show {n}', 'monitored': True}
+             for n in range(1, request.param + 1)]
     payloads = {}
     refs = {}
 
@@ -87,3 +88,47 @@ def test_a_consumed_episode_payload_becomes_collectable(sync_harness, monkeypatc
         f'while the last one was being handled: {observed[0]}. Peak memory '
         'therefore scales with the whole library rather than with what is in '
         'flight.')
+
+
+@pytest.mark.parametrize('sync_harness', [60], indirect=True)
+def test_read_ahead_is_bounded_by_the_window(sync_harness, monkeypatch, schema_session):
+    """Popping consumed futures is not on its own a bound.
+
+    The fetchers run in parallel and finish far ahead of a consumer that writes
+    to the database serially, so submitting every series up front leaves the
+    completed payloads queued regardless of how promptly each one is popped, and
+    peak memory still tracks the size of the library. What bounds it is not
+    submitting them all.
+    """
+    series_mod, shows, payloads, refs = sync_harness
+    submitted = []
+    consumed = []
+
+    real_episodes = series_mod.get_episodes_from_sonarr_api
+
+    def _counting_episodes(**kwargs):
+        submitted.append(kwargs['series_id'])
+        return real_episodes(**kwargs)
+
+    monkeypatch.setattr(series_mod, 'get_episodes_from_sonarr_api', _counting_episodes)
+
+    outstanding_seen = []
+
+    def _sync_episodes(series_id=None, episodes_data=None, **kw):
+        payloads.pop(series_id, None)
+        consumed.append(series_id)
+        # Submitted but not yet consumed, i.e. results that may be in memory.
+        outstanding_seen.append(len(submitted) - len(consumed))
+
+    monkeypatch.setattr(series_mod, 'sync_episodes', _sync_episodes)
+    monkeypatch.setattr(series_mod, 'database', schema_session)
+
+    series_mod.update_series(job_id='job-1')
+
+    assert len(consumed) == len(shows), 'every series should still be processed'
+    assert consumed == [s['id'] for s in shows], 'series order was not preserved'
+    assert max(outstanding_seen) <= series_mod.SONARR_PREFETCH_WINDOW, (
+        f'up to {max(outstanding_seen)} episode payloads were outstanding at '
+        f'once against a window of {series_mod.SONARR_PREFETCH_WINDOW}; the '
+        'read-ahead is not bounded'
+    )

--- a/tests/bazarr/test_sonarr_sync_memory.py
+++ b/tests/bazarr/test_sonarr_sync_memory.py
@@ -1,0 +1,89 @@
+# coding=utf-8
+"""The bulk Sonarr sync must not hold the whole library's episode JSON at once.
+
+The sync prefetches each series' episode list in parallel, which is the right
+shape: the HTTP round trips dominate a full sync. It then walked the series
+serially and read each result out of the futures dict with ``[...]``, leaving
+every consumed future, and therefore every episode payload it had already
+finished with, referenced until the executor block ended.
+
+So peak memory scaled with the size of the library rather than with how much of
+it was in flight, and it did so once an hour per configured instance. On a small
+library that is invisible. On a large one it is the largest single allocation
+the process ever makes.
+
+This test drives the real loop and asserts the payloads become collectable as it
+goes, rather than asserting the shape of the code.
+"""
+import gc
+import weakref
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+class _Payload:
+    """A stand-in episode list. Weak-referenceable, unlike a plain list."""
+
+    def __init__(self, series_id):
+        self.series_id = series_id
+
+
+@pytest.fixture
+def sync_harness(monkeypatch):
+    import sonarr.sync.series as series_mod
+
+    shows = [{'id': n, 'title': f'Show {n}', 'monitored': True} for n in (1, 2, 3)]
+    payloads = {}
+    refs = {}
+
+    def _episodes(apikey_sonarr=None, series_id=None, arr_client=None):
+        payload = _Payload(series_id)
+        payloads[series_id] = payload
+        refs[series_id] = weakref.ref(payload)
+        return payload
+
+    monkeypatch.setattr(series_mod, 'get_episodes_from_sonarr_api', _episodes)
+    monkeypatch.setattr(series_mod, 'get_series_from_sonarr_api', lambda **kw: shows)
+    monkeypatch.setattr(series_mod, 'check_sonarr_rootfolder', lambda **kw: None)
+    monkeypatch.setattr(series_mod, 'get_profile_list', lambda **kw: [])
+    monkeypatch.setattr(series_mod, 'get_tags', lambda **kw: [])
+    monkeypatch.setattr(series_mod, 'update_one_series', lambda *a, **kw: None)
+    monkeypatch.setattr(series_mod, 'event_stream', lambda *a, **kw: None)
+    monkeypatch.setattr(series_mod, 'jobs_queue',
+                        SimpleNamespace(update_job_progress=lambda **kw: None,
+                                        update_job_name=lambda **kw: None,
+                                        add_job_from_function=lambda *a, **kw: None))
+    monkeypatch.setattr(series_mod.settings.sonarr, 'apikey', 'x', raising=False)
+    monkeypatch.setattr(series_mod.settings.sonarr, 'sync_only_monitored_series', False,
+                        raising=False)
+    return series_mod, shows, payloads, refs
+
+
+def test_a_consumed_episode_payload_becomes_collectable(sync_harness, monkeypatch,
+                                                        schema_session):
+    series_mod, shows, payloads, refs = sync_harness
+    observed = []
+
+    def _sync_episodes(series_id=None, episodes_data=None, **kw):
+        # Drop our own strong reference to the payload we were handed, the way
+        # the real consumer does once it has written the rows.
+        payloads.pop(series_id, None)
+        if series_id == shows[-1]['id']:
+            # Processing the LAST series: everything before it is finished with.
+            gc.collect()
+            observed.append([sid for sid in (shows[0]['id'], shows[1]['id'])
+                             if refs[sid]() is not None])
+
+    monkeypatch.setattr(series_mod, 'sync_episodes', _sync_episodes)
+    monkeypatch.setattr(series_mod, 'database', schema_session)
+
+    series_mod.update_series(job_id='job-1')
+
+    assert observed, 'the loop never reached the last series'
+    assert observed[0] == [], (
+        'episode payloads for series already processed were still referenced '
+        f'while the last one was being handled: {observed[0]}. Peak memory '
+        'therefore scales with the whole library rather than with what is in '
+        'flight.')


### PR DESCRIPTION
A memory-reduction pass. Follows https://github.com/LavX/bazarr/pull/365 (the glibc arena cap, 167 MiB off the container): where that changed how memory is held, this changes how much is asked for. Everything here was found by measuring a live install, not by reading the code for suspects.

Five changes.

## 1. AniList refiner: about 30 MB of allocation per refined search

`get_series_mappings` cached the parsed Fribb anime-list, roughly 43,000 dicts, in the file-backed dogpile region. That backend unpickles its value on **every** read, so each jimaku-refined search inflated the pickle into a full object graph, linear-scanned it with a `str()` per entry, took the first match and threw the rest away.

Only `anidb_id` and `imdb_id` are ever consulted, so it caches an index of those instead. Measured at real scale (42,868 entries):

```
unpickled corpus (old, per call):   22.6 MiB     <- gone
pickle on disk   old -> new     :    3.3 MiB -> 1.2 MiB
```

22.6 MiB is against synthetic entries; against the real list it measured 30.4 MiB. The scan becomes a hash lookup, and first-match-wins is preserved because that is what the old `obj[0]` did.

## 2. Bulk Sonarr sync: peak scaled with library size

The sync prefetches each series episode list in parallel, which is the right shape since the HTTP round trips dominate. It then read each result with `episode_futures[...]` and left the consumed future in the dict, so every payload the pass had already finished with stayed referenced until the executor block closed.

Independently measured afterwards on a four-instance install: a sync peaks at **+27.3 MB, about 6.8 MB per instance** on a library of 274 shows and 3,619 episodes. It scales with library size, so that is one point on the curve.

## 3. Upgrade job: whole history join materialised twice

`.all()` built every Row of the join, then a dict per surviving row, holding both at once. Every twelve hours, growing with a history table that is never pruned. Measured at 17.6 MiB in a sqlite analog of this install (10,068 rows, 17 columns).

The episode side now filters `video_path == path` in SQL so those rows are never built, and both sides stream. The movie side deliberately keeps its filtering in Python: the diagnostics there explain why each candidate was dropped, which is worth more than the rows it would save.

## 4. Queued jobs imported a second copy of the whole module tree

`bazarr_dir` was one `dirname()` too high, naming the repository root rather than the package directory, so `add_job_from_function` recorded every job as `bazarr.<x>` while the process had imported `<x>`. `app/libs.py` puts the parent on `sys.path` as well, so **both names resolve** and Python kept two module objects per file with separate module-level state.

This is already documented in the codebase: `bazarr/subtitles/cache.py` carries a comment describing exactly this split and a workaround for it, because the subtitle UUID a manual search stored in one copy was looked for in the other, which is the "Subtitle not found in cache" failure. That workaround keys off `sys.modules` and is unaffected by this fix.

What nobody had connected to it: `subtitles/pool.py` holds `_pools` at module level and Provider Hub spawns a worker subprocess per pool and provider, so a warm install was carrying **two worker fleets**. Visible in one process own log, where the wanted-search path printed a `_pools` containing `movie_1` and `series_1` while the Radarr-event path printed one containing only `series_1` and cold-built its own.

## 5. Idle Provider Hub workers are now reclaimed

Workers spawn lazily per pool and provider and nothing reclaimed them: the pool own recycle only fires the next time that pool is searched, so a quiet install kept the full fleet indefinitely. Measured at 17.6 to 44.6 MiB PSS per worker, roughly 45 of them warm.

They register in a weak set on start and leave it on stop, with a scheduled sweep every ten minutes stopping anything idle for thirty minutes.

Safe rather than clever: `request()` calls `start()`, and `start()` respawns an exited process, so a reaped worker returns on the next search for a cold start measured at 0.5 to 1.7 s. And `stop()` goes through `request()`, so it waits on the same lock a live request holds and cannot kill one mid-flight. `stop()` deregisters in a `finally`, so one plugin refusing to shut down cannot strand the rest of the sweep.

## Measured, cumulative

Deployed to the test server, same database, after driving a full episode re-index so it is not an idle-boot reading:

| | original | + PR 365 | + this branch |
|---|---|---|---|
| container | 514.5 MiB | 347.1 MiB | **272.3 MiB** |
| backend RSS | 388 MiB | 278 MiB | **233 MiB** |

Not a perfectly controlled A/B, since uptime and activity differ between readings; treat the last column as indicative. The direction held across three builds.

## Verification

Local: ruff clean, **1997 backend tests**, **377 compat tests**, 8 skipped, no failures. **Four new test files**, all registered in the CI guard list.

Deployed and checked on the test server: triggering the full scan through the API ran the job normally and indexed 107 files, the log shows no `ModuleNotFoundError` and no `bazarr.`-prefixed module names where the duplicate tree used to be observable, and the reaper appears in the task list as `provider_hub_worker_reaper`.

Honest limit: I have not demonstrated the reaper reclaiming a genuinely warm fleet, because that needs real searches against real providers. The mechanism is unit tested, including the exited-worker and failing-plugin paths, and the schedule is confirmed live, but the warm-install saving is inferred from measurement of the fleet, not observed end to end.