### PR TITLE
Check translation eligibility before source-score logging

### DIFF
--- a/bazarr/subtitles/processing.py
+++ b/bazarr/subtitles/processing.py
@@ -71,15 +71,6 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
         if forced:
             return
 
-        min_score = settings.translator.min_source_score
-        if source_score_percent is not None and source_score_percent < min_score:
-            logging.info(
-                'BAZARR auto-translate skipped: source score %.1f%% '
-                'below threshold %.1f%% for %s',
-                source_score_percent, min_score, video_path,
-            )
-            return
-
         # Fetch the episode/movie row that postprocess_subtitles dereferences
         # for plex/jellyfin refresh (sonarrSeriesId, imdbId, season, episode,
         # tvdbId for episodes; imdbId, tmdbId for movies). Passing None here
@@ -140,6 +131,23 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
         if not profile:
             return
 
+        translation_targets = [
+            item for item in profile.get('items', [])
+            if item.get('translate_from') == downloaded_lang
+            and item.get('language') != downloaded_lang
+        ]
+        if not translation_targets:
+            return
+
+        min_score = settings.translator.min_source_score
+        if source_score_percent is not None and source_score_percent < min_score:
+            logging.info(
+                'BAZARR auto-translate skipped: source score %.1f%% '
+                'below threshold %.1f%% for %s',
+                source_score_percent, min_score, video_path,
+            )
+            return
+
         # Hoisted out of the loop: check_missing_languages is independent of the
         # profile item being considered, so calling it once per profile item
         # (potentially N database/indexer queries) is wasteful. Compute the
@@ -160,14 +168,8 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
             else:
                 missing_codes.add(code2)
 
-        for item in profile.get('items', []):
+        for item in translation_targets:
             target_lang = item.get('language')
-            translate_from = item.get('translate_from')
-
-            if not translate_from or translate_from != downloaded_lang:
-                continue
-            if target_lang == downloaded_lang:
-                continue
 
             target_code = profile_item_language_code(item)
             if target_code not in missing_codes:

--- a/tests/bazarr/test_auto_translation_profile.py
+++ b/tests/bazarr/test_auto_translation_profile.py
@@ -1,14 +1,18 @@
 # coding=utf-8
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
+
+import pytest
 
 
 def _missing_language(alpha3, hi=False, forced=False):
     return SimpleNamespace(alpha3=alpha3, hi=hi, forced=forced)
 
 
-def test_downloaded_series_subtitle_queues_episode_translation():
+@pytest.mark.parametrize('source_score_percent', [90, 100, None])
+def test_downloaded_series_subtitle_queues_episode_translation(source_score_percent):
     from subtitles.processing import _trigger_auto_translation
 
     mock_database = Mock()
@@ -30,7 +34,7 @@ def test_downloaded_series_subtitle_queues_episode_translation():
         patch('subtitles.processing.alpha2_from_alpha3', return_value='hu'),
         patch('subtitles.tools.translate.main.translate_subtitles_file') as mock_translate,
     ):
-        mock_settings.translator.min_source_score = 0
+        mock_settings.translator.min_source_score = 90
         mock_profiles.return_value = {
             'items': [
                 {
@@ -50,11 +54,123 @@ def test_downloaded_series_subtitle_queues_episode_translation():
             media_type='series',
             series_id=10,
             episode_id=20,
-            source_score_percent=100,
+            source_score_percent=source_score_percent,
         )
 
     mock_translate.assert_called_once()
     assert mock_translate.call_args.kwargs['media_type'] == 'episode'
+
+
+@pytest.mark.parametrize('profile', [
+    None,
+    {'items': []},
+    {'items': [
+        {'language': 'en', 'translate_from': None},
+        {'language': 'hr', 'translate_from': None},
+    ]},
+    {'items': [{'language': 'hu', 'translate_from': 'fr'}]},
+    {'items': [{'language': 'en', 'translate_from': 'en'}]},
+], ids=['no-profile', 'empty-profile', 'disabled', 'different-source', 'same-language'])
+def test_downloaded_subtitle_without_matching_translation_target_stays_silent(profile, caplog):
+    from subtitles.processing import _trigger_auto_translation
+
+    mock_database = Mock()
+    mock_database.execute.return_value.first.return_value = SimpleNamespace(
+        imdbId='tt2', tmdbId='2', profileId=1,
+    )
+
+    with (
+        caplog.at_level(logging.INFO),
+        patch('subtitles.processing.settings') as mock_settings,
+        patch('app.database.get_profiles_list', return_value=profile),
+        patch('app.database.database', mock_database),
+        patch('subtitles.download.check_missing_languages') as mock_missing,
+        patch('subtitles.tools.translate.main.translate_subtitles_file') as mock_translate,
+    ):
+        mock_settings.translator.min_source_score = 90
+
+        _trigger_auto_translation(
+            downloaded_lang='en',
+            subtitle_path='/subs/source.en.srt',
+            video_path='/video/movie.mkv',
+            media_type='movie',
+            radarr_id=30,
+            source_score_percent=80,
+        )
+
+    assert not [record for record in caplog.records if 'auto-translate' in record.getMessage()]
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
+    mock_missing.assert_not_called()
+    mock_translate.assert_not_called()
+
+
+def test_low_score_subtitle_logs_once_for_multiple_matching_translation_targets(caplog):
+    from subtitles.processing import _trigger_auto_translation
+
+    mock_database = Mock()
+    mock_database.execute.return_value.first.return_value = SimpleNamespace(
+        imdbId='tt2', tmdbId='2', profileId=1,
+    )
+
+    with (
+        caplog.at_level(logging.INFO),
+        patch('subtitles.processing.settings') as mock_settings,
+        patch('app.database.get_profiles_list') as mock_profiles,
+        patch('app.database.database', mock_database),
+        patch('subtitles.download.check_missing_languages') as mock_missing,
+        patch('subtitles.tools.translate.main.translate_subtitles_file') as mock_translate,
+    ):
+        mock_settings.translator.min_source_score = 90
+        mock_profiles.return_value = {
+            'items': [
+                {'language': 'hu', 'translate_from': 'en'},
+                {'language': 'hr', 'translate_from': 'en'},
+            ]
+        }
+
+        _trigger_auto_translation(
+            downloaded_lang='en',
+            subtitle_path='/subs/source.en.srt',
+            video_path='/video/movie.mkv',
+            media_type='movie',
+            radarr_id=30,
+            source_score_percent=80,
+        )
+
+    score_logs = [record for record in caplog.records if 'below threshold' in record.getMessage()]
+    assert len(score_logs) == 1
+    assert score_logs[0].levelno == logging.INFO
+    assert score_logs[0].args == (80, 90, '/video/movie.mkv')
+    mock_missing.assert_not_called()
+    mock_translate.assert_not_called()
+
+
+@pytest.mark.parametrize('source_score_percent', [80, 100])
+def test_forced_source_subtitle_stays_silent_and_does_not_translate(source_score_percent, caplog):
+    from subtitles.processing import _trigger_auto_translation
+
+    with (
+        caplog.at_level(logging.INFO),
+        patch('subtitles.processing.settings') as mock_settings,
+        patch('app.database.database') as mock_database,
+        patch('subtitles.tools.translate.main.translate_subtitles_file') as mock_translate,
+    ):
+        mock_settings.translator.min_source_score = 90
+
+        _trigger_auto_translation(
+            downloaded_lang='en',
+            subtitle_path='/subs/source.en.forced.srt',
+            video_path='/video/movie.mkv',
+            media_type='movie',
+            radarr_id=30,
+            source_score_percent=source_score_percent,
+            forced=True,
+        )
+
+    assert not [record for record in caplog.records if 'auto-translate' in record.getMessage()]
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
+    mock_database.execute.assert_not_called()
+    mock_translate.assert_not_called()
 
 
 def test_downloaded_subtitle_does_not_translate_for_mismatched_target_variant():


### PR DESCRIPTION
Fixes https://github.com/LavX/bazarr/issues/405

Downloading a low-scoring subtitle logged an auto-translation skip even when its language profile had translation disabled. The profile and matching target languages are now resolved before checking the source-score threshold. Profiles with no eligible targets return silently; eligible low-score sources still produce one skip message per subtitle.

Forced-track rejection, instance scoping, translation metadata, and missing-language checks are preserved. No schema change.

Validation:

- Regression tests reproduced five disabled or ineligible-profile failures before the fix. All 14 profile cases and 37 related processing guards pass; independent review passed.
- Full local CI on Python 3.12, 3.13, and 3.14: 2,821 passed and 8 expected optional snapshot skips per version. All 11 native PostgreSQL checks pass per version.
- All frontend gates pass: 896 tests passed with 2 existing skips. Startup smoke passes on all three Python versions.
- The exact deployed source passed ten translation-gate scenarios using a disposable database copy with translation calls captured. Live APIs and UI checks also passed.
