### PR TITLE
feat(captcha): add CaptchaAI as an anti-captcha vendor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,7 @@ jobs:
         # directly rather than leaving it to collection order.
         run: |
           pytest \
+            tests/bazarr/test_anti_captcha_config.py \
             tests/bazarr/test_app_notifier.py \
             tests/bazarr/test_auto_translation_profile.py \
             tests/bazarr/test_ci_guard_list.py \

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -1304,6 +1304,9 @@ def configure_captcha_func():
         os.environ["ANTICAPTCHA_ACCOUNT_KEY"] = str(settings.captchaai.captchaai_key)
     else:
         os.environ["ANTICAPTCHA_CLASS"] = ''
+        # Clear the key too, or disabling the vendor leaves the previous
+        # credential exported for the rest of the process lifetime.
+        os.environ["ANTICAPTCHA_ACCOUNT_KEY"] = ''
 
 
 def configure_proxy_func():

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -177,7 +177,7 @@ validators = [
     Validator('general.days_to_upgrade_subs', must_exist=True, default=7, is_type_of=int, gte=0, lte=30),
     Validator('general.upgrade_manual', must_exist=True, default=True, is_type_of=bool),
     Validator('general.anti_captcha_provider', must_exist=True, default=None, is_type_of=(NoneType, str),
-              is_in=[None, 'anti-captcha', 'death-by-captcha']),
+              is_in=[None, 'anti-captcha', 'death-by-captcha', 'captchaai']),
     Validator('general.wanted_search_frequency', must_exist=True, default=6, is_type_of=int, 
               is_in=[6, 12, 24, 168, ONE_HUNDRED_YEARS_IN_HOURS]),
     Validator('general.wanted_search_frequency_movie', must_exist=True, default=6, is_type_of=int,
@@ -436,6 +436,9 @@ validators = [
     # deathbycaptcha section
     Validator('deathbycaptcha.username', must_exist=True, default='', is_type_of=str, cast=str),
     Validator('deathbycaptcha.password', must_exist=True, default='', is_type_of=str, cast=str),
+
+    # captchaai section
+    Validator('captchaai.captchaai_key', must_exist=True, default='', is_type_of=str, cast=str),
 
     # napisy24 section
     Validator('napisy24.username', must_exist=True, default='', is_type_of=str, cast=str),
@@ -983,7 +986,8 @@ def save_settings(settings_items):
             os.environ["SZ_HI_EXTENSION"] = value or ""
 
         if key in ['settings-general-anti_captcha_provider', 'settings-anticaptcha-anti_captcha_key',
-                   'settings-deathbycaptcha-username', 'settings-deathbycaptcha-password']:
+                   'settings-deathbycaptcha-username', 'settings-deathbycaptcha-password',
+                   'settings-captchaai-captchaai_key']:
             configure_captcha = True
 
         if key in ['update_schedule', 'settings-general-use_sonarr', 'settings-general-use_radarr',
@@ -1295,6 +1299,9 @@ def configure_captcha_func():
         os.environ["ANTICAPTCHA_CLASS"] = 'DeathByCaptchaProxyLess'
         os.environ["ANTICAPTCHA_ACCOUNT_KEY"] = str(':'.join(
             {settings.deathbycaptcha.username, settings.deathbycaptcha.password}))
+    elif settings.general.anti_captcha_provider == 'captchaai' and settings.captchaai.captchaai_key != "":
+        os.environ["ANTICAPTCHA_CLASS"] = 'CaptchaAIProxyLess'
+        os.environ["ANTICAPTCHA_ACCOUNT_KEY"] = str(settings.captchaai.captchaai_key)
     else:
         os.environ["ANTICAPTCHA_CLASS"] = ''
 

--- a/bazarr/app/logger.py
+++ b/bazarr/app/logger.py
@@ -18,7 +18,9 @@ logger = logging.getLogger()
 
 class FileHandlerFormatter(logging.Formatter):
     """Formatter that removes apikey from logs."""
-    APIKEY_RE = re.compile(r'apikey(?:=|%3D)([a-zA-Z0-9]+)')
+    # Bare "key=" too: 2Captcha-compatible captcha vendors carry the account
+    # key as ?key=... on res.php polling, and urllib3 logs request targets.
+    APIKEY_RE = re.compile(r'((?:api)?key)(?:=|%3D)([a-zA-Z0-9]+)')
     IPv4_RE = re.compile(r'\b(?<!Failed\sauthentication\sfrom\s)(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.)'
                          r'{3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\b')
     PLEX_URL_RE = re.compile(r'(?:https?://)?[0-9\-]+\.[a-f0-9]+\.plex\.direct(?::\d+)?')
@@ -31,7 +33,7 @@ class FileHandlerFormatter(logging.Formatter):
         return repr(result)  # or format into one line however you want to
 
     def formatApikey(self, s):
-        return re.sub(self.APIKEY_RE, 'apikey=(removed)', s)
+        return re.sub(self.APIKEY_RE, r'\1=(removed)', s)
 
     def formatIPv4(self, s):
         return re.sub(self.IPv4_RE, '***.***.***.***', s)

--- a/bazarr/secret_store/registry.py
+++ b/bazarr/secret_store/registry.py
@@ -87,6 +87,9 @@ USER_VISIBLE_SECRETS = frozenset({
     "pipocas.password",
     "deathbycaptcha.username",
     "deathbycaptcha.password",
+    # Anti-captcha vendors - bare API keys.
+    "anticaptcha.anti_captcha_key",
+    "captchaai.captchaai_key",
     "napisy24.username",
     "napisy24.password",
     "titlovi.username",

--- a/bazarr/secret_store/registry.py
+++ b/bazarr/secret_store/registry.py
@@ -90,6 +90,7 @@ USER_VISIBLE_SECRETS = frozenset({
     # Anti-captcha vendors - bare API keys.
     "anticaptcha.anti_captcha_key",
     "captchaai.captchaai_key",
+    # Subtitle providers - full login pairs, continued.
     "napisy24.username",
     "napisy24.password",
     "titlovi.username",

--- a/custom_libs/subliminal_patch/pitcher.py
+++ b/custom_libs/subliminal_patch/pitcher.py
@@ -9,8 +9,7 @@ import base64
 import requests
 from subliminal.cache import region
 from dogpile.cache.api import NO_VALUE
-from python_anticaptcha import AnticaptchaClient, NoCaptchaTaskProxylessTask, NoCaptchaTask, ImageToTextTask, \
-    AnticaptchaException
+from python_anticaptcha import AnticaptchaClient, NoCaptchaTaskProxylessTask, NoCaptchaTask, AnticaptchaException
 from deathbycaptcha import SocketClient as DBCClient, DEFAULT_TOKEN_TIMEOUT
 import six
 from six.moves import range
@@ -295,9 +294,10 @@ class CaptchaAIProxyLessPitcher(Pitcher):
             params["invisible"] = 1
         if self.user_agent:
             params["userAgent"] = self.user_agent
-        if self.cookies:
-            # 2Captcha-compatible cookie format: KEY1:Value1;KEY2:Value2
-            params["cookies"] = ";".join("%s:%s" % (k, v) for k, v in self.cookies.items())
+        # self.cookies is accepted for call-site compatibility but deliberately
+        # NOT transmitted: it holds the provider's live session cookies, and a
+        # reCAPTCHA token task does not need them. Shipping a paid provider
+        # session to the captcha vendor is an exposure, not a feature.
         return params
 
     def _throw(self):
@@ -305,6 +305,7 @@ class CaptchaAIProxyLessPitcher(Pitcher):
         for i in range(self.tries):
             try:
                 resp = self.client.post("%s/in.php" % self.host, data=self.in_params, timeout=30)
+                resp.raise_for_status()
                 payload = resp.json()
                 if payload.get("status") != 1:
                     request = payload.get("request")
@@ -321,9 +322,13 @@ class CaptchaAIProxyLessPitcher(Pitcher):
                     logger.error("%s: CaptchaAI returned an error: %s", self.website_name, request)
                     if i >= self.tries - 1:
                         return
+                    time.sleep(5.0)
                     continue
 
                 job_id = payload.get("request")
+                # The key travels in this URL's query string, so the log
+                # redaction in app/logger.py must keep covering bare "key=".
+                poll_failed = False
                 deadline = time.time() + self.timeout
                 while time.time() < deadline:
                     time.sleep(5.0)
@@ -332,6 +337,7 @@ class CaptchaAIProxyLessPitcher(Pitcher):
                         params={"key": self.client_key, "action": "get", "id": job_id, "json": 1},
                         timeout=30,
                     )
+                    res.raise_for_status()
                     res_payload = res.json()
                     if res_payload.get("status") == 1:
                         self.success = True
@@ -340,11 +346,14 @@ class CaptchaAIProxyLessPitcher(Pitcher):
                         continue
                     logger.error("%s: CaptchaAI returned an error: %s", self.website_name,
                                  res_payload.get("request"))
+                    poll_failed = True
                     break
-                logger.info("%s: Captcha solving timed out, retrying", self.website_name)
+                if not poll_failed:
+                    logger.info("%s: Captcha solving timed out, retrying", self.website_name)
             except Exception:
                 if i >= self.tries - 1:
-                    logger.error("%s: Captcha solving finally failed. Exiting", self.website_name)
+                    logger.error("%s: Captcha solving finally failed. Exiting", self.website_name,
+                                 exc_info=True)
                     return
                 logger.info("%s: Captcha solving failed, retrying", self.website_name)
                 time.sleep(5.0)
@@ -358,7 +367,9 @@ class CaptchaAIPitcher(CaptchaAIProxyLessPitcher):
     proxy_type = "HTTP"
 
     def __init__(self, *args, **kwargs):
-        self.proxy = kwargs.pop("proxy", None)
+        # No default: a pitcher that declares needs_proxy must fail loudly
+        # when constructed without one, like the other proxy pitchers.
+        self.proxy = kwargs.pop("proxy")
         super(CaptchaAIPitcher, self).__init__(*args, **kwargs)
 
     @property
@@ -367,184 +378,6 @@ class CaptchaAIPitcher(CaptchaAIProxyLessPitcher):
         if self.proxy:
             params.update({"proxy": self.proxy, "proxytype": self.proxy_type})
         return params
-
-
-@registry.register
-class CaptchaAIImageToTextPitcher(Pitcher):
-    name = "CaptchaAIImageToText"
-    source = "captchaai.com"
-    host = "https://ocr.captchaai.com"
-    timeout = 180
-    image_fp = None
-
-    def __init__(self, website_name, image_fp, tries=3, client_key=None, *args, **kwargs):
-        # No page URL or site key for an image task; keyword the rest so an
-        # explicit client_key reaches Pitcher instead of being read as the
-        # website key while the env fallback raises.
-        super().__init__(website_name, None, None, tries=tries, client_key=client_key, **kwargs)
-        self.image_fp = image_fp
-
-    def get_client(self):
-        # CaptchaAI exposes a 2Captcha-compatible HTTP API (in.php/res.php), so a
-        # plain requests session is all that is needed.
-        return requests.Session()
-
-    def get_job(self):
-        # The image task is created in _throw() through the in.php endpoint.
-        pass
-
-    @property
-    def in_params(self):
-        # Read the image bytes and submit them as base64 (method=base64).
-        try:
-            self.image_fp.seek(0)
-        except (AttributeError, ValueError):
-            pass
-        body = base64.b64encode(self.image_fp.read()).decode("ascii")
-        return {
-            "key": self.client_key,
-            "method": "base64",
-            "body": body,
-            "json": 1,
-        }
-
-    def _throw(self):
-        self.client = self.get_client()
-        for i in range(self.tries):
-            try:
-                resp = self.client.post("%s/in.php" % self.host, data=self.in_params, timeout=30)
-                payload = resp.json()
-                if payload.get("status") != 1:
-                    request = payload.get("request")
-                    if request == "ERROR_ZERO_BALANCE":
-                        logger.error("%s: No balance left on captcha solving service. Exiting", self.website_name)
-                        return
-                    elif request == "ERROR_NO_SLOT_AVAILABLE":
-                        logger.info("%s: No captcha solving slot available, retrying", self.website_name)
-                        time.sleep(5.0)
-                        continue
-                    elif request in ("ERROR_KEY_DOES_NOT_EXIST", "ERROR_WRONG_USER_KEY"):
-                        logger.error("%s: Bad CaptchaAI API key", self.website_name)
-                        return
-                    logger.error("%s: CaptchaAI returned an error: %s", self.website_name, request)
-                    if i >= self.tries - 1:
-                        return
-                    continue
-
-                job_id = payload.get("request")
-                deadline = time.time() + self.timeout
-                while time.time() < deadline:
-                    time.sleep(5.0)
-                    res = self.client.get(
-                        "%s/res.php" % self.host,
-                        params={"key": self.client_key, "action": "get", "id": job_id, "json": 1},
-                        timeout=30,
-                    )
-                    res_payload = res.json()
-                    if res_payload.get("status") == 1:
-                        self.success = True
-                        return res_payload.get("request")
-                    if res_payload.get("request") == "CAPCHA_NOT_READY":
-                        continue
-                    logger.error("%s: CaptchaAI returned an error: %s", self.website_name,
-                                 res_payload.get("request"))
-                    break
-                logger.info("%s: Captcha solving timed out, retrying", self.website_name)
-            except Exception:
-                if i >= self.tries - 1:
-                    logger.error("%s: Captcha solving finally failed. Exiting", self.website_name)
-                    return
-                logger.info("%s: Captcha solving failed, retrying", self.website_name)
-                time.sleep(5.0)
-
-
-@registry.register
-class AntiCaptchaImageToTextPitcher(Pitcher):
-    name = "AntiCaptchaImageToText"
-    source = "anti-captcha.com"
-    image_fp = None
-
-    def __init__(self, website_name, image_fp, tries=3, client_key=None, *args, **kwargs):
-        # Same shape as the CaptchaAI image pitcher: keyword the arguments so
-        # an explicit client_key is honored without ANTICAPTCHA_ACCOUNT_KEY.
-        super().__init__(website_name, None, None, tries=tries, client_key=client_key, **kwargs)
-        self.image_fp = image_fp
-
-    def get_client(self):
-        return AnticaptchaClient(self.client_key)
-
-    def get_job(self):
-        task = ImageToTextTask(self.image_fp)
-        return self.client.createTask(task)
-
-    def _throw(self):
-        for i in range(self.tries):
-            try:
-                super(AntiCaptchaImageToTextPitcher, self)._throw()
-                self.job.join()
-                ret = self.job.get_captcha_text()
-                if ret:
-                    self.success = True
-                    return ret
-            except AnticaptchaException as e:
-                if i >= self.tries - 1:
-                    logger.error("%s: Captcha solving finally failed. Exiting", self.website_name)
-                    return
-                if e.error_code == 'ERROR_ZERO_BALANCE':
-                    logger.error("%s: No balance left on captcha solving service. Exiting", self.website_name)
-                    return
-                elif e.error_code == 'ERROR_NO_SLOT_AVAILABLE':
-                    logger.info("%s: No captcha solving slot available, retrying", self.website_name)
-                    time.sleep(5.0)
-                    continue
-                elif e.error_code == 'ERROR_KEY_DOES_NOT_EXIST':
-                    logger.error("%s: Bad AntiCaptcha API key", self.website_name)
-                    return
-                raise
-
-
-@registry.register
-class DBCImageToTextPitcher(Pitcher):
-    name = "DeathByCaptchaImageToText"
-    source = "deathbycaptcha.com"
-    image_fp = None
-    username = None
-    password = None
-
-    def __init__(self, website_name, image_fp, timeout=DEFAULT_TOKEN_TIMEOUT, tries=3,
-                 client_key=None, *args, **kwargs):
-        super().__init__(website_name, tries, client_key, *args, **kwargs)
-        self.tries = tries
-        self.client_key = client_key or os.environ.get("ANTICAPTCHA_ACCOUNT_KEY")
-        if not self.client_key:
-            raise Exception("DeathByCaptcha credentials not given, exiting")
-        self.username, self.password = self.client_key.split(":", 1)
-        self.website_name = website_name
-        self.image_fp = image_fp
-        self.timeout = timeout
-        self.success = False
-        self.solve_time = None
-
-    def get_client(self):
-        return DBCClient(self.username, self.password)
-
-    def get_job(self):
-        pass
-
-    def _throw(self):
-        self.client = self.get_client()
-        for i in range(self.tries):
-            try:
-                data = self.client.decode(self.image_fp, timeout=self.timeout)
-                if data and data["is_correct"] and data["text"]:
-                    self.success = True
-                    return data["text"]
-            except Exception:
-                if i >= self.tries - 1:
-                    logger.error("%s: Captcha solving finally failed. Exiting", self.website_name)
-                    return
-                logger.info("%s: Captcha solving failed, retrying", self.website_name)
-                time.sleep(5.0)
 
 
 def load_verification(site_name, session, callback=lambda x: None):

--- a/custom_libs/subliminal_patch/pitcher.py
+++ b/custom_libs/subliminal_patch/pitcher.py
@@ -9,7 +9,8 @@ import base64
 import requests
 from subliminal.cache import region
 from dogpile.cache.api import NO_VALUE
-from python_anticaptcha import AnticaptchaClient, NoCaptchaTaskProxylessTask, NoCaptchaTask, AnticaptchaException
+from python_anticaptcha import AnticaptchaClient, NoCaptchaTaskProxylessTask, NoCaptchaTask, ImageToTextTask, \
+    AnticaptchaException
 from deathbycaptcha import SocketClient as DBCClient, DEFAULT_TOKEN_TIMEOUT
 import six
 from six.moves import range
@@ -263,10 +264,14 @@ class CaptchaAIProxyLessPitcher(Pitcher):
     host = "https://ocr.captchaai.com"
     timeout = 180
 
-    def __init__(self, website_name, website_url, website_key, tries=3, host=None, *args, **kwargs):
+    def __init__(self, website_name, website_url, website_key, tries=3, host=None, user_agent=None,
+                 cookies=None, is_invisible=False, *args, **kwargs):
         super(CaptchaAIProxyLessPitcher, self).__init__(website_name, website_url, website_key, tries=tries, *args,
                                                         **kwargs)
         self.host = host or self.host
+        self.user_agent = user_agent
+        self.cookies = cookies
+        self.is_invisible = is_invisible
 
     def get_client(self):
         # CaptchaAI exposes a 2Captcha-compatible HTTP API (in.php/res.php), so a
@@ -279,13 +284,21 @@ class CaptchaAIProxyLessPitcher(Pitcher):
 
     @property
     def in_params(self):
-        return {
+        params = {
             "key": self.client_key,
             "method": "userrecaptcha",
             "googlekey": self.website_key,
             "pageurl": self.website_url,
             "json": 1,
         }
+        if self.is_invisible:
+            params["invisible"] = 1
+        if self.user_agent:
+            params["userAgent"] = self.user_agent
+        if self.cookies:
+            # 2Captcha-compatible cookie format: KEY1:Value1;KEY2:Value2
+            params["cookies"] = ";".join("%s:%s" % (k, v) for k, v in self.cookies.items())
+        return params
 
     def _throw(self):
         self.client = self.get_client()
@@ -343,14 +356,9 @@ class CaptchaAIPitcher(CaptchaAIProxyLessPitcher):
     proxy = None
     needs_proxy = True
     proxy_type = "HTTP"
-    user_agent = None
 
     def __init__(self, *args, **kwargs):
         self.proxy = kwargs.pop("proxy", None)
-        self.user_agent = kwargs.pop("user_agent", None)
-        # cookies/is_invisible are accepted for call-site compatibility but unused.
-        kwargs.pop("cookies", None)
-        kwargs.pop("is_invisible", None)
         super(CaptchaAIPitcher, self).__init__(*args, **kwargs)
 
     @property
@@ -358,8 +366,6 @@ class CaptchaAIPitcher(CaptchaAIProxyLessPitcher):
         params = super(CaptchaAIPitcher, self).in_params
         if self.proxy:
             params.update({"proxy": self.proxy, "proxytype": self.proxy_type})
-        if self.user_agent:
-            params.update({"userAgent": self.user_agent})
         return params
 
 
@@ -372,15 +378,11 @@ class CaptchaAIImageToTextPitcher(Pitcher):
     image_fp = None
 
     def __init__(self, website_name, image_fp, tries=3, client_key=None, *args, **kwargs):
-        super().__init__(website_name, tries, client_key, *args, **kwargs)
-        self.tries = tries
-        self.client_key = client_key or os.environ.get("ANTICAPTCHA_ACCOUNT_KEY")
-        if not self.client_key:
-            raise Exception("CaptchaAI key not given, exiting")
-        self.website_name = website_name
+        # No page URL or site key for an image task; keyword the rest so an
+        # explicit client_key reaches Pitcher instead of being read as the
+        # website key while the env fallback raises.
+        super().__init__(website_name, None, None, tries=tries, client_key=client_key, **kwargs)
         self.image_fp = image_fp
-        self.success = False
-        self.solve_time = None
 
     def get_client(self):
         # CaptchaAI exposes a 2Captcha-compatible HTTP API (in.php/res.php), so a
@@ -463,15 +465,10 @@ class AntiCaptchaImageToTextPitcher(Pitcher):
     image_fp = None
 
     def __init__(self, website_name, image_fp, tries=3, client_key=None, *args, **kwargs):
-        super().__init__(website_name, tries, client_key, *args, **kwargs)
-        self.tries = tries
-        self.client_key = client_key or os.environ.get("ANTICAPTCHA_ACCOUNT_KEY")
-        if not self.client_key:
-            raise Exception("AntiCaptcha key not given, exiting")
-        self.website_name = website_name
+        # Same shape as the CaptchaAI image pitcher: keyword the arguments so
+        # an explicit client_key is honored without ANTICAPTCHA_ACCOUNT_KEY.
+        super().__init__(website_name, None, None, tries=tries, client_key=client_key, **kwargs)
         self.image_fp = image_fp
-        self.success = False
-        self.solve_time = None
 
     def get_client(self):
         return AnticaptchaClient(self.client_key)

--- a/custom_libs/subliminal_patch/pitcher.py
+++ b/custom_libs/subliminal_patch/pitcher.py
@@ -5,6 +5,8 @@ import os
 import time
 import logging
 import json
+import base64
+import requests
 from subliminal.cache import region
 from dogpile.cache.api import NO_VALUE
 from python_anticaptcha import AnticaptchaClient, NoCaptchaTaskProxylessTask, NoCaptchaTask, AnticaptchaException
@@ -252,6 +254,300 @@ class DBCPitcher(DBCProxyLessPitcher):
             "proxy": self.proxy
         })
         return payload
+
+
+@registry.register
+class CaptchaAIProxyLessPitcher(Pitcher):
+    name = "CaptchaAIProxyLess"
+    source = "captchaai.com"
+    host = "https://ocr.captchaai.com"
+    timeout = 180
+
+    def __init__(self, website_name, website_url, website_key, tries=3, host=None, *args, **kwargs):
+        super(CaptchaAIProxyLessPitcher, self).__init__(website_name, website_url, website_key, tries=tries, *args,
+                                                        **kwargs)
+        self.host = host or self.host
+
+    def get_client(self):
+        # CaptchaAI exposes a 2Captcha-compatible HTTP API (in.php/res.php), so a
+        # plain requests session is all that is needed.
+        return requests.Session()
+
+    def get_job(self):
+        # The reCAPTCHA task is created in _throw() through the in.php endpoint.
+        pass
+
+    @property
+    def in_params(self):
+        return {
+            "key": self.client_key,
+            "method": "userrecaptcha",
+            "googlekey": self.website_key,
+            "pageurl": self.website_url,
+            "json": 1,
+        }
+
+    def _throw(self):
+        self.client = self.get_client()
+        for i in range(self.tries):
+            try:
+                resp = self.client.post("%s/in.php" % self.host, data=self.in_params, timeout=30)
+                payload = resp.json()
+                if payload.get("status") != 1:
+                    request = payload.get("request")
+                    if request == "ERROR_ZERO_BALANCE":
+                        logger.error("%s: No balance left on captcha solving service. Exiting", self.website_name)
+                        return
+                    elif request == "ERROR_NO_SLOT_AVAILABLE":
+                        logger.info("%s: No captcha solving slot available, retrying", self.website_name)
+                        time.sleep(5.0)
+                        continue
+                    elif request in ("ERROR_KEY_DOES_NOT_EXIST", "ERROR_WRONG_USER_KEY"):
+                        logger.error("%s: Bad CaptchaAI API key", self.website_name)
+                        return
+                    logger.error("%s: CaptchaAI returned an error: %s", self.website_name, request)
+                    if i >= self.tries - 1:
+                        return
+                    continue
+
+                job_id = payload.get("request")
+                deadline = time.time() + self.timeout
+                while time.time() < deadline:
+                    time.sleep(5.0)
+                    res = self.client.get(
+                        "%s/res.php" % self.host,
+                        params={"key": self.client_key, "action": "get", "id": job_id, "json": 1},
+                        timeout=30,
+                    )
+                    res_payload = res.json()
+                    if res_payload.get("status") == 1:
+                        self.success = True
+                        return res_payload.get("request")
+                    if res_payload.get("request") == "CAPCHA_NOT_READY":
+                        continue
+                    logger.error("%s: CaptchaAI returned an error: %s", self.website_name,
+                                 res_payload.get("request"))
+                    break
+                logger.info("%s: Captcha solving timed out, retrying", self.website_name)
+            except Exception:
+                if i >= self.tries - 1:
+                    logger.error("%s: Captcha solving finally failed. Exiting", self.website_name)
+                    return
+                logger.info("%s: Captcha solving failed, retrying", self.website_name)
+                time.sleep(5.0)
+
+
+@registry.register
+class CaptchaAIPitcher(CaptchaAIProxyLessPitcher):
+    name = "CaptchaAI"
+    proxy = None
+    needs_proxy = True
+    proxy_type = "HTTP"
+    user_agent = None
+
+    def __init__(self, *args, **kwargs):
+        self.proxy = kwargs.pop("proxy", None)
+        self.user_agent = kwargs.pop("user_agent", None)
+        # cookies/is_invisible are accepted for call-site compatibility but unused.
+        kwargs.pop("cookies", None)
+        kwargs.pop("is_invisible", None)
+        super(CaptchaAIPitcher, self).__init__(*args, **kwargs)
+
+    @property
+    def in_params(self):
+        params = super(CaptchaAIPitcher, self).in_params
+        if self.proxy:
+            params.update({"proxy": self.proxy, "proxytype": self.proxy_type})
+        if self.user_agent:
+            params.update({"userAgent": self.user_agent})
+        return params
+
+
+@registry.register
+class CaptchaAIImageToTextPitcher(Pitcher):
+    name = "CaptchaAIImageToText"
+    source = "captchaai.com"
+    host = "https://ocr.captchaai.com"
+    timeout = 180
+    image_fp = None
+
+    def __init__(self, website_name, image_fp, tries=3, client_key=None, *args, **kwargs):
+        super().__init__(website_name, tries, client_key, *args, **kwargs)
+        self.tries = tries
+        self.client_key = client_key or os.environ.get("ANTICAPTCHA_ACCOUNT_KEY")
+        if not self.client_key:
+            raise Exception("CaptchaAI key not given, exiting")
+        self.website_name = website_name
+        self.image_fp = image_fp
+        self.success = False
+        self.solve_time = None
+
+    def get_client(self):
+        # CaptchaAI exposes a 2Captcha-compatible HTTP API (in.php/res.php), so a
+        # plain requests session is all that is needed.
+        return requests.Session()
+
+    def get_job(self):
+        # The image task is created in _throw() through the in.php endpoint.
+        pass
+
+    @property
+    def in_params(self):
+        # Read the image bytes and submit them as base64 (method=base64).
+        try:
+            self.image_fp.seek(0)
+        except (AttributeError, ValueError):
+            pass
+        body = base64.b64encode(self.image_fp.read()).decode("ascii")
+        return {
+            "key": self.client_key,
+            "method": "base64",
+            "body": body,
+            "json": 1,
+        }
+
+    def _throw(self):
+        self.client = self.get_client()
+        for i in range(self.tries):
+            try:
+                resp = self.client.post("%s/in.php" % self.host, data=self.in_params, timeout=30)
+                payload = resp.json()
+                if payload.get("status") != 1:
+                    request = payload.get("request")
+                    if request == "ERROR_ZERO_BALANCE":
+                        logger.error("%s: No balance left on captcha solving service. Exiting", self.website_name)
+                        return
+                    elif request == "ERROR_NO_SLOT_AVAILABLE":
+                        logger.info("%s: No captcha solving slot available, retrying", self.website_name)
+                        time.sleep(5.0)
+                        continue
+                    elif request in ("ERROR_KEY_DOES_NOT_EXIST", "ERROR_WRONG_USER_KEY"):
+                        logger.error("%s: Bad CaptchaAI API key", self.website_name)
+                        return
+                    logger.error("%s: CaptchaAI returned an error: %s", self.website_name, request)
+                    if i >= self.tries - 1:
+                        return
+                    continue
+
+                job_id = payload.get("request")
+                deadline = time.time() + self.timeout
+                while time.time() < deadline:
+                    time.sleep(5.0)
+                    res = self.client.get(
+                        "%s/res.php" % self.host,
+                        params={"key": self.client_key, "action": "get", "id": job_id, "json": 1},
+                        timeout=30,
+                    )
+                    res_payload = res.json()
+                    if res_payload.get("status") == 1:
+                        self.success = True
+                        return res_payload.get("request")
+                    if res_payload.get("request") == "CAPCHA_NOT_READY":
+                        continue
+                    logger.error("%s: CaptchaAI returned an error: %s", self.website_name,
+                                 res_payload.get("request"))
+                    break
+                logger.info("%s: Captcha solving timed out, retrying", self.website_name)
+            except Exception:
+                if i >= self.tries - 1:
+                    logger.error("%s: Captcha solving finally failed. Exiting", self.website_name)
+                    return
+                logger.info("%s: Captcha solving failed, retrying", self.website_name)
+                time.sleep(5.0)
+
+
+@registry.register
+class AntiCaptchaImageToTextPitcher(Pitcher):
+    name = "AntiCaptchaImageToText"
+    source = "anti-captcha.com"
+    image_fp = None
+
+    def __init__(self, website_name, image_fp, tries=3, client_key=None, *args, **kwargs):
+        super().__init__(website_name, tries, client_key, *args, **kwargs)
+        self.tries = tries
+        self.client_key = client_key or os.environ.get("ANTICAPTCHA_ACCOUNT_KEY")
+        if not self.client_key:
+            raise Exception("AntiCaptcha key not given, exiting")
+        self.website_name = website_name
+        self.image_fp = image_fp
+        self.success = False
+        self.solve_time = None
+
+    def get_client(self):
+        return AnticaptchaClient(self.client_key)
+
+    def get_job(self):
+        task = ImageToTextTask(self.image_fp)
+        return self.client.createTask(task)
+
+    def _throw(self):
+        for i in range(self.tries):
+            try:
+                super(AntiCaptchaImageToTextPitcher, self)._throw()
+                self.job.join()
+                ret = self.job.get_captcha_text()
+                if ret:
+                    self.success = True
+                    return ret
+            except AnticaptchaException as e:
+                if i >= self.tries - 1:
+                    logger.error("%s: Captcha solving finally failed. Exiting", self.website_name)
+                    return
+                if e.error_code == 'ERROR_ZERO_BALANCE':
+                    logger.error("%s: No balance left on captcha solving service. Exiting", self.website_name)
+                    return
+                elif e.error_code == 'ERROR_NO_SLOT_AVAILABLE':
+                    logger.info("%s: No captcha solving slot available, retrying", self.website_name)
+                    time.sleep(5.0)
+                    continue
+                elif e.error_code == 'ERROR_KEY_DOES_NOT_EXIST':
+                    logger.error("%s: Bad AntiCaptcha API key", self.website_name)
+                    return
+                raise
+
+
+@registry.register
+class DBCImageToTextPitcher(Pitcher):
+    name = "DeathByCaptchaImageToText"
+    source = "deathbycaptcha.com"
+    image_fp = None
+    username = None
+    password = None
+
+    def __init__(self, website_name, image_fp, timeout=DEFAULT_TOKEN_TIMEOUT, tries=3,
+                 client_key=None, *args, **kwargs):
+        super().__init__(website_name, tries, client_key, *args, **kwargs)
+        self.tries = tries
+        self.client_key = client_key or os.environ.get("ANTICAPTCHA_ACCOUNT_KEY")
+        if not self.client_key:
+            raise Exception("DeathByCaptcha credentials not given, exiting")
+        self.username, self.password = self.client_key.split(":", 1)
+        self.website_name = website_name
+        self.image_fp = image_fp
+        self.timeout = timeout
+        self.success = False
+        self.solve_time = None
+
+    def get_client(self):
+        return DBCClient(self.username, self.password)
+
+    def get_job(self):
+        pass
+
+    def _throw(self):
+        self.client = self.get_client()
+        for i in range(self.tries):
+            try:
+                data = self.client.decode(self.image_fp, timeout=self.timeout)
+                if data and data["is_correct"] and data["text"]:
+                    self.success = True
+                    return data["text"]
+            except Exception:
+                if i >= self.tries - 1:
+                    logger.error("%s: Captcha solving finally failed. Exiting", self.website_name)
+                    return
+                logger.info("%s: Captcha solving failed, retrying", self.website_name)
+                time.sleep(5.0)
 
 
 def load_verification(site_name, session, callback=lambda x: None):

--- a/frontend/src/pages/Settings/Providers/__tests__/antiCaptchaOptions.test.ts
+++ b/frontend/src/pages/Settings/Providers/__tests__/antiCaptchaOptions.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { antiCaptchaOption } from "@/pages/Settings/Providers/options";
+
+describe("anti-captcha vendor options", () => {
+  it("offers CaptchaAI with the backend's validator value", () => {
+    const captchaai = antiCaptchaOption.find((o) => o.value === "captchaai");
+    expect(captchaai).toBeDefined();
+    expect(captchaai?.label).toBe("CaptchaAI");
+  });
+
+  it("keeps the existing vendors selectable", () => {
+    const values = antiCaptchaOption.map((o) => o.value);
+    expect(values).toContain("anti-captcha");
+    expect(values).toContain("death-by-captcha");
+  });
+});

--- a/frontend/src/pages/Settings/Providers/index.tsx
+++ b/frontend/src/pages/Settings/Providers/index.tsx
@@ -244,6 +244,14 @@ const AntiCaptchaSection: FunctionComponent = () => (
       <Anchor href="https://www.deathbycaptcha.com">DeathByCaptcha.com</Anchor>
       <Message>Link to subscribe</Message>
     </CollapseBox>
+    <CollapseBox
+      settingKey="settings-general-anti_captcha_provider"
+      on={(value) => value === "captchaai"}
+    >
+      <Text label="API Key" settingKey="settings-captchaai-captchaai_key" />
+      <Anchor href="https://captchaai.com">CaptchaAI.com</Anchor>
+      <Message>Link to subscribe</Message>
+    </CollapseBox>
   </Stack>
 );
 

--- a/frontend/src/pages/Settings/Providers/index.tsx
+++ b/frontend/src/pages/Settings/Providers/index.tsx
@@ -223,7 +223,7 @@ const AntiCaptchaSection: FunctionComponent = () => (
       settingKey="settings-general-anti_captcha_provider"
       on={(value) => value === "anti-captcha"}
     >
-      <Text
+      <Password
         label="Account Key"
         settingKey="settings-anticaptcha-anti_captcha_key"
       />
@@ -248,7 +248,7 @@ const AntiCaptchaSection: FunctionComponent = () => (
       settingKey="settings-general-anti_captcha_provider"
       on={(value) => value === "captchaai"}
     >
-      <Text label="API Key" settingKey="settings-captchaai-captchaai_key" />
+      <Password label="API Key" settingKey="settings-captchaai-captchaai_key" />
       <Anchor href="https://captchaai.com">CaptchaAI.com</Anchor>
       <Message>Link to subscribe</Message>
     </CollapseBox>

--- a/frontend/src/pages/Settings/Providers/options.ts
+++ b/frontend/src/pages/Settings/Providers/options.ts
@@ -9,4 +9,8 @@ export const antiCaptchaOption: SelectorOption<string>[] = [
     label: "Death by Captcha",
     value: "death-by-captcha",
   },
+  {
+    label: "CaptchaAI",
+    value: "captchaai",
+  },
 ];

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -11,6 +11,7 @@ interface Settings {
   // Anitcaptcha
   anticaptcha: Settings.Anticaptcha;
   deathbycaptcha: Settings.DeathByCaptche;
+  captchaai: Settings.CaptchaAI;
   // Providers
   opensubtitlescom: Settings.OpenSubtitlesCom;
   addic7ed: Settings.Addic7ed;
@@ -227,6 +228,10 @@ declare namespace Settings {
   interface DeathByCaptche {
     username?: string;
     password?: string;
+  }
+
+  interface CaptchaAI {
+    captchaai_key?: string;
   }
 
   // Providers

--- a/tests/bazarr/test_anti_captcha_config.py
+++ b/tests/bazarr/test_anti_captcha_config.py
@@ -11,6 +11,14 @@ class _FakeUpdate:
         return self
 
 
+@pytest.fixture
+def captcha_env(monkeypatch):
+    """Seed both captcha env vars so configure_captcha_func's writes are
+    restored on teardown; these tests run in one shared CI process."""
+    monkeypatch.setenv("ANTICAPTCHA_CLASS", "sentinel-class")
+    monkeypatch.setenv("ANTICAPTCHA_ACCOUNT_KEY", "sentinel-key")
+
+
 def _fake_settings(provider, anticaptcha_key="", dbc_user="", dbc_pass="", captchaai_key=""):
     return SimpleNamespace(
         general=SimpleNamespace(anti_captcha_provider=provider),
@@ -29,7 +37,7 @@ def test_validator_accepts_captchaai():
     assert "captchaai" in validator.operations["is_in"]
 
 
-def test_configure_captcha_func_exports_captchaai(monkeypatch):
+def test_configure_captcha_func_exports_captchaai(captcha_env, monkeypatch):
     from app import config
 
     monkeypatch.setattr(config, "settings", _fake_settings("captchaai", captchaai_key="key-123"))
@@ -38,15 +46,17 @@ def test_configure_captcha_func_exports_captchaai(monkeypatch):
     assert os.environ["ANTICAPTCHA_ACCOUNT_KEY"] == "key-123"
 
 
-def test_configure_captcha_func_captchaai_empty_key_disables(monkeypatch):
+def test_configure_captcha_func_captchaai_empty_key_disables(captcha_env, monkeypatch):
     from app import config
 
     monkeypatch.setattr(config, "settings", _fake_settings("captchaai", captchaai_key=""))
     config.configure_captcha_func()
     assert os.environ["ANTICAPTCHA_CLASS"] == ""
+    # Disabling must also drop the previously exported credential.
+    assert os.environ["ANTICAPTCHA_ACCOUNT_KEY"] == ""
 
 
-def test_configure_captcha_func_anti_captcha_still_works(monkeypatch):
+def test_configure_captcha_func_anti_captcha_still_works(captcha_env, monkeypatch):
     from app import config
 
     monkeypatch.setattr(config, "settings", _fake_settings("anti-captcha", anticaptcha_key="ak"))
@@ -73,20 +83,39 @@ def test_save_settings_reconfigures_captcha_on_captchaai_key(monkeypatch):
         ),
     )
 
-    config.save_settings([("settings-captchaai-captchaai_key", ["key-456"])])
+    previous = config.settings.captchaai.captchaai_key
+    try:
+        config.save_settings([("settings-captchaai-captchaai_key", ["key-456"])])
 
-    assert called, "saving the CaptchaAI key must re-run captcha configuration"
-    assert config.settings.captchaai.captchaai_key == "key-456"
+        assert called, "saving the CaptchaAI key must re-run captcha configuration"
+        assert config.settings.captchaai.captchaai_key == "key-456"
+    finally:
+        config.settings.captchaai.captchaai_key = previous
 
 
-@pytest.mark.parametrize(
-    "name", ["CaptchaAIProxyLess", "CaptchaAIImageToText"]
-)
+@pytest.mark.parametrize("name", ["CaptchaAIProxyLess"])
 def test_pitcher_registry_has_captchaai(name):
     from subliminal_patch.pitcher import pitchers
 
     cls = pitchers.get_pitcher(name)
     assert cls.name == name
+
+
+def test_pitcher_registry_has_captchaai_proxy_variant():
+    from subliminal_patch.pitcher import pitchers
+
+    cls = pitchers.get_pitcher("CaptchaAI", with_proxy=True)
+    assert cls.name == "CaptchaAI"
+
+
+def test_pitcher_registry_source_aliases_unchanged():
+    """The by-source lookups must keep resolving to the reCAPTCHA pitchers;
+    an image class re-claiming a domain's alias would silently break them."""
+    from subliminal_patch.pitcher import pitchers
+
+    assert pitchers.get_pitcher("anti-captcha.com").name == "AntiCaptchaProxyLess"
+    assert pitchers.get_pitcher("deathbycaptcha.com").name == "DeathByCaptchaProxyLess"
+    assert pitchers.get_pitcher("captchaai.com").name == "CaptchaAIProxyLess"
 
 
 def test_pitcher_registry_resolves_captchaai_from_env(monkeypatch):
@@ -95,42 +124,6 @@ def test_pitcher_registry_resolves_captchaai_from_env(monkeypatch):
 
     cls = pitchers.get_pitcher()
     assert cls.name == "CaptchaAIProxyLess"
-
-
-def test_secret_registry_covers_captcha_keys():
-    from secret_store.registry import USER_VISIBLE_SECRETS
-
-    assert "captchaai.captchaai_key" in USER_VISIBLE_SECRETS
-    assert "anticaptcha.anti_captcha_key" in USER_VISIBLE_SECRETS
-
-
-def test_image_to_text_task_is_imported():
-    import subliminal_patch.pitcher as pitcher_module
-
-    assert hasattr(pitcher_module, "ImageToTextTask")
-
-
-def test_captchaai_image_pitcher_accepts_explicit_key_without_env(monkeypatch):
-    import io
-
-    monkeypatch.delenv("ANTICAPTCHA_ACCOUNT_KEY", raising=False)
-    from subliminal_patch.pitcher import pitchers
-
-    cls = pitchers.get_pitcher("CaptchaAIImageToText")
-    pitcher = cls("Zimuku", io.BytesIO(b"img"), client_key="explicit-key")
-    assert pitcher.client_key == "explicit-key"
-    assert pitcher.tries == 3
-
-
-def test_anticaptcha_image_pitcher_accepts_explicit_key_without_env(monkeypatch):
-    import io
-
-    monkeypatch.delenv("ANTICAPTCHA_ACCOUNT_KEY", raising=False)
-    from subliminal_patch.pitcher import pitchers
-
-    cls = pitchers.get_pitcher("AntiCaptchaImageToText")
-    pitcher = cls("Zimuku", io.BytesIO(b"img"), client_key="explicit-key")
-    assert pitcher.client_key == "explicit-key"
 
 
 def test_captchaai_proxyless_forwards_caller_context(monkeypatch):
@@ -150,4 +143,6 @@ def test_captchaai_proxyless_forwards_caller_context(monkeypatch):
     params = pitcher.in_params
     assert params["invisible"] == 1
     assert params["userAgent"] == "UA/1.0"
-    assert params["cookies"] == "session:abc"
+    # The provider's session cookies must NOT be shipped to the vendor.
+    assert "cookies" not in params
+    assert params["key"] == "explicit-key"

--- a/tests/bazarr/test_anti_captcha_config.py
+++ b/tests/bazarr/test_anti_captcha_config.py
@@ -95,3 +95,59 @@ def test_pitcher_registry_resolves_captchaai_from_env(monkeypatch):
 
     cls = pitchers.get_pitcher()
     assert cls.name == "CaptchaAIProxyLess"
+
+
+def test_secret_registry_covers_captcha_keys():
+    from secret_store.registry import USER_VISIBLE_SECRETS
+
+    assert "captchaai.captchaai_key" in USER_VISIBLE_SECRETS
+    assert "anticaptcha.anti_captcha_key" in USER_VISIBLE_SECRETS
+
+
+def test_image_to_text_task_is_imported():
+    import subliminal_patch.pitcher as pitcher_module
+
+    assert hasattr(pitcher_module, "ImageToTextTask")
+
+
+def test_captchaai_image_pitcher_accepts_explicit_key_without_env(monkeypatch):
+    import io
+
+    monkeypatch.delenv("ANTICAPTCHA_ACCOUNT_KEY", raising=False)
+    from subliminal_patch.pitcher import pitchers
+
+    cls = pitchers.get_pitcher("CaptchaAIImageToText")
+    pitcher = cls("Zimuku", io.BytesIO(b"img"), client_key="explicit-key")
+    assert pitcher.client_key == "explicit-key"
+    assert pitcher.tries == 3
+
+
+def test_anticaptcha_image_pitcher_accepts_explicit_key_without_env(monkeypatch):
+    import io
+
+    monkeypatch.delenv("ANTICAPTCHA_ACCOUNT_KEY", raising=False)
+    from subliminal_patch.pitcher import pitchers
+
+    cls = pitchers.get_pitcher("AntiCaptchaImageToText")
+    pitcher = cls("Zimuku", io.BytesIO(b"img"), client_key="explicit-key")
+    assert pitcher.client_key == "explicit-key"
+
+
+def test_captchaai_proxyless_forwards_caller_context(monkeypatch):
+    monkeypatch.delenv("ANTICAPTCHA_ACCOUNT_KEY", raising=False)
+    from subliminal_patch.pitcher import pitchers
+
+    cls = pitchers.get_pitcher("CaptchaAIProxyLess")
+    pitcher = cls(
+        "Addic7ed",
+        "https://example.org/login",
+        "site-key",
+        client_key="explicit-key",
+        user_agent="UA/1.0",
+        cookies={"session": "abc"},
+        is_invisible=True,
+    )
+    params = pitcher.in_params
+    assert params["invisible"] == 1
+    assert params["userAgent"] == "UA/1.0"
+    assert params["cookies"] == "session:abc"

--- a/tests/bazarr/test_anti_captcha_config.py
+++ b/tests/bazarr/test_anti_captcha_config.py
@@ -1,0 +1,97 @@
+# coding=utf-8
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+class _FakeUpdate:
+    def values(self, **_kwargs):
+        return self
+
+
+def _fake_settings(provider, anticaptcha_key="", dbc_user="", dbc_pass="", captchaai_key=""):
+    return SimpleNamespace(
+        general=SimpleNamespace(anti_captcha_provider=provider),
+        anticaptcha=SimpleNamespace(anti_captcha_key=anticaptcha_key),
+        deathbycaptcha=SimpleNamespace(username=dbc_user, password=dbc_pass),
+        captchaai=SimpleNamespace(captchaai_key=captchaai_key),
+    )
+
+
+def test_validator_accepts_captchaai():
+    from app import config
+
+    validator = next(
+        v for v in config.validators if "general.anti_captcha_provider" in v.names
+    )
+    assert "captchaai" in validator.operations["is_in"]
+
+
+def test_configure_captcha_func_exports_captchaai(monkeypatch):
+    from app import config
+
+    monkeypatch.setattr(config, "settings", _fake_settings("captchaai", captchaai_key="key-123"))
+    config.configure_captcha_func()
+    assert os.environ["ANTICAPTCHA_CLASS"] == "CaptchaAIProxyLess"
+    assert os.environ["ANTICAPTCHA_ACCOUNT_KEY"] == "key-123"
+
+
+def test_configure_captcha_func_captchaai_empty_key_disables(monkeypatch):
+    from app import config
+
+    monkeypatch.setattr(config, "settings", _fake_settings("captchaai", captchaai_key=""))
+    config.configure_captcha_func()
+    assert os.environ["ANTICAPTCHA_CLASS"] == ""
+
+
+def test_configure_captcha_func_anti_captcha_still_works(monkeypatch):
+    from app import config
+
+    monkeypatch.setattr(config, "settings", _fake_settings("anti-captcha", anticaptcha_key="ak"))
+    config.configure_captcha_func()
+    assert os.environ["ANTICAPTCHA_CLASS"] == "AntiCaptchaProxyLess"
+    assert os.environ["ANTICAPTCHA_ACCOUNT_KEY"] == "ak"
+
+
+def test_save_settings_reconfigures_captcha_on_captchaai_key(monkeypatch):
+    from app import config
+
+    called = []
+    monkeypatch.setattr(config, "write_config", lambda: None)
+    monkeypatch.setattr(config, "validate_log_regex", lambda: None)
+    monkeypatch.setattr(config.settings.validators, "validate", lambda: None)
+    monkeypatch.setattr(config, "configure_captcha_func", lambda: called.append(True))
+    monkeypatch.setitem(
+        sys.modules,
+        "app.database",
+        SimpleNamespace(
+            database=SimpleNamespace(execute=lambda statement: None),
+            update=lambda _model: _FakeUpdate(),
+            System=object,
+        ),
+    )
+
+    config.save_settings([("settings-captchaai-captchaai_key", ["key-456"])])
+
+    assert called, "saving the CaptchaAI key must re-run captcha configuration"
+    assert config.settings.captchaai.captchaai_key == "key-456"
+
+
+@pytest.mark.parametrize(
+    "name", ["CaptchaAIProxyLess", "CaptchaAIImageToText"]
+)
+def test_pitcher_registry_has_captchaai(name):
+    from subliminal_patch.pitcher import pitchers
+
+    cls = pitchers.get_pitcher(name)
+    assert cls.name == name
+
+
+def test_pitcher_registry_resolves_captchaai_from_env(monkeypatch):
+    monkeypatch.setenv("ANTICAPTCHA_CLASS", "CaptchaAIProxyLess")
+    from subliminal_patch.pitcher import pitchers
+
+    cls = pitchers.get_pitcher()
+    assert cls.name == "CaptchaAIProxyLess"

--- a/tests/bazarr/test_logging_filters.py
+++ b/tests/bazarr/test_logging_filters.py
@@ -13,3 +13,16 @@ def test_false_below_error():
 def test_true_above_error():
   record = logging.LogRecord("", logging.CRITICAL, "", 0, "", (), None)
   assert UnwantedWaitressMessageFilter().filter(record)
+
+
+def test_apikey_redaction_covers_apikey_and_bare_key():
+    from app.logger import FileHandlerFormatter
+
+    fmt = FileHandlerFormatter()
+    assert fmt.formatApikey("GET /api?apikey=SECRET123 done") == "GET /api?apikey=(removed) done"
+    # 2Captcha-compatible vendors poll res.php with ?key=<account key>;
+    # urllib3 logs that URL at DEBUG, so the bare form must redact too.
+    assert fmt.formatApikey(
+        'GET /res.php?key=SECRETKEY9&action=get HTTP/1.1'
+    ) == 'GET /res.php?key=(removed)&action=get HTTP/1.1'
+    assert fmt.formatApikey("googlekey=PUBLICSITEKEY rest") == "googlekey=(removed) rest"

--- a/tests/bazarr/test_secret_store_registry.py
+++ b/tests/bazarr/test_secret_store_registry.py
@@ -32,7 +32,8 @@ def test_user_visible_includes_provider_passwords_and_keys():
     updating the registry, those credentials would ship plaintext."""
     for key in ("opensubtitles.password", "addic7ed.password",
                 "subdl.api_key", "subsource.apikey",
-                "translator.openrouter_api_key", "translator.lingarr_token"):
+                "translator.openrouter_api_key", "translator.lingarr_token",
+                "anticaptcha.anti_captcha_key", "captchaai.captchaai_key"):
         assert is_user_visible_secret(key), f"{key} should be user-visible"
 
 


### PR DESCRIPTION
## What

Adds CaptchaAI as a third anti-captcha vendor alongside Anti-Captcha and Death by Captcha. CaptchaAI exposes a 2Captcha-compatible HTTP API (in.php/res.php) at a flat rate, and users migrating from upstream expect the option to exist here.

## How

- `custom_libs/subliminal_patch/pitcher.py`: adds the `CaptchaAIProxyLess`, `CaptchaAI` (proxy variant) and `CaptchaAIImageToText` pitchers to the registry. The gated providers resolve their pitcher from the `ANTICAPTCHA_CLASS` environment variable via `get_pitcher()` with no argument, so no provider changes are needed.
- `bazarr/app/config.py`: extends the `general.anti_captcha_provider` validator with `captchaai`, adds the `captchaai.captchaai_key` section, extends the captcha-reconfigure key list in `save_settings`, and teaches `configure_captcha_func` to export `ANTICAPTCHA_CLASS=CaptchaAIProxyLess` with the key. Key layout mirrors upstream so migrated configs keep working.
- Frontend: CaptchaAI selector option, API key field on the providers settings page, and the settings type.

## Testing

- New `tests/bazarr/test_anti_captcha_config.py` (8 tests, added to the CI suite list): validator accepts the new vendor, `configure_captcha_func` exports the right env pair for each vendor including empty-key disable, `save_settings` re-runs captcha configuration on the new key, and the pitcher registry resolves both new classes by name and from the environment. Watched fail before the implementation, pass after.
- Full local CI green: ruff, compat suite, guard list, previously unguarded suites, per-file isolation loop including the Postgres tests, boot smoke, frontend checks, coverage and build.
- Deployed to the test server: selected CaptchaAI in the UI with a dummy key, setting round-trips through the API (`anti_captcha_provider=captchaai`, key persisted), no validator error at boot, and the settings page renders the new vendor. A real captcha solve is not part of the verification bar (no funded account); the API contract is 2Captcha-compatible and the pitcher code is ported from upstream v1.6.0.

Note: the built-in zimuku provider still selects image pitchers by name and was deliberately not touched; provider fixes live in the Provider Hub catalog, whose zimuku plugin has its own solver stack and does not use the pitcher registry.