### PR TITLE
Release prep: Bazarr+ v2.6.1 (Clockwork)

### DIFF
--- a/docs/release-notes/v2.6.1-clockwork.md
+++ b/docs/release-notes/v2.6.1-clockwork.md
@@ -1,0 +1,85 @@
+# Bazarr+ v2.6.1 (Clockwork)
+
+Codename: **Clockwork**
+
+A stability patch on the v2.6 line, one day after Clockwork shipped. If you run a large library with "Treat Embedded Subtitles as Downloaded" enabled, v2.6.0's history pages could take twenty seconds to load a single page and buried your real events under a flood of embedded-detection records. All three reports arrived within a day of the release, precise and measured, and this patch answers them.
+
+---
+
+## Headline: History shows your events again, at any library size
+
+"Treat Embedded Subtitles as Downloaded" writes one Embedded Source history record per episode/language combination. On the reporting library that meant **115,188 records for 5,032 episodes** from a single indexing pass, and that flood exposed three defects at once:
+
+### One history page cost a full scan of the table
+
+The History pages order by timestamp, and no index existed behind that ordering, so the database scanned and sorted the entire six-figure table for every 25-row page: **21.5 seconds** per page on the reporting setup. A new migration (`b8d2c5f1a604`) adds the missing timestamp indexes plus partial event indexes that hold only the rows the default view shows, so the page cost no longer depends on how large your history is. Measured on a database synthesized at the reporter's exact shape: the page query drops from 309 ms to **0.5 ms**.
+
+### Real events drowned in Embedded Source records
+
+Downloads, manual searches, uploads, upgrades and translations were buried under thousands of embedded-detection rows, and the pager counted the noise as pages. The History pages now **hide Embedded Source records by default**, from the rows and the total alike, and a new **"Show Embedded Source records"** switch brings them back on demand. The records keep being written and keep their role: scoring and upgrade logic still read them, and the movie detail view still shows each embedded track's stored score.
+
+### Missing Episodes crawled while Missing Movies flew
+
+The Wanted pages scanned every episode row twice per request, once for the page and once for the count, and episode rows carrying twenty-plus embedded track entries are heavy to read: **5 seconds** per Missing Episodes page against Missing Movies' 0.02 s. The same migration adds partial indexes matching the wanted query exactly, so both the page and the count run off the index and never touch the fat rows. Both dialects verified: SQLite and PostgreSQL plan every one of these queries through the new indexes.
+
+---
+
+## Also in this patch
+
+- The release-hero tooling's dependencies were refreshed, clearing all five open Dependabot alerts on its lockfile (ws, webpack, and extract-zip, which had no patched release and is gone entirely from the updated toolchain). Build tooling only, never part of the shipped image.
+
+---
+
+## CI / Docker
+
+No workflow or image changes. The new test suites (history filtering, index migration) run in the standard backend matrix, including the per-file PostgreSQL isolation batch.
+
+---
+
+## Dependency Updates
+
+None in the shipped application. The Remotion toolchain bump above affects only the repository's release tooling.
+
+---
+
+## Database Migrations
+
+One migration: `b8d2c5f1a604` adds six indexes (history timestamp, history events, and wanted partial indexes, for series and movies each). It creates only what is missing, so adopted databases or manual fixes that already carry an index by one of these names pass through untouched. No table or data changes, and downgrade removes exactly what upgrade added.
+
+---
+
+## Included Pull Requests
+
+- #401: Index the history flood and keep Embedded Source out of the default view.
+
+---
+
+## Upgrade / Migration Notes
+
+- No breaking changes. Update and restart as usual; the migration applies at boot in seconds.
+- The History pages now hide Embedded Source records by default. Nothing was deleted: flip the new switch on the History page to see them again.
+- If you cleaned `action = 7` rows from your database by hand to work around this, you can stop; future scans may recreate them, and that is now fine.
+- **PostgreSQL remains fully supported and first-class**: every new index carries its predicate on both dialects and was verified against a real PostgreSQL 16.
+
+---
+
+## Docker
+
+```bash
+docker pull ghcr.io/lavx/bazarr:2.6.1
+docker pull ghcr.io/lavx/bazarr:latest
+```
+
+After upgrade, confirm the UI loads and `/api/system/status` reports `2.6.1`.
+
+---
+
+## Contributors
+
+Thanks to **[@illusive888](https://github.com/illusive888)**, whose three reports (LavX/bazarr#398, LavX/bazarr#399, LavX/bazarr#400) arrived within a day of v2.6.0 with row counts, timings and query plans attached, on top of the five reports that shaped v2.6.0 itself. Releases get better this fast only when the reports are this good.
+
+Thanks to **[@LavX](https://github.com/LavX)** for the fix and the release.
+
+---
+
+**Full Changelog**: https://github.com/LavX/bazarr/compare/v2.6.0...v2.6.1

--- a/frontend/src/data/whatsNew.ts
+++ b/frontend/src/data/whatsNew.ts
@@ -32,58 +32,71 @@ export interface WhatsNewSlide {
  * cutting a release. Kept as an explicit token so the wizard never has to parse the
  * fork's `version + YYMMDD` runtime string.
  */
-export const latestWhatsNewVersion = "2.6.0";
+export const latestWhatsNewVersion = "2.6.1";
+
+// v2.6.0 feature slides; v2.6.1 (a patch on the same line) leads with its
+// fix and keeps the whole Clockwork tour behind it.
+const clockworkSlides: WhatsNewSlide[] = [
+  {
+    title: "Download your subtitles, single files or whole seasons",
+    body: "Every subtitle menu now has a Download action, including synced and combined outputs. The series and movie pages can also hand you one zip of everything on disk, filtered by season and language, from the new Download button next to Upload.",
+    icon: faDownload,
+    cta: { label: "Open your series", to: "/series" },
+  },
+  {
+    title: "Coming from upstream Bazarr? It just starts now",
+    body: "Pointing Bazarr+ at a config directory created by upstream Bazarr used to crash on boot in a restart loop, because the two projects' migration histories diverged. Any upstream database is now adopted on first start, whatever revision it came from, with your subtitle lists preserved.",
+    icon: faDatabase,
+  },
+  {
+    title: "Movie edition scores are honest now, and some will drop",
+    body: "Subtitles used to get credit for matching a movie's edition (Extended, Director's Cut) even when they named no edition at all, worth up to 30 points. That is fixed. If edition-tagged movies stop getting subtitles, your minimum score is now being applied to an honest number: lower it a notch.",
+    icon: faScaleBalanced,
+    cta: { label: "Open Subtitles settings", to: "/settings/subtitles" },
+  },
+  {
+    title: "Sync rejects a bad result instead of reporting success",
+    body: 'Maximum offset used to bound ffsubsync\'s search, so a subtitle minutes out of sync could come back "synced" and overwrite a good file. It is now an acceptance threshold: a result beyond it is rejected and the next engine gets its turn. Expect more honest failures, and files already ruined stay ruined.',
+    icon: faClockRotateLeft,
+    cta: { label: "Open Subtitles settings", to: "/settings/subtitles" },
+  },
+  {
+    title: "Mass translate can use an embedded track",
+    body: 'If a release only carries its English subtitles inside the video container, mass translate can now extract and translate them. Enable "Treat Embedded Subtitles as Downloaded" so embedded tracks are indexed, then pick the source language as usual: when no external source file exists, the embedded track is used automatically. Each variant is handled separately, so a normal and a hearing-impaired track produce their own outputs.',
+    icon: faWandMagicSparkles,
+    cta: { label: "Open Subtitles settings", to: "/settings/subtitles" },
+  },
+  {
+    title: "Weight one provider up or down",
+    body: "Each provider can carry a score modifier from -100% to +100%, applied before the minimum-score check. It is a percentage of the maximum score rather than raw points, so 25% on an episode is worth roughly 90. Built for keeping something like WhisperAI as a genuine last resort without lowering the bar for everyone else.",
+    icon: faSliders,
+    cta: { label: "Open Providers", to: "/settings/providers" },
+  },
+  {
+    title: "Four dead providers were removed",
+    body: "Hosszupuska, Podnapisi, SubsCenter and XSubs no longer work and are gone. On first start they leave your enabled list and their leftover settings, including any saved password, are deleted from the config so old cleartext credentials cannot linger.",
+    icon: faStore,
+    cta: { label: "Open Providers", to: "/settings/providers" },
+  },
+  {
+    title: "CaptchaAI can solve your captchas",
+    body: "CaptchaAI joins Anti-Captcha and Death by Captcha as a third anti-captcha vendor, using its flat-rate 2Captcha-compatible API for the providers that hit a reCAPTCHA on login. The API keys for both key-based vendors are now encrypted at rest like every other credential.",
+    icon: faShieldHalved,
+    cta: { label: "Open Providers", to: "/settings/providers" },
+  },
+];
 
 export const whatsNew: Record<string, WhatsNewSlide[]> = {
-  "2.6.0": [
+  "2.6.1": [
     {
-      title: "Download your subtitles, single files or whole seasons",
-      body: "Every subtitle menu now has a Download action, including synced and combined outputs. The series and movie pages can also hand you one zip of everything on disk, filtered by season and language, from the new Download button next to Upload.",
-      icon: faDownload,
-      cta: { label: "Open your series", to: "/series" },
-    },
-    {
-      title: "Coming from upstream Bazarr? It just starts now",
-      body: "Pointing Bazarr+ at a config directory created by upstream Bazarr used to crash on boot in a restart loop, because the two projects' migration histories diverged. Any upstream database is now adopted on first start, whatever revision it came from, with your subtitle lists preserved.",
-      icon: faDatabase,
-    },
-    {
-      title: "Movie edition scores are honest now, and some will drop",
-      body: "Subtitles used to get credit for matching a movie's edition (Extended, Director's Cut) even when they named no edition at all, worth up to 30 points. That is fixed. If edition-tagged movies stop getting subtitles, your minimum score is now being applied to an honest number: lower it a notch.",
-      icon: faScaleBalanced,
-      cta: { label: "Open Subtitles settings", to: "/settings/subtitles" },
-    },
-    {
-      title: "Sync rejects a bad result instead of reporting success",
-      body: 'Maximum offset used to bound ffsubsync\'s search, so a subtitle minutes out of sync could come back "synced" and overwrite a good file. It is now an acceptance threshold: a result beyond it is rejected and the next engine gets its turn. Expect more honest failures, and files already ruined stay ruined.',
+      title: "History shows your events again",
+      body: 'On a large library, "Treat Embedded Subtitles as Downloaded" buried your downloads and upgrades under thousands of Embedded Source records and made History and Wanted pages crawl. Those records are now hidden by default (a switch brings them back), and new database indexes make both pages fast at any size.',
       icon: faClockRotateLeft,
-      cta: { label: "Open Subtitles settings", to: "/settings/subtitles" },
+      cta: { label: "Open History", to: "/history/series" },
     },
-    {
-      title: "Mass translate can use an embedded track",
-      body: 'If a release only carries its English subtitles inside the video container, mass translate can now extract and translate them. Enable "Treat Embedded Subtitles as Downloaded" so embedded tracks are indexed, then pick the source language as usual: when no external source file exists, the embedded track is used automatically. Each variant is handled separately, so a normal and a hearing-impaired track produce their own outputs.',
-      icon: faWandMagicSparkles,
-      cta: { label: "Open Subtitles settings", to: "/settings/subtitles" },
-    },
-    {
-      title: "Weight one provider up or down",
-      body: "Each provider can carry a score modifier from -100% to +100%, applied before the minimum-score check. It is a percentage of the maximum score rather than raw points, so 25% on an episode is worth roughly 90. Built for keeping something like WhisperAI as a genuine last resort without lowering the bar for everyone else.",
-      icon: faSliders,
-      cta: { label: "Open Providers", to: "/settings/providers" },
-    },
-    {
-      title: "Four dead providers were removed",
-      body: "Hosszupuska, Podnapisi, SubsCenter and XSubs no longer work and are gone. On first start they leave your enabled list and their leftover settings, including any saved password, are deleted from the config so old cleartext credentials cannot linger.",
-      icon: faStore,
-      cta: { label: "Open Providers", to: "/settings/providers" },
-    },
-    {
-      title: "CaptchaAI can solve your captchas",
-      body: "CaptchaAI joins Anti-Captcha and Death by Captcha as a third anti-captcha vendor, using its flat-rate 2Captcha-compatible API for the providers that hit a reCAPTCHA on login. The API keys for both key-based vendors are now encrypted at rest like every other credential.",
-      icon: faShieldHalved,
-      cta: { label: "Open Providers", to: "/settings/providers" },
-    },
+    ...clockworkSlides,
   ],
+  "2.6.0": clockworkSlides,
   "2.5.2": [
     {
       title: "WhisperAI timeouts no longer cut off at 30 seconds",

--- a/package_info
+++ b/package_info
@@ -1,7 +1,7 @@
 # Bazarr+ Package Information
 
 # Package version identifier (shown in System Status)
-packageversion=Bazarr+ v2.6.0
+packageversion=Bazarr+ v2.6.1
 
 # Package author (shown in System Status)
 packageauthor=LavX

--- a/site/index.html
+++ b/site/index.html
@@ -36,7 +36,7 @@
     "name": "Bazarr+",
     "applicationCategory": "MultimediaApplication",
     "operatingSystem": "Docker, Linux, Windows, macOS",
-    "softwareVersion": "2.6.0",
+    "softwareVersion": "2.6.1",
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "url": "https://lavx.github.io/bazarr/",
     "codeRepository": "https://github.com/LavX/bazarr",


### PR DESCRIPTION
The v2.6.1 stamp and notes, nothing else: package_info, the What's New entry (patch slide first, the full Clockwork tour behind it so upgraders from before 2.6.0 see everything), the site JSON-LD version, and the archived release notes at patch depth.

Render check green on the notes; full frontend suite green on the stamped tree; deploy-verified on the test server (v2.6.1 identity, new slide served, history default filter live).