### PR TITLE
Correct the embedded-subtitles parser option descriptions

### DIFF
--- a/frontend/src/pages/Settings/Subtitles/options.ts
+++ b/frontend/src/pages/Settings/Subtitles/options.ts
@@ -34,12 +34,12 @@ export const folderOptions: SelectorOption<string>[] = [
 export const embeddedSubtitlesParserOption: SelectorOption<string>[] = [
   {
     label:
-      "ffprobe (faster than mediainfo. Part of Bazarr installation already)",
+      "ffprobe (faster; the right choice unless embedded tracks are misdetected)",
     value: "ffprobe",
   },
   {
     label:
-      "mediainfo (slower but may give better results. User must install the mediainfo executable first)",
+      "mediainfo (slower, but reads track language and forced/HI flags more reliably from oddly tagged files. Included in the Docker image; other installs need the mediainfo executable)",
     value: "mediainfo",
   },
 ];


### PR DESCRIPTION
The mediainfo option in Settings > Subtitles claimed "User must install the mediainfo executable first". The Docker image ships /usr/bin/mediainfo alongside ffprobe, so for the primary install method that claim is wrong, and the option never said what mediainfo is actually better at.

New wording: ffprobe is the fast default and the right choice unless embedded tracks are misdetected; mediainfo is slower but reads track language and forced/HI flags more reliably from oddly tagged files, is included in the Docker image, and only other install methods need to provide the executable.

Two label strings in frontend/src/pages/Settings/Subtitles/options.ts. Full frontend suite run locally (typecheck, lint, format, coverage, build); the built image was deploy-verified on the test box: the served bundle carries the new wording and the old string is gone.