### PR TITLE
Accept bare alpha3 string language values on embedded tracks

### DIFF
--- a/bazarr/languages/get_languages.py
+++ b/bazarr/languages/get_languages.py
@@ -96,6 +96,13 @@ def alpha2_from_alpha3(lang):
     return next((item['code2'] for item in languages_dict if lang[:3] in [item['code3'], item['code3b']]), None)
 
 
+def alpha3_from_alpha3b(lang):
+    # Exact match only, unlike the prefix-matching lookups above: maps a
+    # terminological or bibliographic three-letter code to the canonical
+    # terminological alpha3 (ger -> deu), or None for anything else.
+    return next((item['code3'] for item in languages_dict if lang in (item['code3'], item['code3b'])), None)
+
+
 def alpha2_from_language(lang):
     return next((item['code2'] for item in languages_dict if item['name'] == lang), None)
 

--- a/bazarr/subtitles/refiners/ffprobe.py
+++ b/bazarr/subtitles/refiners/ffprobe.py
@@ -10,7 +10,7 @@ from guessit.jsonutils import GuessitEncoder
 from utilities.path_mappings import path_mappings
 from app.database import TableEpisodes, TableMovies, database, select
 from arr_instances.resolution import scoped
-from utilities.video_analyzer import parse_video_metadata
+from utilities.video_analyzer import alpha3_from_language_value, parse_video_metadata
 
 
 def refine_from_ffprobe(path, video):
@@ -89,11 +89,12 @@ def refine_from_ffprobe(path, video):
                 video.audio_codec = parser_data['audio'][0]['codec']
         for track in parser_data['audio']:
             if 'language' in track:
-                if isinstance(track['language'], str):
+                alpha3 = alpha3_from_language_value(track['language'])
+                if alpha3 is None:
                     logging.debug(
-                        'BAZARR ffprobe returned a string for audio language,'
+                        'BAZARR ffprobe returned an unusable audio language,'
                         ' skipping: %s', track['language'])
                     continue
-                video.audio_languages.add(track['language'].alpha3)
+                video.audio_languages.add(alpha3)
 
     return video

--- a/bazarr/utilities/video_analyzer.py
+++ b/bazarr/utilities/video_analyzer.py
@@ -9,7 +9,8 @@ from app.config import settings
 from app.database import TableEpisodes, TableMovies, database, update, select
 from arr_instances.resolution import scoped
 from languages.custom_lang import CustomLanguage
-from languages.get_languages import language_from_alpha2, language_from_alpha3, alpha3_from_alpha2
+from languages.get_languages import (language_from_alpha2, language_from_alpha3, alpha3_from_alpha2,
+                                     alpha3_from_alpha3b)
 from utilities.path_mappings import path_mappings
 
 from knowit.api import know, KnowitException
@@ -36,14 +37,42 @@ def _title_is_forced(title):
     return bool(_FORCED_TITLE_RE.search(text))
 
 
+def alpha3_from_language_value(language):
+    """Alpha3 code from a knowit/ffprobe language value, or None.
+
+    knowit normally yields a babelfish Language object, but replayed metadata
+    caches can hand the language through as a bare string. A string is accepted
+    only when it is exactly a known three-letter code, and it is normalized to
+    the terminological alpha3 (ger -> deu) so indexing, extraction and scoring
+    all see the same code a Language object would have produced.
+    """
+    if hasattr(language, "alpha3"):
+        return language.alpha3
+    if isinstance(language, str):
+        code = language.strip().lower()
+        if code == "und":
+            # Not in the languages table, but a Language("und") object returns
+            # it, so the string form must resolve the same way.
+            return code
+        return alpha3_from_alpha3b(code)
+    return None
+
+
 def _handle_alpha3(detected_language: dict):
-    alpha3 = detected_language["language"].alpha3
+    language = detected_language.get("language")
+    alpha3 = alpha3_from_language_value(language)
+
+    if alpha3 is None:
+        return None
+
     custom = CustomLanguage.from_value(alpha3, "official_alpha3")
 
     if not custom:
         return alpha3
 
-    found = custom.language_found(detected_language["language"])
+    # language_found needs a Language object; a bare string code can only be
+    # matched through the track name.
+    found = custom.language_found(language) if hasattr(language, "alpha3") else False
     if not found:
         found = custom.ffprobe_found(detected_language)
 
@@ -72,10 +101,16 @@ def embedded_track_language(track, und_default_language=None):
     if "commentary" in name:
         return None
 
-    language = _handle_alpha3(track) if "language" in track else None
-    if not language and und_default_language:
-        language = und_default_language
-    return language or None
+    if "language" in track:
+        language = _handle_alpha3(track)
+        if language is None:
+            # A language tag that exists but cannot be parsed is not the same
+            # as no tag at all: the undefined-language default must not claim
+            # it, and silence here would hide the drop.
+            logging.debug("BAZARR unusable embedded subtitle track language, ignoring: %s",
+                          track.get("language"))
+        return language
+    return und_default_language or None
 
 
 def embedded_subs_reader(file, file_size, episode_file_id=None, movie_file_id=None, use_cache=True,
@@ -133,12 +168,12 @@ def embedded_audio_reader(file, file_size, episode_file_id=None, movie_file_id=N
                 audio_list.append(None)
                 continue
 
-            if isinstance(detected_language['language'], str):
+            alpha3 = _handle_alpha3(detected_language)
+            if alpha3 is None:
                 logging.error(f"Cannot identify audio track language for this file: {file}. Value detected is "  # noqa: G004
                               f"{detected_language['language']}.")
                 continue
 
-            alpha3 = _handle_alpha3(detected_language)
             language = language_from_alpha3(alpha3)
 
             if language not in audio_list:
@@ -202,7 +237,7 @@ def subtitles_sync_references(subtitles_path, sonarr_episode_id=None, radarr_mov
                     language = 'Undefined'
                 else:
                     alpha3 = _handle_alpha3(detected_language)
-                    language = language_from_alpha3(alpha3)
+                    language = language_from_alpha3(alpha3) if alpha3 else 'Undefined'
 
                 references_dict['audio_tracks'].append({'stream': f'a:{track_id}', 'name': name, 'language': language})
 
@@ -223,7 +258,7 @@ def subtitles_sync_references(subtitles_path, sonarr_episode_id=None, radarr_mov
                     language = 'Undefined'
                 else:
                     alpha3 = _handle_alpha3(detected_language)
-                    language = language_from_alpha3(alpha3)
+                    language = language_from_alpha3(alpha3) if alpha3 else 'Undefined'
 
                 forced = detected_language.get("forced", False) or _title_is_forced(name)
                 hearing_impaired = detected_language.get("hearing_impaired", False)

--- a/tests/bazarr/test_utilities_video_analyzer.py
+++ b/tests/bazarr/test_utilities_video_analyzer.py
@@ -340,3 +340,168 @@ def test_embedded_subs_reader_disposition_forced_preserved(video_file):
     ):
         result = video_analyzer.embedded_subs_reader(video_file, 1e6)
         assert ["eng", True, False, "SubRip"] in result
+
+
+# A real-shaped languages table, patched over the DB-backed module global so the
+# REAL language_from_alpha3 / alpha3_from_alpha3b / alpha3_from_alpha2 lookups
+# run in these tests; a hand-written fake of their matching rules is exactly how
+# a prefix-acceptance bug stays invisible.
+_LANGUAGES_TABLE = [
+    {"code3": "eng", "code3b": None, "code2": "en", "name": "English", "enabled": 1},
+    {"code3": "por", "code3b": None, "code2": "pt", "name": "Portuguese", "enabled": 1},
+    {"code3": "deu", "code3b": "ger", "code2": "de", "name": "German", "enabled": 1},
+    {"code3": "spa", "code3b": None, "code2": "es", "name": "Spanish", "enabled": 1},
+]
+
+
+@pytest.fixture
+def real_languages_table(monkeypatch):
+    import languages.get_languages as get_languages
+
+    monkeypatch.setattr(get_languages, "languages_dict", _LANGUAGES_TABLE, raising=False)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (Language("eng"), "eng"),   # normal knowit value keeps working
+        (Language("und"), "und"),   # knowit's fallback object
+        ("eng", "eng"),             # bare valid alpha3 string is accepted
+        ("ger", "deu"),             # bibliographic code normalizes to terminological
+        (" GER ", "deu"),           # case and padding from a replayed cache
+        ("und", "und"),             # string und resolves like the object does
+        ("english", None),          # full names are not codes
+        ("eng-US", None),           # IETF-ish tags are not codes
+        ("banana", None),           # junk is rejected
+        ("", None),
+        (None, None),
+    ],
+)
+def test_alpha3_from_language_value(real_languages_table, value, expected):
+    assert video_analyzer.alpha3_from_language_value(value) == expected
+
+
+def test_embedded_audio_reader_accepts_alpha3_string(real_languages_table, video_file):
+    """ffprobe/knowit sometimes yield a bare string language; a valid alpha3
+    code must resolve instead of dropping the track."""
+    from unittest.mock import patch
+
+    data = {"subtitle": [], "audio": [{"language": "eng", "format": "AAC"}]}
+    with patch(
+        "utilities.video_analyzer.parse_video_metadata",
+        return_value={"mediainfo": data},
+    ):
+        result = video_analyzer.embedded_audio_reader(video_file, 1e6)
+        assert result == ["English"]
+
+
+def test_embedded_audio_reader_normalizes_bibliographic_string(real_languages_table, video_file):
+    """A bibliographic tag (ger) must resolve to the same language a
+    Language object would have produced (deu -> German)."""
+    from unittest.mock import patch
+
+    data = {"subtitle": [], "audio": [{"language": "ger", "format": "AC-3"}]}
+    with patch(
+        "utilities.video_analyzer.parse_video_metadata",
+        return_value={"mediainfo": data},
+    ):
+        result = video_analyzer.embedded_audio_reader(video_file, 1e6)
+        assert result == ["German"]
+
+
+@pytest.mark.parametrize("bad_value", ["banana", "english", "eng-US"])
+def test_embedded_audio_reader_drops_invalid_string(real_languages_table, video_file, bad_value):
+    """A string that is not exactly a known three-letter code still drops
+    the track; prefix matches like 'english' must not slip through."""
+    from unittest.mock import patch
+
+    data = {"subtitle": [], "audio": [{"language": bad_value, "format": "AAC"}]}
+    with patch(
+        "utilities.video_analyzer.parse_video_metadata",
+        return_value={"mediainfo": data},
+    ):
+        result = video_analyzer.embedded_audio_reader(video_file, 1e6)
+        assert result == []
+
+
+def test_embedded_audio_reader_custom_language_string_no_crash(real_languages_table, video_file):
+    """A string code that maps onto a CustomLanguage (por) must not crash in
+    language_found, which expects a Language object."""
+    from unittest.mock import patch
+
+    data = {"subtitle": [], "audio": [{"language": "por", "format": "AAC"}]}
+    with patch(
+        "utilities.video_analyzer.parse_video_metadata",
+        return_value={"mediainfo": data},
+    ):
+        result = video_analyzer.embedded_audio_reader(video_file, 1e6)
+        assert result == ["Portuguese"]
+
+
+def test_embedded_subs_reader_accepts_alpha3_string(real_languages_table, video_file):
+    """A subtitle track whose language arrives as a bare valid alpha3 string
+    is indexed instead of raising AttributeError in _handle_alpha3."""
+    from unittest.mock import patch
+
+    data = {
+        "subtitle": [
+            {"language": "eng", "format": "SubRip", "forced": False,
+             "hearing_impaired": False, "name": ""},
+        ],
+        "audio": [],
+    }
+    with patch(
+        "utilities.video_analyzer.parse_video_metadata",
+        return_value={"mediainfo": data},
+    ), patch(
+        "utilities.video_analyzer.alpha3_from_alpha2", return_value=None
+    ):
+        result = video_analyzer.embedded_subs_reader(video_file, 1e6)
+        assert ["eng", False, False, "SubRip"] in result
+
+
+def test_embedded_subs_reader_invalid_string_ignored(real_languages_table, video_file):
+    """An unusable string language with no undefined-language default set
+    means the track is ignored, not a crash."""
+    from unittest.mock import patch
+
+    data = {
+        "subtitle": [
+            {"language": "banana", "format": "SubRip", "forced": False,
+             "hearing_impaired": False, "name": ""},
+        ],
+        "audio": [],
+    }
+    with patch(
+        "utilities.video_analyzer.parse_video_metadata",
+        return_value={"mediainfo": data},
+    ), patch(
+        "utilities.video_analyzer.alpha3_from_alpha2", return_value=None
+    ):
+        result = video_analyzer.embedded_subs_reader(video_file, 1e6)
+        assert result == []
+
+
+def test_embedded_subs_reader_unusable_string_not_claimed_by_und_default(real_languages_table, video_file):
+    """A garbage language tag must NOT be absorbed by the undefined-language
+    default: that default is for tracks with no tag at all. A track without a
+    tag still takes it."""
+    from unittest.mock import patch
+
+    data = {
+        "subtitle": [
+            {"language": "banana", "format": "SubRip", "forced": False,
+             "hearing_impaired": False, "name": ""},
+            {"format": "SubRip", "forced": False,
+             "hearing_impaired": False, "name": ""},
+        ],
+        "audio": [],
+    }
+    with patch(
+        "utilities.video_analyzer.parse_video_metadata",
+        return_value={"mediainfo": data},
+    ), patch(
+        "utilities.video_analyzer.alpha3_from_alpha2", return_value="spa"
+    ):
+        result = video_analyzer.embedded_subs_reader(video_file, 1e6)
+        assert result == [["spa", False, False, "SubRip"]]


### PR DESCRIPTION
## What

knowit normally returns a babelfish Language object for a track's language, but replayed metadata caches can hand it through as a plain string such as `eng`. Until now every string was treated as unusable:

- `embedded_audio_reader` logged "Cannot identify audio track language" and dropped the track, so audio-language profile conditions saw fewer tracks than the file has.
- The ffprobe refiner skipped the track, losing entries from `video.audio_languages`.
- A string on an embedded subtitle track raised `AttributeError` inside `_handle_alpha3` and aborted the read. The subsync references view had the same latent crash.

## How

`alpha3_from_language_value` accepts a value with an `alpha3` attribute as before. A bare string is accepted only when it is exactly a known three-letter code, normalized through the new exact-match `alpha3_from_alpha3b` lookup to the terminological alpha3 (`ger` becomes `deu`), so indexing, extraction and scoring all see the same code a Language object would have produced; prefix look-alikes (`english`, `eng-US`) are rejected. `_handle_alpha3` returns None for unusable values and its callers skip (audio reader), log and ignore the track (subtitle indexing; the undefined-language default stays reserved for tracks with no tag at all), or show Undefined (sync references). Extraction shares `embedded_track_language` with indexing, so both sides keep reaching the same answer. The CustomLanguage matching path only ever receives Language objects; a bare string code is matched through the track name instead.

## Testing

- 20 new unit tests in `tests/bazarr/test_utilities_video_analyzer.py` running against the real lookup semantics via a patched languages table (helper matrix incl. bibliographic and prefix-look-alike cases, audio accept/normalize/reject, custom-language string, subtitle accept/ignore, und-default separation); file already on the CI guard list. All were verified to fail on the unfixed code.
- Full local CI green on the final branch state: ruff, compat suite, guard list, previously unguarded suites, per-file isolation loop including the Postgres tests against a throwaway container, boot smoke, frontend checks and build.
- Deployed to the test server: disk scan over a full series re-ran the embedded readers with no errors and audio languages populate correctly.