### PR TITLE
fix(api): serve the swagger UI assets from the installed flask_restx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,7 @@ jobs:
             tests/bazarr/test_sql_profiler.py \
             tests/bazarr/test_subtitle_content_sync_outputs.py \
             tests/bazarr/test_subtitles_pool.py \
+            tests/bazarr/test_swagger_static.py \
             tests/bazarr/test_supervisor_proxy.py \
             tests/bazarr/test_supervisor_stages.py \
             tests/bazarr/test_tracemalloc_dumper.py \

--- a/bazarr/app/ui.py
+++ b/bazarr/app/ui.py
@@ -300,13 +300,24 @@ def backup_download(filename):
     return send_file(fullpath, max_age=0, as_attachment=True)
 
 
+def swaggerui_static_dir():
+    """Where flask_restx keeps the swagger UI assets.
+
+    Resolved from the installed package: the old vendored ``libs/flask_restx``
+    tree is gone since the library unvendoring, and pointing there made every
+    asset request 500 so the API documentation page rendered blank.
+    """
+    import flask_restx
+
+    return os.path.realpath(os.path.join(os.path.dirname(flask_restx.__file__), 'static'))
+
+
 @ui_bp.route('/api/swaggerui/static/<path:filename>', methods=['GET'])
 def swaggerui_static(filename):
-    basepath = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'libs', 'flask_restx',
-                            'static')
+    basepath = swaggerui_static_dir()
     fullpath = os.path.realpath(os.path.join(basepath, filename))
     # Use startswith to prevent path traversal
-    if not fullpath.startswith(os.path.realpath(basepath) + os.sep):
+    if not fullpath.startswith(basepath + os.sep):
         return '', 404
     else:
         return send_file(fullpath)

--- a/tests/bazarr/test_swagger_static.py
+++ b/tests/bazarr/test_swagger_static.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+"""The swagger UI must serve its own assets from wherever flask_restx lives.
+
+The handler used to point at the vendored ``libs/flask_restx/static`` tree,
+which the library unvendoring removed, so every asset request returned 500 and
+the API documentation page rendered blank.
+"""
+import os
+
+
+def test_the_swagger_static_dir_exists_and_holds_the_ui():
+    from app.ui import swaggerui_static_dir
+
+    basepath = swaggerui_static_dir()
+    assert os.path.isdir(basepath), f'{basepath} does not exist'
+    for asset in ('swagger-ui.css', 'swagger-ui-bundle.js',
+                  'swagger-ui-standalone-preset.js'):
+        assert os.path.isfile(os.path.join(basepath, asset)), (
+            f'{asset} missing from {basepath}; the swagger page loads these '
+            'and renders blank without them')


### PR DESCRIPTION
## What

The API documentation page at /api/ rendered blank on the v2.6.0 RC: every swagger UI asset request (css/js under /api/swaggerui/static/) returned 500 with FileNotFoundError.

## Why

The handler still pointed at the vendored libs/flask_restx/static tree, which the library unvendoring removed this cycle; flask_restx now lives in site-packages.

## How

The static base path resolves from the installed package via a small helper. The path-traversal containment guard is unchanged, and was re-verified live: a raw ../ request 404s, an encoded one never reaches the route.

## Testing

- New tests/bazarr/test_swagger_static.py (on the CI list) pins the resolved directory to exist and contain the three swagger UI files; it fails on the old vendored path.
- Guard and unguarded backend batches green locally; verified live on a booted instance that the exact failing URLs now serve the real assets (css 145 KB, bundle 1 MB).

Found during manual acceptance of v2.6.0-rc.1.