### PR TITLE
Subtitle downloads and viewer light-mode contrast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,7 @@ jobs:
             tests/bazarr/test_sonarr_sync_episodes.py \
             tests/bazarr/test_sql_profiler.py \
             tests/bazarr/test_subtitle_content_sync_outputs.py \
+            tests/bazarr/test_subtitle_download_api.py \
             tests/bazarr/test_subtitles_pool.py \
             tests/bazarr/test_swagger_static.py \
             tests/bazarr/test_supervisor_proxy.py \

--- a/bazarr/api/subtitles/__init__.py
+++ b/bazarr/api/subtitles/__init__.py
@@ -6,6 +6,7 @@ from .batch import api_ns_batch
 from .content import api_ns_subtitle_content
 from .subtitles_contents import api_ns_subtitle_contents
 from .archive import api_ns_subtitle_archive
+from .download import api_ns_subtitle_download
 
 
 api_ns_list_subtitles = [
@@ -15,4 +16,5 @@ api_ns_list_subtitles = [
     api_ns_subtitle_content,
     api_ns_subtitle_contents,
     api_ns_subtitle_archive,
+    api_ns_subtitle_download,
 ]

--- a/bazarr/api/subtitles/content.py
+++ b/bazarr/api/subtitles/content.py
@@ -53,7 +53,10 @@ _LANGUAGE_CODE_RE = re.compile(
     r'sync-(ffsubsync|autosubsync|alass)|'
     r'combined-[a-z]{2}(-[a-z]{2})?'
     # \Z, not $: $ would accept a trailing newline (en%0A in the route).
-    r'))*\Z'
+    r'))*\Z',
+    # Custom languages index uppercase modifiers (zh:HI, zt:HI, pb:HI);
+    # validation is case-insensitive while lookups keep the exact label.
+    re.IGNORECASE
 )
 
 

--- a/bazarr/api/subtitles/content.py
+++ b/bazarr/api/subtitles/content.py
@@ -44,8 +44,11 @@ def _is_safe_path(path):
 # "en:sync-ffsubsync", "en:combined-hu", "de:combined-es-zh".
 # Anchored + char-class prevents `..`, slashes, or shell metachars from reaching
 # the file-system probe paths downstream.
+# The base-tag half is shared with download.py's bundle language filter so a
+# grammar change lands in both consumers.
+LANGUAGE_BASE_TAG_FRAGMENT = r'[A-Za-z]{2,3}(-[A-Za-z0-9]{2,4})?'
 _LANGUAGE_CODE_RE = re.compile(
-    r'^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,4})?'
+    r'^' + LANGUAGE_BASE_TAG_FRAGMENT +
     r'(:(forced|hi|'
     r'sync-(ffsubsync|autosubsync|alass)|'
     r'combined-[a-z]{2}(-[a-z]{2})?'

--- a/bazarr/api/subtitles/content.py
+++ b/bazarr/api/subtitles/content.py
@@ -52,7 +52,8 @@ _LANGUAGE_CODE_RE = re.compile(
     r'(:(forced|hi|'
     r'sync-(ffsubsync|autosubsync|alass)|'
     r'combined-[a-z]{2}(-[a-z]{2})?'
-    r'))*$'
+    # \Z, not $: $ would accept a trailing newline (en%0A in the route).
+    r'))*\Z'
 )
 
 

--- a/bazarr/api/subtitles/content.py
+++ b/bazarr/api/subtitles/content.py
@@ -287,15 +287,18 @@ def resolve_subtitle_path(media_type, media_id, language_code, arr_instance_id=N
         # <basename>.<primary>.combined-<sec>[-<ter>].<ext>
         # Pick that path before the hi/forced suffixes so we generate the
         # right filename.
+        # Modifiers compare lowercased: the grammar accepts the indexed
+        # uppercase HI form (pb:HI), while on-disk suffixes are lowercase.
+        modifiers_lower = [m.lower() for m in language_code.split(':')[1:]]
         combined_mod = next(
-            (m for m in language_code.split(':')[1:] if m.startswith('combined-')),
+            (m for m in modifiers_lower if m.startswith('combined-')),
             None,
         )
         if combined_mod:
             suffix = f'{lang_base}.{combined_mod}'
-        elif ':hi' in language_code:
+        elif 'hi' in modifiers_lower:
             suffix += '.hi'
-        elif ':forced' in language_code:
+        elif 'forced' in modifiers_lower:
             suffix += '.forced'
 
         for ext in ['.srt', '.ass', '.ssa', '.vtt', '.sub', '.smi', '.mpl', '.txt']:

--- a/bazarr/api/subtitles/content.py
+++ b/bazarr/api/subtitles/content.py
@@ -49,14 +49,16 @@ def _is_safe_path(path):
 LANGUAGE_BASE_TAG_FRAGMENT = r'[A-Za-z]{2,3}(-[A-Za-z0-9]{2,4})?'
 _LANGUAGE_CODE_RE = re.compile(
     r'^' + LANGUAGE_BASE_TAG_FRAGMENT +
-    r'(:(forced|hi|'
+    # hi|HI, not IGNORECASE: custom languages index the uppercase HI form
+    # (zh:HI, zt:HI, pb:HI) and lookups keep the exact label, but a blanket
+    # case-insensitive grammar would accept variants like en:FORCED that the
+    # exact DB lookup misses, sending resolution down the on-disk fallback
+    # whose suffix checks are case-sensitive.
+    r'(:(forced|hi|HI|'
     r'sync-(ffsubsync|autosubsync|alass)|'
     r'combined-[a-z]{2}(-[a-z]{2})?'
     # \Z, not $: $ would accept a trailing newline (en%0A in the route).
-    r'))*\Z',
-    # Custom languages index uppercase modifiers (zh:HI, zt:HI, pb:HI);
-    # validation is case-insensitive while lookups keep the exact label.
-    re.IGNORECASE
+    r'))*\Z'
 )
 
 

--- a/bazarr/api/subtitles/download.py
+++ b/bazarr/api/subtitles/download.py
@@ -1,8 +1,11 @@
 # coding=utf-8
 
 import ast
+import mimetypes
 import os
 import re
+import shutil
+import stat
 import tempfile
 import time
 import zipfile
@@ -35,6 +38,10 @@ MAX_BUNDLE_UNCOMPRESSED_SIZE = 256 * 1024 * 1024
 BUNDLE_SPOOL_MEMORY_CEILING = 16 * 1024 * 1024
 
 _BUNDLE_COPY_CHUNK = 1 << 20
+
+# Per-entry staging buffer: spills to disk past this, so reading a source is
+# fully guarded before anything touches the archive.
+_ENTRY_STAGE_MEMORY_CEILING = 4 * 1024 * 1024
 
 # Base language filter for bundles: "en", "pt-BR". Variants (hi/forced/sync)
 # of the base language are included by design, so modifiers are not accepted.
@@ -190,6 +197,25 @@ def resolve_bundle_path(disk_path, trusted_roots):
     return None
 
 
+def open_validated_subtitle(path):
+    """Open a previously validated path for reading, refusing a replacement
+    symlink at the final component (O_NOFOLLOW where the platform has it) and
+    anything that is not a regular file. Validation and opening are separate
+    operations, so a writer in the media directory could swap the file in the
+    window between them; this closes that window at the open."""
+    flags = (os.O_RDONLY
+             | getattr(os, 'O_NOFOLLOW', 0)
+             | getattr(os, 'O_BINARY', 0))
+    descriptor = os.open(path, flags)
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise OSError(f'not a regular file: {path}')
+        return os.fdopen(descriptor, 'rb')
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
 def _collect_bundle_entries(rows, media_type, language=None, season=None):
     """Build (arcname, disk_path) pairs for rows with .path, .subtitles and
     .arr_instance_id (episode rows also carry .season)."""
@@ -274,30 +300,39 @@ def build_subtitle_bundle(entries, max_total_size=MAX_BUNDLE_UNCOMPRESSED_SIZE):
                 if disk_path in seen_paths:
                     continue
                 try:
-                    source = open(disk_path, 'rb')
+                    source = open_validated_subtitle(disk_path)
                 except OSError:
                     continue
-                # A successfully opened POSIX file stays readable even if it
-                # is unlinked mid-copy, so streaming after the open cannot
-                # produce a partial entry from a vanished file.
-                with source:
+                # Each source is staged in full (bounded memory, spills to
+                # disk) BEFORE anything touches the archive: a read failing
+                # mid-way (NAS I/O error) skips the entry instead of leaving
+                # a truncated member or failing the request.
+                with source, tempfile.SpooledTemporaryFile(
+                        max_size=_ENTRY_STAGE_MEMORY_CEILING) as staging:
                     mtime = os.fstat(source.fileno()).st_mtime
+                    entry_size = 0
+                    try:
+                        while True:
+                            chunk = source.read(_BUNDLE_COPY_CHUNK)
+                            if not chunk:
+                                break
+                            entry_size += len(chunk)
+                            if total_size + entry_size > max_total_size:
+                                raise BundleTooLargeError
+                            staging.write(chunk)
+                    except OSError:
+                        continue
                     seen_paths.add(disk_path)
+                    total_size += entry_size
                     # An explicit ZipInfo: archive.write would raise on
                     # out-of-range mtimes; here the timestamp is clamped.
                     info = zipfile.ZipInfo(unique_arcname(used_names, arcname),
                                            date_time=_zip_date_time(mtime))
                     info.compress_type = zipfile.ZIP_DEFLATED
                     info.external_attr = 0o644 << 16
+                    staging.seek(0)
                     with archive.open(info, 'w') as target:
-                        while True:
-                            chunk = source.read(_BUNDLE_COPY_CHUNK)
-                            if not chunk:
-                                break
-                            total_size += len(chunk)
-                            if total_size > max_total_size:
-                                raise BundleTooLargeError
-                            target.write(chunk)
+                        shutil.copyfileobj(staging, target)
                 added += 1
     except BaseException:
         buffer.close()
@@ -378,13 +413,23 @@ def _send_single_subtitle(media_type, media_id, language_code):
         return result
     subtitle_path = result[0]
     try:
-        response = send_file(subtitle_path,
-                             as_attachment=True,
-                             download_name=os.path.basename(subtitle_path),
-                             max_age=0)
+        # Open before handing off, refusing a replacement symlink: send_file
+        # on a pathname would follow whatever sits there by the time it opens.
+        handle = open_validated_subtitle(subtitle_path)
     except OSError:
-        # Deleted in the window since resolve_subtitle_path's existence check.
+        # Deleted or swapped in the window since resolve_subtitle_path.
         return 'Subtitle file or directory not found', 404
+    basename = os.path.basename(subtitle_path)
+    try:
+        response = send_file(handle,
+                             as_attachment=True,
+                             download_name=basename,
+                             mimetype=(mimetypes.guess_type(basename)[0]
+                                       or 'application/octet-stream'),
+                             max_age=0)
+    except Exception:
+        handle.close()
+        raise
     return _with_nosniff(response)
 
 

--- a/bazarr/api/subtitles/download.py
+++ b/bazarr/api/subtitles/download.py
@@ -83,16 +83,20 @@ def sanitize_arcname_component(name):
 
 
 def unique_arcname(used, arcname):
-    """Return arcname, suffixed with ' (n)' before the extension if taken."""
-    if arcname not in used:
-        used.add(arcname)
+    """Return arcname, suffixed with ' (n)' before the extension if taken.
+
+    Collisions are tracked case-insensitively: names differing only by case
+    would overwrite each other when the zip is extracted on a
+    case-insensitive filesystem."""
+    if arcname.casefold() not in used:
+        used.add(arcname.casefold())
         return arcname
     stem, ext = os.path.splitext(arcname)
     counter = 2
-    while f'{stem} ({counter}){ext}' in used:
+    while f'{stem} ({counter}){ext}'.casefold() in used:
         counter += 1
     result = f'{stem} ({counter}){ext}'
-    used.add(result)
+    used.add(result.casefold())
     return result
 
 
@@ -165,7 +169,9 @@ def trusted_roots_for(video_disk_path):
     if media_dir:
         roots.append(os.path.realpath(media_dir))
     try:
-        target = get_target_folder(video_disk_path)
+        # Read-only: a bundle request must not create subtitle folders
+        # across the library as a side effect.
+        target = get_target_folder(video_disk_path, create=False)
     except Exception:
         target = None
     if target and isinstance(target, str):
@@ -208,8 +214,17 @@ def open_validated_subtitle(path):
              | getattr(os, 'O_BINARY', 0))
     descriptor = os.open(path, flags)
     try:
-        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        opened = os.fstat(descriptor)
+        if not stat.S_ISREG(opened.st_mode):
             raise OSError(f'not a regular file: {path}')
+        if not hasattr(os, 'O_NOFOLLOW'):
+            # No O_NOFOLLOW on this platform (Windows): require the directory
+            # entry to be the very file that was opened, so a replacement
+            # symlink cannot smuggle in an outside target.
+            entry = os.lstat(path)
+            if stat.S_ISLNK(entry.st_mode) or (
+                    (entry.st_dev, entry.st_ino) != (opened.st_dev, opened.st_ino)):
+                raise OSError(f'path was replaced: {path}')
         return os.fdopen(descriptor, 'rb')
     except Exception:
         os.close(descriptor)

--- a/bazarr/api/subtitles/download.py
+++ b/bazarr/api/subtitles/download.py
@@ -1,0 +1,284 @@
+# coding=utf-8
+
+import ast
+import io
+import os
+import re
+import zipfile
+
+from flask import request, send_file
+from flask_restx import Resource, Namespace
+
+from app.database import TableEpisodes, TableMovies, TableShows, database, select
+from utilities.path_mappings import path_mappings
+
+from .content import resolve_subtitle_path
+from ..utils import authenticate
+
+api_ns_subtitle_download = Namespace('SubtitleDownload', description='Download subtitle files')
+
+# Uncompressed ceiling for a bundle. Text subtitles are tiny; only a library
+# full of PGS (.sup) files could approach this, and those should not be
+# bundled into memory anyway.
+MAX_BUNDLE_UNCOMPRESSED_SIZE = 256 * 1024 * 1024
+
+# Base language filter for bundles: "en", "pt-BR". Variants (hi/forced/sync)
+# of the base language are included by design, so modifiers are not accepted.
+_LANGUAGE_FILTER_RE = re.compile(r'^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,4})?$')
+
+
+class BundleTooLargeError(Exception):
+    pass
+
+
+def safe_filename_component(value, fallback):
+    """Reduce a title to something usable inside a download filename."""
+    cleaned = re.sub(r'[\\/:*?"<>|\x00-\x1f]', '_', str(value or ''))
+    cleaned = re.sub(r'\s+', ' ', cleaned).strip().strip('.')
+    return cleaned or fallback
+
+
+def unique_arcname(used, arcname):
+    """Return arcname, suffixed with ' (n)' before the extension if taken."""
+    if arcname not in used:
+        used.add(arcname)
+        return arcname
+    stem, ext = os.path.splitext(arcname)
+    counter = 2
+    while f'{stem} ({counter}){ext}' in used:
+        counter += 1
+    result = f'{stem} ({counter}){ext}'
+    used.add(result)
+    return result
+
+
+def iter_external_subtitles(raw_subtitles):
+    """Parse a subtitles DB column into (language, reversed_path) pairs.
+
+    Embedded tracks carry a null/empty path and are skipped: there is no file
+    on disk to hand out.
+    """
+    if not raw_subtitles:
+        return []
+    try:
+        parsed = ast.literal_eval(raw_subtitles)
+    except (ValueError, SyntaxError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [
+        (item[0], item[1])
+        for item in parsed
+        if (isinstance(item, list)
+            and len(item) >= 2
+            and isinstance(item[0], str)
+            and isinstance(item[1], str)
+            and item[1])
+    ]
+
+
+def matches_language(language_value, language_filter):
+    """True when the entry's base language matches the filter (or no filter).
+
+    The DB language label can carry modifiers ("en:hi", "en:forced",
+    "en:sync-ffsubsync"); a filter of "en" includes all of them.
+    """
+    if not language_filter:
+        return True
+    return language_value.split(':', 1)[0].lower() == language_filter.lower()
+
+
+def collect_series_bundle_entries(episode_rows, season=None, language=None):
+    """Build (arcname, disk_path) pairs for a series bundle.
+
+    episode_rows: iterables with .season, .subtitles, .arr_instance_id.
+    Entries are grouped under "Season NN/" folders in the archive.
+    """
+    entries = []
+    for row in episode_rows:
+        if season is not None and row.season != season:
+            continue
+        for language_value, reversed_path in iter_external_subtitles(row.subtitles):
+            if not matches_language(language_value, language):
+                continue
+            disk_path = path_mappings.path_replace_instance(
+                reversed_path, row.arr_instance_id, 'episode')
+            arcname = f'Season {row.season:02d}/{os.path.basename(disk_path)}'
+            entries.append((arcname, disk_path))
+    return entries
+
+
+def collect_movie_bundle_entries(movie_row, language=None):
+    """Build (arcname, disk_path) pairs for one movie's subtitle files."""
+    entries = []
+    for language_value, reversed_path in iter_external_subtitles(movie_row.subtitles):
+        if not matches_language(language_value, language):
+            continue
+        disk_path = path_mappings.path_replace_instance(
+            reversed_path, movie_row.arr_instance_id, 'movie')
+        entries.append((os.path.basename(disk_path), disk_path))
+    return entries
+
+
+def build_subtitle_bundle(entries, max_total_size=MAX_BUNDLE_UNCOMPRESSED_SIZE):
+    """Zip the given (arcname, disk_path) pairs into an in-memory buffer.
+
+    Files missing on disk are skipped (the index can be stale). Returns None
+    when nothing could be added; raises BundleTooLargeError past the cap.
+    """
+    buffer = io.BytesIO()
+    used_names = set()
+    total_size = 0
+    added = 0
+    with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as archive:
+        for arcname, disk_path in entries:
+            try:
+                if not os.path.isfile(disk_path):
+                    continue
+                total_size += os.path.getsize(disk_path)
+            except OSError:
+                continue
+            if total_size > max_total_size:
+                raise BundleTooLargeError
+            archive.write(disk_path, unique_arcname(used_names, arcname))
+            added += 1
+    if added == 0:
+        return None
+    buffer.seek(0)
+    return buffer
+
+
+def bundle_download_name(title_component, season=None, language=None):
+    parts = [title_component]
+    if season is not None:
+        parts.append(f'Season {season:02d}')
+    if language:
+        parts.append(language.lower())
+    parts.append('subtitles')
+    return ' - '.join(parts) + '.zip'
+
+
+def _request_arr_instance_id():
+    return request.args.get('arr_instance_id', type=int)
+
+
+def _validated_language_filter():
+    """Return (language_or_None, error_response_or_None)."""
+    language = request.args.get('language')
+    if language and not _LANGUAGE_FILTER_RE.match(language):
+        return None, ('Invalid language filter', 400)
+    return language, None
+
+
+def _send_single_subtitle(media_type, media_id, language_code):
+    result = resolve_subtitle_path(media_type, media_id, language_code,
+                                   arr_instance_id=_request_arr_instance_id())
+    if isinstance(result[1], int):
+        return result
+    subtitle_path = result[0]
+    return send_file(subtitle_path,
+                     as_attachment=True,
+                     download_name=os.path.basename(subtitle_path),
+                     max_age=0)
+
+
+def _send_bundle(entries, download_name):
+    try:
+        buffer = build_subtitle_bundle(entries)
+    except BundleTooLargeError:
+        return 'Subtitle bundle too large', 413
+    if buffer is None:
+        return 'No subtitle files found', 404
+    return send_file(buffer,
+                     mimetype='application/zip',
+                     as_attachment=True,
+                     download_name=download_name,
+                     max_age=0)
+
+
+@api_ns_subtitle_download.route('episodes/<int:sonarrEpisodeId>/subtitles/<language>/download')
+class EpisodeSubtitleFileDownload(Resource):
+    @authenticate
+    @api_ns_subtitle_download.doc(description='Download one episode subtitle file')
+    def get(self, sonarrEpisodeId, language):
+        return _send_single_subtitle('episode', sonarrEpisodeId, language)
+
+
+@api_ns_subtitle_download.route('movies/<int:radarrId>/subtitles/<language>/download')
+class MovieSubtitleFileDownload(Resource):
+    @authenticate
+    @api_ns_subtitle_download.doc(description='Download one movie subtitle file')
+    def get(self, radarrId, language):
+        return _send_single_subtitle('movie', radarrId, language)
+
+
+@api_ns_subtitle_download.route('series/<int:seriesId>/subtitles/download')
+class SeriesSubtitleBundleDownload(Resource):
+    @authenticate
+    @api_ns_subtitle_download.doc(
+        description='Download a zip of the series subtitle files, optionally '
+                    'filtered by season and/or base language')
+    def get(self, seriesId):
+        season = request.args.get('season', type=int)
+        language, error = _validated_language_filter()
+        if error:
+            return error
+        arr_instance_id = _request_arr_instance_id()
+
+        series_query = (
+            select(TableShows.title, TableShows.arr_instance_id)
+            .where(TableShows.sonarrSeriesId == seriesId)
+        )
+        if arr_instance_id is not None:
+            series_query = series_query.where(TableShows.arr_instance_id == arr_instance_id)
+        series_row = database.execute(series_query).first()
+        if not series_row:
+            return 'Series not found', 404
+
+        episodes_query = (
+            select(TableEpisodes.season, TableEpisodes.subtitles, TableEpisodes.arr_instance_id)
+            .where(TableEpisodes.sonarrSeriesId == seriesId)
+        )
+        # Scope episodes to the owning instance: upstream ids are only unique
+        # per Sonarr server (#156). Fall back to the matched series row's
+        # instance when the caller did not pass one.
+        effective_instance_id = (arr_instance_id if arr_instance_id is not None
+                                 else series_row.arr_instance_id)
+        if effective_instance_id is not None:
+            episodes_query = episodes_query.where(
+                TableEpisodes.arr_instance_id == effective_instance_id)
+        episode_rows = database.execute(episodes_query).all()
+
+        entries = collect_series_bundle_entries(episode_rows, season=season, language=language)
+        download_name = bundle_download_name(
+            safe_filename_component(series_row.title, 'series'),
+            season=season, language=language)
+        return _send_bundle(entries, download_name)
+
+
+@api_ns_subtitle_download.route('movies/<int:radarrId>/subtitles/download')
+class MovieSubtitleBundleDownload(Resource):
+    @authenticate
+    @api_ns_subtitle_download.doc(
+        description='Download a zip of the movie subtitle files, optionally '
+                    'filtered by base language')
+    def get(self, radarrId):
+        language, error = _validated_language_filter()
+        if error:
+            return error
+        arr_instance_id = _request_arr_instance_id()
+
+        movie_query = (
+            select(TableMovies.title, TableMovies.subtitles, TableMovies.arr_instance_id)
+            .where(TableMovies.radarrId == radarrId)
+        )
+        if arr_instance_id is not None:
+            movie_query = movie_query.where(TableMovies.arr_instance_id == arr_instance_id)
+        movie_row = database.execute(movie_query).first()
+        if not movie_row:
+            return 'Movie not found', 404
+
+        entries = collect_movie_bundle_entries(movie_row, language=language)
+        download_name = bundle_download_name(
+            safe_filename_component(movie_row.title, 'movie'), language=language)
+        return _send_bundle(entries, download_name)

--- a/bazarr/api/subtitles/download.py
+++ b/bazarr/api/subtitles/download.py
@@ -434,7 +434,10 @@ def _send_single_subtitle(media_type, media_id, language_code):
     except OSError:
         # Deleted or swapped in the window since resolve_subtitle_path.
         return 'Subtitle file or directory not found', 404
-    basename = os.path.basename(subtitle_path)
+    # Control characters in an (otherwise valid POSIX) filename would make
+    # Werkzeug reject the Content-Disposition header with a 500.
+    basename = re.sub(r'[\x00-\x1f\x7f]', '_',
+                      os.path.basename(subtitle_path))
     try:
         response = send_file(handle,
                              as_attachment=True,

--- a/bazarr/api/subtitles/download.py
+++ b/bazarr/api/subtitles/download.py
@@ -1,9 +1,9 @@
 # coding=utf-8
 
 import ast
-import io
 import os
 import re
+import tempfile
 import time
 import zipfile
 
@@ -26,9 +26,15 @@ from ..utils import authenticate
 
 api_ns_subtitle_download = Namespace('SubtitleDownload', description='Download subtitle files')
 
-# Uncompressed ceiling for a bundle, enforced while reading each file (the
-# pre-stat size is advisory only: a file can grow between stat and read).
+# Uncompressed ceiling for a bundle, enforced while streaming each file (a
+# file growing after collection cannot overshoot it).
 MAX_BUNDLE_UNCOMPRESSED_SIZE = 256 * 1024 * 1024
+
+# The archive is spooled: it stays in memory up to this size and spills to a
+# temp file beyond it, so a large bundle never holds hundreds of MB resident.
+BUNDLE_SPOOL_MEMORY_CEILING = 16 * 1024 * 1024
+
+_BUNDLE_COPY_CHUNK = 1 << 20
 
 # Base language filter for bundles: "en", "pt-BR". Variants (hi/forced/sync)
 # of the base language are included by design, so modifiers are not accepted.
@@ -36,9 +42,11 @@ MAX_BUNDLE_UNCOMPRESSED_SIZE = 256 * 1024 * 1024
 # so a trailing newline does not pass.
 _LANGUAGE_FILTER_RE = re.compile(r'^' + LANGUAGE_BASE_TAG_FRAGMENT + r'\Z')
 
-# Zip timestamps cannot predate 1980; files with older mtimes (epoch-0 after
-# restores/rsync/SMB) get clamped instead of failing the whole bundle.
+# Zip timestamps can only represent 1980..2107; files outside that range
+# (epoch-0 after restores/rsync/SMB, or corrupt future metadata) get clamped
+# instead of failing the whole bundle.
 _ZIP_EPOCH = (1980, 1, 1, 0, 0, 0)
+_ZIP_LAST_TIMESTAMP = (2107, 12, 31, 23, 59, 58)
 
 
 class BundleTooLargeError(Exception):
@@ -165,11 +173,13 @@ def resolve_bundle_path(disk_path, trusted_roots):
     guarantees resolve_subtitle_path gives the single-file endpoint: the
     realpath (symlinks resolved) must sit under a trusted directory and carry
     a recognized subtitle extension. Returns the realpath, or None."""
-    if os.path.splitext(disk_path)[1].lower() not in SUBTITLE_EXTENSIONS:
-        return None
     try:
         real = os.path.realpath(disk_path)
     except OSError:
+        return None
+    # The allowlist runs on the RESOLVED path: an indexed .srt that is really
+    # a symlink to Movie.nfo must not pass on the link's own extension.
+    if os.path.splitext(real)[1].lower() not in SUBTITLE_EXTENSIONS:
         return None
     for root in trusted_roots:
         try:
@@ -238,6 +248,8 @@ def _zip_date_time(mtime):
         return _ZIP_EPOCH
     if parts.tm_year < 1980:
         return _ZIP_EPOCH
+    if parts.tm_year > 2107:
+        return _ZIP_LAST_TIMESTAMP
     return (parts.tm_year, parts.tm_mon, parts.tm_mday,
             parts.tm_hour, parts.tm_min, parts.tm_sec)
 
@@ -251,35 +263,47 @@ def build_subtitle_bundle(entries, max_total_size=MAX_BUNDLE_UNCOMPRESSED_SIZE):
     file growing after its stat cannot overshoot it. Returns None when nothing
     could be added; raises BundleTooLargeError past the cap.
     """
-    buffer = io.BytesIO()
+    buffer = tempfile.SpooledTemporaryFile(max_size=BUNDLE_SPOOL_MEMORY_CEILING)
     used_names = set()
     seen_paths = set()
     total_size = 0
     added = 0
-    with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as archive:
-        for arcname, disk_path in entries:
-            if disk_path in seen_paths:
-                continue
-            remaining = max_total_size - total_size
-            try:
-                mtime = os.path.getmtime(disk_path)
-                with open(disk_path, 'rb') as source:
-                    data = source.read(remaining + 1)
-            except OSError:
-                continue
-            if len(data) > remaining:
-                raise BundleTooLargeError
-            seen_paths.add(disk_path)
-            total_size += len(data)
-            # writestr with an explicit ZipInfo: archive.write would raise
-            # ValueError on pre-1980 mtimes; here the timestamp is clamped.
-            info = zipfile.ZipInfo(unique_arcname(used_names, arcname),
-                                   date_time=_zip_date_time(mtime))
-            info.compress_type = zipfile.ZIP_DEFLATED
-            info.external_attr = 0o644 << 16
-            archive.writestr(info, data)
-            added += 1
+    try:
+        with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as archive:
+            for arcname, disk_path in entries:
+                if disk_path in seen_paths:
+                    continue
+                try:
+                    source = open(disk_path, 'rb')
+                except OSError:
+                    continue
+                # A successfully opened POSIX file stays readable even if it
+                # is unlinked mid-copy, so streaming after the open cannot
+                # produce a partial entry from a vanished file.
+                with source:
+                    mtime = os.fstat(source.fileno()).st_mtime
+                    seen_paths.add(disk_path)
+                    # An explicit ZipInfo: archive.write would raise on
+                    # out-of-range mtimes; here the timestamp is clamped.
+                    info = zipfile.ZipInfo(unique_arcname(used_names, arcname),
+                                           date_time=_zip_date_time(mtime))
+                    info.compress_type = zipfile.ZIP_DEFLATED
+                    info.external_attr = 0o644 << 16
+                    with archive.open(info, 'w') as target:
+                        while True:
+                            chunk = source.read(_BUNDLE_COPY_CHUNK)
+                            if not chunk:
+                                break
+                            total_size += len(chunk)
+                            if total_size > max_total_size:
+                                raise BundleTooLargeError
+                            target.write(chunk)
+                added += 1
+    except BaseException:
+        buffer.close()
+        raise
     if added == 0:
+        buffer.close()
         return None
     buffer.seek(0)
     return buffer
@@ -309,7 +333,9 @@ def _validated_season_filter():
     raw = request.args.get('season')
     if raw is None:
         return None, None
-    if not raw.isdigit():
+    # Length-bounded: isdigit alone lets a huge digit string past, and int()
+    # would then raise on Python's conversion limit instead of returning 400.
+    if not raw.isdigit() or len(raw) > 4:
         return None, ('Invalid season filter', 400)
     return int(raw), None
 
@@ -319,9 +345,35 @@ def _with_nosniff(response):
     return response
 
 
+def _ambiguous_media_error(media_type, media_id, arr_instance_id):
+    """400 tuple when the upstream id matches more than one instance's row
+    and the caller did not disambiguate; None otherwise. Mirrors the bundle
+    endpoints: resolve_subtitle_path would silently .first() one of them."""
+    if media_type == 'episode':
+        query = scoped(
+            select(TableEpisodes.id)
+            .where(TableEpisodes.sonarrEpisodeId == media_id),
+            TableEpisodes.arr_instance_id, arr_instance_id)
+        label = 'Sonarr episode'
+    else:
+        query = scoped(
+            select(TableMovies.id)
+            .where(TableMovies.radarrId == media_id),
+            TableMovies.arr_instance_id, arr_instance_id)
+        label = 'Radarr movie'
+    rows = database.execute(query).all()
+    if len(rows) > 1:
+        return f'Ambiguous {label} ID; pass arr_instance_id', 400
+    return None
+
+
 def _send_single_subtitle(media_type, media_id, language_code):
+    arr_instance_id = _request_arr_instance_id()
+    ambiguous = _ambiguous_media_error(media_type, media_id, arr_instance_id)
+    if ambiguous:
+        return ambiguous
     result = resolve_subtitle_path(media_type, media_id, language_code,
-                                   arr_instance_id=_request_arr_instance_id())
+                                   arr_instance_id=arr_instance_id)
     if isinstance(result[1], int):
         return result
     subtitle_path = result[0]

--- a/bazarr/api/subtitles/download.py
+++ b/bazarr/api/subtitles/download.py
@@ -4,27 +4,41 @@ import ast
 import io
 import os
 import re
+import time
 import zipfile
 
 from flask import request, send_file
 from flask_restx import Resource, Namespace
 
 from app.database import TableEpisodes, TableMovies, TableShows, database, select
+from arr_instances.resolution import scoped
+from utilities.helper import get_target_folder
 from utilities.path_mappings import path_mappings
 
-from .content import resolve_subtitle_path
+from .content import (
+    LANGUAGE_BASE_TAG_FRAGMENT,
+    SUBTITLE_EXTENSIONS,
+    _language_base,
+    _request_arr_instance_id,
+    resolve_subtitle_path,
+)
 from ..utils import authenticate
 
 api_ns_subtitle_download = Namespace('SubtitleDownload', description='Download subtitle files')
 
-# Uncompressed ceiling for a bundle. Text subtitles are tiny; only a library
-# full of PGS (.sup) files could approach this, and those should not be
-# bundled into memory anyway.
+# Uncompressed ceiling for a bundle, enforced while reading each file (the
+# pre-stat size is advisory only: a file can grow between stat and read).
 MAX_BUNDLE_UNCOMPRESSED_SIZE = 256 * 1024 * 1024
 
 # Base language filter for bundles: "en", "pt-BR". Variants (hi/forced/sync)
 # of the base language are included by design, so modifiers are not accepted.
-_LANGUAGE_FILTER_RE = re.compile(r'^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,4})?$')
+# The fragment is owned by content.py so the grammar cannot drift; \Z (not $)
+# so a trailing newline does not pass.
+_LANGUAGE_FILTER_RE = re.compile(r'^' + LANGUAGE_BASE_TAG_FRAGMENT + r'\Z')
+
+# Zip timestamps cannot predate 1980; files with older mtimes (epoch-0 after
+# restores/rsync/SMB) get clamped instead of failing the whole bundle.
+_ZIP_EPOCH = (1980, 1, 1, 0, 0, 0)
 
 
 class BundleTooLargeError(Exception):
@@ -32,10 +46,25 @@ class BundleTooLargeError(Exception):
 
 
 def safe_filename_component(value, fallback):
-    """Reduce a title to something usable inside a download filename."""
-    cleaned = re.sub(r'[\\/:*?"<>|\x00-\x1f]', '_', str(value or ''))
+    """Reduce a title to something usable inside a download filename.
+
+    The strip set includes ';' because the frontend parses the plain quoted
+    Content-Disposition form, where an embedded semicolon ends the parameter
+    for naive parsers.
+    """
+    cleaned = re.sub(r'[\\/:;*?"<>|\x00-\x1f]', '_', str(value or ''))
     cleaned = re.sub(r'\s+', ' ', cleaned).strip().strip('.')
     return cleaned or fallback
+
+
+def sanitize_arcname_component(name):
+    """Neutralize separators in a single archive-entry component.
+
+    os.path.basename does not split on backslash on POSIX, so a literal
+    backslash-bearing filename (or an unmapped Windows path) would otherwise
+    produce entries some extractors treat as nested paths.
+    """
+    return re.sub(r'[\\/]', '_', name)
 
 
 def unique_arcname(used, arcname):
@@ -77,6 +106,31 @@ def iter_external_subtitles(raw_subtitles):
     ]
 
 
+def _entry_mtime(disk_path):
+    try:
+        return os.path.getmtime(disk_path)
+    except OSError:
+        return -1.0
+
+
+def dedupe_language_entries(pairs, to_disk_path):
+    """Keep one path per exact language label, preferring the newest file.
+
+    Mirrors resolve_subtitle_path: a combined output can be indexed twice for
+    one language when a stale file in another format lingers next to the
+    current output; the most recently written file is the current one.
+    """
+    by_language = {}
+    for language_value, reversed_path in pairs:
+        existing = by_language.get(language_value)
+        if existing is None:
+            by_language[language_value] = reversed_path
+        elif existing != reversed_path:
+            if _entry_mtime(to_disk_path(reversed_path)) > _entry_mtime(to_disk_path(existing)):
+                by_language[language_value] = reversed_path
+    return list(by_language.items())
+
+
 def matches_language(language_value, language_filter):
     """True when the entry's base language matches the filter (or no filter).
 
@@ -85,62 +139,145 @@ def matches_language(language_value, language_filter):
     """
     if not language_filter:
         return True
-    return language_value.split(':', 1)[0].lower() == language_filter.lower()
+    return _language_base(language_value).lower() == language_filter.lower()
+
+
+def trusted_roots_for(video_disk_path):
+    """The directories a media item's subtitle files may legitimately live in:
+    the media directory and the configured subtitle target folder."""
+    roots = []
+    media_dir = os.path.dirname(video_disk_path)
+    if media_dir:
+        roots.append(os.path.realpath(media_dir))
+    try:
+        target = get_target_folder(video_disk_path)
+    except Exception:
+        target = None
+    if target and isinstance(target, str):
+        real_target = os.path.realpath(target)
+        if real_target not in roots:
+            roots.append(real_target)
+    return roots
+
+
+def resolve_bundle_path(disk_path, trusted_roots):
+    """Containment + allowlist barrier for bundle entries, mirroring the
+    guarantees resolve_subtitle_path gives the single-file endpoint: the
+    realpath (symlinks resolved) must sit under a trusted directory and carry
+    a recognized subtitle extension. Returns the realpath, or None."""
+    if os.path.splitext(disk_path)[1].lower() not in SUBTITLE_EXTENSIONS:
+        return None
+    try:
+        real = os.path.realpath(disk_path)
+    except OSError:
+        return None
+    for root in trusted_roots:
+        try:
+            if os.path.commonpath([real, root]) == root:
+                return real
+        except ValueError:
+            continue
+    return None
+
+
+def _collect_bundle_entries(rows, media_type, language=None, season=None):
+    """Build (arcname, disk_path) pairs for rows with .path, .subtitles and
+    .arr_instance_id (episode rows also carry .season)."""
+    entries = []
+    mapped = {}
+
+    def map_path(raw_path, arr_instance_id):
+        # One mapping resolution per unique path: multi-episode files share a
+        # path across rows, and the underlying lookup is uncached.
+        key = (raw_path, arr_instance_id)
+        if key not in mapped:
+            mapped[key] = path_mappings.path_replace_instance(
+                raw_path, arr_instance_id, media_type)
+        return mapped[key]
+
+    for row in rows:
+        if season is not None and getattr(row, 'season', None) != season:
+            continue
+        pairs = dedupe_language_entries(
+            iter_external_subtitles(row.subtitles),
+            lambda raw, instance=row.arr_instance_id: map_path(raw, instance))
+        if not pairs:
+            continue
+        if not row.path:
+            continue
+        roots = trusted_roots_for(map_path(row.path, row.arr_instance_id))
+        for language_value, reversed_path in pairs:
+            if not matches_language(language_value, language):
+                continue
+            real_path = resolve_bundle_path(
+                map_path(reversed_path, row.arr_instance_id), roots)
+            if real_path is None:
+                continue
+            component = sanitize_arcname_component(os.path.basename(real_path))
+            if media_type == 'episode':
+                arcname = f'Season {row.season:02d}/{component}'
+            else:
+                arcname = component
+            entries.append((arcname, real_path))
+    return entries
 
 
 def collect_series_bundle_entries(episode_rows, season=None, language=None):
-    """Build (arcname, disk_path) pairs for a series bundle.
-
-    episode_rows: iterables with .season, .subtitles, .arr_instance_id.
-    Entries are grouped under "Season NN/" folders in the archive.
-    """
-    entries = []
-    for row in episode_rows:
-        if season is not None and row.season != season:
-            continue
-        for language_value, reversed_path in iter_external_subtitles(row.subtitles):
-            if not matches_language(language_value, language):
-                continue
-            disk_path = path_mappings.path_replace_instance(
-                reversed_path, row.arr_instance_id, 'episode')
-            arcname = f'Season {row.season:02d}/{os.path.basename(disk_path)}'
-            entries.append((arcname, disk_path))
-    return entries
+    return _collect_bundle_entries(episode_rows, 'episode',
+                                   language=language, season=season)
 
 
 def collect_movie_bundle_entries(movie_row, language=None):
-    """Build (arcname, disk_path) pairs for one movie's subtitle files."""
-    entries = []
-    for language_value, reversed_path in iter_external_subtitles(movie_row.subtitles):
-        if not matches_language(language_value, language):
-            continue
-        disk_path = path_mappings.path_replace_instance(
-            reversed_path, movie_row.arr_instance_id, 'movie')
-        entries.append((os.path.basename(disk_path), disk_path))
-    return entries
+    return _collect_bundle_entries([movie_row], 'movie', language=language)
+
+
+def _zip_date_time(mtime):
+    try:
+        parts = time.localtime(mtime)
+    except (OSError, OverflowError, ValueError):
+        return _ZIP_EPOCH
+    if parts.tm_year < 1980:
+        return _ZIP_EPOCH
+    return (parts.tm_year, parts.tm_mon, parts.tm_mday,
+            parts.tm_hour, parts.tm_min, parts.tm_sec)
 
 
 def build_subtitle_bundle(entries, max_total_size=MAX_BUNDLE_UNCOMPRESSED_SIZE):
     """Zip the given (arcname, disk_path) pairs into an in-memory buffer.
 
-    Files missing on disk are skipped (the index can be stale). Returns None
-    when nothing could be added; raises BundleTooLargeError past the cap.
+    Files that vanish or error between collection and read are skipped (the
+    index can be stale); duplicate disk paths (multi-episode files share one
+    row path) are added once. The size budget is enforced while reading, so a
+    file growing after its stat cannot overshoot it. Returns None when nothing
+    could be added; raises BundleTooLargeError past the cap.
     """
     buffer = io.BytesIO()
     used_names = set()
+    seen_paths = set()
     total_size = 0
     added = 0
     with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as archive:
         for arcname, disk_path in entries:
+            if disk_path in seen_paths:
+                continue
+            remaining = max_total_size - total_size
             try:
-                if not os.path.isfile(disk_path):
-                    continue
-                total_size += os.path.getsize(disk_path)
+                mtime = os.path.getmtime(disk_path)
+                with open(disk_path, 'rb') as source:
+                    data = source.read(remaining + 1)
             except OSError:
                 continue
-            if total_size > max_total_size:
+            if len(data) > remaining:
                 raise BundleTooLargeError
-            archive.write(disk_path, unique_arcname(used_names, arcname))
+            seen_paths.add(disk_path)
+            total_size += len(data)
+            # writestr with an explicit ZipInfo: archive.write would raise
+            # ValueError on pre-1980 mtimes; here the timestamp is clamped.
+            info = zipfile.ZipInfo(unique_arcname(used_names, arcname),
+                                   date_time=_zip_date_time(mtime))
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            archive.writestr(info, data)
             added += 1
     if added == 0:
         return None
@@ -158,10 +295,6 @@ def bundle_download_name(title_component, season=None, language=None):
     return ' - '.join(parts) + '.zip'
 
 
-def _request_arr_instance_id():
-    return request.args.get('arr_instance_id', type=int)
-
-
 def _validated_language_filter():
     """Return (language_or_None, error_response_or_None)."""
     language = request.args.get('language')
@@ -170,16 +303,37 @@ def _validated_language_filter():
     return language, None
 
 
+def _validated_season_filter():
+    """Return (season_or_None, error_response_or_None). A malformed value is
+    rejected rather than silently meaning 'all seasons'."""
+    raw = request.args.get('season')
+    if raw is None:
+        return None, None
+    if not raw.isdigit():
+        return None, ('Invalid season filter', 400)
+    return int(raw), None
+
+
+def _with_nosniff(response):
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    return response
+
+
 def _send_single_subtitle(media_type, media_id, language_code):
     result = resolve_subtitle_path(media_type, media_id, language_code,
                                    arr_instance_id=_request_arr_instance_id())
     if isinstance(result[1], int):
         return result
     subtitle_path = result[0]
-    return send_file(subtitle_path,
-                     as_attachment=True,
-                     download_name=os.path.basename(subtitle_path),
-                     max_age=0)
+    try:
+        response = send_file(subtitle_path,
+                             as_attachment=True,
+                             download_name=os.path.basename(subtitle_path),
+                             max_age=0)
+    except OSError:
+        # Deleted in the window since resolve_subtitle_path's existence check.
+        return 'Subtitle file or directory not found', 404
+    return _with_nosniff(response)
 
 
 def _send_bundle(entries, download_name):
@@ -189,17 +343,21 @@ def _send_bundle(entries, download_name):
         return 'Subtitle bundle too large', 413
     if buffer is None:
         return 'No subtitle files found', 404
-    return send_file(buffer,
-                     mimetype='application/zip',
-                     as_attachment=True,
-                     download_name=download_name,
-                     max_age=0)
+    return _with_nosniff(send_file(buffer,
+                                   mimetype='application/zip',
+                                   as_attachment=True,
+                                   download_name=download_name,
+                                   max_age=0))
 
 
 @api_ns_subtitle_download.route('episodes/<int:sonarrEpisodeId>/subtitles/<language>/download')
 class EpisodeSubtitleFileDownload(Resource):
     @authenticate
     @api_ns_subtitle_download.doc(description='Download one episode subtitle file')
+    @api_ns_subtitle_download.response(200, 'The subtitle file')
+    @api_ns_subtitle_download.response(400, 'Invalid language code')
+    @api_ns_subtitle_download.response(401, 'Not authenticated')
+    @api_ns_subtitle_download.response(404, 'Media or subtitle not found')
     def get(self, sonarrEpisodeId, language):
         return _send_single_subtitle('episode', sonarrEpisodeId, language)
 
@@ -208,6 +366,10 @@ class EpisodeSubtitleFileDownload(Resource):
 class MovieSubtitleFileDownload(Resource):
     @authenticate
     @api_ns_subtitle_download.doc(description='Download one movie subtitle file')
+    @api_ns_subtitle_download.response(200, 'The subtitle file')
+    @api_ns_subtitle_download.response(400, 'Invalid language code')
+    @api_ns_subtitle_download.response(401, 'Not authenticated')
+    @api_ns_subtitle_download.response(404, 'Media or subtitle not found')
     def get(self, radarrId, language):
         return _send_single_subtitle('movie', radarrId, language)
 
@@ -218,35 +380,39 @@ class SeriesSubtitleBundleDownload(Resource):
     @api_ns_subtitle_download.doc(
         description='Download a zip of the series subtitle files, optionally '
                     'filtered by season and/or base language')
+    @api_ns_subtitle_download.response(200, 'Zip archive of subtitle files')
+    @api_ns_subtitle_download.response(400, 'Invalid filter or ambiguous series id')
+    @api_ns_subtitle_download.response(401, 'Not authenticated')
+    @api_ns_subtitle_download.response(404, 'Series not found or no subtitle files')
+    @api_ns_subtitle_download.response(413, 'Bundle exceeds the size limit')
     def get(self, seriesId):
-        season = request.args.get('season', type=int)
-        language, error = _validated_language_filter()
-        if error:
-            return error
+        season, season_error = _validated_season_filter()
+        if season_error:
+            return season_error
+        language, language_error = _validated_language_filter()
+        if language_error:
+            return language_error
         arr_instance_id = _request_arr_instance_id()
 
-        series_query = (
+        series_query = scoped(
             select(TableShows.title, TableShows.arr_instance_id)
-            .where(TableShows.sonarrSeriesId == seriesId)
-        )
-        if arr_instance_id is not None:
-            series_query = series_query.where(TableShows.arr_instance_id == arr_instance_id)
-        series_row = database.execute(series_query).first()
-        if not series_row:
+            .where(TableShows.sonarrSeriesId == seriesId),
+            TableShows.arr_instance_id, arr_instance_id)
+        series_rows = database.execute(series_query).all()
+        if not series_rows:
             return 'Series not found', 404
+        if len(series_rows) > 1:
+            # Upstream ids are only unique per instance; refuse to guess.
+            return 'Ambiguous Sonarr series ID; pass arr_instance_id', 400
+        series_row = series_rows[0]
 
-        episodes_query = (
-            select(TableEpisodes.season, TableEpisodes.subtitles, TableEpisodes.arr_instance_id)
-            .where(TableEpisodes.sonarrSeriesId == seriesId)
-        )
-        # Scope episodes to the owning instance: upstream ids are only unique
-        # per Sonarr server (#156). Fall back to the matched series row's
-        # instance when the caller did not pass one.
         effective_instance_id = (arr_instance_id if arr_instance_id is not None
                                  else series_row.arr_instance_id)
-        if effective_instance_id is not None:
-            episodes_query = episodes_query.where(
-                TableEpisodes.arr_instance_id == effective_instance_id)
+        episodes_query = scoped(
+            select(TableEpisodes.season, TableEpisodes.path,
+                   TableEpisodes.subtitles, TableEpisodes.arr_instance_id)
+            .where(TableEpisodes.sonarrSeriesId == seriesId),
+            TableEpisodes.arr_instance_id, effective_instance_id)
         episode_rows = database.execute(episodes_query).all()
 
         entries = collect_series_bundle_entries(episode_rows, season=season, language=language)
@@ -262,21 +428,29 @@ class MovieSubtitleBundleDownload(Resource):
     @api_ns_subtitle_download.doc(
         description='Download a zip of the movie subtitle files, optionally '
                     'filtered by base language')
+    @api_ns_subtitle_download.response(200, 'Zip archive of subtitle files')
+    @api_ns_subtitle_download.response(400, 'Invalid filter or ambiguous movie id')
+    @api_ns_subtitle_download.response(401, 'Not authenticated')
+    @api_ns_subtitle_download.response(404, 'Movie not found or no subtitle files')
+    @api_ns_subtitle_download.response(413, 'Bundle exceeds the size limit')
     def get(self, radarrId):
-        language, error = _validated_language_filter()
-        if error:
-            return error
+        language, language_error = _validated_language_filter()
+        if language_error:
+            return language_error
         arr_instance_id = _request_arr_instance_id()
 
-        movie_query = (
-            select(TableMovies.title, TableMovies.subtitles, TableMovies.arr_instance_id)
-            .where(TableMovies.radarrId == radarrId)
-        )
-        if arr_instance_id is not None:
-            movie_query = movie_query.where(TableMovies.arr_instance_id == arr_instance_id)
-        movie_row = database.execute(movie_query).first()
-        if not movie_row:
+        movie_query = scoped(
+            select(TableMovies.title, TableMovies.path,
+                   TableMovies.subtitles, TableMovies.arr_instance_id)
+            .where(TableMovies.radarrId == radarrId),
+            TableMovies.arr_instance_id, arr_instance_id)
+        movie_rows = database.execute(movie_query).all()
+        if not movie_rows:
             return 'Movie not found', 404
+        if len(movie_rows) > 1:
+            # Upstream ids are only unique per instance; refuse to guess.
+            return 'Ambiguous Radarr movie ID; pass arr_instance_id', 400
+        movie_row = movie_rows[0]
 
         entries = collect_movie_bundle_entries(movie_row, language=language)
         download_name = bundle_download_name(

--- a/bazarr/utilities/helper.py
+++ b/bazarr/utilities/helper.py
@@ -82,13 +82,14 @@ def get_subtitle_destination_folder():
     return fld_custom
 
 
-def get_target_folder(file_path):
+def get_target_folder(file_path, create=True):
     subfolder = settings.general.subfolder
     fld_custom = str(settings.general.subfolder_custom).strip() \
         if settings.general.subfolder_custom else None
 
     if subfolder != "current" and fld_custom:
         # specific subFolder requested, create it if it doesn't exist
+        # (create=False for read-only callers that only need the location)
         fld_base = os.path.split(file_path)[0]
 
         if subfolder == "absolute":
@@ -101,7 +102,7 @@ def get_target_folder(file_path):
 
         fld = force_unicode(fld)
 
-        if not os.path.isdir(fld):
+        if create and not os.path.isdir(fld):
             try:
                 os.makedirs(fld)
             except Exception:

--- a/frontend/src/apis/hooks/subtitles.ts
+++ b/frontend/src/apis/hooks/subtitles.ts
@@ -482,6 +482,18 @@ export function useSubtitleCreate() {
   });
 }
 
+// An unmatched route is served by the SPA catch-all as 200 text/html, so a
+// "successful" blob can actually be the app shell (seen live when a backend
+// without these endpoints sat behind a browser whose service worker kept the
+// newer UI). Never save that as a subtitle: fail loudly instead.
+function assertDownloadPayload(blob: Blob): void {
+  if (blob.type.includes("text/html")) {
+    throw new Error(
+      "The server returned a page instead of a file; is the backend up to date?",
+    );
+  }
+}
+
 // The error body of a blob request is itself a Blob; read it back to get the
 // backend's actual message (a JSON-encoded string like "No subtitle files
 // found") instead of a generic one.
@@ -491,6 +503,9 @@ async function downloadErrorMessage(
 ): Promise<string> {
   const response = (error as { response?: { status?: number; data?: unknown } })
     .response;
+  if (!response && error instanceof Error && error.message) {
+    return error.message;
+  }
   const data = response?.data;
   let text: string | undefined;
   if (data instanceof Blob) {
@@ -535,6 +550,7 @@ export function useSubtitleFileDownload() {
         param.language,
         param.arrInstanceId,
       );
+      assertDownloadPayload(response.data);
       saveBlobAs(
         response.data,
         filenameFromContentDisposition(
@@ -586,6 +602,7 @@ export function useSubtitleArchiveDownload() {
               language: param.language,
               arrInstanceId: param.arrInstanceId,
             });
+      assertDownloadPayload(response.data);
       saveBlobAs(
         response.data,
         filenameFromContentDisposition(

--- a/frontend/src/apis/hooks/subtitles.ts
+++ b/frontend/src/apis/hooks/subtitles.ts
@@ -482,6 +482,42 @@ export function useSubtitleCreate() {
   });
 }
 
+// The error body of a blob request is itself a Blob; read it back to get the
+// backend's actual message (a JSON-encoded string like "No subtitle files
+// found") instead of a generic one.
+async function downloadErrorMessage(
+  error: unknown,
+  fallback: string,
+): Promise<string> {
+  const response = (error as { response?: { status?: number; data?: unknown } })
+    .response;
+  const data = response?.data;
+  let text: string | undefined;
+  if (data instanceof Blob) {
+    try {
+      text = (await data.text()).trim();
+    } catch {
+      // Unreadable body; keep the fallback.
+    }
+  } else if (typeof data === "string") {
+    text = data;
+  }
+  if (text) {
+    try {
+      const parsed = JSON.parse(text);
+      if (typeof parsed === "string") {
+        return parsed;
+      }
+      if (parsed && typeof parsed.message === "string") {
+        return parsed.message;
+      }
+    } catch {
+      return text.slice(0, 200);
+    }
+  }
+  return fallback;
+}
+
 export function useSubtitleFileDownload() {
   interface Param {
     type: "episode" | "movie";
@@ -493,18 +529,12 @@ export function useSubtitleFileDownload() {
   return useMutation({
     mutationKey: [QueryKeys.Subtitles, "download-file"],
     mutationFn: async (param: Param) => {
-      const response =
-        param.type === "episode"
-          ? await api.episodes.downloadSubtitleFile(
-              param.mediaId,
-              param.language,
-              param.arrInstanceId,
-            )
-          : await api.movies.downloadSubtitleFile(
-              param.mediaId,
-              param.language,
-              param.arrInstanceId,
-            );
+      const response = await api.subtitles.downloadFile(
+        param.type,
+        param.mediaId,
+        param.language,
+        param.arrInstanceId,
+      );
       saveBlobAs(
         response.data,
         filenameFromContentDisposition(
@@ -513,11 +543,14 @@ export function useSubtitleFileDownload() {
         ),
       );
     },
-    onError: () => {
+    onError: async (error) => {
       showNotification(
         notification.error(
           "Download failed",
-          "The subtitle file could not be downloaded",
+          await downloadErrorMessage(
+            error,
+            "The subtitle file could not be downloaded",
+          ),
         ),
       );
     },
@@ -561,15 +594,14 @@ export function useSubtitleArchiveDownload() {
         ),
       );
     },
-    onError: (error) => {
-      const status = (error as { response?: { status?: number } }).response
-        ?.status;
+    onError: async (error) => {
       showNotification(
         notification.error(
           "Download failed",
-          status === 404
-            ? "No subtitle files found for this selection"
-            : "The subtitle archive could not be downloaded",
+          await downloadErrorMessage(
+            error,
+            "The subtitle archive could not be downloaded",
+          ),
         ),
       );
     },

--- a/frontend/src/apis/hooks/subtitles.ts
+++ b/frontend/src/apis/hooks/subtitles.ts
@@ -1,7 +1,10 @@
+import { showNotification } from "@mantine/notifications";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { QueryKeys } from "@/apis/queries/keys";
 import api from "@/apis/raw";
 import { BatchAction, BatchItem, BatchOptions } from "@/apis/raw/subtitles";
+import { notification } from "@/modules/task";
+import { filenameFromContentDisposition, saveBlobAs } from "@/utilities/files";
 
 export function useSubtitleAction() {
   const client = useQueryClient();
@@ -475,6 +478,100 @@ export function useSubtitleCreate() {
       } else {
         client.invalidateQueries({ queryKey: [QueryKeys.Movies] });
       }
+    },
+  });
+}
+
+export function useSubtitleFileDownload() {
+  interface Param {
+    type: "episode" | "movie";
+    mediaId: number;
+    // Viewer/editor language key ("en", "en:hi", "en:forced", ...).
+    language: string;
+    arrInstanceId?: number;
+  }
+  return useMutation({
+    mutationKey: [QueryKeys.Subtitles, "download-file"],
+    mutationFn: async (param: Param) => {
+      const response =
+        param.type === "episode"
+          ? await api.episodes.downloadSubtitleFile(
+              param.mediaId,
+              param.language,
+              param.arrInstanceId,
+            )
+          : await api.movies.downloadSubtitleFile(
+              param.mediaId,
+              param.language,
+              param.arrInstanceId,
+            );
+      saveBlobAs(
+        response.data,
+        filenameFromContentDisposition(
+          response.headers["content-disposition"],
+          "subtitle.srt",
+        ),
+      );
+    },
+    onError: () => {
+      showNotification(
+        notification.error(
+          "Download failed",
+          "The subtitle file could not be downloaded",
+        ),
+      );
+    },
+  });
+}
+
+export function useSubtitleArchiveDownload() {
+  type Param =
+    | {
+        kind: "series";
+        seriesId: number;
+        season?: number;
+        language?: string;
+        arrInstanceId?: number;
+      }
+    | {
+        kind: "movie";
+        radarrId: number;
+        language?: string;
+        arrInstanceId?: number;
+      };
+  return useMutation({
+    mutationKey: [QueryKeys.Subtitles, "download-archive"],
+    mutationFn: async (param: Param) => {
+      const response =
+        param.kind === "series"
+          ? await api.series.downloadSubtitlesArchive(param.seriesId, {
+              season: param.season,
+              language: param.language,
+              arrInstanceId: param.arrInstanceId,
+            })
+          : await api.movies.downloadSubtitlesArchive(param.radarrId, {
+              language: param.language,
+              arrInstanceId: param.arrInstanceId,
+            });
+      saveBlobAs(
+        response.data,
+        filenameFromContentDisposition(
+          response.headers["content-disposition"],
+          "subtitles.zip",
+        ),
+      );
+    },
+    onError: (error) => {
+      const status = (error as { response?: { status?: number } }).response
+        ?.status;
+      showNotification(
+        notification.error(
+          "Download failed",
+          status === 404
+            ? "No subtitle files found for this selection"
+            : "The subtitle archive could not be downloaded",
+        ),
+      );
     },
   });
 }

--- a/frontend/src/apis/raw/base.ts
+++ b/frontend/src/apis/raw/base.ts
@@ -38,6 +38,18 @@ class BaseApi {
     return response.data;
   }
 
+  // Full response (not just data): callers need headers like
+  // Content-Disposition to name the file they save.
+  protected getBlob(
+    path: string,
+    params?: LooseObject,
+  ): Promise<AxiosResponse<Blob>> {
+    return client.axios.get<Blob>(this.prefix + path, {
+      params,
+      responseType: "blob",
+    });
+  }
+
   protected post<T = void>(
     path: string,
     formdata?: LooseObject,

--- a/frontend/src/apis/raw/client.ts
+++ b/frontend/src/apis/raw/client.ts
@@ -65,10 +65,15 @@ class BazarrClient {
         }
       },
       (error: AxiosError) => {
-        const message = GetErrorMessage(
-          error.response?.data,
-          "You have disconnected from the server",
-        );
+        // A blob response (file downloads) carries its error body as a Blob,
+        // which cannot be read synchronously: give it a status-based message
+        // (never the disconnect sentinel, which would suppress the 401
+        // handling below) and let the caller surface the real reason.
+        const data = error.response?.data;
+        const isBlobBody = typeof Blob !== "undefined" && data instanceof Blob;
+        const message = isBlobBody
+          ? `Error ${error.response?.status ?? 500}`
+          : GetErrorMessage(data, "You have disconnected from the server");
 
         const backendError: BackendError = {
           code: error.response?.status ?? 500,
@@ -76,14 +81,14 @@ class BazarrClient {
         };
 
         error.message = backendError.message;
-        this.handleError(backendError);
+        this.handleError(backendError, isBlobBody);
 
         return Promise.reject(error);
       },
     );
   }
 
-  handleError(error: BackendError) {
+  handleError(error: BackendError, silent = false) {
     const { code, message } = error;
 
     // Backend not ready yet: suppress everything, don't trigger auth changes
@@ -111,6 +116,11 @@ class BazarrClient {
     }
 
     LOG("error", "A error has occurred", code);
+    if (silent) {
+      // The caller owns the user-facing message (e.g. blob downloads read
+      // the error body asynchronously); avoid a duplicate generic toast.
+      return;
+    }
     showNotification(notification.error(`Error ${code}`, message));
   }
 }

--- a/frontend/src/apis/raw/episodes.ts
+++ b/frontend/src/apis/raw/episodes.ts
@@ -68,18 +68,6 @@ class EpisodeApi extends BaseApi {
     });
   }
 
-  async downloadSubtitleFile(
-    episodeid: number,
-    language: string,
-    arrInstanceId?: number,
-  ) {
-    // language is the viewer/editor language key ("en", "en:hi", ...).
-    return this.getBlob(
-      `/${episodeid}/subtitles/${encodeURIComponent(language)}/download`,
-      { arr_instance_id: arrInstanceId },
-    );
-  }
-
   async uploadSubtitles(
     seriesid: number,
     episodeid: number,

--- a/frontend/src/apis/raw/episodes.ts
+++ b/frontend/src/apis/raw/episodes.ts
@@ -68,6 +68,18 @@ class EpisodeApi extends BaseApi {
     });
   }
 
+  async downloadSubtitleFile(
+    episodeid: number,
+    language: string,
+    arrInstanceId?: number,
+  ) {
+    // language is the viewer/editor language key ("en", "en:hi", ...).
+    return this.getBlob(
+      `/${episodeid}/subtitles/${encodeURIComponent(language)}/download`,
+      { arr_instance_id: arrInstanceId },
+    );
+  }
+
   async uploadSubtitles(
     seriesid: number,
     episodeid: number,

--- a/frontend/src/apis/raw/movies.ts
+++ b/frontend/src/apis/raw/movies.ts
@@ -90,18 +90,6 @@ class MovieApi extends BaseApi {
     });
   }
 
-  async downloadSubtitleFile(
-    radarrid: number,
-    language: string,
-    arrInstanceId?: number,
-  ) {
-    // language is the viewer/editor language key ("en", "en:hi", ...).
-    return this.getBlob(
-      `/${radarrid}/subtitles/${encodeURIComponent(language)}/download`,
-      { arr_instance_id: arrInstanceId },
-    );
-  }
-
   async downloadSubtitlesArchive(
     radarrid: number,
     options: { language?: string; arrInstanceId?: number } = {},

--- a/frontend/src/apis/raw/movies.ts
+++ b/frontend/src/apis/raw/movies.ts
@@ -90,6 +90,29 @@ class MovieApi extends BaseApi {
     });
   }
 
+  async downloadSubtitleFile(
+    radarrid: number,
+    language: string,
+    arrInstanceId?: number,
+  ) {
+    // language is the viewer/editor language key ("en", "en:hi", ...).
+    return this.getBlob(
+      `/${radarrid}/subtitles/${encodeURIComponent(language)}/download`,
+      { arr_instance_id: arrInstanceId },
+    );
+  }
+
+  async downloadSubtitlesArchive(
+    radarrid: number,
+    options: { language?: string; arrInstanceId?: number } = {},
+  ) {
+    // Zip of the movie's external subtitle files, optionally one base language.
+    return this.getBlob(`/${radarrid}/subtitles/download`, {
+      language: options.language,
+      arr_instance_id: options.arrInstanceId,
+    });
+  }
+
   async uploadSubtitles(
     radarrid: number,
     form: FormType.UploadSubtitle,

--- a/frontend/src/apis/raw/series.ts
+++ b/frontend/src/apis/raw/series.ts
@@ -29,6 +29,23 @@ class SeriesApi extends BaseApi {
   async action(form: FormType.SeriesAction) {
     await this.patch("", form);
   }
+
+  async downloadSubtitlesArchive(
+    seriesid: number,
+    options: {
+      season?: number;
+      language?: string;
+      arrInstanceId?: number;
+    } = {},
+  ) {
+    // Zip of the series' external subtitle files, optionally narrowed to one
+    // season and/or one base language.
+    return this.getBlob(`/${seriesid}/subtitles/download`, {
+      season: options.season,
+      language: options.language,
+      arr_instance_id: options.arrInstanceId,
+    });
+  }
 }
 
 const seriesApi = new SeriesApi();

--- a/frontend/src/apis/raw/subtitles.ts
+++ b/frontend/src/apis/raw/subtitles.ts
@@ -180,6 +180,20 @@ class SubtitlesApi extends BaseApi {
     return response;
   }
 
+  async downloadFile(
+    mediaType: "episode" | "movie",
+    mediaId: number,
+    language: string,
+    arrInstanceId?: number,
+  ) {
+    // language is the viewer/editor language key ("en", "en:hi", ...).
+    const base = mediaType === "episode" ? "episodes" : "movies";
+    return client.axios.get<Blob>(
+      `/${base}/${mediaId}/subtitles/${encodeURIComponent(language)}/download`,
+      { params: { arr_instance_id: arrInstanceId }, responseType: "blob" },
+    );
+  }
+
   async getContent(
     mediaType: string,
     mediaId: number,

--- a/frontend/src/components/SubtitleToolsMenu.tsx
+++ b/frontend/src/components/SubtitleToolsMenu.tsx
@@ -5,6 +5,7 @@ import {
   faClock,
   faClosedCaptioning,
   faCode,
+  faDownload,
   faExchangeAlt,
   faEye,
   faFaceGrinStars,
@@ -153,7 +154,14 @@ interface Props {
   menu?: Omit<MenuProps, "children">;
   canSync?: boolean;
   onAction?: (
-    action: "delete" | "search" | "view" | "edit" | "compare-sync" | "rebuild",
+    action:
+      | "delete"
+      | "search"
+      | "view"
+      | "edit"
+      | "compare-sync"
+      | "rebuild"
+      | "download",
   ) => void;
   canCompareSyncOutputs?: boolean;
   // When true: hide the editing tool groups (sync, cleanup, style) and show
@@ -375,6 +383,20 @@ const SubtitleToolsMenu: FunctionComponent<Props> = ({
           {isCombinedOutput || selections.length > 0
             ? "Edit"
             : "Create / Upload"}
+        </Menu.Item>
+        {/* Embedded tracks have no file on disk to hand out */}
+        <Menu.Item
+          disabled={
+            selections.length === 0 ||
+            onAction === undefined ||
+            isTranslateOnlyMode
+          }
+          leftSection={<FontAwesomeIcon icon={faDownload}></FontAwesomeIcon>}
+          onClick={() => {
+            onAction?.("download");
+          }}
+        >
+          Download
         </Menu.Item>
         {!isCombinedOutput && (
           <Menu.Item

--- a/frontend/src/components/forms/SubtitleDownloadForm.tsx
+++ b/frontend/src/components/forms/SubtitleDownloadForm.tsx
@@ -1,0 +1,108 @@
+import { FunctionComponent, useState } from "react";
+import { Alert, Button, Divider, Select, Stack } from "@mantine/core";
+import { useSubtitleArchiveDownload } from "@/apis/hooks";
+import { useModals, withModal } from "@/modules/modals";
+
+type Scope =
+  | {
+      kind: "series";
+      seriesId: number;
+      arrInstanceId?: number;
+      seasons: number[];
+    }
+  | { kind: "movie"; radarrId: number; arrInstanceId?: number };
+
+interface Props {
+  scope: Scope;
+  availableLanguages: string[];
+}
+
+const ALL = "all";
+
+const SubtitleDownloadForm: FunctionComponent<Props> = ({
+  scope,
+  availableLanguages,
+}) => {
+  const [season, setSeason] = useState<string>(ALL);
+  const [language, setLanguage] = useState<string>(ALL);
+  const { mutateAsync, isPending } = useSubtitleArchiveDownload();
+  const modals = useModals();
+
+  const submit = async () => {
+    const languageFilter = language === ALL ? undefined : language;
+    try {
+      if (scope.kind === "series") {
+        await mutateAsync({
+          kind: "series",
+          seriesId: scope.seriesId,
+          season: season === ALL ? undefined : Number(season),
+          language: languageFilter,
+          arrInstanceId: scope.arrInstanceId,
+        });
+      } else {
+        await mutateAsync({
+          kind: "movie",
+          radarrId: scope.radarrId,
+          language: languageFilter,
+          arrInstanceId: scope.arrInstanceId,
+        });
+      }
+      modals.closeSelf();
+    } catch {
+      // The hook already surfaced a notification; keep the modal open so the
+      // user can adjust the selection.
+    }
+  };
+
+  return (
+    <Stack>
+      <Alert>
+        Downloads a zip of the subtitle files already on disk
+        {scope.kind === "series" ? " for this series" : " for this movie"}.
+        Embedded tracks are not included.
+      </Alert>
+      {scope.kind === "series" && (
+        <Select
+          label="Season"
+          allowDeselect={false}
+          value={season}
+          onChange={(next) => setSeason(next ?? ALL)}
+          data={[
+            { value: ALL, label: "All seasons" },
+            ...scope.seasons.map((s) => ({
+              value: String(s),
+              label: `Season ${String(s).padStart(2, "0")}`,
+            })),
+          ]}
+        />
+      )}
+      <Select
+        label="Language"
+        allowDeselect={false}
+        value={language}
+        onChange={(next) => setLanguage(next ?? ALL)}
+        data={[
+          { value: ALL, label: "All languages" },
+          ...availableLanguages.map((code) => ({
+            value: code,
+            label: code.toUpperCase(),
+          })),
+        ]}
+      />
+      <Divider />
+      <Button loading={isPending} onClick={submit}>
+        Download
+      </Button>
+    </Stack>
+  );
+};
+
+export const SubtitleDownloadModal = withModal(
+  SubtitleDownloadForm,
+  "download-subtitles",
+  {
+    title: "Download subtitles",
+  },
+);
+
+export default SubtitleDownloadForm;

--- a/frontend/src/components/forms/SubtitleDownloadForm.tsx
+++ b/frontend/src/components/forms/SubtitleDownloadForm.tsx
@@ -9,6 +9,9 @@ type Scope =
       seriesId: number;
       arrInstanceId?: number;
       seasons: number[];
+      // Languages that actually exist per season, so a season/language
+      // combination that would bundle nothing is never offered.
+      languagesBySeason: Record<number, string[]>;
     }
   | { kind: "movie"; radarrId: number; arrInstanceId?: number };
 
@@ -27,6 +30,11 @@ const SubtitleDownloadForm: FunctionComponent<Props> = ({
   const [language, setLanguage] = useState<string>(ALL);
   const { mutateAsync, isPending } = useSubtitleArchiveDownload();
   const modals = useModals();
+
+  const languageOptions =
+    scope.kind === "series" && season !== ALL
+      ? (scope.languagesBySeason[Number(season)] ?? [])
+      : availableLanguages;
 
   const submit = async () => {
     const languageFilter = language === ALL ? undefined : language;
@@ -66,7 +74,19 @@ const SubtitleDownloadForm: FunctionComponent<Props> = ({
           label="Season"
           allowDeselect={false}
           value={season}
-          onChange={(next) => setSeason(next ?? ALL)}
+          onChange={(next) => {
+            const value = next ?? ALL;
+            setSeason(value);
+            // A language picked for the whole series may not exist in the
+            // newly selected season; fall back to All rather than 404.
+            if (
+              value !== ALL &&
+              language !== ALL &&
+              !(scope.languagesBySeason[Number(value)] ?? []).includes(language)
+            ) {
+              setLanguage(ALL);
+            }
+          }}
           data={[
             { value: ALL, label: "All seasons" },
             ...scope.seasons.map((s) => ({
@@ -83,7 +103,7 @@ const SubtitleDownloadForm: FunctionComponent<Props> = ({
         onChange={(next) => setLanguage(next ?? ALL)}
         data={[
           { value: ALL, label: "All languages" },
-          ...availableLanguages.map((code) => ({
+          ...languageOptions.map((code) => ({
             value: code,
             label: code.toUpperCase(),
           })),

--- a/frontend/src/components/modals/SubtitleToolsModal.tsx
+++ b/frontend/src/components/modals/SubtitleToolsModal.tsx
@@ -189,7 +189,29 @@ const SubtitleToolView: FunctionComponent<SubtitleToolViewProps> = ({
       <Group>
         <SubtitleToolsMenu
           selections={selections}
-          onAction={(action) => {
+          onAction={async (action) => {
+            if (action === "download") {
+              // Sequential on purpose: parallel programmatic anchor clicks
+              // are dropped by browsers that restrict multiple automatic
+              // downloads; one at a time surfaces the browser's own
+              // multi-download permission prompt instead.
+              for (const selection of selections) {
+                try {
+                  await fileDownload.mutateAsync({
+                    type: selection.type,
+                    mediaId: selection.id,
+                    language: buildSubtitleLanguageKey(
+                      selection.raw_language as Subtitle,
+                    ),
+                    arrInstanceId: selection.arr_instance_id,
+                  });
+                } catch {
+                  // The hook already notified; continue with the rest.
+                }
+              }
+              modals.closeAll();
+              return;
+            }
             selections.forEach(async (selection) => {
               const actionPayload = {
                 form: {
@@ -218,17 +240,6 @@ const SubtitleToolView: FunctionComponent<SubtitleToolViewProps> = ({
                 await download.mutateAsync(actionPayload);
               } else if (action === "delete" && selection.path) {
                 await remove.mutateAsync(actionPayload);
-              } else if (action === "download") {
-                // raw_language holds the full subtitle entry, so the key
-                // carries hi/forced and sync/combined variants correctly.
-                fileDownload.mutate({
-                  type: selection.type,
-                  mediaId: selection.id,
-                  language: buildSubtitleLanguageKey(
-                    selection.raw_language as Subtitle,
-                  ),
-                  arrInstanceId: selection.arr_instance_id,
-                });
               }
             });
             modals.closeAll();

--- a/frontend/src/components/modals/SubtitleToolsModal.tsx
+++ b/frontend/src/components/modals/SubtitleToolsModal.tsx
@@ -12,12 +12,14 @@ import { ColumnDef } from "@tanstack/react-table";
 import {
   useEpisodeSubtitleModification,
   useMovieSubtitleModification,
+  useSubtitleFileDownload,
 } from "@/apis/hooks";
 import Language from "@/components/bazarr/Language";
 import SubtitleToolsMenu from "@/components/SubtitleToolsMenu";
 import SimpleTable from "@/components/tables/SimpleTable";
 import { useModals, withModal } from "@/modules/modals";
 import { fromPython, isMovie, toPython } from "@/utilities";
+import { buildSubtitleLanguageKey } from "@/utilities/subtitles";
 
 type SupportType = Item.Episode | Item.Movie;
 
@@ -73,6 +75,7 @@ const SubtitleToolView: FunctionComponent<SubtitleToolViewProps> = ({
     useEpisodeSubtitleModification();
   const { download: downloadMovie, remove: removeMovie } =
     useMovieSubtitleModification();
+  const fileDownload = useSubtitleFileDownload();
   const modals = useModals();
 
   const columns = useMemo<ColumnDef<TableColumnType>[]>(
@@ -215,6 +218,17 @@ const SubtitleToolView: FunctionComponent<SubtitleToolViewProps> = ({
                 await download.mutateAsync(actionPayload);
               } else if (action === "delete" && selection.path) {
                 await remove.mutateAsync(actionPayload);
+              } else if (action === "download") {
+                // raw_language holds the full subtitle entry, so the key
+                // carries hi/forced and sync/combined variants correctly.
+                fileDownload.mutate({
+                  type: selection.type,
+                  mediaId: selection.id,
+                  language: buildSubtitleLanguageKey(
+                    selection.raw_language as Subtitle,
+                  ),
+                  arrInstanceId: selection.arr_instance_id,
+                });
               }
             });
             modals.closeAll();

--- a/frontend/src/pages/Episodes/components.tsx
+++ b/frontend/src/pages/Episodes/components.tsx
@@ -1,7 +1,10 @@
 import { FunctionComponent, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { Badge, Group, MantineColor, UnstyledButton } from "@mantine/core";
-import { useEpisodeSubtitleModification } from "@/apis/hooks";
+import {
+  useEpisodeSubtitleModification,
+  useSubtitleFileDownload,
+} from "@/apis/hooks";
 import { useCombineSubtitles } from "@/apis/hooks/combine";
 import { CombinedSubtitleBadge } from "@/components/bazarr";
 import Language from "@/components/bazarr/Language";
@@ -82,6 +85,7 @@ export const Subtitle: FunctionComponent<Props> = ({
   const navigate = useNavigate();
   const { remove, download } = useEpisodeSubtitleModification();
   const combine = useCombineSubtitles();
+  const fileDownload = useSubtitleFileDownload();
 
   const [opened, setOpen] = useState(false);
   const [compareOpened, setCompareOpened] = useState(false);
@@ -193,6 +197,13 @@ export const Subtitle: FunctionComponent<Props> = ({
                   arrInstanceId,
                 ),
               );
+            } else if (action === "download") {
+              fileDownload.mutate({
+                type: "episode",
+                mediaId: episodeId,
+                language: buildSubtitleLanguageKey(subtitle),
+                arrInstanceId,
+              });
             } else if (action === "delete" && subtitlePath) {
               await remove.mutateAsync({
                 seriesId,
@@ -271,6 +282,13 @@ export const Subtitle: FunctionComponent<Props> = ({
             });
           } else if (action === "compare-sync") {
             setCompareOpened(true);
+          } else if (action === "download") {
+            fileDownload.mutate({
+              type: "episode",
+              mediaId: episodeId,
+              language: buildSubtitleLanguageKey(subtitle),
+              arrInstanceId,
+            });
           } else if (action === "delete" && subtitle.path) {
             await remove.mutateAsync({
               seriesId,

--- a/frontend/src/pages/Episodes/index.tsx
+++ b/frontend/src/pages/Episodes/index.tsx
@@ -155,6 +155,25 @@ const SeriesEpisodesView: FunctionComponent = () => {
     return Array.from(seen).sort();
   }, [episodes]);
 
+  const languagesBySeason = useMemo(() => {
+    const bySeason: Record<number, string[]> = {};
+    const seen = new Map<number, Set<string>>();
+    for (const episode of episodes ?? []) {
+      for (const s of episode.subtitles) {
+        if (s.path) {
+          if (!seen.has(episode.season)) {
+            seen.set(episode.season, new Set());
+          }
+          seen.get(episode.season)!.add(s.code2);
+        }
+      }
+    }
+    for (const [season, codes] of seen) {
+      bySeason[season] = Array.from(codes).sort();
+    }
+    return bySeason;
+  }, [episodes]);
+
   // Only seasons that actually have a file on disk: offering an empty season
   // would just produce a guaranteed 404 bundle.
   const seasons = useMemo(
@@ -324,6 +343,7 @@ const SeriesEpisodesView: FunctionComponent = () => {
                       seriesId: series.sonarrSeriesId,
                       arrInstanceId: series.arr_instance_id ?? undefined,
                       seasons,
+                      languagesBySeason,
                     },
                     availableLanguages: downloadableLangs,
                   });

--- a/frontend/src/pages/Episodes/index.tsx
+++ b/frontend/src/pages/Episodes/index.tsx
@@ -155,11 +155,17 @@ const SeriesEpisodesView: FunctionComponent = () => {
     return Array.from(seen).sort();
   }, [episodes]);
 
+  // Only seasons that actually have a file on disk: offering an empty season
+  // would just produce a guaranteed 404 bundle.
   const seasons = useMemo(
     () =>
-      Array.from(new Set((episodes ?? []).map((e) => e.season))).sort(
-        (a, b) => a - b,
-      ),
+      Array.from(
+        new Set(
+          (episodes ?? [])
+            .filter((e) => e.subtitles.some((s) => s.path))
+            .map((e) => e.season),
+        ),
+      ).sort((a, b) => a - b),
     [episodes],
   );
 

--- a/frontend/src/pages/Episodes/index.tsx
+++ b/frontend/src/pages/Episodes/index.tsx
@@ -24,6 +24,7 @@ import {
   faCircleChevronDown,
   faCircleChevronRight,
   faCloudUploadAlt,
+  faDownload,
   faEllipsisVertical,
   faHardDrive,
   faHdd,
@@ -52,6 +53,7 @@ import { QueryOverlay } from "@/components/async";
 import { CombineModal } from "@/components/forms/CombineForm";
 import { ItemEditModal } from "@/components/forms/ItemEditForm";
 import { SeriesUploadModal } from "@/components/forms/SeriesUploadForm";
+import { SubtitleDownloadModal } from "@/components/forms/SubtitleDownloadForm";
 import { SubtitleToolsModal } from "@/components/modals";
 import { useModals } from "@/modules/modals";
 import { notification, task, TaskGroup } from "@/modules/task";
@@ -138,6 +140,28 @@ const SeriesEpisodesView: FunctionComponent = () => {
     }
     return Array.from(seen);
   }, [episodes]);
+
+  // Every base language with a file on disk, sync/combined outputs included:
+  // the bundle download ships whatever exists, not just original subtitles.
+  const downloadableLangs = useMemo(() => {
+    const seen = new Set<string>();
+    for (const episode of episodes ?? []) {
+      for (const s of episode.subtitles) {
+        if (s.path) {
+          seen.add(s.code2);
+        }
+      }
+    }
+    return Array.from(seen).sort();
+  }, [episodes]);
+
+  const seasons = useMemo(
+    () =>
+      Array.from(new Set((episodes ?? []).map((e) => e.season))).sort(
+        (a, b) => a - b,
+      ),
+    [episodes],
+  );
 
   const onDrop = useCallback(
     (files: File[]) => {
@@ -278,6 +302,29 @@ const SeriesEpisodesView: FunctionComponent = () => {
               onClick={() => openDropzone.current?.()}
             >
               Upload
+            </Toolbox.Button>
+            <Toolbox.Button
+              disabled={
+                series === undefined ||
+                !available ||
+                downloadableLangs.length === 0
+              }
+              icon={faDownload}
+              onClick={() => {
+                if (series) {
+                  modals.openContextModal(SubtitleDownloadModal, {
+                    scope: {
+                      kind: "series",
+                      seriesId: series.sonarrSeriesId,
+                      arrInstanceId: series.arr_instance_id ?? undefined,
+                      seasons,
+                    },
+                    availableLanguages: downloadableLangs,
+                  });
+                }
+              }}
+            >
+              Download
             </Toolbox.Button>
           </Group>
           <Group gap="xs">

--- a/frontend/src/pages/Movies/Details/index.tsx
+++ b/frontend/src/pages/Movies/Details/index.tsx
@@ -13,6 +13,7 @@ import { useDocumentTitle } from "@mantine/hooks";
 import { showNotification } from "@mantine/notifications";
 import {
   faCloudUploadAlt,
+  faDownload,
   faEllipsis,
   faHardDrive,
   faHistory,
@@ -44,6 +45,7 @@ import { QueryOverlay } from "@/components/async";
 import { CombineModal } from "@/components/forms/CombineForm";
 import { ItemEditModal } from "@/components/forms/ItemEditForm";
 import { MovieUploadModal } from "@/components/forms/MovieUploadForm";
+import { SubtitleDownloadModal } from "@/components/forms/SubtitleDownloadForm";
 import { MovieHistoryModal, SubtitleToolsModal } from "@/components/modals";
 import { MovieSearchModal } from "@/components/modals/ManualSearchModal";
 import { useModals } from "@/modules/modals";
@@ -159,6 +161,12 @@ const MovieDetailView: FunctionComponent = () => {
     ),
   );
 
+  // Every base language with a file on disk, sync/combined outputs included:
+  // the bundle download ships whatever exists, not just original subtitles.
+  const downloadableLangs = Array.from(
+    new Set((movie?.subtitles ?? []).filter((s) => s.path).map((s) => s.code2)),
+  ).sort();
+
   return (
     <Container fluid px={0}>
       <nav aria-label="Breadcrumb">
@@ -266,6 +274,24 @@ const MovieDetailView: FunctionComponent = () => {
               onClick={() => openDropzone.current?.()}
             >
               Upload
+            </Toolbox.Button>
+            <Toolbox.Button
+              disabled={downloadableLangs.length === 0}
+              icon={faDownload}
+              onClick={() => {
+                if (movie) {
+                  modals.openContextModal(SubtitleDownloadModal, {
+                    scope: {
+                      kind: "movie",
+                      radarrId: movie.radarrId,
+                      arrInstanceId: movie.arr_instance_id ?? undefined,
+                    },
+                    availableLanguages: downloadableLangs,
+                  });
+                }
+              }}
+            >
+              Download
             </Toolbox.Button>
             <Toolbox.Button
               icon={faWrench}

--- a/frontend/src/pages/Movies/Details/table.tsx
+++ b/frontend/src/pages/Movies/Details/table.tsx
@@ -11,6 +11,7 @@ import { ColumnDef } from "@tanstack/react-table";
 import { isString } from "lodash";
 import {
   useMovieSubtitleModification,
+  useSubtitleFileDownload,
   useSubtitleSyncStatus,
 } from "@/apis/hooks";
 import { useCombineSubtitles } from "@/apis/hooks/combine";
@@ -298,6 +299,7 @@ const Table: FunctionComponent<Props> = ({
 
   const { download, remove } = useMovieSubtitleModification();
   const combine = useCombineSubtitles();
+  const fileDownload = useSubtitleFileDownload();
 
   // Available subtitles for translate-from source, include embedded tracks
   // (backend handles bitmap exclusion at extraction time)
@@ -405,6 +407,13 @@ const Table: FunctionComponent<Props> = ({
                   movie.arr_instance_id,
                 ),
               );
+            } else if (action === "download") {
+              fileDownload.mutate({
+                type: "movie",
+                mediaId: radarrId,
+                language: buildSubtitleLanguageKey(item),
+                arrInstanceId: movie.arr_instance_id,
+              });
             } else if (action === "delete" && path) {
               await remove.mutateAsync({
                 radarrId,
@@ -499,6 +508,13 @@ const Table: FunctionComponent<Props> = ({
             );
           } else if (action === "compare-sync") {
             setCompareSelection({ original: item, outputs: syncOutputs });
+          } else if (action === "download") {
+            fileDownload.mutate({
+              type: "movie",
+              mediaId: radarrId,
+              language: buildSubtitleLanguageKey(item),
+              arrInstanceId: movie.arr_instance_id,
+            });
           } else if (action === "delete" && path) {
             await remove.mutateAsync({
               radarrId,

--- a/frontend/src/pages/SubtitleEditor/CueTable.tsx
+++ b/frontend/src/pages/SubtitleEditor/CueTable.tsx
@@ -245,7 +245,9 @@ const monoStyle: React.CSSProperties = {
   ...cellStyle,
   fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
   fontSize: "0.8rem",
-  color: "var(--mantine-color-yellow-4)",
+  // Brand anchor color, same as the breadcrumb links: resolves to a readable
+  // shade in both color schemes (yellow-4 was near-invisible in light mode).
+  color: "var(--mantine-color-anchor)",
   letterSpacing: "-0.2px",
 };
 

--- a/frontend/src/pages/SubtitleEditor/EditorPage.tsx
+++ b/frontend/src/pages/SubtitleEditor/EditorPage.tsx
@@ -40,6 +40,7 @@ import { QueryKeys } from "@/apis/queries/keys";
 import api from "@/apis/raw";
 import client from "@/apis/raw/client";
 import { Environment } from "@/utilities/env";
+import { saveBlobAs } from "@/utilities/files";
 import { isCombinedOutputLanguageKey } from "@/utilities/subtitles";
 import { cueId } from "./parsers/uuid";
 import DetailPane, { type DetailPaneHandle } from "./DetailPane";
@@ -865,17 +866,10 @@ export default function EditorPage() {
   const handleDownload = useCallback(() => {
     const serialized = getSerializer(format).serialize(buildParseResult());
     const blob = new Blob([serialized], { type: "text/plain;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
     const title =
       data?.mediaTitle?.replace(/[/\\?%*:|"<>]/g, "_") ?? "subtitle";
     const langPart = data?.language ?? language ?? "unknown";
-    a.download = `${title}.${langPart}.${format}`;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+    saveBlobAs(blob, `${title}.${langPart}.${format}`);
   }, [format, language, data?.mediaTitle, data?.language, buildParseResult]);
 
   // Toolbar action handler

--- a/frontend/src/utilities/files.test.ts
+++ b/frontend/src/utilities/files.test.ts
@@ -37,6 +37,21 @@ describe("filenameFromContentDisposition", () => {
     ).toBe("Rock; Roll - subtitles.zip");
   });
 
+  it("unescapes quoted-pairs inside a quoted filename", () => {
+    expect(
+      filenameFromContentDisposition(
+        'attachment; filename="a\\"b.srt"',
+        "fallback",
+      ),
+    ).toBe('a"b.srt');
+    expect(
+      filenameFromContentDisposition(
+        'attachment; filename="back\\\\slash.srt"',
+        "fallback",
+      ),
+    ).toBe("back\\slash.srt");
+  });
+
   it("falls back when the header is missing or unparsable", () => {
     expect(filenameFromContentDisposition(undefined, "fallback")).toBe(
       "fallback",

--- a/frontend/src/utilities/files.test.ts
+++ b/frontend/src/utilities/files.test.ts
@@ -1,0 +1,49 @@
+import { filenameFromContentDisposition } from "./files";
+
+describe("filenameFromContentDisposition", () => {
+  it("parses the plain quoted form", () => {
+    expect(
+      filenameFromContentDisposition(
+        'attachment; filename="Movie.en.srt"',
+        "fallback",
+      ),
+    ).toBe("Movie.en.srt");
+  });
+
+  it("parses the unquoted form", () => {
+    expect(
+      filenameFromContentDisposition(
+        "attachment; filename=Movie.en.srt",
+        "fallback",
+      ),
+    ).toBe("Movie.en.srt");
+  });
+
+  it("prefers the RFC 5987 extended form and decodes it", () => {
+    expect(
+      filenameFromContentDisposition(
+        "attachment; filename*=UTF-8''K%C3%A9m%20-%20subtitles.zip",
+        "fallback",
+      ),
+    ).toBe("Kém - subtitles.zip");
+  });
+
+  it("falls back when the header is missing or unparsable", () => {
+    expect(filenameFromContentDisposition(undefined, "fallback")).toBe(
+      "fallback",
+    );
+    expect(filenameFromContentDisposition(null, "fallback")).toBe("fallback");
+    expect(filenameFromContentDisposition("attachment", "fallback")).toBe(
+      "fallback",
+    );
+  });
+
+  it("survives malformed percent-encoding in the extended form", () => {
+    expect(
+      filenameFromContentDisposition(
+        "attachment; filename*=UTF-8''bad%zz; filename=\"plain.srt\"",
+        "fallback",
+      ),
+    ).toBe("plain.srt");
+  });
+});

--- a/frontend/src/utilities/files.test.ts
+++ b/frontend/src/utilities/files.test.ts
@@ -28,6 +28,15 @@ describe("filenameFromContentDisposition", () => {
     ).toBe("Kém - subtitles.zip");
   });
 
+  it("keeps a semicolon inside a quoted filename", () => {
+    expect(
+      filenameFromContentDisposition(
+        'attachment; filename="Rock; Roll - subtitles.zip"',
+        "fallback",
+      ),
+    ).toBe("Rock; Roll - subtitles.zip");
+  });
+
   it("falls back when the header is missing or unparsable", () => {
     expect(filenameFromContentDisposition(undefined, "fallback")).toBe(
       "fallback",

--- a/frontend/src/utilities/files.ts
+++ b/frontend/src/utilities/files.ts
@@ -1,0 +1,45 @@
+/**
+ * Extract the filename a server suggested via Content-Disposition.
+ *
+ * Handles both the RFC 5987 `filename*=UTF-8''...` form (which Flask's
+ * send_file emits for non-ASCII names) and the plain quoted `filename="..."`
+ * form. Returns the fallback when the header is absent or unparsable.
+ */
+export function filenameFromContentDisposition(
+  header: string | undefined | null,
+  fallback: string,
+): string {
+  if (!header) {
+    return fallback;
+  }
+
+  const extended = header.match(/filename\*=(?:UTF-8|utf-8)''([^;]+)/);
+  if (extended) {
+    try {
+      return decodeURIComponent(extended[1].trim());
+    } catch {
+      // Malformed percent-encoding; fall through to the plain form.
+    }
+  }
+
+  const plain = header.match(/filename="?([^";]+)"?/);
+  if (plain) {
+    return plain[1].trim();
+  }
+
+  return fallback;
+}
+
+/**
+ * Hand a blob to the browser as a file download.
+ */
+export function saveBlobAs(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/utilities/files.ts
+++ b/frontend/src/utilities/files.ts
@@ -26,10 +26,14 @@ export function filenameFromContentDisposition(
   }
 
   // Quoted form first, consumed to the closing quote: a semicolon INSIDE the
-  // quotes is part of the filename, not a parameter separator.
-  const quoted = header.match(/filename="([^"]*)"/);
-  if (quoted && quoted[1].trim()) {
-    return quoted[1].trim();
+  // quotes is part of the filename, not a parameter separator, and escaped
+  // quotes/backslashes (quoted-pairs) are part of the value.
+  const quoted = header.match(/filename="((?:[^"\\]|\\.)*)"/);
+  if (quoted) {
+    const unescaped = quoted[1].replace(/\\(.)/g, "$1").trim();
+    if (unescaped) {
+      return unescaped;
+    }
   }
 
   const token = header.match(/filename=([^;"\s]+)/);

--- a/frontend/src/utilities/files.ts
+++ b/frontend/src/utilities/files.ts
@@ -16,15 +16,25 @@ export function filenameFromContentDisposition(
   const extended = header.match(/filename\*=(?:UTF-8|utf-8)''([^;]+)/);
   if (extended) {
     try {
-      return decodeURIComponent(extended[1].trim());
+      const decoded = decodeURIComponent(extended[1].trim());
+      if (decoded) {
+        return decoded;
+      }
     } catch {
-      // Malformed percent-encoding; fall through to the plain form.
+      // Malformed percent-encoding; fall through to the plain forms.
     }
   }
 
-  const plain = header.match(/filename="?([^";]+)"?/);
-  if (plain) {
-    return plain[1].trim();
+  // Quoted form first, consumed to the closing quote: a semicolon INSIDE the
+  // quotes is part of the filename, not a parameter separator.
+  const quoted = header.match(/filename="([^"]*)"/);
+  if (quoted && quoted[1].trim()) {
+    return quoted[1].trim();
+  }
+
+  const token = header.match(/filename=([^;"\s]+)/);
+  if (token) {
+    return token[1].trim();
   }
 
   return fallback;

--- a/tests/bazarr/test_subtitle_download_api.py
+++ b/tests/bazarr/test_subtitle_download_api.py
@@ -102,6 +102,7 @@ sys.modules.pop('api.subtitles.download', None)
 sys.modules.pop('api.subtitles.content', None)
 
 import api.subtitles.download as download_module  # noqa: E402
+import api.subtitles.content as content_module  # noqa: E402
 
 _module_isolation.restore(_SYS_BEFORE)
 
@@ -243,6 +244,13 @@ class TestLanguageFilterRe:
         assert download_module._LANGUAGE_FILTER_RE.match('pt-BR')
         assert download_module._LANGUAGE_FILTER_RE.match('zho')
 
+    def test_content_grammar_rejects_trailing_newline(self):
+        # The single-file route validates through content.py's full grammar;
+        # \Z (not $) so an encoded trailing newline cannot pass.
+        assert not content_module._LANGUAGE_CODE_RE.match('en\n')
+        assert not content_module._LANGUAGE_CODE_RE.match('en:hi\n')
+        assert content_module._LANGUAGE_CODE_RE.match('en:hi')
+
     def test_rejects_modifiers_traversal_and_newlines(self):
         assert not download_module._LANGUAGE_FILTER_RE.match('en:hi')
         assert not download_module._LANGUAGE_FILTER_RE.match('../evil')
@@ -274,6 +282,15 @@ class TestResolveBundlePath:
         link = media / 'movie.en.srt'
         link.symlink_to(secret)
         assert download_module.resolve_bundle_path(str(link), [str(media)]) is None
+
+    def test_rejects_symlink_to_in_root_non_subtitle(self, tmp_path):
+        # The extension allowlist must run on the RESOLVED path: an indexed
+        # .srt that is a symlink to Movie.nfo inside the root must not pass.
+        nfo = tmp_path / 'Movie.nfo'
+        nfo.write_text('metadata')
+        link = tmp_path / 'movie.en.srt'
+        link.symlink_to(nfo)
+        assert download_module.resolve_bundle_path(str(link), [str(tmp_path)]) is None
 
     def test_rejects_path_outside_all_roots(self, tmp_path):
         assert download_module.resolve_bundle_path(
@@ -419,6 +436,15 @@ class TestBuildSubtitleBundle:
             info = archive.getinfo('old.srt')
             assert info.date_time[0] == 1980
 
+    def test_zip_date_time_clamps_both_ends(self):
+        assert download_module._zip_date_time(0) == download_module._ZIP_EPOCH
+        assert download_module._zip_date_time(-1) == download_module._ZIP_EPOCH
+        # Year 2110: beyond the zip date field's 2107 ceiling.
+        assert download_module._zip_date_time(4418064000) == \
+            download_module._ZIP_LAST_TIMESTAMP
+        assert download_module._zip_date_time(10**18) == \
+            download_module._ZIP_EPOCH
+
     def test_directory_entry_is_skipped(self, tmp_path):
         sub = tmp_path / 'dir.srt'
         sub.mkdir()
@@ -489,6 +515,11 @@ class _FakeDatabase:
 
 class TestSingleFileDownload:
 
+    @pytest.fixture(autouse=True)
+    def _unambiguous(self, monkeypatch):
+        monkeypatch.setattr(download_module, '_ambiguous_media_error',
+                            lambda *a, **k: None)
+
     def test_error_tuple_passes_through(self, monkeypatch, no_instance_param):
         monkeypatch.setattr(download_module, 'request', _fake_request())
         monkeypatch.setattr(download_module, 'resolve_subtitle_path',
@@ -536,6 +567,31 @@ class TestSingleFileDownload:
         assert resource.get(12, 'en') == ('Subtitle file or directory not found', 404)
 
 
+class TestSingleFileAmbiguity:
+
+    def test_two_instance_rows_without_param_is_400(self, monkeypatch, no_instance_param):
+        rows = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+        monkeypatch.setattr(download_module, 'database', _FakeDatabase([rows]))
+        resource = download_module.EpisodeSubtitleFileDownload()
+        assert resource.get(12, 'en') == \
+            ('Ambiguous Sonarr episode ID; pass arr_instance_id', 400)
+
+    def test_movie_two_rows_is_400(self, monkeypatch, no_instance_param):
+        rows = [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+        monkeypatch.setattr(download_module, 'database', _FakeDatabase([rows]))
+        resource = download_module.MovieSubtitleFileDownload()
+        assert resource.get(654, 'en') == \
+            ('Ambiguous Radarr movie ID; pass arr_instance_id', 400)
+
+    def test_single_row_proceeds_to_resolution(self, monkeypatch, no_instance_param):
+        monkeypatch.setattr(download_module, 'database',
+                            _FakeDatabase([[SimpleNamespace(id=1)]]))
+        monkeypatch.setattr(download_module, 'resolve_subtitle_path',
+                            lambda *a, **k: ('missing', 404))
+        resource = download_module.EpisodeSubtitleFileDownload()
+        assert resource.get(12, 'en') == ('missing', 404)
+
+
 class TestSeriesBundleDownload:
 
     def test_series_not_found(self, monkeypatch, no_instance_param):
@@ -561,6 +617,13 @@ class TestSeriesBundleDownload:
     def test_invalid_season_filter_rejected(self, monkeypatch, no_instance_param):
         monkeypatch.setattr(download_module, 'request',
                             _fake_request({'season': 'abc'}))
+        resource = download_module.SeriesSubtitleBundleDownload()
+        assert resource.get(1) == ('Invalid season filter', 400)
+
+    def test_huge_season_digit_string_rejected(self, monkeypatch, no_instance_param):
+        # isdigit passes but int() would hit the conversion limit: still 400.
+        monkeypatch.setattr(download_module, 'request',
+                            _fake_request({'season': '9' * 5000}))
         resource = download_module.SeriesSubtitleBundleDownload()
         assert resource.get(1) == ('Invalid season filter', 400)
 

--- a/tests/bazarr/test_subtitle_download_api.py
+++ b/tests/bazarr/test_subtitle_download_api.py
@@ -244,6 +244,13 @@ class TestLanguageFilterRe:
         assert download_module._LANGUAGE_FILTER_RE.match('pt-BR')
         assert download_module._LANGUAGE_FILTER_RE.match('zho')
 
+    def test_content_grammar_accepts_uppercase_modifiers(self):
+        # Custom languages index uppercase HI labels (zh:HI, zt:HI, pb:HI);
+        # validation must accept them or those Download/View actions 400.
+        assert content_module._LANGUAGE_CODE_RE.match('zt:HI')
+        assert content_module._LANGUAGE_CODE_RE.match('pb:HI')
+        assert content_module._LANGUAGE_CODE_RE.match('en:FORCED')
+
     def test_content_grammar_rejects_trailing_newline(self):
         # The single-file route validates through content.py's full grammar;
         # \Z (not $) so an encoded trailing newline cannot pass.

--- a/tests/bazarr/test_subtitle_download_api.py
+++ b/tests/bazarr/test_subtitle_download_api.py
@@ -1,0 +1,477 @@
+# coding=utf-8
+
+"""Unit tests for the subtitle download endpoints (single files and zip bundles).
+
+Pattern matches test_combine_api_movies.py: patch heavy dependencies in
+sys.modules before importing the module under test, keep a reference, then
+fully restore sys.modules so nothing leaks into later test files.
+"""
+
+import sys
+import zipfile
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.bazarr import _module_isolation
+
+_SYS_BEFORE = dict(sys.modules)
+
+
+# ---------------------------------------------------------------------------
+# Patch heavy dependencies before importing the module under test.
+# ---------------------------------------------------------------------------
+
+def _passthrough_decorator(*args, **kwargs):
+    def wrap(target):
+        return target
+    return wrap
+
+
+class _FakeNamespace:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def route(self, *args, **kwargs):
+        return _passthrough_decorator()
+
+    def doc(self, *args, **kwargs):
+        return _passthrough_decorator()
+
+    def response(self, *args, **kwargs):
+        return _passthrough_decorator()
+
+    def __getattr__(self, name):
+        return MagicMock()
+
+
+class _FakeResource:
+    pass
+
+
+_fake_flask_restx = MagicMock()
+_fake_flask_restx.Namespace = _FakeNamespace
+_fake_flask_restx.Resource = _FakeResource
+_fake_flask_restx.fields = MagicMock()
+_fake_flask_restx.reqparse = MagicMock()
+
+_api_utils_mock = MagicMock()
+_api_utils_mock.authenticate = lambda fn: fn
+
+_patches = {
+    'flask_restx': _fake_flask_restx,
+    'app.get_args': MagicMock(args=MagicMock(config_dir='/tmp/bazarr_test')),
+    'app.config': MagicMock(),
+    'app.database': MagicMock(),
+    'app.event_handler': MagicMock(),
+    'app.get_providers': MagicMock(),
+    'app.jobs_queue': MagicMock(),
+    'app.scheduler': MagicMock(),
+    'app.signalr_client': MagicMock(),
+    'utilities.path_mappings': MagicMock(),
+    'utilities.binaries': MagicMock(),
+    'api.utils': _api_utils_mock,
+    'subliminal_patch': MagicMock(),
+    'subliminal_patch.core': MagicMock(SUBTITLE_EXTENSIONS=['.srt', '.ass']),
+    'subliminal_patch.core_persistent': MagicMock(),
+    'subliminal_patch.exceptions': MagicMock(),
+    'subliminal_patch.extensions': MagicMock(),
+    'subliminal_patch.score': MagicMock(MAX_SCORES={'movie': 100, 'episode': 100}),
+    'subliminal_patch.subtitle': MagicMock(),
+    'subtitles.indexer.movies': MagicMock(),
+    'subtitles.indexer.series': MagicMock(),
+    'subtitles.manual': MagicMock(),
+    'subtitles.upload': MagicMock(),
+    'subtitles.mass_download.movies': MagicMock(),
+    'subtitles.upgrade': MagicMock(),
+    'subtitles.download': MagicMock(),
+    'subtitles.tools.delete': MagicMock(),
+    'subtitles.tools.combine': MagicMock(),
+    'subtitles.tools.combine.main': MagicMock(),
+    'init': MagicMock(startTime=0),
+    'flask': MagicMock(),
+}
+
+_preexisting = {k: sys.modules.get(k) for k in _patches}
+for _mod, _obj in _patches.items():
+    sys.modules[_mod] = _obj
+
+# Drop cached copies so the re-import resolves against the mocks above.
+sys.modules.pop('api.subtitles.download', None)
+sys.modules.pop('api.subtitles.content', None)
+
+import api.subtitles.download as download_module  # noqa: E402
+
+_module_isolation.restore(_SYS_BEFORE)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _IdentityPathMappings:
+    """path_replace_instance stub that records calls and returns the path."""
+
+    def __init__(self):
+        self.calls = []
+
+    def path_replace_instance(self, path, arr_instance_id, media_type):
+        self.calls.append((path, arr_instance_id, media_type))
+        return path
+
+
+@pytest.fixture
+def identity_mappings(monkeypatch):
+    stub = _IdentityPathMappings()
+    monkeypatch.setattr(download_module, 'path_mappings', stub)
+    return stub
+
+
+def _episode_row(season, subtitles, arr_instance_id=None):
+    return SimpleNamespace(season=season, subtitles=subtitles,
+                           arr_instance_id=arr_instance_id)
+
+
+def _movie_row(subtitles, arr_instance_id=None, title='Movie'):
+    return SimpleNamespace(subtitles=subtitles, arr_instance_id=arr_instance_id,
+                           title=title)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+class TestSafeFilenameComponent:
+
+    def test_strips_forbidden_characters(self):
+        assert download_module.safe_filename_component(
+            'A/B\\C:D*E?F"G<H>I|J', 'x') == 'A_B_C_D_E_F_G_H_I_J'
+
+    def test_collapses_whitespace_and_trims_dots(self):
+        assert download_module.safe_filename_component('  A   B. ', 'x') == 'A B'
+
+    def test_fallback_on_empty(self):
+        assert download_module.safe_filename_component('', 'series') == 'series'
+        assert download_module.safe_filename_component(None, 'movie') == 'movie'
+        assert download_module.safe_filename_component('...', 'x') == 'x'
+
+
+class TestUniqueArcname:
+
+    def test_first_use_passes_through(self):
+        used = set()
+        assert download_module.unique_arcname(used, 'a/b.srt') == 'a/b.srt'
+
+    def test_collisions_get_numbered(self):
+        used = set()
+        download_module.unique_arcname(used, 'a/b.srt')
+        assert download_module.unique_arcname(used, 'a/b.srt') == 'a/b (2).srt'
+        assert download_module.unique_arcname(used, 'a/b.srt') == 'a/b (3).srt'
+
+
+class TestIterExternalSubtitles:
+
+    def test_parses_pairs_and_skips_embedded(self):
+        raw = "[['en', '/sub/a.en.srt'], ['hu', None], ['de', ''], ['fr', '/sub/a.fr.srt', 123]]"
+        assert download_module.iter_external_subtitles(raw) == [
+            ('en', '/sub/a.en.srt'),
+            ('fr', '/sub/a.fr.srt'),
+        ]
+
+    def test_bad_input(self):
+        assert download_module.iter_external_subtitles(None) == []
+        assert download_module.iter_external_subtitles('') == []
+        assert download_module.iter_external_subtitles('not a literal [') == []
+        assert download_module.iter_external_subtitles("{'a': 1}") == []
+
+
+class TestMatchesLanguage:
+
+    def test_no_filter_matches_everything(self):
+        assert download_module.matches_language('en:hi', None)
+        assert download_module.matches_language('en', '')
+
+    def test_base_match_includes_variants(self):
+        assert download_module.matches_language('en', 'en')
+        assert download_module.matches_language('en:hi', 'en')
+        assert download_module.matches_language('en:forced', 'en')
+        assert download_module.matches_language('en:sync-ffsubsync', 'EN')
+        assert download_module.matches_language('pt-BR', 'pt-br')
+
+    def test_other_language_rejected(self):
+        assert not download_module.matches_language('hu', 'en')
+        assert not download_module.matches_language('en:hi', 'hu')
+
+
+class TestLanguageFilterRe:
+
+    def test_accepts_base_codes(self):
+        assert download_module._LANGUAGE_FILTER_RE.match('en')
+        assert download_module._LANGUAGE_FILTER_RE.match('pt-BR')
+        assert download_module._LANGUAGE_FILTER_RE.match('zho')
+
+    def test_rejects_modifiers_and_traversal(self):
+        assert not download_module._LANGUAGE_FILTER_RE.match('en:hi')
+        assert not download_module._LANGUAGE_FILTER_RE.match('../evil')
+        assert not download_module._LANGUAGE_FILTER_RE.match('en/..')
+        assert not download_module._LANGUAGE_FILTER_RE.match('')
+
+
+# ---------------------------------------------------------------------------
+# Entry collection
+# ---------------------------------------------------------------------------
+
+class TestCollectSeriesBundleEntries:
+
+    def test_groups_by_season_folder(self, identity_mappings):
+        rows = [
+            _episode_row(1, "[['en', '/tv/S01E01.en.srt']]"),
+            _episode_row(2, "[['en', '/tv/S02E01.en.srt'], ['hu', '/tv/S02E01.hu.srt']]"),
+        ]
+        entries = download_module.collect_series_bundle_entries(rows)
+        assert entries == [
+            ('Season 01/S01E01.en.srt', '/tv/S01E01.en.srt'),
+            ('Season 02/S02E01.en.srt', '/tv/S02E01.en.srt'),
+            ('Season 02/S02E01.hu.srt', '/tv/S02E01.hu.srt'),
+        ]
+
+    def test_season_and_language_filters(self, identity_mappings):
+        rows = [
+            _episode_row(1, "[['en', '/tv/S01E01.en.srt'], ['hu', '/tv/S01E01.hu.srt']]"),
+            _episode_row(2, "[['en:hi', '/tv/S02E01.en.hi.srt']]"),
+        ]
+        only_s2 = download_module.collect_series_bundle_entries(rows, season=2)
+        assert only_s2 == [('Season 02/S02E01.en.hi.srt', '/tv/S02E01.en.hi.srt')]
+
+        only_en = download_module.collect_series_bundle_entries(rows, language='en')
+        assert [arc for arc, _ in only_en] == [
+            'Season 01/S01E01.en.srt',
+            'Season 02/S02E01.en.hi.srt',
+        ]
+
+    def test_paths_map_through_owning_instance(self, identity_mappings):
+        rows = [_episode_row(3, "[['en', '/tv/S03E01.en.srt']]", arr_instance_id=7)]
+        download_module.collect_series_bundle_entries(rows)
+        assert identity_mappings.calls == [('/tv/S03E01.en.srt', 7, 'episode')]
+
+
+class TestCollectMovieBundleEntries:
+
+    def test_collects_and_filters(self, identity_mappings):
+        row = _movie_row("[['en', '/movies/M.en.srt'], ['hu', '/movies/M.hu.srt'], ['de', None]]",
+                         arr_instance_id=2)
+        all_entries = download_module.collect_movie_bundle_entries(row)
+        assert all_entries == [
+            ('M.en.srt', '/movies/M.en.srt'),
+            ('M.hu.srt', '/movies/M.hu.srt'),
+        ]
+        hu_only = download_module.collect_movie_bundle_entries(row, language='hu')
+        assert hu_only == [('M.hu.srt', '/movies/M.hu.srt')]
+        assert ('/movies/M.en.srt', 2, 'movie') in identity_mappings.calls
+
+
+# ---------------------------------------------------------------------------
+# Zip assembly
+# ---------------------------------------------------------------------------
+
+class TestBuildSubtitleBundle:
+
+    def test_zips_existing_files_with_arcnames(self, tmp_path):
+        a = tmp_path / 'a.en.srt'
+        b = tmp_path / 'b.en.srt'
+        a.write_text('1\n00:00:01,000 --> 00:00:02,000\nA\n')
+        b.write_text('1\n00:00:01,000 --> 00:00:02,000\nB\n')
+        entries = [
+            ('Season 01/a.en.srt', str(a)),
+            ('Season 02/b.en.srt', str(b)),
+            ('Season 02/missing.srt', str(tmp_path / 'missing.srt')),
+        ]
+        buffer = download_module.build_subtitle_bundle(entries)
+        assert buffer is not None
+        with zipfile.ZipFile(buffer) as archive:
+            assert sorted(archive.namelist()) == [
+                'Season 01/a.en.srt', 'Season 02/b.en.srt']
+            assert archive.read('Season 01/a.en.srt').endswith(b'A\n')
+
+    def test_duplicate_arcnames_are_deduplicated(self, tmp_path):
+        a = tmp_path / 'a.srt'
+        a.write_text('x')
+        entries = [('same.srt', str(a)), ('same.srt', str(a))]
+        buffer = download_module.build_subtitle_bundle(entries)
+        with zipfile.ZipFile(buffer) as archive:
+            assert sorted(archive.namelist()) == ['same (2).srt', 'same.srt']
+
+    def test_nothing_to_add_returns_none(self, tmp_path):
+        entries = [('gone.srt', str(tmp_path / 'gone.srt'))]
+        assert download_module.build_subtitle_bundle(entries) is None
+        assert download_module.build_subtitle_bundle([]) is None
+
+    def test_size_cap_raises(self, tmp_path):
+        big = tmp_path / 'big.srt'
+        big.write_text('x' * 1024)
+        with pytest.raises(download_module.BundleTooLargeError):
+            download_module.build_subtitle_bundle(
+                [('big.srt', str(big))], max_total_size=100)
+
+
+class TestBundleDownloadName:
+
+    def test_variants(self):
+        f = download_module.bundle_download_name
+        assert f('Show') == 'Show - subtitles.zip'
+        assert f('Show', season=2) == 'Show - Season 02 - subtitles.zip'
+        assert f('Show', language='EN') == 'Show - en - subtitles.zip'
+        assert f('Show', season=10, language='hu') == \
+            'Show - Season 10 - hu - subtitles.zip'
+
+
+# ---------------------------------------------------------------------------
+# Route handlers (module-level attributes patched per test)
+# ---------------------------------------------------------------------------
+
+def _fake_request(args=None):
+    values = args or {}
+
+    class _Args:
+        def get(self, key, default=None, type=None):  # flask-like signature
+            value = values.get(key, default)
+            if value is not None and type is not None:
+                try:
+                    return type(value)
+                except (TypeError, ValueError):
+                    return default
+            return value
+
+    return SimpleNamespace(args=_Args())
+
+
+class TestSingleFileDownload:
+
+    def test_error_tuple_passes_through(self, monkeypatch):
+        monkeypatch.setattr(download_module, 'request', _fake_request())
+        monkeypatch.setattr(download_module, 'resolve_subtitle_path',
+                            lambda *a, **k: ('No subtitle found for requested language', 404))
+        resource = download_module.EpisodeSubtitleFileDownload()
+        assert resource.get(12, 'en') == ('No subtitle found for requested language', 404)
+
+    def test_success_sends_attachment(self, monkeypatch):
+        sent = {}
+
+        def fake_send_file(path, **kwargs):
+            sent['path'] = path
+            sent.update(kwargs)
+            return 'SENT'
+
+        monkeypatch.setattr(download_module, 'request',
+                            _fake_request({'arr_instance_id': 3}))
+        captured = {}
+
+        def fake_resolve(media_type, media_id, language_code, arr_instance_id=None):
+            captured['args'] = (media_type, media_id, language_code, arr_instance_id)
+            return ('/media/Movie (2020)/Movie.en.srt', {'mediaTitle': 'Movie'})
+
+        monkeypatch.setattr(download_module, 'resolve_subtitle_path', fake_resolve)
+        monkeypatch.setattr(download_module, 'send_file', fake_send_file)
+
+        resource = download_module.MovieSubtitleFileDownload()
+        assert resource.get(654, 'en:hi') == 'SENT'
+        assert captured['args'] == ('movie', 654, 'en:hi', 3)
+        assert sent['path'] == '/media/Movie (2020)/Movie.en.srt'
+        assert sent['as_attachment'] is True
+        assert sent['download_name'] == 'Movie.en.srt'
+
+
+class _FakeDatabase:
+    """Returns queued results for successive execute() calls."""
+
+    def __init__(self, results):
+        self._results = list(results)
+
+    def execute(self, query):
+        result = self._results.pop(0)
+
+        class _Result:
+            def first(self):
+                return result if not isinstance(result, list) else (
+                    result[0] if result else None)
+
+            def all(self):
+                return result if isinstance(result, list) else [result]
+
+        return _Result()
+
+
+class TestSeriesBundleDownload:
+
+    def test_series_not_found(self, monkeypatch):
+        monkeypatch.setattr(download_module, 'request', _fake_request())
+        monkeypatch.setattr(download_module, 'database', _FakeDatabase([None]))
+        resource = download_module.SeriesSubtitleBundleDownload()
+        assert resource.get(99) == ('Series not found', 404)
+
+    def test_invalid_language_filter_rejected(self, monkeypatch):
+        monkeypatch.setattr(download_module, 'request',
+                            _fake_request({'language': 'en:hi'}))
+        resource = download_module.SeriesSubtitleBundleDownload()
+        assert resource.get(1) == ('Invalid language filter', 400)
+
+    def test_bundles_matching_episodes(self, monkeypatch, tmp_path, identity_mappings):
+        sub = tmp_path / 'S01E01.en.srt'
+        sub.write_text('x')
+        series_row = SimpleNamespace(title='My Show', arr_instance_id=None)
+        episode_rows = [_episode_row(1, f"[['en', '{sub}']]")]
+        monkeypatch.setattr(download_module, 'request',
+                            _fake_request({'language': 'en'}))
+        monkeypatch.setattr(download_module, 'database',
+                            _FakeDatabase([series_row, episode_rows]))
+        sent = {}
+
+        def fake_send_file(buffer, **kwargs):
+            sent['names'] = zipfile.ZipFile(buffer).namelist()
+            sent.update(kwargs)
+            return 'SENT'
+
+        monkeypatch.setattr(download_module, 'send_file', fake_send_file)
+        resource = download_module.SeriesSubtitleBundleDownload()
+        assert resource.get(1) == 'SENT'
+        assert sent['names'] == ['Season 01/S01E01.en.srt']
+        assert sent['download_name'] == 'My Show - en - subtitles.zip'
+        assert sent['mimetype'] == 'application/zip'
+
+    def test_no_files_is_404(self, monkeypatch, identity_mappings):
+        series_row = SimpleNamespace(title='My Show', arr_instance_id=None)
+        monkeypatch.setattr(download_module, 'request', _fake_request())
+        monkeypatch.setattr(download_module, 'database',
+                            _FakeDatabase([series_row, []]))
+        resource = download_module.SeriesSubtitleBundleDownload()
+        assert resource.get(1) == ('No subtitle files found', 404)
+
+
+class TestMovieBundleDownload:
+
+    def test_movie_not_found(self, monkeypatch):
+        monkeypatch.setattr(download_module, 'request', _fake_request())
+        monkeypatch.setattr(download_module, 'database', _FakeDatabase([None]))
+        resource = download_module.MovieSubtitleBundleDownload()
+        assert resource.get(1) == ('Movie not found', 404)
+
+    def test_bundles_movie_files(self, monkeypatch, tmp_path, identity_mappings):
+        sub = tmp_path / 'Movie.en.srt'
+        sub.write_text('x')
+        movie_row = _movie_row(f"[['en', '{sub}']]", title='Movie: The Sequel')
+        monkeypatch.setattr(download_module, 'request', _fake_request())
+        monkeypatch.setattr(download_module, 'database',
+                            _FakeDatabase([movie_row]))
+        sent = {}
+
+        def fake_send_file(buffer, **kwargs):
+            sent['names'] = zipfile.ZipFile(buffer).namelist()
+            sent.update(kwargs)
+            return 'SENT'
+
+        monkeypatch.setattr(download_module, 'send_file', fake_send_file)
+        resource = download_module.MovieSubtitleBundleDownload()
+        assert resource.get(654) == 'SENT'
+        assert sent['names'] == ['Movie.en.srt']
+        assert sent['download_name'] == 'Movie_ The Sequel - subtitles.zip'

--- a/tests/bazarr/test_subtitle_download_api.py
+++ b/tests/bazarr/test_subtitle_download_api.py
@@ -7,6 +7,7 @@ sys.modules before importing the module under test, keep a reference, then
 fully restore sys.modules so nothing leaks into later test files.
 """
 
+import os
 import sys
 import zipfile
 from types import SimpleNamespace
@@ -93,7 +94,6 @@ _patches = {
     'flask': MagicMock(),
 }
 
-_preexisting = {k: sys.modules.get(k) for k in _patches}
 for _mod, _obj in _patches.items():
     sys.modules[_mod] = _obj
 
@@ -122,20 +122,30 @@ class _IdentityPathMappings:
 
 
 @pytest.fixture
+def no_instance_param(monkeypatch):
+    # _request_arr_instance_id lives in content.py and reads content's own
+    # flask request; pin it directly for route tests.
+    monkeypatch.setattr(download_module, '_request_arr_instance_id', lambda: None)
+
+
+@pytest.fixture
 def identity_mappings(monkeypatch):
     stub = _IdentityPathMappings()
     monkeypatch.setattr(download_module, 'path_mappings', stub)
+    # The subfolder target depends on live settings; the tests pin it off.
+    monkeypatch.setattr(download_module, 'get_target_folder', lambda path: None)
     return stub
 
 
-def _episode_row(season, subtitles, arr_instance_id=None):
+def _episode_row(season, subtitles, arr_instance_id=None, path='/tv/video.mkv'):
     return SimpleNamespace(season=season, subtitles=subtitles,
-                           arr_instance_id=arr_instance_id)
+                           arr_instance_id=arr_instance_id, path=path)
 
 
-def _movie_row(subtitles, arr_instance_id=None, title='Movie'):
+def _movie_row(subtitles, arr_instance_id=None, title='Movie',
+               path='/movies/Movie.mkv'):
     return SimpleNamespace(subtitles=subtitles, arr_instance_id=arr_instance_id,
-                           title=title)
+                           title=title, path=path)
 
 
 # ---------------------------------------------------------------------------
@@ -146,7 +156,7 @@ class TestSafeFilenameComponent:
 
     def test_strips_forbidden_characters(self):
         assert download_module.safe_filename_component(
-            'A/B\\C:D*E?F"G<H>I|J', 'x') == 'A_B_C_D_E_F_G_H_I_J'
+            'A/B\\C:D*E?F"G<H>I|J;K', 'x') == 'A_B_C_D_E_F_G_H_I_J_K'
 
     def test_collapses_whitespace_and_trims_dots(self):
         assert download_module.safe_filename_component('  A   B. ', 'x') == 'A B'
@@ -155,6 +165,14 @@ class TestSafeFilenameComponent:
         assert download_module.safe_filename_component('', 'series') == 'series'
         assert download_module.safe_filename_component(None, 'movie') == 'movie'
         assert download_module.safe_filename_component('...', 'x') == 'x'
+
+
+class TestSanitizeArcnameComponent:
+
+    def test_neutralizes_separators(self):
+        f = download_module.sanitize_arcname_component
+        assert f(r'..\..\evil.srt') == '.._.._evil.srt'
+        assert f('plain.en.srt') == 'plain.en.srt'
 
 
 class TestUniqueArcname:
@@ -186,6 +204,20 @@ class TestIterExternalSubtitles:
         assert download_module.iter_external_subtitles("{'a': 1}") == []
 
 
+class TestDedupeLanguageEntries:
+
+    def test_keeps_newest_for_duplicate_language(self, tmp_path):
+        older = tmp_path / 'old.en.ass'
+        newer = tmp_path / 'new.en.srt'
+        older.write_text('old')
+        newer.write_text('new')
+        os.utime(older, (1000, 1000))
+        os.utime(newer, (2000, 2000))
+        pairs = [('en', str(older)), ('en', str(newer)), ('hu', str(older))]
+        result = dict(download_module.dedupe_language_entries(pairs, lambda p: p))
+        assert result == {'en': str(newer), 'hu': str(older)}
+
+
 class TestMatchesLanguage:
 
     def test_no_filter_matches_everything(self):
@@ -211,11 +243,47 @@ class TestLanguageFilterRe:
         assert download_module._LANGUAGE_FILTER_RE.match('pt-BR')
         assert download_module._LANGUAGE_FILTER_RE.match('zho')
 
-    def test_rejects_modifiers_and_traversal(self):
+    def test_rejects_modifiers_traversal_and_newlines(self):
         assert not download_module._LANGUAGE_FILTER_RE.match('en:hi')
         assert not download_module._LANGUAGE_FILTER_RE.match('../evil')
         assert not download_module._LANGUAGE_FILTER_RE.match('en/..')
         assert not download_module._LANGUAGE_FILTER_RE.match('')
+        # $ would accept a trailing newline; \Z must not.
+        assert not download_module._LANGUAGE_FILTER_RE.match('en\n')
+
+
+# ---------------------------------------------------------------------------
+# Containment barrier
+# ---------------------------------------------------------------------------
+
+class TestResolveBundlePath:
+
+    def test_accepts_file_under_trusted_root(self, tmp_path):
+        sub = tmp_path / 'a.en.srt'
+        sub.write_text('x')
+        assert download_module.resolve_bundle_path(
+            str(sub), [str(tmp_path)]) == str(sub)
+
+    def test_rejects_symlink_escaping_the_root(self, tmp_path):
+        outside = tmp_path / 'outside'
+        media = tmp_path / 'media'
+        outside.mkdir()
+        media.mkdir()
+        secret = outside / 'secret.conf'
+        secret.write_text('apikey')
+        link = media / 'movie.en.srt'
+        link.symlink_to(secret)
+        assert download_module.resolve_bundle_path(str(link), [str(media)]) is None
+
+    def test_rejects_path_outside_all_roots(self, tmp_path):
+        assert download_module.resolve_bundle_path(
+            '/etc/passwd.srt', [str(tmp_path)]) is None
+
+    def test_rejects_unknown_extension(self, tmp_path):
+        exe = tmp_path / 'a.exe'
+        exe.write_text('x')
+        assert download_module.resolve_bundle_path(
+            str(exe), [str(tmp_path)]) is None
 
 
 # ---------------------------------------------------------------------------
@@ -253,7 +321,22 @@ class TestCollectSeriesBundleEntries:
     def test_paths_map_through_owning_instance(self, identity_mappings):
         rows = [_episode_row(3, "[['en', '/tv/S03E01.en.srt']]", arr_instance_id=7)]
         download_module.collect_series_bundle_entries(rows)
-        assert identity_mappings.calls == [('/tv/S03E01.en.srt', 7, 'episode')]
+        assert ('/tv/S03E01.en.srt', 7, 'episode') in identity_mappings.calls
+        assert ('/tv/video.mkv', 7, 'episode') in identity_mappings.calls
+
+    def test_entry_outside_media_dir_is_dropped(self, identity_mappings):
+        rows = [_episode_row(1, "[['en', '/elsewhere/S01E01.en.srt']]")]
+        assert download_module.collect_series_bundle_entries(rows) == []
+
+    def test_mapping_resolved_once_per_unique_path(self, identity_mappings):
+        # Two rows sharing one video path (a multi-episode file): the mapping
+        # must not be recomputed per row.
+        rows = [
+            _episode_row(1, "[['en', '/tv/S01E01E02.en.srt']]"),
+            _episode_row(1, "[['en', '/tv/S01E01E02.en.srt']]"),
+        ]
+        download_module.collect_series_bundle_entries(rows)
+        assert identity_mappings.calls.count(('/tv/S01E01E02.en.srt', None, 'episode')) == 1
 
 
 class TestCollectMovieBundleEntries:
@@ -294,10 +377,23 @@ class TestBuildSubtitleBundle:
                 'Season 01/a.en.srt', 'Season 02/b.en.srt']
             assert archive.read('Season 01/a.en.srt').endswith(b'A\n')
 
-    def test_duplicate_arcnames_are_deduplicated(self, tmp_path):
+    def test_same_disk_path_is_added_once(self, tmp_path):
         a = tmp_path / 'a.srt'
         a.write_text('x')
-        entries = [('same.srt', str(a)), ('same.srt', str(a))]
+        entries = [('Season 01/a.srt', str(a)), ('Season 01/a.srt', str(a))]
+        buffer = download_module.build_subtitle_bundle(entries)
+        with zipfile.ZipFile(buffer) as archive:
+            assert archive.namelist() == ['Season 01/a.srt']
+
+    def test_distinct_files_with_same_arcname_get_suffixed(self, tmp_path):
+        one = tmp_path / 'one'
+        two = tmp_path / 'two'
+        one.mkdir()
+        two.mkdir()
+        (one / 'same.srt').write_text('1')
+        (two / 'same.srt').write_text('2')
+        entries = [('same.srt', str(one / 'same.srt')),
+                   ('same.srt', str(two / 'same.srt'))]
         buffer = download_module.build_subtitle_bundle(entries)
         with zipfile.ZipFile(buffer) as archive:
             assert sorted(archive.namelist()) == ['same (2).srt', 'same.srt']
@@ -307,12 +403,31 @@ class TestBuildSubtitleBundle:
         assert download_module.build_subtitle_bundle(entries) is None
         assert download_module.build_subtitle_bundle([]) is None
 
-    def test_size_cap_raises(self, tmp_path):
+    def test_size_cap_enforced_while_reading(self, tmp_path):
         big = tmp_path / 'big.srt'
         big.write_text('x' * 1024)
         with pytest.raises(download_module.BundleTooLargeError):
             download_module.build_subtitle_bundle(
                 [('big.srt', str(big))], max_total_size=100)
+
+    def test_pre_1980_mtime_is_clamped_not_fatal(self, tmp_path):
+        old = tmp_path / 'old.srt'
+        old.write_text('x')
+        os.utime(old, (0, 0))
+        buffer = download_module.build_subtitle_bundle([('old.srt', str(old))])
+        with zipfile.ZipFile(buffer) as archive:
+            info = archive.getinfo('old.srt')
+            assert info.date_time[0] == 1980
+
+    def test_directory_entry_is_skipped(self, tmp_path):
+        sub = tmp_path / 'dir.srt'
+        sub.mkdir()
+        ok = tmp_path / 'ok.srt'
+        ok.write_text('x')
+        buffer = download_module.build_subtitle_bundle(
+            [('dir.srt', str(sub)), ('ok.srt', str(ok))])
+        with zipfile.ZipFile(buffer) as archive:
+            assert archive.namelist() == ['ok.srt']
 
 
 class TestBundleDownloadName:
@@ -321,6 +436,7 @@ class TestBundleDownloadName:
         f = download_module.bundle_download_name
         assert f('Show') == 'Show - subtitles.zip'
         assert f('Show', season=2) == 'Show - Season 02 - subtitles.zip'
+        assert f('Show', season=0) == 'Show - Season 00 - subtitles.zip'
         assert f('Show', language='EN') == 'Show - en - subtitles.zip'
         assert f('Show', season=10, language='hu') == \
             'Show - Season 10 - hu - subtitles.zip'
@@ -346,40 +462,9 @@ def _fake_request(args=None):
     return SimpleNamespace(args=_Args())
 
 
-class TestSingleFileDownload:
-
-    def test_error_tuple_passes_through(self, monkeypatch):
-        monkeypatch.setattr(download_module, 'request', _fake_request())
-        monkeypatch.setattr(download_module, 'resolve_subtitle_path',
-                            lambda *a, **k: ('No subtitle found for requested language', 404))
-        resource = download_module.EpisodeSubtitleFileDownload()
-        assert resource.get(12, 'en') == ('No subtitle found for requested language', 404)
-
-    def test_success_sends_attachment(self, monkeypatch):
-        sent = {}
-
-        def fake_send_file(path, **kwargs):
-            sent['path'] = path
-            sent.update(kwargs)
-            return 'SENT'
-
-        monkeypatch.setattr(download_module, 'request',
-                            _fake_request({'arr_instance_id': 3}))
-        captured = {}
-
-        def fake_resolve(media_type, media_id, language_code, arr_instance_id=None):
-            captured['args'] = (media_type, media_id, language_code, arr_instance_id)
-            return ('/media/Movie (2020)/Movie.en.srt', {'mediaTitle': 'Movie'})
-
-        monkeypatch.setattr(download_module, 'resolve_subtitle_path', fake_resolve)
-        monkeypatch.setattr(download_module, 'send_file', fake_send_file)
-
-        resource = download_module.MovieSubtitleFileDownload()
-        assert resource.get(654, 'en:hi') == 'SENT'
-        assert captured['args'] == ('movie', 654, 'en:hi', 3)
-        assert sent['path'] == '/media/Movie (2020)/Movie.en.srt'
-        assert sent['as_attachment'] is True
-        assert sent['download_name'] == 'Movie.en.srt'
+class _FakeResponse:
+    def __init__(self):
+        self.headers = {}
 
 
 class _FakeDatabase:
@@ -402,76 +487,183 @@ class _FakeDatabase:
         return _Result()
 
 
+class TestSingleFileDownload:
+
+    def test_error_tuple_passes_through(self, monkeypatch, no_instance_param):
+        monkeypatch.setattr(download_module, 'request', _fake_request())
+        monkeypatch.setattr(download_module, 'resolve_subtitle_path',
+                            lambda *a, **k: ('No subtitle found for requested language', 404))
+        resource = download_module.EpisodeSubtitleFileDownload()
+        assert resource.get(12, 'en') == ('No subtitle found for requested language', 404)
+
+    def test_success_sends_attachment_with_nosniff(self, monkeypatch):
+        sent = {}
+
+        def fake_send_file(path, **kwargs):
+            sent['path'] = path
+            sent.update(kwargs)
+            return _FakeResponse()
+
+        monkeypatch.setattr(download_module, 'request', _fake_request())
+        monkeypatch.setattr(download_module, '_request_arr_instance_id', lambda: 3)
+        captured = {}
+
+        def fake_resolve(media_type, media_id, language_code, arr_instance_id=None):
+            captured['args'] = (media_type, media_id, language_code, arr_instance_id)
+            return ('/media/Movie (2020)/Movie.en.srt', {'mediaTitle': 'Movie'})
+
+        monkeypatch.setattr(download_module, 'resolve_subtitle_path', fake_resolve)
+        monkeypatch.setattr(download_module, 'send_file', fake_send_file)
+
+        resource = download_module.MovieSubtitleFileDownload()
+        response = resource.get(654, 'en:hi')
+        assert captured['args'] == ('movie', 654, 'en:hi', 3)
+        assert sent['path'] == '/media/Movie (2020)/Movie.en.srt'
+        assert sent['as_attachment'] is True
+        assert sent['download_name'] == 'Movie.en.srt'
+        assert response.headers['X-Content-Type-Options'] == 'nosniff'
+
+    def test_file_deleted_after_resolution_is_404(self, monkeypatch, no_instance_param):
+        monkeypatch.setattr(download_module, 'request', _fake_request())
+        monkeypatch.setattr(download_module, 'resolve_subtitle_path',
+                            lambda *a, **k: ('/media/gone.srt', {}))
+
+        def raising_send_file(path, **kwargs):
+            raise FileNotFoundError(path)
+
+        monkeypatch.setattr(download_module, 'send_file', raising_send_file)
+        resource = download_module.EpisodeSubtitleFileDownload()
+        assert resource.get(12, 'en') == ('Subtitle file or directory not found', 404)
+
+
 class TestSeriesBundleDownload:
 
-    def test_series_not_found(self, monkeypatch):
+    def test_series_not_found(self, monkeypatch, no_instance_param):
         monkeypatch.setattr(download_module, 'request', _fake_request())
-        monkeypatch.setattr(download_module, 'database', _FakeDatabase([None]))
+        monkeypatch.setattr(download_module, 'database', _FakeDatabase([[]]))
         resource = download_module.SeriesSubtitleBundleDownload()
         assert resource.get(99) == ('Series not found', 404)
 
-    def test_invalid_language_filter_rejected(self, monkeypatch):
+    def test_ambiguous_series_without_instance_is_400(self, monkeypatch, no_instance_param):
+        rows = [SimpleNamespace(title='A', arr_instance_id=1),
+                SimpleNamespace(title='B', arr_instance_id=2)]
+        monkeypatch.setattr(download_module, 'request', _fake_request())
+        monkeypatch.setattr(download_module, 'database', _FakeDatabase([rows]))
+        resource = download_module.SeriesSubtitleBundleDownload()
+        assert resource.get(5) == ('Ambiguous Sonarr series ID; pass arr_instance_id', 400)
+
+    def test_invalid_language_filter_rejected(self, monkeypatch, no_instance_param):
         monkeypatch.setattr(download_module, 'request',
                             _fake_request({'language': 'en:hi'}))
         resource = download_module.SeriesSubtitleBundleDownload()
         assert resource.get(1) == ('Invalid language filter', 400)
 
-    def test_bundles_matching_episodes(self, monkeypatch, tmp_path, identity_mappings):
+    def test_invalid_season_filter_rejected(self, monkeypatch, no_instance_param):
+        monkeypatch.setattr(download_module, 'request',
+                            _fake_request({'season': 'abc'}))
+        resource = download_module.SeriesSubtitleBundleDownload()
+        assert resource.get(1) == ('Invalid season filter', 400)
+
+    def test_episode_query_scoped_to_series_rows_instance(self, monkeypatch,
+                                                          identity_mappings):
+        # No arr_instance_id from the caller: the matched series row's owner
+        # must scope the episode query.
+        scoped_calls = []
+
+        def fake_scoped(stmt, column, arr_instance_id):
+            scoped_calls.append(arr_instance_id)
+            return stmt
+
+        monkeypatch.setattr(download_module, 'scoped', fake_scoped)
+        monkeypatch.setattr(download_module, '_request_arr_instance_id', lambda: None)
+        series_row = SimpleNamespace(title='My Show', arr_instance_id=7)
+        monkeypatch.setattr(download_module, 'request', _fake_request())
+        monkeypatch.setattr(download_module, 'database',
+                            _FakeDatabase([[series_row], []]))
+        resource = download_module.SeriesSubtitleBundleDownload()
+        resource.get(1)
+        assert scoped_calls == [None, 7]
+
+    def test_bundles_matching_episodes(self, monkeypatch, no_instance_param, tmp_path, identity_mappings):
         sub = tmp_path / 'S01E01.en.srt'
         sub.write_text('x')
         series_row = SimpleNamespace(title='My Show', arr_instance_id=None)
-        episode_rows = [_episode_row(1, f"[['en', '{sub}']]")]
+        episode_rows = [_episode_row(1, f"[['en', '{sub}']]",
+                                     path=str(tmp_path / 'S01E01.mkv'))]
         monkeypatch.setattr(download_module, 'request',
                             _fake_request({'language': 'en'}))
         monkeypatch.setattr(download_module, 'database',
-                            _FakeDatabase([series_row, episode_rows]))
+                            _FakeDatabase([[series_row], episode_rows]))
         sent = {}
 
         def fake_send_file(buffer, **kwargs):
             sent['names'] = zipfile.ZipFile(buffer).namelist()
             sent.update(kwargs)
-            return 'SENT'
+            return _FakeResponse()
 
         monkeypatch.setattr(download_module, 'send_file', fake_send_file)
         resource = download_module.SeriesSubtitleBundleDownload()
-        assert resource.get(1) == 'SENT'
+        response = resource.get(1)
         assert sent['names'] == ['Season 01/S01E01.en.srt']
         assert sent['download_name'] == 'My Show - en - subtitles.zip'
         assert sent['mimetype'] == 'application/zip'
+        assert response.headers['X-Content-Type-Options'] == 'nosniff'
 
-    def test_no_files_is_404(self, monkeypatch, identity_mappings):
+    def test_no_files_is_404(self, monkeypatch, no_instance_param, identity_mappings):
         series_row = SimpleNamespace(title='My Show', arr_instance_id=None)
         monkeypatch.setattr(download_module, 'request', _fake_request())
         monkeypatch.setattr(download_module, 'database',
-                            _FakeDatabase([series_row, []]))
+                            _FakeDatabase([[series_row], []]))
         resource = download_module.SeriesSubtitleBundleDownload()
         assert resource.get(1) == ('No subtitle files found', 404)
+
+    def test_oversized_bundle_is_413(self, monkeypatch, no_instance_param, identity_mappings):
+        series_row = SimpleNamespace(title='My Show', arr_instance_id=None)
+        monkeypatch.setattr(download_module, 'request', _fake_request())
+        monkeypatch.setattr(download_module, 'database',
+                            _FakeDatabase([[series_row], []]))
+
+        def too_big(entries, **kwargs):
+            raise download_module.BundleTooLargeError
+
+        monkeypatch.setattr(download_module, 'build_subtitle_bundle', too_big)
+        resource = download_module.SeriesSubtitleBundleDownload()
+        assert resource.get(1) == ('Subtitle bundle too large', 413)
 
 
 class TestMovieBundleDownload:
 
-    def test_movie_not_found(self, monkeypatch):
+    def test_movie_not_found(self, monkeypatch, no_instance_param):
         monkeypatch.setattr(download_module, 'request', _fake_request())
-        monkeypatch.setattr(download_module, 'database', _FakeDatabase([None]))
+        monkeypatch.setattr(download_module, 'database', _FakeDatabase([[]]))
         resource = download_module.MovieSubtitleBundleDownload()
         assert resource.get(1) == ('Movie not found', 404)
 
-    def test_bundles_movie_files(self, monkeypatch, tmp_path, identity_mappings):
+    def test_ambiguous_movie_without_instance_is_400(self, monkeypatch, no_instance_param):
+        rows = [_movie_row('[]', arr_instance_id=1),
+                _movie_row('[]', arr_instance_id=2)]
+        monkeypatch.setattr(download_module, 'request', _fake_request())
+        monkeypatch.setattr(download_module, 'database', _FakeDatabase([rows]))
+        resource = download_module.MovieSubtitleBundleDownload()
+        assert resource.get(1) == ('Ambiguous Radarr movie ID; pass arr_instance_id', 400)
+
+    def test_bundles_movie_files(self, monkeypatch, no_instance_param, tmp_path, identity_mappings):
         sub = tmp_path / 'Movie.en.srt'
         sub.write_text('x')
-        movie_row = _movie_row(f"[['en', '{sub}']]", title='Movie: The Sequel')
+        movie_row = _movie_row(f"[['en', '{sub}']]", title='Movie: The Sequel',
+                               path=str(tmp_path / 'Movie.mkv'))
         monkeypatch.setattr(download_module, 'request', _fake_request())
         monkeypatch.setattr(download_module, 'database',
-                            _FakeDatabase([movie_row]))
+                            _FakeDatabase([[movie_row]]))
         sent = {}
 
         def fake_send_file(buffer, **kwargs):
             sent['names'] = zipfile.ZipFile(buffer).namelist()
             sent.update(kwargs)
-            return 'SENT'
+            return _FakeResponse()
 
         monkeypatch.setattr(download_module, 'send_file', fake_send_file)
         resource = download_module.MovieSubtitleBundleDownload()
-        assert resource.get(654) == 'SENT'
+        resource.get(654)
         assert sent['names'] == ['Movie.en.srt']
         assert sent['download_name'] == 'Movie_ The Sequel - subtitles.zip'

--- a/tests/bazarr/test_subtitle_download_api.py
+++ b/tests/bazarr/test_subtitle_download_api.py
@@ -310,6 +310,27 @@ class TestResolveBundlePath:
             str(exe), [str(tmp_path)]) is None
 
 
+class TestOpenValidatedSubtitle:
+
+    def test_opens_regular_file(self, tmp_path):
+        sub = tmp_path / 'a.srt'
+        sub.write_text('x')
+        with download_module.open_validated_subtitle(str(sub)) as handle:
+            assert handle.read() == b'x'
+
+    def test_refuses_symlink(self, tmp_path):
+        target = tmp_path / 'target.srt'
+        target.write_text('x')
+        link = tmp_path / 'link.srt'
+        link.symlink_to(target)
+        with pytest.raises(OSError):
+            download_module.open_validated_subtitle(str(link))
+
+    def test_refuses_directory(self, tmp_path):
+        with pytest.raises(OSError):
+            download_module.open_validated_subtitle(str(tmp_path))
+
+
 # ---------------------------------------------------------------------------
 # Entry collection
 # ---------------------------------------------------------------------------
@@ -534,11 +555,14 @@ class TestSingleFileDownload:
         resource = download_module.EpisodeSubtitleFileDownload()
         assert resource.get(12, 'en') == ('No subtitle found for requested language', 404)
 
-    def test_success_sends_attachment_with_nosniff(self, monkeypatch):
+    def test_success_sends_attachment_with_nosniff(self, monkeypatch, tmp_path):
+        subtitle = tmp_path / 'Movie.en.srt'
+        subtitle.write_text('1\n00:00:01,000 --> 00:00:02,000\nA\n')
         sent = {}
 
-        def fake_send_file(path, **kwargs):
-            sent['path'] = path
+        def fake_send_file(handle, **kwargs):
+            sent['content'] = handle.read()
+            handle.close()
             sent.update(kwargs)
             return _FakeResponse()
 
@@ -548,7 +572,7 @@ class TestSingleFileDownload:
 
         def fake_resolve(media_type, media_id, language_code, arr_instance_id=None):
             captured['args'] = (media_type, media_id, language_code, arr_instance_id)
-            return ('/media/Movie (2020)/Movie.en.srt', {'mediaTitle': 'Movie'})
+            return (str(subtitle), {'mediaTitle': 'Movie'})
 
         monkeypatch.setattr(download_module, 'resolve_subtitle_path', fake_resolve)
         monkeypatch.setattr(download_module, 'send_file', fake_send_file)
@@ -556,22 +580,31 @@ class TestSingleFileDownload:
         resource = download_module.MovieSubtitleFileDownload()
         response = resource.get(654, 'en:hi')
         assert captured['args'] == ('movie', 654, 'en:hi', 3)
-        assert sent['path'] == '/media/Movie (2020)/Movie.en.srt'
+        assert sent['content'].endswith(b'A\n')
         assert sent['as_attachment'] is True
         assert sent['download_name'] == 'Movie.en.srt'
+        assert sent['mimetype'] == 'text/plain'
         assert response.headers['X-Content-Type-Options'] == 'nosniff'
 
-    def test_file_deleted_after_resolution_is_404(self, monkeypatch, no_instance_param):
+    def test_file_deleted_after_resolution_is_404(self, monkeypatch, no_instance_param,
+                                                  tmp_path):
         monkeypatch.setattr(download_module, 'request', _fake_request())
         monkeypatch.setattr(download_module, 'resolve_subtitle_path',
-                            lambda *a, **k: ('/media/gone.srt', {}))
-
-        def raising_send_file(path, **kwargs):
-            raise FileNotFoundError(path)
-
-        monkeypatch.setattr(download_module, 'send_file', raising_send_file)
+                            lambda *a, **k: (str(tmp_path / 'gone.srt'), {}))
         resource = download_module.EpisodeSubtitleFileDownload()
         assert resource.get(12, 'en') == ('Subtitle file or directory not found', 404)
+
+    def test_replacement_symlink_at_send_time_is_refused(self, monkeypatch,
+                                                         no_instance_param, tmp_path):
+        secret = tmp_path / 'secret.conf'
+        secret.write_text('apikey')
+        link = tmp_path / 'Movie.en.srt'
+        link.symlink_to(secret)
+        monkeypatch.setattr(download_module, 'request', _fake_request())
+        monkeypatch.setattr(download_module, 'resolve_subtitle_path',
+                            lambda *a, **k: (str(link), {}))
+        resource = download_module.MovieSubtitleFileDownload()
+        assert resource.get(1, 'en') == ('Subtitle file or directory not found', 404)
 
 
 class TestSingleFileAmbiguity:

--- a/tests/bazarr/test_subtitle_download_api.py
+++ b/tests/bazarr/test_subtitle_download_api.py
@@ -188,6 +188,13 @@ class TestUniqueArcname:
         assert download_module.unique_arcname(used, 'a/b.srt') == 'a/b (2).srt'
         assert download_module.unique_arcname(used, 'a/b.srt') == 'a/b (3).srt'
 
+    def test_collisions_are_case_insensitive(self):
+        # Names differing only by case overwrite each other when extracted
+        # on a case-insensitive filesystem.
+        used = set()
+        assert download_module.unique_arcname(used, 'English.srt') == 'English.srt'
+        assert download_module.unique_arcname(used, 'english.srt') == 'english (2).srt'
+
 
 class TestIterExternalSubtitles:
 
@@ -244,12 +251,17 @@ class TestLanguageFilterRe:
         assert download_module._LANGUAGE_FILTER_RE.match('pt-BR')
         assert download_module._LANGUAGE_FILTER_RE.match('zho')
 
-    def test_content_grammar_accepts_uppercase_modifiers(self):
+    def test_content_grammar_accepts_only_the_indexed_uppercase_form(self):
         # Custom languages index uppercase HI labels (zh:HI, zt:HI, pb:HI);
-        # validation must accept them or those Download/View actions 400.
+        # validation must accept exactly those. A blanket case-insensitive
+        # grammar would accept en:FORCED, which the exact DB lookup misses
+        # and the case-sensitive fallback probe then resolves to the WRONG
+        # (plain) file.
         assert content_module._LANGUAGE_CODE_RE.match('zt:HI')
         assert content_module._LANGUAGE_CODE_RE.match('pb:HI')
-        assert content_module._LANGUAGE_CODE_RE.match('en:FORCED')
+        assert content_module._LANGUAGE_CODE_RE.match('en:hi')
+        assert not content_module._LANGUAGE_CODE_RE.match('en:FORCED')
+        assert not content_module._LANGUAGE_CODE_RE.match('en:SYNC-FFSUBSYNC')
 
     def test_content_grammar_rejects_trailing_newline(self):
         # The single-file route validates through content.py's full grammar;

--- a/tests/bazarr/test_subtitle_download_api.py
+++ b/tests/bazarr/test_subtitle_download_api.py
@@ -598,6 +598,25 @@ class TestSingleFileDownload:
         assert sent['mimetype'] == 'text/plain'
         assert response.headers['X-Content-Type-Options'] == 'nosniff'
 
+    def test_control_characters_in_filename_are_sanitized(self, monkeypatch, tmp_path):
+        subtitle = tmp_path / 'Movie\nevil.en.srt'
+        subtitle.write_text('x')
+        sent = {}
+
+        def fake_send_file(handle, **kwargs):
+            handle.close()
+            sent.update(kwargs)
+            return _FakeResponse()
+
+        monkeypatch.setattr(download_module, 'request', _fake_request())
+        monkeypatch.setattr(download_module, '_request_arr_instance_id', lambda: None)
+        monkeypatch.setattr(download_module, 'resolve_subtitle_path',
+                            lambda *a, **k: (str(subtitle), {}))
+        monkeypatch.setattr(download_module, 'send_file', fake_send_file)
+        resource = download_module.MovieSubtitleFileDownload()
+        resource.get(1, 'en')
+        assert sent['download_name'] == 'Movie_evil.en.srt'
+
     def test_file_deleted_after_resolution_is_404(self, monkeypatch, no_instance_param,
                                                   tmp_path):
         monkeypatch.setattr(download_module, 'request', _fake_request())


### PR DESCRIPTION
Two fixes from v2.6.0 release-candidate testing.

## Subtitle viewer timestamps unreadable in light mode

The cue table's START and END columns were styled with the yellow-4 palette entry, which is nearly invisible on the light scheme's white surface. They now use the brand anchor color, the same color the breadcrumb links render in, which resolves to a readable shade in both color schemes.

## Subtitle file downloads

There was no way to get a subtitle file out of the UI.

**Single files.** Every subtitle tools menu (episode rows, movie detail rows, combined outputs) gains a Download action. It resolves through the same language-key grammar as the viewer/editor (`en`, `en:hi`, `en:forced`, sync and combined variants) and saves the file with its on-disk name. Embedded tracks stay disabled: there is no file on disk to hand out.

**Zip bundles.** The series and movie detail toolbars gain a Download button next to Upload. It opens a small modal with Season (series only) and Language selects and produces a zip: whole series, one season, one base language, or a season/language combination; movies offer whole or per language. Entries are grouped under `Season NN/` folders, name collisions get numbered suffixes, and files missing on disk are skipped.

### Backend

New namespace `bazarr/api/subtitles/download.py`:

- `GET /api/episodes/<sonarrEpisodeId>/subtitles/<language>/download`, `GET /api/movies/<radarrId>/subtitles/<language>/download`: single file via the existing `resolve_subtitle_path` (inherits its validation and path anchoring).
- `GET /api/series/<sonarrSeriesId>/subtitles/download?season=&language=&arr_instance_id=`, `GET /api/movies/<radarrId>/subtitles/download?language=&arr_instance_id=`: in-memory zip assembled from DB-tracked paths only, capped at 256 MB uncompressed, 404 when nothing matches, 400 on malformed language filters. Episode queries are scoped to the owning instance since upstream ids are only unique per server.

### Verification

- New `tests/bazarr/test_subtitle_download_api.py` (29 tests: helpers, zip assembly, route handlers), added to the CI guard list; full local backend batches green (compat 377, guard 1220, unguarded 755, per-file isolation loop with Postgres).
- Frontend check:ts / lint / fmt / vitest (894 passed) / build green; new unit tests for the Content-Disposition filename parser.
- Deploy-verified on the test instance: movie single download and bundle, series whole bundle (26 files across seasons), season+language filtered bundle, episode single download including an `en:hi` variant, 400 on a traversal-shaped language filter, 404 on unknown media, 401 unauthenticated.