### PR TITLE
Scope generated sync outputs to their owning media

### DIFF
--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -130,7 +130,8 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True, arr_inst
                     full_dest_folder_path = dest_folder
                 elif settings.general.subfolder == "relative":
                     full_dest_folder_path = os.path.join(os.path.dirname(reversed_path), dest_folder)
-            subtitles = add_sync_engine_outputs(full_dest_folder_path, subtitles)
+            subtitles = add_sync_engine_outputs(full_dest_folder_path, subtitles,
+                                                video_filename=os.path.basename(reversed_path))
             subtitles = add_combined_outputs(full_dest_folder_path, subtitles,
                                              video_filename=os.path.basename(reversed_path))
             subtitles = guess_external_subtitles(full_dest_folder_path, subtitles, "movie",

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -131,7 +131,8 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True, arr_inst
                 elif settings.general.subfolder == "relative":
                     full_dest_folder_path = os.path.join(os.path.dirname(reversed_path), dest_folder)
             subtitles = add_sync_engine_outputs(full_dest_folder_path, subtitles,
-                                                video_filename=os.path.basename(reversed_path))
+                                                video_filename=os.path.basename(reversed_path),
+                                                single_language=settings.general.single_language)
             subtitles = add_combined_outputs(full_dest_folder_path, subtitles,
                                              video_filename=os.path.basename(reversed_path))
             subtitles = guess_external_subtitles(full_dest_folder_path, subtitles, "movie",

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -131,8 +131,7 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True, arr_inst
                 elif settings.general.subfolder == "relative":
                     full_dest_folder_path = os.path.join(os.path.dirname(reversed_path), dest_folder)
             subtitles = add_sync_engine_outputs(full_dest_folder_path, subtitles,
-                                                video_filename=os.path.basename(reversed_path),
-                                                single_language=settings.general.single_language)
+                                                video_path=reversed_path)
             subtitles = add_combined_outputs(full_dest_folder_path, subtitles,
                                              video_filename=os.path.basename(reversed_path))
             subtitles = guess_external_subtitles(full_dest_folder_path, subtitles, "movie",

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -130,7 +130,8 @@ def store_subtitles(original_path, reversed_path, use_cache=True, arr_instance_i
                     full_dest_folder_path = dest_folder
                 elif settings.general.subfolder == "relative":
                     full_dest_folder_path = os.path.join(os.path.dirname(reversed_path), dest_folder)
-            subtitles = add_sync_engine_outputs(full_dest_folder_path, subtitles)
+            subtitles = add_sync_engine_outputs(full_dest_folder_path, subtitles,
+                                                video_filename=os.path.basename(reversed_path))
             subtitles = add_combined_outputs(full_dest_folder_path, subtitles,
                                              video_filename=os.path.basename(reversed_path))
             subtitles = guess_external_subtitles(full_dest_folder_path, subtitles, "series",

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -131,7 +131,8 @@ def store_subtitles(original_path, reversed_path, use_cache=True, arr_instance_i
                 elif settings.general.subfolder == "relative":
                     full_dest_folder_path = os.path.join(os.path.dirname(reversed_path), dest_folder)
             subtitles = add_sync_engine_outputs(full_dest_folder_path, subtitles,
-                                                video_filename=os.path.basename(reversed_path))
+                                                video_filename=os.path.basename(reversed_path),
+                                                single_language=settings.general.single_language)
             subtitles = add_combined_outputs(full_dest_folder_path, subtitles,
                                              video_filename=os.path.basename(reversed_path))
             subtitles = guess_external_subtitles(full_dest_folder_path, subtitles, "series",

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -131,8 +131,7 @@ def store_subtitles(original_path, reversed_path, use_cache=True, arr_instance_i
                 elif settings.general.subfolder == "relative":
                     full_dest_folder_path = os.path.join(os.path.dirname(reversed_path), dest_folder)
             subtitles = add_sync_engine_outputs(full_dest_folder_path, subtitles,
-                                                video_filename=os.path.basename(reversed_path),
-                                                single_language=settings.general.single_language)
+                                                video_path=reversed_path)
             subtitles = add_combined_outputs(full_dest_folder_path, subtitles,
                                              video_filename=os.path.basename(reversed_path))
             subtitles = guess_external_subtitles(full_dest_folder_path, subtitles, "series",

--- a/bazarr/subtitles/indexer/utils.py
+++ b/bazarr/subtitles/indexer/utils.py
@@ -76,8 +76,8 @@ def sync_engine_from_subtitle_name(subtitle):
     return sync_engine_from_output_path(subtitle)
 
 
-def _same_video_stem(left, right):
-    return unicodedata.normalize('NFC', left.lower()) == unicodedata.normalize('NFC', right.lower())
+def _normalized_video_stem(stem):
+    return unicodedata.normalize('NFC', stem.lower())
 
 
 def _language_code_from_sync_engine_output(subtitle, video_filename=None):
@@ -112,7 +112,7 @@ def _language_code_from_sync_engine_output(subtitle, video_filename=None):
 
     if video_filename is not None:
         video_stem = os.path.splitext(video_filename)[0]
-        if not _same_video_stem('.'.join(parts[:-1]), video_stem):
+        if _normalized_video_stem('.'.join(parts[:-1])) != _normalized_video_stem(video_stem):
             return None
 
     language = parts[-1].lower().replace('_', '-')
@@ -122,10 +122,22 @@ def _language_code_from_sync_engine_output(subtitle, video_filename=None):
     return ':'.join([language] + variants)
 
 
-def add_sync_engine_outputs(dest_folder, subtitles, video_filename=None, single_language=False):
-    """Add generated outputs, optionally scoped to the video's exact basename stem."""
+def add_sync_engine_outputs(dest_folder, subtitles, video_filename=None, video_path=None):
+    """Add generated outputs belonging to the video, regardless of save preferences."""
     if not os.path.isdir(dest_folder):
         return subtitles
+
+    video_stem = None
+    media_stems = set()
+    if video_path is not None:
+        video_filename = os.path.basename(video_path)
+    if video_filename is not None:
+        video_stem = _normalized_video_stem(os.path.splitext(video_filename)[0])
+        media_folder = (os.path.dirname(video_path) or '.') if video_path is not None else dest_folder
+        with os.scandir(media_folder) as media_files:
+            media_stems = {_normalized_video_stem(os.path.splitext(entry.name)[0])
+                           for entry in media_files
+                           if entry.is_file() and entry.name.lower().endswith(core.VIDEO_EXTENSIONS)}
 
     for subtitle in os.listdir(dest_folder):
         if subtitle in subtitles or not sync_engine_from_subtitle_name(subtitle):
@@ -135,16 +147,20 @@ def add_sync_engine_outputs(dest_folder, subtitles, video_filename=None, single_
         if not os.path.isfile(subtitle_path):
             continue
 
-        if single_language and video_filename is not None:
+        if video_stem is not None:
             stem, extension = os.path.splitext(subtitle)
-            owner_stem = stem.rsplit('.', 1)[0]
-            video_stem = os.path.splitext(video_filename)[0]
-            if extension.lower() in core.SUBTITLE_EXTENSIONS and _same_video_stem(owner_stem, video_stem):
-                # Single-language saves append neither a language nor HI/forced
-                # tags. Keep every component of the video stem and let the usual
-                # cached-language/content detection identify the subtitle.
+            if extension.lower() not in core.SUBTITLE_EXTENSIONS:
+                continue
+            owner_stem = _normalized_video_stem(stem.rsplit('.', 1)[0])
+            if owner_stem == video_stem:
+                # The complete basename owns an untagged output. Detect its
+                # language normally, even if the save preference has changed.
                 subtitles[subtitle] = None
-            continue
+                continue
+            if owner_stem in media_stems:
+                # Movie.en.mkv owns Movie.en.ffsubsync.srt when it exists.
+                # Without that sibling, it can be a tagged output of Movie.mkv.
+                continue
 
         language_code = _language_code_from_sync_engine_output(subtitle, video_filename=video_filename)
         if not language_code:

--- a/bazarr/subtitles/indexer/utils.py
+++ b/bazarr/subtitles/indexer/utils.py
@@ -2,6 +2,7 @@
 
 import os
 import logging
+import unicodedata
 
 from guess_language import guess_language
 from subliminal_patch import core
@@ -75,6 +76,10 @@ def sync_engine_from_subtitle_name(subtitle):
     return sync_engine_from_output_path(subtitle)
 
 
+def _same_video_stem(left, right):
+    return unicodedata.normalize('NFC', left.lower()) == unicodedata.normalize('NFC', right.lower())
+
+
 def _language_code_from_sync_engine_output(subtitle, video_filename=None):
     filename = os.path.basename(subtitle)
     stem, extension = os.path.splitext(filename)
@@ -107,7 +112,7 @@ def _language_code_from_sync_engine_output(subtitle, video_filename=None):
 
     if video_filename is not None:
         video_stem = os.path.splitext(video_filename)[0]
-        if '.'.join(parts[:-1]) != video_stem:
+        if not _same_video_stem('.'.join(parts[:-1]), video_stem):
             return None
 
     language = parts[-1].lower().replace('_', '-')
@@ -117,7 +122,7 @@ def _language_code_from_sync_engine_output(subtitle, video_filename=None):
     return ':'.join([language] + variants)
 
 
-def add_sync_engine_outputs(dest_folder, subtitles, video_filename=None):
+def add_sync_engine_outputs(dest_folder, subtitles, video_filename=None, single_language=False):
     """Add generated outputs, optionally scoped to the video's exact basename stem."""
     if not os.path.isdir(dest_folder):
         return subtitles
@@ -128,6 +133,17 @@ def add_sync_engine_outputs(dest_folder, subtitles, video_filename=None):
 
         subtitle_path = os.path.join(dest_folder, subtitle)
         if not os.path.isfile(subtitle_path):
+            continue
+
+        if single_language and video_filename is not None:
+            stem, extension = os.path.splitext(subtitle)
+            owner_stem = stem.rsplit('.', 1)[0]
+            video_stem = os.path.splitext(video_filename)[0]
+            if extension.lower() in core.SUBTITLE_EXTENSIONS and _same_video_stem(owner_stem, video_stem):
+                # Single-language saves append neither a language nor HI/forced
+                # tags. Keep every component of the video stem and let the usual
+                # cached-language/content detection identify the subtitle.
+                subtitles[subtitle] = None
             continue
 
         language_code = _language_code_from_sync_engine_output(subtitle, video_filename=video_filename)

--- a/bazarr/subtitles/indexer/utils.py
+++ b/bazarr/subtitles/indexer/utils.py
@@ -75,14 +75,14 @@ def sync_engine_from_subtitle_name(subtitle):
     return sync_engine_from_output_path(subtitle)
 
 
-def _language_code_from_sync_engine_output(subtitle):
-    filename = os.path.basename(subtitle).lower()
+def _language_code_from_sync_engine_output(subtitle, video_filename=None):
+    filename = os.path.basename(subtitle)
     stem, extension = os.path.splitext(filename)
-    if extension not in core.SUBTITLE_EXTENSIONS:
+    if extension.lower() not in core.SUBTITLE_EXTENSIONS:
         return None
 
     parts = stem.split('.')
-    if len(parts) < 3 or parts[-1] not in SYNC_ENGINES:
+    if len(parts) < 3 or parts[-1].lower() not in SYNC_ENGINES:
         return None
 
     parts = parts[:-1]
@@ -93,26 +93,32 @@ def _language_code_from_sync_engine_output(subtitle):
     # combined output is a known limitation: it is left on disk but not indexed
     # as a tracked variant. Overwrite-mode sync of a combined file works in
     # place (it keeps the Movie.en.combined-hu.srt name) and is unaffected.
-    if parts and _COMBINED_MODIFIER_PATTERN.match(parts[-1]):
+    if parts and _COMBINED_MODIFIER_PATTERN.match(parts[-1].lower()):
         return None
     variants = []
-    if parts and parts[-1] in ['hi', 'sdh', 'cc']:
+    if parts and parts[-1].lower() in ['hi', 'sdh', 'cc']:
         variants.append('hi')
         parts = parts[:-1]
-    if parts and parts[-1] == 'forced':
+    if parts and parts[-1].lower() == 'forced':
         variants.append('forced')
         parts = parts[:-1]
     if not parts:
         return None
 
-    language = parts[-1].replace('_', '-')
+    if video_filename is not None:
+        video_stem = os.path.splitext(video_filename)[0]
+        if '.'.join(parts[:-1]) != video_stem:
+            return None
+
+    language = parts[-1].lower().replace('_', '-')
     if not language:
         return None
 
     return ':'.join([language] + variants)
 
 
-def add_sync_engine_outputs(dest_folder, subtitles):
+def add_sync_engine_outputs(dest_folder, subtitles, video_filename=None):
+    """Add generated outputs, optionally scoped to the video's exact basename stem."""
     if not os.path.isdir(dest_folder):
         return subtitles
 
@@ -124,9 +130,9 @@ def add_sync_engine_outputs(dest_folder, subtitles):
         if not os.path.isfile(subtitle_path):
             continue
 
-        language_code = _language_code_from_sync_engine_output(subtitle)
+        language_code = _language_code_from_sync_engine_output(subtitle, video_filename=video_filename)
         if not language_code:
-            logging.debug("BAZARR skipping generated sync subtitle with unknown language: %s", subtitle_path)
+            logging.debug("BAZARR skipping unrelated or unrecognized generated sync subtitle: %s", subtitle_path)
             continue
 
         try:

--- a/tests/bazarr/test_indexer_owner_scope.py
+++ b/tests/bazarr/test_indexer_owner_scope.py
@@ -16,6 +16,8 @@ wrong data rather than a harmless duplicate.
 
 Callers know the owner. They must be able to say so.
 """
+import ast
+
 import pytest
 
 from sqlalchemy import select
@@ -35,7 +37,7 @@ def stub_indexing(monkeypatch):
     for mod in (se, mv):
         monkeypatch.setattr(mod.os.path, 'exists', lambda p: True)
         monkeypatch.setattr(mod, 'search_external_subtitles', lambda *a, **kw: {})
-        monkeypatch.setattr(mod, 'add_sync_engine_outputs', lambda folder, subs: subs)
+        monkeypatch.setattr(mod, 'add_sync_engine_outputs', lambda folder, subs, **kw: subs)
         monkeypatch.setattr(mod, 'add_combined_outputs', lambda folder, subs, **kw: subs)
         monkeypatch.setattr(mod, 'guess_external_subtitles', lambda *a, **kw: {})
         monkeypatch.setattr(mod, 'event_stream', lambda *a, **kw: None)
@@ -71,6 +73,81 @@ def two_series_rows(schema_session, stub_indexing, monkeypatch):
 
 def _subs(session, table, row_id):
     return session.execute(select(table.subtitles).where(table.id == row_id)).scalar()
+
+
+@pytest.mark.parametrize('media_type', ['series', 'movie'])
+@pytest.mark.parametrize('subfolder', ['current', 'relative', 'absolute'])
+def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, tmp_path,
+                                                 media_type, subfolder):
+    from subzero.language import Language
+    import subtitles.indexer.movies as mv
+    import subtitles.indexer.series as se
+
+    module = se if media_type == 'series' else mv
+    table = TableEpisodes if media_type == 'series' else TableMovies
+    store = se.store_subtitles if media_type == 'series' else mv.store_subtitles_movie
+    stems = (['Show.S01E01', 'Show.S01E02', 'Show.S01E01.Extended'] if media_type == 'series'
+             else ['Movie (2020)', 'Other (2021)', 'Movie (2020).Extended'])
+    media_folder = tmp_path / 'media'
+    media_folder.mkdir()
+    subtitle_folder = {'current': media_folder, 'relative': media_folder / 'subs',
+                       'absolute': tmp_path / 'shared-subs'}[subfolder]
+    subtitle_folder.mkdir(exist_ok=True)
+    custom_folder = 'subs' if subfolder == 'relative' else str(subtitle_folder)
+    monkeypatch.setattr(module.settings.general, 'use_embedded_subs', False)
+    monkeypatch.setattr(module.settings.general, 'single_language', False)
+    monkeypatch.setattr(module.settings.general, 'subfolder', subfolder)
+    monkeypatch.setattr(module.settings.general, 'subfolder_custom', custom_folder)
+    monkeypatch.setattr(module.core, 'CUSTOM_PATHS', [])
+    monkeypatch.setattr(module, 'database', schema_session)
+    monkeypatch.setattr(module, 'get_language_set', lambda: {Language.fromietf('en')})
+    monkeypatch.setattr(module, 'alpha2_from_alpha3', lambda code: Language(code).alpha2)
+    monkeypatch.setattr(module.path_mappings, 'path_replace_instance', lambda p, *a: p)
+    monkeypatch.setattr(module.path_mappings, 'path_replace_reverse_instance', lambda p, *a: p)
+    monkeypatch.setattr(module, 'event_stream', lambda *a, **kw: None)
+    missing = 'list_missing_subtitles' if media_type == 'series' else 'list_missing_subtitles_movies'
+    monkeypatch.setattr(module, missing, lambda *a, **kw: None)
+
+    if media_type == 'series':
+        schema_session.add(TableShows(id=1, arr_instance_id=1, sonarrSeriesId=1, title='Show',
+                                      path=str(media_folder), profileId=None))
+        schema_session.flush()
+
+    suffixes = {'en.srt': 'en', 'hu.ffsubsync.srt': 'hu:sync-ffsubsync',
+                'en.hi.alass.ass': 'en:hi:sync-alass',
+                'fr.forced.autosubsync.vtt': 'fr:forced:sync-autosubsync'}
+    expected = {}
+    for row_id, stem in enumerate(stems, 1):
+        video = media_folder / f'{stem}.mkv'
+        video.write_bytes(b'video')
+        if media_type == 'series':
+            row = TableEpisodes(id=row_id, arr_instance_id=1, series_id=1, sonarrSeriesId=1,
+                                sonarrEpisodeId=row_id, title=stem, path=str(video), season=1,
+                                episode=row_id, subtitles='[]')
+        else:
+            row = TableMovies(id=row_id, arr_instance_id=1, radarrId=row_id, title=stem,
+                              path=str(video), tmdbId=str(row_id), subtitles='[]')
+        schema_session.add(row)
+        expected[row_id] = []
+        for suffix, language in suffixes.items():
+            subtitle = subtitle_folder / f'{stem}.{suffix}'
+            subtitle.write_text('1\n00:00:00,000 --> 00:00:01,000\nSubtitle\n', encoding='utf-8')
+            expected[row_id].append([language, str(subtitle), subtitle.stat().st_size])
+    schema_session.commit()
+
+    first_scan = {}
+    for scan in range(2):
+        for row_id, stem in enumerate(stems, 1):
+            video = str(media_folder / f'{stem}.mkv')
+            actual = store(video, video, arr_instance_id=1)
+            assert len(actual) == len(expected[row_id])
+            assert {path: (set(language.split(':')), size) for language, path, size in actual} == {
+                path: (set(language.split(':')), size) for language, path, size in expected[row_id]}
+            assert ast.literal_eval(_subs(schema_session, table, row_id)) == actual
+            if scan == 0:
+                first_scan[row_id] = sorted(actual)
+            else:
+                assert sorted(actual) == first_scan[row_id]
 
 
 def test_only_the_owning_episode_row_is_indexed(two_series_rows):

--- a/tests/bazarr/test_indexer_owner_scope.py
+++ b/tests/bazarr/test_indexer_owner_scope.py
@@ -17,10 +17,11 @@ wrong data rather than a harmless duplicate.
 Callers know the owner. They must be able to say so.
 """
 import ast
+import unicodedata
 
 import pytest
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from app.database import TableEpisodes, TableMovies, TableShows
 
@@ -77,8 +78,9 @@ def _subs(session, table, row_id):
 
 @pytest.mark.parametrize('media_type', ['series', 'movie'])
 @pytest.mark.parametrize('subfolder', ['current', 'relative', 'absolute'])
+@pytest.mark.parametrize('naming', ['original', 'case', 'unicode', 'single-language'])
 def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, tmp_path,
-                                                 media_type, subfolder):
+                                                 media_type, subfolder, naming):
     from subzero.language import Language
     import subtitles.indexer.movies as mv
     import subtitles.indexer.series as se
@@ -88,6 +90,10 @@ def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, t
     store = se.store_subtitles if media_type == 'series' else mv.store_subtitles_movie
     stems = (['Show.S01E01', 'Show.S01E02', 'Show.S01E01.Extended'] if media_type == 'series'
              else ['Movie (2020)', 'Other (2021)', 'Movie (2020).Extended'])
+    if naming == 'unicode':
+        stems = ['\u00c9pisode.S01E01', '\u00c9pisode.S01E02', '\u00c9pisode.S01E01.Extended']
+    elif naming == 'single-language':
+        stems = ['Movie', 'Movie.en', 'Movie.en.Extended', 'Movie.hi', 'Movie.forced']
     media_folder = tmp_path / 'media'
     media_folder.mkdir()
     subtitle_folder = {'current': media_folder, 'relative': media_folder / 'subs',
@@ -95,7 +101,7 @@ def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, t
     subtitle_folder.mkdir(exist_ok=True)
     custom_folder = 'subs' if subfolder == 'relative' else str(subtitle_folder)
     monkeypatch.setattr(module.settings.general, 'use_embedded_subs', False)
-    monkeypatch.setattr(module.settings.general, 'single_language', False)
+    monkeypatch.setattr(module.settings.general, 'single_language', naming == 'single-language')
     monkeypatch.setattr(module.settings.general, 'subfolder', subfolder)
     monkeypatch.setattr(module.settings.general, 'subfolder_custom', custom_folder)
     monkeypatch.setattr(module.core, 'CUSTOM_PATHS', [])
@@ -116,6 +122,9 @@ def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, t
     suffixes = {'en.srt': 'en', 'hu.ffsubsync.srt': 'hu:sync-ffsubsync',
                 'en.hi.alass.ass': 'en:hi:sync-alass',
                 'fr.forced.autosubsync.vtt': 'fr:forced:sync-autosubsync'}
+    if naming == 'single-language':
+        suffixes = {f'{engine}.srt': f'en:sync-{engine}'
+                    for engine in ['ffsubsync', 'alass', 'autosubsync']}
     expected = {}
     for row_id, stem in enumerate(stems, 1):
         video = media_folder / f'{stem}.mkv'
@@ -129,14 +138,26 @@ def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, t
                               path=str(video), tmdbId=str(row_id), subtitles='[]')
         schema_session.add(row)
         expected[row_id] = []
+        subtitle_stem = stem.lower() if naming == 'case' else stem
+        if naming == 'unicode':
+            subtitle_stem = unicodedata.normalize('NFD', stem.lower())
         for suffix, language in suffixes.items():
-            subtitle = subtitle_folder / f'{stem}.{suffix}'
-            subtitle.write_text('1\n00:00:00,000 --> 00:00:01,000\nSubtitle\n', encoding='utf-8')
+            subtitle = subtitle_folder / f'{subtitle_stem}.{suffix}'
+            subtitle.write_text('1\n00:00:00,000 --> 00:00:01,000\n'
+                                'This is an English subtitle. We are going to the house together. '
+                                'There is a friend waiting for us in the garden. '
+                                'Please tell everyone that we will arrive before dinner.\n', encoding='utf-8')
             expected[row_id].append([language, str(subtitle), subtitle.stat().st_size])
+    schema_session.flush()
+    contaminated = [entry for entries in expected.values() for entry in entries]
+    schema_session.execute(update(table).values(subtitles=str(contaminated)))
     schema_session.commit()
 
     first_scan = {}
-    for scan in range(2):
+    for scan in range(3):
+        if scan == 2:
+            schema_session.execute(update(table).values(subtitles='[]'))
+            schema_session.commit()
         for row_id, stem in enumerate(stems, 1):
             video = str(media_folder / f'{stem}.mkv')
             actual = store(video, video, arr_instance_id=1)

--- a/tests/bazarr/test_indexer_owner_scope.py
+++ b/tests/bazarr/test_indexer_owner_scope.py
@@ -78,9 +78,14 @@ def _subs(session, table, row_id):
 
 @pytest.mark.parametrize('media_type', ['series', 'movie'])
 @pytest.mark.parametrize('subfolder', ['current', 'relative', 'absolute'])
-@pytest.mark.parametrize('naming', ['original', 'case', 'unicode', 'single-language'])
+@pytest.mark.parametrize('naming,single_language', [
+    ('original', False), ('case', False), ('unicode', False),
+    ('single-language', True), ('single-language', False),
+    ('legacy-tagged', True), ('legacy-tagged', False),
+    ('legacy-case', True), ('legacy-unicode', True),
+])
 def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, tmp_path,
-                                                 media_type, subfolder, naming):
+                                                 media_type, subfolder, naming, single_language):
     from subzero.language import Language
     import subtitles.indexer.movies as mv
     import subtitles.indexer.series as se
@@ -90,7 +95,7 @@ def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, t
     store = se.store_subtitles if media_type == 'series' else mv.store_subtitles_movie
     stems = (['Show.S01E01', 'Show.S01E02', 'Show.S01E01.Extended'] if media_type == 'series'
              else ['Movie (2020)', 'Other (2021)', 'Movie (2020).Extended'])
-    if naming == 'unicode':
+    if naming in ['unicode', 'legacy-unicode']:
         stems = ['\u00c9pisode.S01E01', '\u00c9pisode.S01E02', '\u00c9pisode.S01E01.Extended']
     elif naming == 'single-language':
         stems = ['Movie', 'Movie.en', 'Movie.en.Extended', 'Movie.hi', 'Movie.forced']
@@ -101,7 +106,7 @@ def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, t
     subtitle_folder.mkdir(exist_ok=True)
     custom_folder = 'subs' if subfolder == 'relative' else str(subtitle_folder)
     monkeypatch.setattr(module.settings.general, 'use_embedded_subs', False)
-    monkeypatch.setattr(module.settings.general, 'single_language', naming == 'single-language')
+    monkeypatch.setattr(module.settings.general, 'single_language', single_language)
     monkeypatch.setattr(module.settings.general, 'subfolder', subfolder)
     monkeypatch.setattr(module.settings.general, 'subfolder_custom', custom_folder)
     monkeypatch.setattr(module.core, 'CUSTOM_PATHS', [])
@@ -125,6 +130,10 @@ def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, t
     if naming == 'single-language':
         suffixes = {f'{engine}.srt': f'en:sync-{engine}'
                     for engine in ['ffsubsync', 'alass', 'autosubsync']}
+        suffixes.update({'hu.ffsubsync.srt': 'hu:sync-ffsubsync',
+                         'en.hi.alass.ass': 'en:hi:sync-alass'})
+    elif naming.startswith('legacy-'):
+        suffixes['en.ffsubsync.srt'] = 'en:sync-ffsubsync'
     expected = {}
     for row_id, stem in enumerate(stems, 1):
         video = media_folder / f'{stem}.mkv'
@@ -138,8 +147,8 @@ def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, t
                               path=str(video), tmdbId=str(row_id), subtitles='[]')
         schema_session.add(row)
         expected[row_id] = []
-        subtitle_stem = stem.lower() if naming == 'case' else stem
-        if naming == 'unicode':
+        subtitle_stem = stem.lower() if naming in ['case', 'legacy-case'] else stem
+        if naming in ['unicode', 'legacy-unicode']:
             subtitle_stem = unicodedata.normalize('NFD', stem.lower())
         for suffix, language in suffixes.items():
             subtitle = subtitle_folder / f'{subtitle_stem}.{suffix}'

--- a/tests/bazarr/test_subsync_engines.py
+++ b/tests/bazarr/test_subsync_engines.py
@@ -811,6 +811,30 @@ def test_sync_output_owner_filter_preserves_existing_entries_and_is_idempotent(t
                                    video_filename='Movie.mkv') == first_scan
 
 
+@pytest.mark.parametrize('video,subtitle', [
+    ('Movie.mkv', 'movie.en.ffsubsync.srt'),
+    ('\u00c9pisode.mkv', 'E\u0301PISODE.en.ffsubsync.srt'),
+    ('E\u0301pisode.mkv', '\u00e9pisode.en.ffsubsync.srt'),
+])
+def test_sync_output_owner_uses_case_and_unicode_normalization(tmp_path, video, subtitle):
+    from subtitles.indexer.utils import add_sync_engine_outputs
+
+    _write(tmp_path / subtitle, 'subtitle')
+    _write(tmp_path / subtitle.replace('.en.', '.Extended.en.'), 'sibling')
+    assert set(add_sync_engine_outputs(str(tmp_path), {}, video_filename=video)) == {subtitle}
+
+
+@pytest.mark.parametrize('stem', ['Movie', 'Movie.en', 'Movie.hi', 'Movie.forced'])
+def test_single_language_sync_output_keeps_complete_owner_stem(tmp_path, stem):
+    from subtitles.indexer.utils import add_sync_engine_outputs
+
+    for sibling in ['Movie', 'Movie.en', 'Movie.hi', 'Movie.forced', 'Movie.en.Extended']:
+        _write(tmp_path / f'{sibling}.ffsubsync.srt', 'subtitle')
+    result = add_sync_engine_outputs(str(tmp_path), {}, video_filename=f'{stem}.mkv',
+                                     single_language=True)
+    assert result == {f'{stem}.ffsubsync.srt': None}
+
+
 def test_keep_all_job_name_does_not_claim_original_was_overwritten():
     from subtitles.sync import _sync_complete_job_name
     from subtitles.tools.subsync_engines import (

--- a/tests/bazarr/test_subsync_engines.py
+++ b/tests/bazarr/test_subsync_engines.py
@@ -770,12 +770,12 @@ def test_sync_output_owner_filter_preserves_language_and_format(tmp_path, engine
                                                                suffix, basename, hi, forced):
     from subtitles.indexer.utils import add_sync_engine_outputs
 
-    filename = f'Movie.en.{suffix}.{engine}.{extension}'
+    filename = f'Movie.Release.{suffix}.{engine}.{extension}'
     _write(tmp_path / filename, 'subtitle')
-    _write(tmp_path / f'Movie.en.Extended.{suffix}.{engine}.{extension}', 'sibling')
+    _write(tmp_path / f'Movie.Release.Extended.{suffix}.{engine}.{extension}', 'sibling')
     _write(tmp_path / f'Movie.{suffix}.{engine}.{extension}', 'shorter stem')
 
-    result = add_sync_engine_outputs(str(tmp_path), {}, video_filename='Movie.en.mkv')
+    result = add_sync_engine_outputs(str(tmp_path), {}, video_filename='Movie.Release.mkv')
 
     assert set(result) == {filename}
     language = result[filename]
@@ -825,14 +825,51 @@ def test_sync_output_owner_uses_case_and_unicode_normalization(tmp_path, video, 
 
 
 @pytest.mark.parametrize('stem', ['Movie', 'Movie.en', 'Movie.hi', 'Movie.forced'])
-def test_single_language_sync_output_keeps_complete_owner_stem(tmp_path, stem):
+def test_sync_output_keeps_complete_actual_owner_stem(tmp_path, stem):
     from subtitles.indexer.utils import add_sync_engine_outputs
 
     for sibling in ['Movie', 'Movie.en', 'Movie.hi', 'Movie.forced', 'Movie.en.Extended']:
+        _write(tmp_path / f'{sibling}.mkv', 'video')
         _write(tmp_path / f'{sibling}.ffsubsync.srt', 'subtitle')
-    result = add_sync_engine_outputs(str(tmp_path), {}, video_filename=f'{stem}.mkv',
-                                     single_language=True)
+    result = add_sync_engine_outputs(str(tmp_path), {}, video_filename=f'{stem}.mkv')
     assert result == {f'{stem}.ffsubsync.srt': None}
+
+
+@pytest.mark.parametrize('video_stem,subtitle_stem,sibling_stem', [
+    ('Movie', 'movie', 'MOVIE.EN'),
+    ('\u00c9pisode', 'E\u0301PISODE', '\u00e9pisode.en'),
+    ('E\u0301pisode', '\u00e9pisode', 'E\u0301PISODE.EN'),
+])
+@pytest.mark.parametrize('sibling_kind', ['media', 'directory', 'non-media', 'absent'])
+def test_tagged_sync_output_defers_only_to_an_actual_media_owner(
+        tmp_path, video_stem, subtitle_stem, sibling_stem, sibling_kind):
+    from subtitles.indexer.utils import add_sync_engine_outputs
+
+    media_folder = tmp_path / 'media'
+    media_folder.mkdir()
+    subtitle_folder = tmp_path / 'subtitles'
+    subtitle_folder.mkdir()
+    video = media_folder / f'{video_stem}.mkv'
+    _write(video, 'video')
+    _write(media_folder / f'{sibling_stem}.Extended.mkv', 'prefix sibling')
+    sibling = media_folder / f'{sibling_stem}.MP4'
+    if sibling_kind == 'media':
+        _write(sibling, 'video')
+    elif sibling_kind == 'directory':
+        sibling.mkdir()
+    elif sibling_kind == 'non-media':
+        _write(media_folder / f'{sibling_stem}.txt', 'not a video')
+    subtitle = f'{subtitle_stem}.en.ffsubsync.srt'
+    _write(subtitle_folder / subtitle, 'subtitle')
+
+    result = add_sync_engine_outputs(str(subtitle_folder), {}, video_path=str(video))
+
+    if sibling_kind == 'media':
+        assert result == {}
+        assert add_sync_engine_outputs(str(subtitle_folder), {}, video_path=str(sibling)) == {subtitle: None}
+    else:
+        assert set(result) == {subtitle}
+        assert result[subtitle].basename == 'en'
 
 
 def test_keep_all_job_name_does_not_claim_original_was_overwritten():

--- a/tests/bazarr/test_subsync_engines.py
+++ b/tests/bazarr/test_subsync_engines.py
@@ -756,6 +756,61 @@ def test_add_sync_engine_outputs_indexes_generated_files(tmp_path):
     ) == 'hu:sync-alass'
 
 
+@pytest.mark.parametrize('engine', ['ffsubsync', 'autosubsync', 'ALASS'])
+@pytest.mark.parametrize('extension', ['srt', 'sub', 'smi', 'txt', 'ssa', 'ASS', 'mpl', 'vtt'])
+@pytest.mark.parametrize('suffix, basename, hi, forced', [
+    ('en', 'en', False, False),
+    ('en.HI', 'en', True, False),
+    ('hu.sdh', 'hu', True, False),
+    ('fr.cc', 'fr', True, False),
+    ('pt_BR.forced', 'pt-BR', False, True),
+    ('pb.forced.hi', 'pt-BR', True, True),
+])
+def test_sync_output_owner_filter_preserves_language_and_format(tmp_path, engine, extension,
+                                                               suffix, basename, hi, forced):
+    from subtitles.indexer.utils import add_sync_engine_outputs
+
+    filename = f'Movie.en.{suffix}.{engine}.{extension}'
+    _write(tmp_path / filename, 'subtitle')
+    _write(tmp_path / f'Movie.en.Extended.{suffix}.{engine}.{extension}', 'sibling')
+    _write(tmp_path / f'Movie.{suffix}.{engine}.{extension}', 'shorter stem')
+
+    result = add_sync_engine_outputs(str(tmp_path), {}, video_filename='Movie.en.mkv')
+
+    assert set(result) == {filename}
+    language = result[filename]
+    assert language.basename == basename
+    assert language.hi is hi
+    assert language.forced is forced
+
+
+def test_sync_output_owner_filter_preserves_existing_entries_and_is_idempotent(tmp_path):
+    from subzero.language import Language
+    from subtitles.indexer.utils import add_sync_engine_outputs
+
+    original = Language.fromietf('hu')
+    existing = Language.fromietf('de')
+    subtitles = {'Movie.hu.srt': original, 'Movie.en.alass.srt': existing,
+                 'Existing.en.srt': Language.fromietf('en')}
+    for filename in ['Movie.hu.srt', 'Movie.en.alass.srt', 'Movie.en.ffsubsync.srt',
+                     'Other.en.alass.srt', 'Movie.en.unknown.srt', 'Movie.en.alass.mkv',
+                     'Movie.invalid.alass.srt', 'Movie.en.combined-hu.alass.srt']:
+        _write(tmp_path / filename, 'subtitle')
+    (tmp_path / 'Movie.fr.alass.srt').mkdir()
+
+    result = add_sync_engine_outputs(str(tmp_path), subtitles, video_filename='Movie.mkv')
+    assert result is subtitles
+    assert set(result) == {'Movie.hu.srt', 'Movie.en.alass.srt', 'Existing.en.srt',
+                           'Movie.en.ffsubsync.srt'}
+    assert result['Movie.hu.srt'] is original
+    assert result['Movie.en.alass.srt'] is existing
+    first_scan = result.copy()
+
+    assert add_sync_engine_outputs(str(tmp_path), result, video_filename='Movie.mkv') == first_scan
+    assert add_sync_engine_outputs(str(tmp_path / 'missing'), result,
+                                   video_filename='Movie.mkv') == first_scan
+
+
 def test_keep_all_job_name_does_not_claim_original_was_overwritten():
     from subtitles.sync import _sync_complete_job_name
     from subtitles.tools.subsync_engines import (

--- a/tests/bazarr/test_threading_followup.py
+++ b/tests/bazarr/test_threading_followup.py
@@ -303,7 +303,7 @@ def test_store_subtitles_uses_instance_path_mapping(schema_session, monkeypatch)
             return "en"
 
     monkeypatch.setattr(si, "search_external_subtitles", lambda *a, **k: {sub_local: _Lang()})
-    monkeypatch.setattr(si, "add_sync_engine_outputs", lambda f, s: s)
+    monkeypatch.setattr(si, "add_sync_engine_outputs", lambda f, s, **k: s)
     monkeypatch.setattr(si, "add_combined_outputs", lambda f, s, **k: s)
     monkeypatch.setattr(si, "guess_external_subtitles", lambda f, s, t, e: s)
     monkeypatch.setattr(si, "get_external_subtitles_path", lambda r, s: s)


### PR DESCRIPTION
Generated synchronization files in a shared subtitle folder could be indexed against the wrong episode or movie. Both indexers now match outputs using the complete media stem and the scanner's case and Unicode normalization. Actual sibling videos disambiguate dotted title suffixes, while existing language-tagged outputs remain discoverable after switching to single-language naming. Existing language, HI and forced markers remain supported.

Validation: independent review; full local frontend, backend, native PostgreSQL and startup CI, with 3,029 backend tests passing on each Python version. The exact deployed image passed 54 scenarios through 558 real indexer calls, cleaned 186 contaminated fixture rows and checked 2,628 subtitle entries while preserving all 1,062 fixture files. Library/history counts, live settings and exact source hashes were preserved. All fixture writes used disposable guarded state.
