### PR TITLE
Stop provider-pool adoption resurrecting excluded providers

### DIFF
--- a/bazarr/app/get_providers.py
+++ b/bazarr/app/get_providers.py
@@ -154,6 +154,19 @@ PROVIDERS_FORCED_OFF = ["addic7ed", "tvsubtitles", "legendasdivx", "napiprojekt"
 throttle_count = {}
 
 
+def provider_is_usable(name):
+    """Adoption gate for the provider pools (see SZProviderPool.__getitem__):
+    True only when the provider is enabled in settings and not currently
+    throttled, so a download naming a provider from a stale cached search
+    cannot resurrect one the user disabled or the backoff excluded."""
+    if name not in settings.general.enabled_providers:
+        return False
+    reason, until, _ = tp.get(name, (None, None, None))
+    if reason and until and datetime.datetime.now() < until:
+        return False
+    return True
+
+
 def provider_pool():
     if settings.general.multithreading:
         return subliminal_patch.core.SZAsyncProviderPool

--- a/bazarr/subtitles/pool.py
+++ b/bazarr/subtitles/pool.py
@@ -9,7 +9,7 @@ from inspect import getfullargspec
 from radarr.blacklist import get_blacklist_movie
 from sonarr.blacklist import get_blacklist
 from app.get_providers import get_providers, get_providers_auth, provider_throttle, provider_pool, get_language_equals, \
-    get_provider_language_hook, get_providers_sorted  # noqa: F401
+    get_provider_language_hook, get_providers_sorted, provider_is_usable  # noqa: F401
 
 from .utils import get_ban_list
 
@@ -25,6 +25,7 @@ def _init_pool(media_type, profile_id=None, providers=None):
         ban_list=get_ban_list(profile_id),
         language_hook=get_provider_language_hook(),
         language_equals=get_language_equals(),
+        adoption_gate=provider_is_usable,
     )
 
 

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -236,7 +236,8 @@ class SZProviderPool(ProviderPool):
         return list(dict.fromkeys(providers or []))
 
     def __init__(self, providers=None, provider_configs=None, blacklist=None, ban_list=None, throttle_callback=None,
-                 pre_download_hook=None, post_download_hook=None, language_hook=None, language_equals=None):
+                 pre_download_hook=None, post_download_hook=None, language_hook=None, language_equals=None,
+                 adoption_gate=None):
         #: Name of providers to use
         self.providers = self._dedupe_provider_names(providers)
 
@@ -262,6 +263,11 @@ class SZProviderPool(ProviderPool):
         self._born = time.time()
 
         self.provider_progress_callback = None
+
+        #: Optional callable(name) -> bool consulted before __getitem__ adopts
+        #: a provider the pool was not built with. None leaves adoption open to
+        #: any registered provider (the historical behaviour).
+        self.adoption_gate = adoption_gate
 
         if not self.throttle_callback:
             self.throttle_callback = lambda x, y, ids=None, language=None: x
@@ -334,7 +340,17 @@ class SZProviderPool(ProviderPool):
             # self.providers is always an ordered list (see __init__ and
             # update(), both of which route through _dedupe_provider_names), so
             # appending keeps the configured priority order.
+            #
+            # Absence from self.providers is also how the pool encodes
+            # discarded providers, and how update() encodes disabled or
+            # throttled ones. Never resurrect a provider this pool discarded,
+            # and let the adoption gate (the caller's enabled-and-not-throttled
+            # check) veto names the configuration currently excludes.
             if name not in provider_registry:
+                raise KeyError(name)
+            if name in self.discarded_providers:
+                raise KeyError(name)
+            if self.adoption_gate is not None and not self.adoption_gate(name):
                 raise KeyError(name)
             self.providers.append(name)
         if name not in self.initialized_providers:

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -230,6 +230,14 @@ class _LanguageEquals(list):
                 break
 
 
+class ProviderExcludedError(KeyError):
+    """A lookup named a provider the configuration currently excludes
+    (discarded by this pool, disabled, or throttled). Distinct from a bare
+    KeyError so callers can treat it as a quiet no-op: routing it through the
+    generic error handlers would call throttle_callback, and an unmapped
+    exception REPLACES an existing long backoff with the 10-minute default."""
+
+
 class SZProviderPool(ProviderPool):
     @staticmethod
     def _dedupe_provider_names(providers):
@@ -349,9 +357,9 @@ class SZProviderPool(ProviderPool):
             if name not in provider_registry:
                 raise KeyError(name)
             if name in self.discarded_providers:
-                raise KeyError(name)
+                raise ProviderExcludedError(name)
             if self.adoption_gate is not None and not self.adoption_gate(name):
-                raise KeyError(name)
+                raise ProviderExcludedError(name)
             self.providers.append(name)
         if name not in self.initialized_providers:
             logger.info('Initializing provider %s', name)
@@ -457,7 +465,13 @@ class SZProviderPool(ProviderPool):
             self.provider_progress_callback(provider)
 
         try:
-            results = self[provider].list_subtitles(video, to_request)
+            try:
+                initialized_provider = self[provider]
+            except ProviderExcludedError:
+                logger.info('Provider %r is currently excluded (disabled, '
+                            'throttled or discarded); not searching it', provider)
+                return
+            results = initialized_provider.list_subtitles(video, to_request)
             seen = []
             out = []
             for s in results:
@@ -683,7 +697,14 @@ class SZProviderPool(ProviderPool):
                 if self.pre_download_hook:
                     self.pre_download_hook(subtitle)
 
-                self[subtitle.provider_name].download_subtitle(subtitle)
+                try:
+                    initialized_provider = self[subtitle.provider_name]
+                except ProviderExcludedError:
+                    logger.info('Provider %r is currently excluded (disabled, '
+                                'throttled or discarded); not downloading from it',
+                                subtitle.provider_name)
+                    return False
+                initialized_provider.download_subtitle(subtitle)
                 if self.post_download_hook:
                     self.post_download_hook(subtitle)
 

--- a/tests/bazarr/test_app_get_providers.py
+++ b/tests/bazarr/test_app_get_providers.py
@@ -202,3 +202,47 @@ def test_get_traceback_info():
     if error_ is not None:
         msg = get_providers._get_traceback_info(error_)
         assert len(msg) == 100
+
+
+class TestProviderIsUsable:
+    """provider_is_usable is the pools' adoption gate: a stale cached search
+    result must not resurrect a provider the user disabled or the backoff
+    throttled (see SZProviderPool.__getitem__)."""
+
+    def test_disabled_provider_is_not_usable(self, monkeypatch):
+        monkeypatch.setattr(
+            get_providers.settings.general, "enabled_providers", ["opensubtitlescom"]
+        )
+        monkeypatch.setattr(get_providers, "tp", {})
+        assert not get_providers.provider_is_usable("podnapisi")
+
+    def test_enabled_unthrottled_provider_is_usable(self, monkeypatch):
+        monkeypatch.setattr(
+            get_providers.settings.general, "enabled_providers", ["opensubtitlescom"]
+        )
+        monkeypatch.setattr(get_providers, "tp", {})
+        assert get_providers.provider_is_usable("opensubtitlescom")
+
+    def test_throttled_provider_is_not_usable(self, monkeypatch):
+        import datetime
+
+        monkeypatch.setattr(
+            get_providers.settings.general, "enabled_providers", ["opensubtitlescom"]
+        )
+        until = datetime.datetime.now() + datetime.timedelta(hours=1)
+        monkeypatch.setattr(
+            get_providers, "tp", {"opensubtitlescom": ("Throttled", until, "1h")}
+        )
+        assert not get_providers.provider_is_usable("opensubtitlescom")
+
+    def test_expired_throttle_is_usable_again(self, monkeypatch):
+        import datetime
+
+        monkeypatch.setattr(
+            get_providers.settings.general, "enabled_providers", ["opensubtitlescom"]
+        )
+        until = datetime.datetime.now() - datetime.timedelta(minutes=1)
+        monkeypatch.setattr(
+            get_providers, "tp", {"opensubtitlescom": ("Throttled", until, "1h")}
+        )
+        assert get_providers.provider_is_usable("opensubtitlescom")

--- a/tests/bazarr/test_subtitles_pool.py
+++ b/tests/bazarr/test_subtitles_pool.py
@@ -14,3 +14,15 @@ def test_pool_update():
         mock_pool.return_value = MagicMock()
         pool_ = pool._init_pool("movie")
         assert pool._pool_update(pool_, "movie")
+
+
+def test_init_pool_wires_the_adoption_gate():
+    # The gate keeps a stale cached search result from resurrecting a
+    # disabled or throttled provider via SZProviderPool.__getitem__ adoption.
+    from app.get_providers import provider_is_usable
+
+    with patch("subtitles.pool.provider_pool") as mock_pool:
+        mock_pool.return_value = MagicMock()
+        pool._init_pool("movie")
+        kwargs = mock_pool.return_value.call_args.kwargs
+        assert kwargs["adoption_gate"] is provider_is_usable

--- a/tests/subliminal_patch/test_provider_pool.py
+++ b/tests/subliminal_patch/test_provider_pool.py
@@ -12,9 +12,15 @@ from subliminal_patch import core
 
 
 class _FakeProvider:
+    languages = set()
+
     def __init__(self, **kwargs):
         self.kwargs = kwargs
         self.initialized = False
+
+    @classmethod
+    def check(cls, video):
+        return True
 
     def initialize(self):
         self.initialized = True
@@ -106,3 +112,43 @@ def test_pool_getitem_gate_not_consulted_for_configured_providers(registry):
 
     assert isinstance(pool["alpha"], _FakeProvider)
     assert calls == []
+
+
+def test_excluded_download_neither_throttles_nor_discards(registry):
+    # A vetoed adoption during download must be a quiet no-op: routing it
+    # through the generic handler would call throttle_callback with an
+    # unmapped exception, REPLACING an existing long backoff with the
+    # 10-minute default.
+    throttled = []
+    pool = core.SZProviderPool(
+        ["alpha"],
+        {},
+        throttle_callback=lambda name, exc, ids=None, language=None: throttled.append(name),
+        adoption_gate=lambda name: False,
+    )
+    subtitle = type(
+        "FakeSubtitle", (), {"provider_name": "beta", "language": None}
+    )()
+
+    assert pool.download_subtitle(subtitle) is False
+    assert throttled == []
+    assert "beta" not in pool.discarded_providers
+
+
+def test_excluded_search_neither_throttles_nor_discards(registry):
+    throttled = []
+    pool = core.SZProviderPool(
+        ["alpha"],
+        {},
+        throttle_callback=lambda name, exc, ids=None, language=None: throttled.append(name),
+        adoption_gate=lambda name: False,
+    )
+    video = type("FakeVideo", (), {})()
+    language = core.Language("eng")
+    _FakeProvider.languages = {language}
+    try:
+        assert pool.list_subtitles_provider("beta", video, {language}) is None
+    finally:
+        _FakeProvider.languages = set()
+    assert throttled == []
+    assert "beta" not in pool.discarded_providers

--- a/tests/subliminal_patch/test_provider_pool.py
+++ b/tests/subliminal_patch/test_provider_pool.py
@@ -61,3 +61,48 @@ def test_pool_getitem_rejects_unregistered_provider(registry):
         pool["nosuchprovider"]
 
     assert pool.providers == ["alpha"]
+
+
+def test_pool_getitem_never_resurrects_a_discarded_provider(registry):
+    # Absence from pool.providers is how the pool encodes a discarded
+    # provider; adoption must not undo that.
+    pool = core.SZProviderPool(["alpha"], {})
+    pool.discarded_providers.add("beta")
+
+    with pytest.raises(KeyError):
+        pool["beta"]
+
+    assert pool.providers == ["alpha"]
+
+
+def test_pool_getitem_honors_adoption_gate_veto(registry):
+    # The gate is the caller's enabled-and-not-throttled check: a registered
+    # provider the configuration currently excludes must not be adopted.
+    pool = core.SZProviderPool(["alpha"], {}, adoption_gate=lambda name: False)
+
+    with pytest.raises(KeyError):
+        pool["beta"]
+
+    assert pool.providers == ["alpha"]
+    assert "beta" not in pool.initialized_providers
+
+
+def test_pool_getitem_adopts_when_gate_allows(registry):
+    pool = core.SZProviderPool(["alpha"], {}, adoption_gate=lambda name: name == "beta")
+
+    provider = pool["beta"]
+
+    assert isinstance(provider, _FakeProvider)
+    assert pool.providers == ["alpha", "beta"]
+
+
+def test_pool_getitem_gate_not_consulted_for_configured_providers(registry):
+    # The gate only guards adoption; providers the pool was built with
+    # initialize regardless (get_providers already filtered them).
+    calls = []
+    pool = core.SZProviderPool(
+        ["alpha"], {}, adoption_gate=lambda name: calls.append(name) or False
+    )
+
+    assert isinstance(pool["alpha"], _FakeProvider)
+    assert calls == []


### PR DESCRIPTION
The RAR-restoration work taught `SZProviderPool.__getitem__` to adopt any provider found in the global registry when a download names one the pool was not built with. That adoption is useful for the legitimate case (a subtitle chosen from an earlier search after the enabled-provider list changed), but absence from the pool's provider list is also how the pool encodes discarded providers, and how `update()` encodes disabled or throttled ones. A stale cached search result could therefore resurrect a provider the user disabled or the backoff logic excluded.

Two guards, both scoped to the adoption path only:

- The pool never adopts a provider it has itself discarded.
- The pool consults an optional `adoption_gate` callable before adopting anything else. Bazarr wires the gate to a new `provider_is_usable` check in `app/get_providers.py`: enabled in settings and not currently throttled. A pool constructed without a gate (the compat service, tests) keeps the historical behaviour, and providers the pool was built with initialize exactly as before since `get_providers()` already filtered them.

### Verification

- Regression tests in `tests/subliminal_patch/test_provider_pool.py` (discarded never adopted, gate veto honored, gate allow adopts, gate not consulted for configured providers), `tests/bazarr/test_app_get_providers.py` (`provider_is_usable` across disabled/enabled/throttled/expired-throttle), and `tests/bazarr/test_subtitles_pool.py` (the pools are built with the gate wired).
- Full local backend CI green: compat 377, guard batch 1228, unguarded 727, 39-file isolation loop with Postgres, ruff clean.
- Deploy-verified on the test instance: boots clean, manual search runs through the pool against live providers.