### PR TITLE
Fix the mass translate What's New slide to name the real setting

### DIFF
--- a/frontend/src/data/whatsNew.ts
+++ b/frontend/src/data/whatsNew.ts
@@ -61,7 +61,7 @@ export const whatsNew: Record<string, WhatsNewSlide[]> = {
     },
     {
       title: "Mass translate can use an embedded track",
-      body: 'If a release only carries its English subtitles inside the video container, mass translate can now extract and translate them. Turn on "Use embedded subtitles" and pick the source language as usual. Each variant is handled separately, so a normal and a hearing-impaired track produce their own outputs.',
+      body: 'If a release only carries its English subtitles inside the video container, mass translate can now extract and translate them. Enable "Treat Embedded Subtitles as Downloaded" so embedded tracks are indexed, then pick the source language as usual: when no external source file exists, the embedded track is used automatically. Each variant is handled separately, so a normal and a hearing-impaired track produce their own outputs.',
       icon: faWandMagicSparkles,
       cta: { label: "Open Subtitles settings", to: "/settings/subtitles" },
     },


### PR DESCRIPTION
The 2.6.0 What's New slide for the embedded-track mass translate feature told users to turn on "Use embedded subtitles". No option with that label exists in this UI; it is upstream Bazarr's old name for the setting. The setting that actually gates embedded-track indexing is "Treat Embedded Subtitles as Downloaded" under Settings > Subtitles > Embedded Subtitles Handling.

The slide now names that setting and describes the behavior as it is: once embedded tracks are indexed, mass translate falls back to them automatically when an item has no external source subtitle, so there is nothing extra to enable in the translate dialog itself.

One string change in frontend/src/data/whatsNew.ts. Full frontend suite run locally (typecheck, lint, format, coverage, build) and the built image deploy-verified: the served bundle carries the corrected text and no longer contains the phantom label.