### PR TITLE
Add the subtitle downloads slide to the 2.6.0 What's New

### DIFF
--- a/frontend/src/data/whatsNew.ts
+++ b/frontend/src/data/whatsNew.ts
@@ -1,8 +1,8 @@
 import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import {
   faClockRotateLeft,
-  faDownload,
   faDatabase,
+  faDownload,
   faFileZipper,
   faLayerGroup,
   faScaleBalanced,

--- a/frontend/src/data/whatsNew.ts
+++ b/frontend/src/data/whatsNew.ts
@@ -1,6 +1,7 @@
 import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import {
   faClockRotateLeft,
+  faDownload,
   faDatabase,
   faFileZipper,
   faLayerGroup,
@@ -35,6 +36,12 @@ export const latestWhatsNewVersion = "2.6.0";
 
 export const whatsNew: Record<string, WhatsNewSlide[]> = {
   "2.6.0": [
+    {
+      title: "Download your subtitles, single files or whole seasons",
+      body: "Every subtitle menu now has a Download action, including synced and combined outputs. The series and movie pages can also hand you one zip of everything on disk, filtered by season and language, from the new Download button next to Upload.",
+      icon: faDownload,
+      cta: { label: "Open your series", to: "/series" },
+    },
     {
       title: "Coming from upstream Bazarr? It just starts now",
       body: "Pointing Bazarr+ at a config directory created by upstream Bazarr used to crash on boot in a restart loop, because the two projects' migration histories diverged. Any upstream database is now adopted on first start, whatever revision it came from, with your subtitle lists preserved.",


### PR DESCRIPTION
Found by the second milestone sweep: the 2.6.0 What's New entry was authored before subtitle downloads merged, so the cycle's biggest late user-visible addition had no slide. The modal is many users' only contact with the release, and the way of work treats the entry as a content deliverable that must agree with the release notes.

One new slide, leading the entry: the Download action in every subtitle menu (sync and combined outputs included) and the season/language zip bundles behind the Download button next to Upload on the series and movie pages. The cta deep-links to /series, which exists.

Frontend check:ts / lint / fmt / full vitest (896) / build green; deploy-verified on the test instance (the slide's copy is present in the served bundle, and the modal fires for a fresh profile on the bumped version token, which is unchanged).