### PR TITLE
Backfill the release-notes archive for v2.5.0 through v2.5.2

### DIFF
--- a/docs/release-notes/v2.5.0-murmuration.md
+++ b/docs/release-notes/v2.5.0-murmuration.md
@@ -1,0 +1,197 @@
+![Bazarr+ v2.5.0 - Murmuration](https://raw.githubusercontent.com/LavX/bazarr/development/screenshot/hero-murmuration-v2.5.0.png)
+
+# Bazarr+ v2.5.0 (Murmuration)
+
+Codename: **Murmuration** (opening the v2.5 line).
+
+A murmuration is a thousand starlings moving as one. Bazarr+ v2.5.0, Murmuration, teaches Bazarr+ the same trick: point it at **as many Sonarr and Radarr servers as you run** and manage them as a single flock, with every operation scoped to the server that actually owns each show or movie. Around that headline it adds per-instance subtitle settings, compressed-archive uploads with real drag-and-drop, a cinematic login screen, a guided first-run setup wizard, a full SSRF / path-traversal security pass, and a complete refresh of the frontend stack to React 19.
+
+This cycle was almost entirely host-side work (the multi-instance control plane, per-instance resolution, the new onboarding and login UX, and the security hardening all live in the `bazarr` repo):
+
+| Repo | Files | Insertions | Commits |
+|------|------:|-----------:|---------|
+| `bazarr` (host) | 320+ | 23,000+ | 130+ \* |
+
+<sub>\* The host side is squash-merged, so the commit count understates real development volume; the multiple-arr-instances feature alone landed as a long-lived branch (#224) before the per-instance, onboarding, login, dependency, and hardening work on top.</sub>
+
+---
+
+## Headline: Multiple Sonarr/Radarr instances
+
+The OpenSubtitles era of Bazarr+ assumed one Sonarr and one Radarr. v2.5.0 removes that assumption: you can register **multiple Sonarr and Radarr servers** in one Bazarr+ and treat them as a single library, while every action stays scoped to the instance that owns each item (#224).
+
+### Isolated end to end
+
+Sync, search, manual search, download, upgrade, blacklist (add and remove), history, wanted, scan-disk and mass-edit all route to the correct instance. Colliding upstream IDs across servers no longer cross-contaminate: items are addressed by their owning instance, not by an upstream id that two servers might both use. This is the central invariant of the feature, and it is enforced by a dedicated suite of cross-instance isolation tests that seed colliding ids across servers and assert no leak.
+
+### Per-instance routing for the whole stack
+
+- **Webhooks** for Sonarr, Radarr and Plex resolve per instance, including a configurable webhook URL per instance.
+- **SignalR** maintains a client per server, each on its own connection.
+- The **cover-image proxy**, **root folders** and **path mappings** are each resolved against the owning instance.
+- **Plex** library updates can fan out to every configured server.
+
+### One Connections page
+
+Sonarr, Radarr, Plex and Jellyfin now live together under a single tabbed **Settings → Connections** page, mirroring the Subtitle Hub layout. Each connection is a card with an inline connection test, and one instance per kind acts as the default for newly added content.
+
+### First-class PostgreSQL
+
+The schema, an idempotent backfill, and a native Postgres cutover path are all covered and tested. Single-instance setups keep working exactly as before; multi-instance is purely additive.
+
+---
+
+## Per-instance subtitle settings
+
+Each instance can override how subtitles are produced, and Bazarr+ resolves the right settings against the media's **owning** instance rather than a single global default.
+
+### Resolved against the owning media
+
+The storage, resolver and API foundation (#231, #234) look up the owning instance for each show or movie and merge its overrides over the global defaults, so two libraries can produce subtitles differently from the same Bazarr+.
+
+### What you can override per instance
+
+- **Subzero modifications** threaded through the download path (#235).
+- **Custom post-processing** resolved per instance on downloads (#236) and on manual uploads (#239).
+- **Audio synchronization (subsync)** engines and options (#237).
+- The **keep-lyrics** override honored in the apply-mods action (#247).
+
+A dedicated per-instance Subtitle settings UI (#238) exposes all of it.
+
+---
+
+## Subtitle workflow
+
+- **Compressed-archive uploads** (#248): drop a `.zip`, `.rar` or `.7z` of subtitles into the upload modal; archives are expanded in memory (zip-slip-safe, with entry and size caps) and fed into the normal upload flow.
+- **Reliable drag-and-drop** (#248, #250): restored inside the upload modal and across the whole show/movie page; manual episode picks are preserved and the modal no longer closes mid-extraction (#249).
+- **Keep song lyrics** (#229): preserve lyric lines when removing hearing-impaired content.
+- **Forced embedded tracks** (#228): forced embedded subtitle tracks are detected from the track title tag.
+- **Anti-Captcha awareness** (#230): the Subtitle Hub flags providers that need an Anti-Captcha service.
+
+---
+
+## Cinematic login screen
+
+The login page is now a full-screen, atmospheric experience: blurred, gently graded TMDB trending backdrops rotate behind a centered glassmorphism card, in the Atmospheric Dark palette (#262).
+
+### Public catalog art, not your library
+
+A server-side `/system/backdrops` endpoint serves TMDB trending backdrop URLs, the same approach Overseerr and Jellyseerr use. The browser only ever receives public `image.tmdb.org` URLs, and the API key stays on the server.
+
+### Zero setup
+
+A shared public TMDB key is built in, so backdrops work out of the box. Set `BAZARR_TMDB_API_KEY` to use your own. Results are cached for several hours.
+
+### Respectful
+
+The cross-fade honors reduced-motion, and the card stays legible and scrollable on small or zoomed screens.
+
+---
+
+## First-run setup wizard
+
+A fresh install used to land on the General settings page with no direction. Now a guided, skippable wizard at `/setup` walks a new user through the whole stack, and it never auto-triggers for an install that already has any configuration (#263).
+
+### A step for every part of the stack
+
+- **Connect your media**: add Sonarr and Radarr with a live connection test, and optionally Plex or Jellyfin.
+- **Languages and providers**: pick languages and create a language profile, then install and enable at least one subtitle provider.
+
+### Survives the provider restart
+
+Installing providers stages new code that needs a restart to load, so the wizard restarts Bazarr+, shows a clear status with a manual reload escape hatch, waits for the backend to come back, and resumes on the provider configure step.
+
+### Just the essentials
+
+The configure step shows only the credentials a provider needs to start working. The full set of advanced options stays in **Settings → Providers**, and the upgrade "What's New" dialog stays out of the wizard's way (it shows the first time you land in-app afterward, never on top of setup).
+
+---
+
+## Frontend stack refresh
+
+The entire frontend was moved to the latest majors and validated against the whole UI test suite (#261): **React 19, react-router 8, Vite 8, TypeScript 6, and vitest 4**, plus the Mantine group. This also cleared a batch of frontend transitive-dependency Dependabot advisories (ws, undici, form-data, vite, esbuild) in one pass, since the refreshed lockfile pulls the patched versions.
+
+---
+
+## Security hardening
+
+A full SSRF and path-traversal pass shipped this cycle (#252, private advisory `GHSA-w6f4-fvxw-4crf`). **Localhost and private-LAN usage, the normal way to run Bazarr+, is unaffected**; only credential leaks to arbitrary public hosts and out-of-library file access are closed:
+
+- **Plex test-connection** no longer sends your Plex token to an untrusted public host (local/LAN, `plex.tv`, `*.plex.direct`, and your configured server stay allowed).
+- **Connection-test proxies** (`/test/...`) now require the API key, so they are never an unauthenticated SSRF surface on a default install.
+- **Subtitle API path containment**: the mods/sync/translate path and the subtitle-contents reader are constrained to their media areas; the reader is limited to subtitle files and never echoes file contents on error.
+- **Backup download** containment hardened.
+
+> [!NOTE]
+> This release also clears a **high-severity Dependabot advisory in `msgpack`** (`GHSA-6v7p-g79w-8964`) by moving to msgpack 1.2.1 (#264). `signalrcore` over-pins the vulnerable `1.1.2` in its metadata, so it is now installed with `--no-deps`; Bazarr+ forces the JSON SignalR protocol, so msgpack's MessagePack deserialization path was never reachable in the first place.
+
+---
+
+## Other Improvements & Fixes
+
+- **Frontend audit** (#254): 30+ bugs fixed, including a Subtitle Editor crash on plain-HTTP deployments (`crypto.randomUUID` is unavailable outside secure contexts), settings that silently failed to clear, query-cache invalidation gaps, and manual-search result-state bugs.
+- **RAR via system 7z** (#265): Bazarr+ no longer tries to self-download `unrar` into a read-only app directory at startup (which logged a `PermissionError` on every boot). The image extracts RAR via p7zip's `7z`, and `init_binaries()` now selects it first.
+- **Flaky settings test fixed** (#266): the Jellyfin settings render test now mounts inside a `FormContext` the way it does in the app, so it is deterministic under React 19's concurrent rendering.
+- **Provider Hub** (#223): worker display metadata no longer corrupts subtitle candidates.
+- **Background jobs** (#226): fixed a progress-overflow display bug.
+
+---
+
+## CI / Docker
+
+- **Release-only image publishing**: Docker images publish on a push to `master` and on a `v*` tag (`build-docker.yml`); the GitHub Pages site deploys from `site/` on `master`.
+- **No-regress frontend coverage floor** (#259) enforced on every build, so coverage cannot silently drop.
+- **CI coverage** (#253): the UI and editor-API suites plus the new SSRF / path-traversal guard tests now run on every build, alongside the cross-instance isolation guards (each in its own process) and a PostgreSQL service so the native-PG cutover migration is actually exercised.
+
+---
+
+## Dependency Updates
+
+Routine dependency and CI maintenance across the cycle: frontend dev-deps bumped to clear Dependabot alerts (vite, undici, esbuild) (#251), plus the Mantine group, cryptography, ffsubsync, sqlalchemy, apprise, numpy, flask-cors, beautifulsoup4, ruff and several GitHub Actions (#216–#222, #240–#246). The headline dependency change is the full frontend refresh to the latest majors (#261, see **Frontend stack refresh** above), and the `msgpack` security bump (#264, see **Security hardening**).
+
+---
+
+## Database Migrations
+
+Configuration and database migrations run automatically on first start.
+
+- The **multiple-instances schema** adds the `arr_instances` table plus ownership columns, with an **idempotent backfill** that stamps existing media with its owning instance derived from your current single-server config.
+- A **native PostgreSQL cutover path** for the local-id migration is covered and tested (CI runs it against a real Postgres service). **PostgreSQL is fully supported and first-class.**
+- Nothing to do manually: single-instance installs migrate transparently and keep working exactly as before.
+
+---
+
+## Included Pull Requests
+
+#216, #217, #218, #219, #220, #221, #222, #223, #224, #226, #228, #229, #230, #231, #234, #235, #236, #237, #238, #239, #240, #241, #242, #243, #244, #245, #246, #247, #248, #249, #250, #251, #252, #253, #254, #259, #261, #262, #263, #264, #265, #266
+
+---
+
+## Upgrade / Migration Notes
+
+- Configuration and database migrations run automatically on first start; **PostgreSQL is fully supported**.
+- Existing single-instance installs need no changes. To add a second server, open **Settings → Connections**.
+- A brand-new install now opens the **first-run setup wizard** at `/setup`; existing installs are never interrupted by it.
+- **No breaking changes** for single-instance users.
+
+---
+
+## Docker
+
+```bash
+docker pull ghcr.io/lavx/bazarr:2.5.0
+docker pull ghcr.io/lavx/bazarr:latest
+```
+
+After upgrade, confirm the UI loads and `/api/system/status` reports `2.5.0`.
+
+---
+
+## Contributors
+
+Thanks to everyone who ran Bazarr+, tested pre-release builds, reported issues, and shared feedback this cycle. 🪶
+
+---
+
+**Full Changelog:** https://github.com/LavX/bazarr/compare/v2.4.0...v2.5.0
+

--- a/docs/release-notes/v2.5.1-murmuration.md
+++ b/docs/release-notes/v2.5.1-murmuration.md
@@ -1,0 +1,99 @@
+# Bazarr+ v2.5.1 (Murmuration)
+
+Codename: **Murmuration** (stability patch on the v2.5 line).
+
+v2.5.0 taught Bazarr+ to fly as a flock of many Sonarr and Radarr servers. v2.5.1 is the follow-up that tightens the formation: it fixes the two most-reported rough edges from the multi-instance rollout, refreshes a stale community link, and folds in a full round of dependency and security maintenance. No schema changes, no breaking changes, and existing installs self-heal on upgrade.
+
+---
+
+## Headline: Fresh multi-server setups stop spamming the log
+
+A brand-new install configured through the onboarding wizard connected Sonarr and Radarr correctly (the connection test passed, media synced), yet the log filled with `Connection refused` retries against the **default** ports `8989` / `7878`, and the System page could show one app "down" while it actually worked (#276, #279).
+
+### Root cause
+
+The onboarding wizard (and the Connections page) create each arr instance directly through the API and flip `use_sonarr` / `use_radarr` on, but they never populated the legacy scalar `settings.<kind>.*` config. A handful of single-instance compatibility paths (the health-check rootfolder validation, the shared version probe, and the scheduler / SignalR fall-back) still read that scalar config whenever there is exactly one instance, on the assumption that it mirrors the default instance. That assumption holds for installs upgraded from an older single-server config (which was backfilled into an instance) but not for a fresh wizard setup, so those paths kept polling `127.0.0.1:8989` / `:7878`.
+
+### The fix, and it auto-heals
+
+Bazarr+ now mirrors the default instance's connection details back into the scalar config after every instance create/update, and once at startup. The startup reconcile is idempotent (it only writes when something actually changed), so **existing affected installs heal themselves on the first boot of this release, with no manual steps**.
+
+> Upgrading from a fresh v2.5.0 setup that was noisy? Just update and restart as usual. The scalar config is reconciled from your default instance on boot and the connection-refused spam stops.
+
+---
+
+## Reverse-proxy subpath no longer shows a blank page
+
+Running Bazarr+ behind a reverse proxy on a subpath (`base_url`, e.g. `/bazarr`, with `PathPrefix` and no `StripPrefix`) rendered a blank/white page: the HTML loaded with the correct `<base href="/bazarr/">`, but every JavaScript and CSS asset 404'd (#277, #278).
+
+The supervisor injected the `<base href>` while its static allowlist only held bare `assets/…` keys, so `/bazarr/assets/*` never matched and fell through to the known-extension 404 guard. The supervisor now strips the configured `base_url` prefix before the static lookup, so assets resolve correctly under the prefix. Deployments without `base_url` are unchanged.
+
+Thanks to **@slother**, who both reported the issue and sent the fix.
+
+---
+
+## Community
+
+- The Discord invite had been created as a 30-day link and quietly expired; it is replaced with a current never-expiring invite across the README, the in-app System status page, and the marketing site (#279).
+
+---
+
+## CI / Docker
+
+- **Release-only image publishing** is unchanged: Docker images publish on a push to `master` and on a `v*` tag (`build-docker.yml`); the GitHub Pages site deploys from `site/` on `master`.
+- The dynaconf bump kept the startup **requirements probe** honest: the fork pins its security-probed dependency versions in `bazarr/app/requirements.py` and a guard test asserts `requirements.txt` and the probe agree, so a bump has to update all three in lockstep (#285).
+
+---
+
+## Dependency Updates
+
+A full round of dependency and security maintenance, with **no known vulnerabilities outstanding** (0 open Dependabot alerts, 0 open code-scanning alerts):
+
+- **Python**: dynaconf 3.3.2 (#285), pillow ≥12.3.0 (#283), apscheduler 3.11.3 (#282), alembic 1.18.5 (#271), cloudscraper ≤1.2.71 (#270), python-dateutil 2.9.0.post0 (#269), numpy 2.5.x (#268), ruff 0.15.20 (#273).
+- **Frontend**: the FontAwesome group (#281) and `@tanstack/react-query-devtools` 5.101.1 (#272).
+- **CI**: `actions/cache` v6 (#267).
+
+> **Deferred:** guessit 4.0.2 (#280) is intentionally held back. It requires `rebulk>=6`, but the tree cannot get there (`subliminal → knowit → trakit`, and every published `trakit` pins `rebulk<4`). It will be revisited when upstream `trakit` / `knowit` support rebulk 6.
+
+---
+
+## Database Migrations
+
+**No schema changes in this release.** Configuration and database migrations still run automatically on first start, and the multi-instance scalar-config reconcile described above runs on boot and is idempotent. Nothing to do manually; single-instance installs are unaffected.
+
+---
+
+## Included Pull Requests
+
+#267, #268, #269, #270, #271, #272, #273, #278, #279, #281, #282, #283, #285
+
+---
+
+## Upgrade / Migration Notes
+
+- **No breaking changes.** Update and restart as usual.
+- A fresh-onboarding install that was noisy on v2.5.0 **self-heals on this upgrade**: the scalar config is reconciled from your default instance on first boot.
+- Behind a reverse proxy on a subpath, the blank-page issue is resolved with no config change on your side.
+- **PostgreSQL remains fully supported and first-class.**
+
+---
+
+## Docker
+
+```bash
+docker pull ghcr.io/lavx/bazarr:2.5.1
+docker pull ghcr.io/lavx/bazarr:latest
+```
+
+After upgrade, confirm the UI loads and `/api/system/status` reports `2.5.1`.
+
+---
+
+## Contributors
+
+Thanks to **@slother** for reporting and fixing the reverse-proxy subpath issue, and to **@Ultimatum22** and **@MikeTrysome** for the detailed, reproducible bug reports that drove this release. 🪶
+
+---
+
+**Full Changelog:** https://github.com/LavX/bazarr/compare/v2.5.0...v2.5.1
+

--- a/docs/release-notes/v2.5.2-murmuration.md
+++ b/docs/release-notes/v2.5.2-murmuration.md
@@ -1,0 +1,80 @@
+# Bazarr+ v2.5.2 (Murmuration)
+
+Codename: **Murmuration** (Provider Hub patch on the v2.5 line).
+
+v2.5.1 tightened the multi-instance formation. v2.5.2 is a focused Provider Hub fix: WhisperAI transcriptions that legitimately take longer than 30 seconds are no longer killed mid-flight, no matter what timeouts you had configured. It also adds a global "default worker timeout" setting so the general case the reporter asked about is tunable too. No schema changes, no breaking changes.
+
+---
+
+## Headline: WhisperAI transcriptions no longer die at 30 seconds
+
+If you pointed Bazarr+ at a self-hosted Whisper service as a last-resort provider, every transcription was cut off after ~30 seconds and failed, **regardless of the response and transcription timeouts you set** on the provider (#288). Setting transcription to 600s or 3600s made no difference; the worker was killed at 30.
+
+### Root cause
+
+WhisperAI is a migrated built-in, so on Bazarr+ it runs inside a **Provider Hub worker subprocess**. The host that supervises that subprocess enforces a deadline and kills the worker when it expires. That deadline was computed from a hardcoded 30-second default and only recognized the config keys `worker_timeout` / `timeout_seconds` / `timeout`. WhisperAI's Provider Hub config declares `response_timeout_seconds` and `transcription_timeout_seconds`, which matched none of those keys, so the deadline stayed at 30s. Your configured timeouts only ever bounded the HTTP calls *inside* the worker; the host guillotined the whole subprocess first.
+
+### The fix
+
+The host-side worker deadline now derives from whatever timeouts a plugin actually declares (any `*_timeout_seconds` key, plus the legacy keys), padded with a small margin so the worker's own timeout fires cleanly before the host steps in, and capped at 24 hours (raised from the previous 1-hour ceiling so a long transcription is never silently re-clipped). For a config of response 600 / transcription 3600, the worker is now given 3630 seconds instead of 30.
+
+> Upgrading with a WhisperAI provider that kept failing on long files? Just update and restart. Your existing response/transcription timeouts now take effect, no reconfiguration needed.
+
+---
+
+## New setting: Default worker timeout
+
+The reporter also asked for a general, tunable worker timeout. There is now a **Default worker timeout** setting under **Settings → General → Provider Hub** (default 120 seconds, range 30–86400).
+
+It is the fallback deadline for any Provider Hub plugin that does not declare its own timeouts. Plugins that *do* declare a longer timeout (like WhisperAI's transcription timeout) raise the deadline above this value, so this is a floor, not a cap.
+
+---
+
+## Verification
+
+Beyond unit coverage, the fix was verified end to end against a real Whisper ASR service through the real worker machinery: a genuine 95-second transcription **completes** under the new deadline, and is killed at exactly 30 seconds under the old one, reproducing and then resolving the reported failure.
+
+---
+
+## CI / Docker
+
+- **Release-only image publishing** is unchanged: Docker images publish on a push to `master` and on a `v*` tag (`build-docker.yml`); the GitHub Pages site deploys from `site/` on `master`.
+- A new backend test module (`test_provider_hub_worker_timeout.py`) was added to the CI guard-list, so the timeout derivation, floor, margin, cap, and fallback are all covered on every run.
+
+---
+
+## Dependency Updates
+
+None in this release. v2.5.2 is a focused code fix with no dependency changes.
+
+---
+
+## Database Migrations
+
+**No schema changes in this release.** The new setting lives in the normal configuration and is created with its default on first start. Single-instance and PostgreSQL installs are unaffected. Nothing to do manually.
+
+---
+
+## Included Pull Requests
+
+#289
+
+---
+
+## Contributors
+
+- Thanks to **Aracnoss** for the clear, reproducible bug report (#288) that made the root cause easy to pin down.
+
+---
+
+## Upgrade / Migration Notes
+
+- **No breaking changes.** Update and restart as usual.
+- A WhisperAI provider that was timing out at 30s **starts working on this upgrade** with your existing timeout settings; no reconfiguration required.
+- The new Default worker timeout defaults to 120s and only acts as a fallback; you do not need to touch it unless you run a plugin that declares no timeout of its own.
+- **PostgreSQL remains fully supported and first-class.**
+
+---
+
+**Full Changelog**: https://github.com/LavX/bazarr/compare/v2.5.1...v2.5.2
+


### PR DESCRIPTION
The repo's release-notes archive stopped at v2.4.0 while v2.5.0, v2.5.1 and v2.5.2 existed only as GitHub release bodies. This adds the three missing entries under the archive's existing version-plus-codename naming.

- Verbatim exports: each file is byte-identical to its published release body after trailing-whitespace normalization (verified programmatically against the GitHub API).
- Pandoc GFM render check passed for all three: the v2.5.0 hero renders as an image (v2.5.1 and v2.5.2 were published without heroes, and the archive preserves that), and no code fence degrades to literal backticks.
- The commit touches only docs/release-notes/, which the Docker build ignores.