### PR TITLE
Right-size the waitress thread pool and make it configurable

### DIFF
--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -95,8 +95,9 @@ validators = [
     Validator('general.port', must_exist=True, default=6767, is_type_of=int, gte=1, lte=65535),
     # Waitress worker threads. The old inherited constant was 100, a 25x
     # multiple of waitress's own default that dominated the process's thread
-    # count and resident memory; see the default's justification in server.py.
-    Validator('general.web_server_threads', must_exist=True, default=16, is_type_of=int, gte=4, lte=100),
+    # count and resident memory; see the default's justification in server.py
+    # (Socket.IO long-polling parks one worker per open browser tab).
+    Validator('general.web_server_threads', must_exist=True, default=32, is_type_of=int, gte=4, lte=100),
     Validator('general.hostname', must_exist=True, default=platform.node(), is_type_of=str),
     Validator('general.base_url', must_exist=True, default='', is_type_of=str),
     Validator('general.instance_name', must_exist=True, default='Bazarr+', is_type_of=str,

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -93,6 +93,10 @@ validators = [
     Validator('general.secrets_encryption_key', must_exist=True, default='', is_type_of=str),
     Validator('general.ip', must_exist=True, default='*', is_type_of=str, condition=validate_ip_address),
     Validator('general.port', must_exist=True, default=6767, is_type_of=int, gte=1, lte=65535),
+    # Waitress worker threads. The old inherited constant was 100, a 25x
+    # multiple of waitress's own default that dominated the process's thread
+    # count and resident memory; see the default's justification in server.py.
+    Validator('general.web_server_threads', must_exist=True, default=16, is_type_of=int, gte=4, lte=100),
     Validator('general.hostname', must_exist=True, default=platform.node(), is_type_of=str),
     Validator('general.base_url', must_exist=True, default='', is_type_of=str),
     Validator('general.instance_name', must_exist=True, default='Bazarr+', is_type_of=str,

--- a/bazarr/app/server.py
+++ b/bazarr/app/server.py
@@ -57,12 +57,14 @@ class Server:
             # Thread count: measured on a live 4-instance install, the old
             # inherited threads=100 accounted for 100 of 123 process threads
             # at idle for a single-user UI whose heavy work runs in background
-            # schedulers and out-of-process Provider Hub workers. The busiest
-            # in-process surface is the subtitle editor's stream/peaks
-            # endpoints, which a browser fans out over at most a handful of
-            # connections; 16 covers that with headroom, and waitress queues
-            # rather than drops beyond it. Configurable (4..100) for larger
-            # installs via general.web_server_threads.
+            # schedulers and out-of-process Provider Hub workers. Two things
+            # size the pool: the event stream runs Socket.IO in forced
+            # long-polling mode (app.py), so every open browser tab parks one
+            # worker in a poll, and the subtitle editor's stream/peaks
+            # endpoints fan out a handful of concurrent requests. 32 leaves a
+            # dozen parked tabs with ample headroom for bursts, and waitress
+            # queues rather than drops beyond it. Configurable (4..100) for
+            # larger installs via general.web_server_threads.
             self.server = create_server(app,
                                         host=self.address,
                                         port=self.port,

--- a/bazarr/app/server.py
+++ b/bazarr/app/server.py
@@ -54,10 +54,19 @@ class Server:
             # endpoint reads X-Forwarded-Host/Proto for download-link
             # construction; trusting arbitrary client values would let an
             # attacker forge stream URLs and exfiltrate the Api-Key.
+            # Thread count: measured on a live 4-instance install, the old
+            # inherited threads=100 accounted for 100 of 123 process threads
+            # at idle for a single-user UI whose heavy work runs in background
+            # schedulers and out-of-process Provider Hub workers. The busiest
+            # in-process surface is the subtitle editor's stream/peaks
+            # endpoints, which a browser fans out over at most a handful of
+            # connections; 16 covers that with headroom, and waitress queues
+            # rather than drops beyond it. Configurable (4..100) for larger
+            # installs via general.web_server_threads.
             self.server = create_server(app,
                                         host=self.address,
                                         port=self.port,
-                                        threads=100,
+                                        threads=settings.general.web_server_threads,
                                         trusted_proxy='127.0.0.1',
                                         trusted_proxy_headers={'x-forwarded-host',
                                                                'x-forwarded-proto',

--- a/tests/bazarr/test_config.py
+++ b/tests/bazarr/test_config.py
@@ -3,3 +3,17 @@ from app import config
 
 def test_get_settings():
     assert isinstance(config.get_settings(), dict)
+
+
+def test_web_server_threads_default_and_bounds():
+    # The waitress worker-thread count is configurable with a measured
+    # default; the validator pins the default and the sane range.
+    validator = next(
+        v for v in config.validators
+        if v.names == ('general.web_server_threads',)
+    )
+    assert validator.default == 16
+    operations = validator.operations
+    assert operations.get('gte') == 4
+    assert operations.get('lte') == 100
+    assert isinstance(config.settings.general.web_server_threads, int)

--- a/tests/bazarr/test_config.py
+++ b/tests/bazarr/test_config.py
@@ -12,7 +12,7 @@ def test_web_server_threads_default_and_bounds():
         v for v in config.validators
         if v.names == ('general.web_server_threads',)
     )
-    assert validator.default == 16
+    assert validator.default == 32
     operations = validator.operations
     assert operations.get('gte') == 4
     assert operations.get('lte') == 100

--- a/tests/bazarr/test_image_memory_config.py
+++ b/tests/bazarr/test_image_memory_config.py
@@ -9,9 +9,10 @@ heap arena on most of them.
 
 Measured on a real deployment, same database and same workload: capping arenas
 at two took the container from 514 MiB to 347 MiB and the backend process from
-388 MiB to 278 MiB, with the thread count unchanged at 123. That is the whole
-of the difference, which is why the thread count itself was left alone: after
-this, threads are no longer what the memory is spent on.
+388 MiB to 278 MiB, with the thread count unchanged at 123 at the time. The
+web-server pool has since been right-sized separately (general.web_server_threads,
+default 32; see app/server.py), which is complementary: the arena cap bounds
+what each thread costs, the pool size bounds how many exist.
 
 Asserted here because it is one environment variable in the Dockerfile with
 nothing else referring to it, so it would be removed by a tidy-up without


### PR DESCRIPTION
The waitress server ran with an inherited `threads=100`, a 25x multiple of waitress's own default, for a single-user web UI whose heavy work already runs in background schedulers and out-of-process Provider Hub workers. On glibc each thread contributes to resident memory through arena proliferation, and on a live 4-instance install the pool accounted for 100 of 123 process threads at idle.

- The default is now 16, with the justification recorded in a comment next to the call rather than inherited silently.
- `general.web_server_threads` makes it configurable (validated 4..100) for larger installs.
- The `trusted_proxy` / `trusted_proxy_headers` arguments on the same call are untouched; they are a security control unrelated to sizing.

### Measurements (same box, same library, idle)

| | threads=100 (before) | threads=16 (after) |
| --- | --- | --- |
| Process threads | 123 (100 waitress) | 49 (16 waitress) |
| VmRSS | 268,944 kB | 256,704 kB |

The RSS delta is modest because the image already caps glibc malloc arenas; the thread-count reduction is the durable part and the arena cap no longer has 100 request threads to fight.

### Concurrency check

The busiest in-process surface is the subtitle editor's streaming/content path. Against the deployed 16-thread build: 20 concurrent library list requests plus 8 concurrent subtitle-content requests, all returned 200, none dropped (waitress queues beyond the pool).

Full local backend CI green (compat 377, guard 1220, unguarded 727, 39-file isolation loop with Postgres), config validator covered by a new test, deploy-verified on the test instance.