### PR TITLE
fix(translator): keep partial sidecar results and stop timing out finished jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,8 @@ jobs:
             tests/bazarr/test_jellyfin_client.py \
             tests/bazarr/test_jellyfin_operations.py \
             tests/bazarr/test_logging_filters.py \
+            tests/bazarr/test_openrouter_model_migration.py \
+            tests/bazarr/test_openrouter_translator_partial.py \
             tests/bazarr/test_provider_hub_install_serialization.py \
             tests/bazarr/test_provider_hub_language_fallback.py \
             tests/bazarr/test_provider_hub_release_scoring.py \
@@ -289,6 +291,7 @@ jobs:
             tests/bazarr/test_sonarr_sync_episodes.py \
             tests/bazarr/test_sql_profiler.py \
             tests/bazarr/test_subtitle_content_sync_outputs.py \
+            tests/bazarr/test_subtitle_destination_path.py \
             tests/bazarr/test_subtitle_download_api.py \
             tests/bazarr/test_subtitles_pool.py \
             tests/bazarr/test_swagger_static.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,10 @@ jobs:
             tests/bazarr/test_jellyfin_client.py \
             tests/bazarr/test_jellyfin_operations.py \
             tests/bazarr/test_logging_filters.py \
+            tests/bazarr/test_openrouter_model_migration.py \
+            tests/bazarr/test_openrouter_translator_partial.py \
+            tests/bazarr/test_openrouter_translator.py \
+            tests/bazarr/test_translator_model_migration.py \
             tests/bazarr/test_provider_hub_install_serialization.py \
             tests/bazarr/test_provider_hub_language_fallback.py \
             tests/bazarr/test_provider_hub_release_scoring.py \
@@ -289,6 +293,7 @@ jobs:
             tests/bazarr/test_sonarr_sync_episodes.py \
             tests/bazarr/test_sql_profiler.py \
             tests/bazarr/test_subtitle_content_sync_outputs.py \
+            tests/bazarr/test_subtitle_destination_path.py \
             tests/bazarr/test_subtitle_download_api.py \
             tests/bazarr/test_subtitles_pool.py \
             tests/bazarr/test_swagger_static.py \

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ The OpenSubtitles.org plugin no longer uses environment variables. Configure its
 1. Go to **Settings** > **AI Translator**
 2. Select **"AI Subtitle Translator"** as the translator engine
 3. Enter your **OpenRouter API Key** (get one at [openrouter.ai/keys](https://openrouter.ai/keys))
-4. Choose your preferred **AI Model** (Google: Gemini 2.5 Flash Lite Preview 09-2025 recommended)
+4. Choose your preferred **AI Model** (`google/gemini-2.5-flash-lite` recommended)
 5. Save and test with a manual translation
 
 </details>

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -238,7 +238,7 @@ validators = [
     Validator('translator.lingarr_url', must_exist=True, default='http://lingarr:9876', is_type_of=str),
     Validator('translator.openrouter_url', must_exist=True, default='http://subtitle-translator:8765', is_type_of=str),
     Validator('translator.openrouter_api_key', must_exist=True, default='', is_type_of=str, cast=str),
-    Validator('translator.openrouter_model', must_exist=True, default='google/gemini-2.5-flash-preview-05-20', is_type_of=str),
+    Validator('translator.openrouter_model', must_exist=True, default='google/gemini-2.5-flash-lite', is_type_of=str),
     Validator('translator.openrouter_temperature', must_exist=True, default=0.3, is_type_of=float),
     Validator('translator.openrouter_max_concurrent', must_exist=True, default=2, is_type_of=int, gte=1, lte=10),
     Validator('translator.openrouter_reasoning', must_exist=True, default='disabled', is_type_of=str,
@@ -727,6 +727,26 @@ def write_config():
                 _force_first_save_migration = False
 
 
+# OpenRouter retired these ids, including Bazarr's default and documented recommendation.
+# Users who never chose a model would otherwise get a model-not-found error.
+RETIRED_OPENROUTER_MODELS = {
+    'google/gemini-2.5-flash-preview-05-20': 'google/gemini-2.5-flash',
+    'google/gemini-2.5-flash-lite-preview-06-17': 'google/gemini-2.5-flash-lite',
+    'google/gemini-2.5-flash-lite-preview-09-2025': 'google/gemini-2.5-flash-lite',
+    'google/gemini-3-pro-preview': 'google/gemini-3.1-pro-preview',
+}
+
+
+def migrate_retired_openrouter_model(settings) -> bool:
+    current_model = settings.translator.openrouter_model.strip()
+    replacement = RETIRED_OPENROUTER_MODELS.get(current_model)
+    if replacement is None:
+        return False
+    settings.translator.openrouter_model = replacement
+    logging.warning(f'Replaced retired OpenRouter model {current_model} with {replacement}')  # noqa: G004
+    return True
+
+
 base_url = settings.general.base_url.rstrip('/')
 
 array_keys = ['excluded_tags',
@@ -789,6 +809,8 @@ if hasattr(settings.translator, 'gemini_key'):
     if legacy_key and not settings.translator.gemini_keys:
         settings.translator.gemini_keys = [legacy_key]
     del settings.translator.gemini_key
+
+migrate_retired_openrouter_model(settings)
 
 # save updated settings to file
 write_config()

--- a/bazarr/app/requirements.py
+++ b/bazarr/app/requirements.py
@@ -108,7 +108,7 @@ RUNTIME_REQUIREMENTS = {
     "charset_normalizer": ("charset-normalizer", "==3.5.1"),
     "click_option_group": ("click-option-group", ">=0.5.6"),
     "cloudscraper": ("cloudscraper", "<=1.2.58"),
-    "cryptography": ("cryptography", ">=48.0.0"),
+    "cryptography": ("cryptography", ">=50.0.1"),
     "dateutil": ("python-dateutil", "==2.9.0"),
     "deathbycaptcha": ("deathbycaptcha-official", "==4.7.1"),
     "deep_translator": ("deep-translator", "==1.11.4"),

--- a/bazarr/subtitles/indexer/utils.py
+++ b/bazarr/subtitles/indexer/utils.py
@@ -46,6 +46,23 @@ def get_external_subtitles_path(file, subtitle):
     return path
 
 
+def get_subtitle_destination_path(file, subtitle):
+    """Where a new external subtitle for ``file`` gets written.
+
+    get_external_subtitles_path() answers only for files that already exist, which is
+    right for indexing and wrong for a first-time write: in the absolute and relative
+    subfolder modes it returned None and a translation crashed on save. An existing file
+    in either location is still preferred so a re-run overwrites what the user already
+    sees; otherwise the configured folder is used and created, the way downloads do it.
+    """
+    existing = get_external_subtitles_path(file, subtitle)
+    if existing:
+        return existing
+    from utilities.helper import get_target_folder
+    folder = get_target_folder(file) or os.path.dirname(file)
+    return os.path.join(folder, subtitle)
+
+
 def normalize_subtitle_language_variant(language, forced=False, hi=False):
     language_text = str(language)
     parts = language_text.split(':')

--- a/bazarr/subtitles/tools/mods.py
+++ b/bazarr/subtitles/tools/mods.py
@@ -12,7 +12,7 @@ from app.config import settings, get_array_from
 from app.jobs_queue import jobs_queue
 from languages.custom_lang import CustomLanguage
 from languages.get_languages import alpha3_from_alpha2
-from subtitles.indexer.utils import get_external_subtitles_path
+from subtitles.indexer.utils import get_subtitle_destination_path
 
 
 def has_remove_hi(mods):
@@ -180,7 +180,7 @@ def subtitles_apply_mods(language, subtitle_path, mods, video_path, arr_instance
 
             # get the real modded subtitles path taking into account if the user set up Bazarr to store external
             # subtitles in a custom folder or relative folder
-            modded_subtitles_path = get_external_subtitles_path(
+            modded_subtitles_path = get_subtitle_destination_path(
                 file=video_path,
                 subtitle=os.path.basename(modded_subtitles_path_if_alongside_video)
             )

--- a/bazarr/subtitles/tools/translate/main.py
+++ b/bazarr/subtitles/tools/translate/main.py
@@ -12,7 +12,7 @@ from .services.translator_factory import TranslatorFactory
 from languages.get_languages import alpha3_from_alpha2
 from app.config import settings
 from app.jobs_queue import jobs_queue
-from subtitles.indexer.utils import get_external_subtitles_path
+from subtitles.indexer.utils import get_subtitle_destination_path
 
 
 def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, forced, hi,
@@ -46,7 +46,9 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
             hi_tag=hi
         )
 
-        dest_srt_file = get_external_subtitles_path(
+        # Resolved as a write target, not a lookup: the file does not exist yet on a
+        # first translation, and the lookup helper answered None for custom folders.
+        dest_srt_file = get_subtitle_destination_path(
             file=video_path,
             subtitle=os.path.basename(dest_srt_file_if_alongside_video)
         )

--- a/bazarr/subtitles/tools/translate/main.py
+++ b/bazarr/subtitles/tools/translate/main.py
@@ -12,7 +12,7 @@ from .services.translator_factory import TranslatorFactory
 from languages.get_languages import alpha3_from_alpha2
 from app.config import settings
 from app.jobs_queue import jobs_queue
-from subtitles.indexer.utils import get_external_subtitles_path
+from subtitles.indexer.utils import get_subtitle_destination_path
 
 
 def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, forced, hi,
@@ -46,7 +46,9 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
             hi_tag=hi
         )
 
-        dest_srt_file = get_external_subtitles_path(
+        # Resolved as a write target, not a lookup: the file does not exist yet on a
+        # first translation, and the lookup helper answered None for custom folders.
+        dest_srt_file = get_subtitle_destination_path(
             file=video_path,
             subtitle=os.path.basename(dest_srt_file_if_alongside_video)
         )
@@ -105,11 +107,12 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
             logging.exception("BAZARR combine-after-translate failed for %s", video_path)
 
         # Get current job name (which batch.py already set with title) and mark as done
+        completion_label = 'Partially translated' if getattr(translator, 'partial_error', None) else 'Translated'
         current_name = jobs_queue.get_job_name(job_id)
         if current_name and 'Translating' in current_name:
-            done_name = current_name.replace('Translating', 'Translated')
+            done_name = current_name.replace('Translating', completion_label)
         else:
-            done_name = f'Translated {from_lang.upper()} \u2192 {to_lang.upper()} using {translator_label}'
+            done_name = f'{completion_label} {from_lang.upper()} \u2192 {to_lang.upper()} using {translator_label}'
         jobs_queue.update_job_name(job_id=job_id, new_job_name=done_name)
         return result
 

--- a/bazarr/subtitles/tools/translate/services/openrouter_translator.py
+++ b/bazarr/subtitles/tools/translate/services/openrouter_translator.py
@@ -21,6 +21,16 @@ from .auth import get_translator_auth_headers
 
 logger = logging.getLogger(__name__)
 
+POLL_HARD_CAP_SECONDS = 12 * 3600
+POLL_UNREACHABLE_LIMIT_SECONDS = 600
+POLL_INTERVAL_SECONDS = 2
+
+
+def _extract_job_lines(result):
+    if isinstance(result, dict):
+        result = result.get("lines")
+    return result if isinstance(result, list) else None
+
 
 class OpenRouterTranslatorService:
     """
@@ -44,6 +54,7 @@ class OpenRouterTranslatorService:
         self.sonarr_series_id = sonarr_series_id
         self.sonarr_episode_id = sonarr_episode_id
         self.radarr_id = radarr_id
+        self.partial_error = None
         self.language_code_convert_dict = {
             'he': 'iw',
             'zh': 'zh-CN',
@@ -117,6 +128,8 @@ class OpenRouterTranslatorService:
                 raise OSError
 
             message = f"{language_from_alpha2(self.from_lang)} subtitles translated to {language_from_alpha3(self.to_lang)} using AI Subtitle Translator."
+            if self.partial_error:
+                message += f" Partial result: {self.partial_error[:200]}"
             result = create_process_result(message, self.video_path, self.orig_to_lang, self.forced, self.hi, self.dest_srt_file, self.media_type)
 
             if self.media_type == 'episode':
@@ -230,12 +243,30 @@ class OpenRouterTranslatorService:
             return None
 
     def _poll_job(self, base_url: str, job_id: str, total_lines: int, bazarr_job_id=None) -> Optional[Any]:
-        """Poll job status until completion"""
-        poll_interval = 2  # seconds
-        max_wait_time = 1800  # 30 minutes
-        elapsed = 0
+        """Poll until a terminal status, subject to reachability and safety limits.
 
-        while elapsed < max_wait_time:
+        The sidecar owns request timeouts and retries, so there is no normal total-time cap.
+        A slow model with reasoning enabled and a shrunk batch size can take over half an hour.
+        The old 30-minute cap discarded a translation that the sidecar finished successfully.
+        A 12-hour hard cap remains as a safety net.
+        """
+        started_at = time.monotonic()
+        last_reachable_at = started_at
+
+        while True:
+            now = time.monotonic()
+            if now - started_at >= POLL_HARD_CAP_SECONDS:
+                reason = "reached the 12-hour polling hard cap"
+                user_message = "Translation stopped after 12 hours"
+                break
+
+            unreachable_seconds = now - last_reachable_at
+            if unreachable_seconds >= POLL_UNREACHABLE_LIMIT_SECONDS:
+                unreachable_minutes = int(unreachable_seconds // 60)
+                reason = f"status endpoint unreachable for {unreachable_minutes} minutes"
+                user_message = f"Translation service unreachable for {unreachable_minutes} minutes"
+                break
+
             try:
                 status_response = requests.get(
                     f"{base_url}/api/v1/jobs/{job_id}",
@@ -245,10 +276,10 @@ class OpenRouterTranslatorService:
 
                 if status_response.status_code != 200:
                     logger.error(f"Error getting job status: {status_response.status_code}")  # noqa: G004
-                    time.sleep(poll_interval)
-                    elapsed += poll_interval
+                    time.sleep(POLL_INTERVAL_SECONDS)
                     continue
 
+                last_reachable_at = time.monotonic()
                 job_status = status_response.json()
                 status = job_status.get("status")
                 progress = job_status.get("progress", 0)
@@ -275,15 +306,10 @@ class OpenRouterTranslatorService:
 
                 if status == "completed":
                     hide_progress(id=f'translate_progress_{self.dest_srt_file}')
-                    result = job_status.get("result")
-                    if result:
-                        # Handle structured response with "lines" key from AI Subtitle Translator
-                        # The service returns {"lines": [...], "model_used": ..., "tokens_used": ...}
-                        if isinstance(result, dict) and "lines" in result:
-                            logger.debug(f'Extracted {len(result["lines"])} lines from structured result')  # noqa: G004
-                            return result["lines"]
-                        # Fallback for direct list response
-                        return result
+                    lines = _extract_job_lines(job_status.get("result"))
+                    if lines is not None:
+                        logger.debug(f'Extracted {len(lines)} lines from job result')  # noqa: G004
+                        return lines
                     logger.error("Job completed but no result returned")
                     return None
 
@@ -297,6 +323,12 @@ class OpenRouterTranslatorService:
                 elif status == "partial":
                     hide_progress(id=f'translate_progress_{self.dest_srt_file}')
                     error = job_status.get("error", message or "Partial translation")
+                    lines = _extract_job_lines(job_status.get("result"))
+                    if lines:
+                        logger.warning(f"Translation completed with untranslated lines: {error}")  # noqa: G004
+                        show_message(f"Translation completed with untranslated lines: {error[:200]}")
+                        self.partial_error = error
+                        return lines
                     logger.error(f"Translation partially failed: {error}")  # noqa: G004
                     show_message(f"Translation failed (partial): {error}")
                     return None
@@ -307,18 +339,15 @@ class OpenRouterTranslatorService:
                     return None
 
                 # Still processing or queued
-                time.sleep(poll_interval)
-                elapsed += poll_interval
+                time.sleep(POLL_INTERVAL_SECONDS)
 
             except requests.exceptions.RequestException as e:
                 logger.warning(f"Error polling job status: {e}")  # noqa: G004
-                time.sleep(poll_interval)
-                elapsed += poll_interval
+                time.sleep(POLL_INTERVAL_SECONDS)
 
-        # Timeout
         hide_progress(id=f'translate_progress_{self.dest_srt_file}')
-        logger.error("Translation job timed out")
-        show_message("Translation timed out after 30 minutes")
+        logger.error(f"Translation job {job_id} {reason}")  # noqa: G004
+        show_message(user_message)
         return None
 
     @retry(exceptions=(TooManyRequests, RequestError, requests.exceptions.RequestException), tries=3, delay=1, backoff=2, jitter=(0, 1))

--- a/bazarr/subtitles/tools/translate/services/openrouter_translator.py
+++ b/bazarr/subtitles/tools/translate/services/openrouter_translator.py
@@ -2,6 +2,9 @@
 
 import time
 import logging
+import os
+import shutil
+import uuid
 import pysubs2
 import requests
 from typing import Optional, List, Dict, Any
@@ -20,6 +23,10 @@ from ..core.translator_utils import add_translator_info, create_process_result, 
 from .auth import get_translator_auth_headers
 
 logger = logging.getLogger(__name__)
+
+POLL_HARD_CAP_SECONDS = 12 * 3600
+POLL_UNREACHABLE_LIMIT_SECONDS = 600
+POLL_INTERVAL_SECONDS = 2
 
 
 class OpenRouterTranslatorService:
@@ -44,6 +51,7 @@ class OpenRouterTranslatorService:
         self.sonarr_series_id = sonarr_series_id
         self.sonarr_episode_id = sonarr_episode_id
         self.radarr_id = radarr_id
+        self.partial_error = None
         self.language_code_convert_dict = {
             'he': 'iw',
             'zh': 'zh-CN',
@@ -78,6 +86,7 @@ class OpenRouterTranslatorService:
         return api_key
 
     def translate(self, job_id=None):
+        self.partial_error = None
         try:
             subs = pysubs2.load(self.source_srt_file, encoding='utf-8')
             lines_list: List[str] = [x.plaintext for x in subs]
@@ -85,7 +94,7 @@ class OpenRouterTranslatorService:
 
             if lines_list_len == 0:
                 logger.debug('No lines to translate in subtitle file')
-                return self.dest_srt_file
+                return False
 
             logger.debug(f'Starting AI translation for {self.source_srt_file}')  # noqa: G004
 
@@ -104,19 +113,38 @@ class OpenRouterTranslatorService:
                 if isinstance(item, dict) and 'position' in item and 'line' in item:
                     translation_map[item['position']] = item['line']
 
+            missing_lines = sum(bool(source.strip()) and not translation_map.get(i, '').strip()
+                                for i, source in enumerate(lines_list))
+            if missing_lines and not self.partial_error:
+                self._mark_partial(f'No translated text was returned for {missing_lines} of {lines_list_len} cues.')
+
             for i, line in enumerate(subs):
-                if i in translation_map and translation_map[i]:
+                if i in translation_map and translation_map[i].strip():
                     line.text = translation_map[i]
 
+            temporary_file = os.path.join(os.path.dirname(self.dest_srt_file),
+                                          f'.bazarr-translate-{uuid.uuid4().hex}.srt')
+            temporary_file_created = False
             try:
-                subs.save(self.dest_srt_file)
-                add_translator_info(self.dest_srt_file, "# Subtitles translated with AI Subtitle Translator #")
+                with open(temporary_file, 'x', encoding='utf-8'):
+                    temporary_file_created = True
+                subs.save(temporary_file)
+                translated = 'partially translated' if self.partial_error else 'translated'
+                add_translator_info(temporary_file, f"# Subtitles {translated} with AI Subtitle Translator #")
+                if os.path.exists(self.dest_srt_file):
+                    shutil.copymode(self.dest_srt_file, temporary_file)
+                os.replace(temporary_file, self.dest_srt_file)
             except OSError:
                 logger.error(f'BAZARR is unable to save translated subtitles to {self.dest_srt_file}')  # noqa: G004
                 show_message(f'Translation failed: Unable to save translated subtitles to {self.dest_srt_file}')
-                raise OSError
+                raise
+            finally:
+                if temporary_file_created and os.path.exists(temporary_file):
+                    os.remove(temporary_file)
 
-            message = f"{language_from_alpha2(self.from_lang)} subtitles translated to {language_from_alpha3(self.to_lang)} using AI Subtitle Translator."
+            message = f"{language_from_alpha2(self.from_lang)} subtitles {translated} to {language_from_alpha3(self.to_lang)} using AI Subtitle Translator."
+            if self.partial_error:
+                message += f' Some lines may remain in the source language. {self.partial_error}'
             result = create_process_result(message, self.video_path, self.orig_to_lang, self.forced, self.hi, self.dest_srt_file, self.media_type)
 
             if self.media_type == 'episode':
@@ -229,13 +257,38 @@ class OpenRouterTranslatorService:
             logger.error(f'AI Subtitle Translator error: {str(e)}')  # noqa: G004
             return None
 
-    def _poll_job(self, base_url: str, job_id: str, total_lines: int, bazarr_job_id=None) -> Optional[Any]:
-        """Poll job status until completion"""
-        poll_interval = 2  # seconds
-        max_wait_time = 1800  # 30 minutes
-        elapsed = 0
+    def _mark_partial(self, detail):
+        self.partial_error = ' '.join(str(detail).split())[:500] or 'Some translation batches failed.'
+        logger.warning("Translation partially completed: %s", self.partial_error)
+        show_message('Translation is partial. Some lines may remain in the source language. '
+                     f'{self.partial_error}')
 
-        while elapsed < max_wait_time:
+    def _poll_job(self, base_url: str, job_id: str, total_lines: int, bazarr_job_id=None) -> Optional[Any]:
+        """Poll until a terminal status, subject to reachability and safety limits.
+
+        The sidecar owns request timeouts and retries, so there is no normal total-time cap.
+        A slow model with reasoning enabled and a shrunk batch size can take over half an hour.
+        The old 30-minute cap discarded a translation that the sidecar finished successfully.
+        A 12-hour hard cap remains as a safety net.
+        """
+        self.partial_error = None
+        started_at = time.monotonic()
+        last_reachable_at = started_at
+
+        while True:
+            now = time.monotonic()
+            if now - started_at >= POLL_HARD_CAP_SECONDS:
+                reason = "reached the 12-hour polling hard cap"
+                user_message = "Translation stopped after 12 hours"
+                break
+
+            unreachable_seconds = now - last_reachable_at
+            if unreachable_seconds >= POLL_UNREACHABLE_LIMIT_SECONDS:
+                unreachable_minutes = int(unreachable_seconds // 60)
+                reason = f"status endpoint unreachable for {unreachable_minutes} minutes"
+                user_message = f"Translation service unreachable for {unreachable_minutes} minutes"
+                break
+
             try:
                 status_response = requests.get(
                     f"{base_url}/api/v1/jobs/{job_id}",
@@ -245,10 +298,10 @@ class OpenRouterTranslatorService:
 
                 if status_response.status_code != 200:
                     logger.error(f"Error getting job status: {status_response.status_code}")  # noqa: G004
-                    time.sleep(poll_interval)
-                    elapsed += poll_interval
+                    time.sleep(POLL_INTERVAL_SECONDS)
                     continue
 
+                last_reachable_at = time.monotonic()
                 job_status = status_response.json()
                 status = job_status.get("status")
                 progress = job_status.get("progress", 0)
@@ -275,15 +328,12 @@ class OpenRouterTranslatorService:
 
                 if status == "completed":
                     hide_progress(id=f'translate_progress_{self.dest_srt_file}')
-                    result = job_status.get("result")
-                    if result:
-                        # Handle structured response with "lines" key from AI Subtitle Translator
-                        # The service returns {"lines": [...], "model_used": ..., "tokens_used": ...}
-                        if isinstance(result, dict) and "lines" in result:
-                            logger.debug(f'Extracted {len(result["lines"])} lines from structured result')  # noqa: G004
-                            return result["lines"]
-                        # Fallback for direct list response
-                        return result
+                    lines = self._validated_result_lines(job_status.get("result"), total_lines)
+                    # An empty list is not a translation: saving it would write every source
+                    # line under the target name and record a success in History.
+                    if lines:
+                        logger.debug(f'Extracted {len(lines)} lines from job result')  # noqa: G004
+                        return lines
                     logger.error("Job completed but no result returned")
                     return None
 
@@ -296,7 +346,11 @@ class OpenRouterTranslatorService:
 
                 elif status == "partial":
                     hide_progress(id=f'translate_progress_{self.dest_srt_file}')
-                    error = job_status.get("error", message or "Partial translation")
+                    error = job_status.get("error") or message or "Partial translation"
+                    lines = self._validated_result_lines(job_status.get("result"), total_lines)
+                    if lines is not None:
+                        self._mark_partial(error)
+                        return lines
                     logger.error(f"Translation partially failed: {error}")  # noqa: G004
                     show_message(f"Translation failed (partial): {error}")
                     return None
@@ -307,19 +361,36 @@ class OpenRouterTranslatorService:
                     return None
 
                 # Still processing or queued
-                time.sleep(poll_interval)
-                elapsed += poll_interval
+                time.sleep(POLL_INTERVAL_SECONDS)
 
             except requests.exceptions.RequestException as e:
                 logger.warning(f"Error polling job status: {e}")  # noqa: G004
-                time.sleep(poll_interval)
-                elapsed += poll_interval
+                time.sleep(POLL_INTERVAL_SECONDS)
 
-        # Timeout
         hide_progress(id=f'translate_progress_{self.dest_srt_file}')
-        logger.error("Translation job timed out")
-        show_message("Translation timed out after 30 minutes")
+        logger.error(f"Translation job {job_id} {reason}")  # noqa: G004
+        show_message(user_message)
         return None
+
+    @staticmethod
+    def _validated_result_lines(result, total_lines):
+        if isinstance(result, dict):
+            result = result.get('lines')
+        if not isinstance(result, list) or not result:
+            return None
+        positions = set()
+        has_translation = False
+        for item in result:
+            if not isinstance(item, dict):
+                return None
+            position = item.get('position')
+            line = item.get('line')
+            if (type(position) is not int or not 0 <= position < total_lines
+                    or position in positions or not isinstance(line, str)):
+                return None
+            positions.add(position)
+            has_translation = has_translation or bool(line.strip())
+        return result if has_translation else None
 
     @retry(exceptions=(TooManyRequests, RequestError, requests.exceptions.RequestException), tries=3, delay=1, backoff=2, jitter=(0, 1))
     def _translate_sync(self, lines_list: List[str], payload: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
@@ -334,16 +405,7 @@ class OpenRouterTranslatorService:
         )
 
         if response.status_code == 200:
-            translated_batch = response.json()
-            if isinstance(translated_batch, list):
-                for item in translated_batch:
-                    if not isinstance(item, dict) or 'position' not in item or 'line' not in item:
-                        logger.error(f'Invalid response format: {item}')  # noqa: G004
-                        return None
-                return translated_batch
-            else:
-                logger.error(f'Unexpected response format: {translated_batch}')  # noqa: G004
-                return None
+            return self._validated_result_lines(response.json(), len(lines_list))
         elif response.status_code == 429:
             raise TooManyRequests("Rate limit exceeded")
         elif response.status_code >= 500:

--- a/bazarr/subtitles/tools/translate/services/openrouter_translator.py
+++ b/bazarr/subtitles/tools/translate/services/openrouter_translator.py
@@ -307,7 +307,9 @@ class OpenRouterTranslatorService:
                 if status == "completed":
                     hide_progress(id=f'translate_progress_{self.dest_srt_file}')
                     lines = _extract_job_lines(job_status.get("result"))
-                    if lines is not None:
+                    # An empty list is not a translation: saving it would write every source
+                    # line under the target name and record a success in History.
+                    if lines:
                         logger.debug(f'Extracted {len(lines)} lines from job result')  # noqa: G004
                         return lines
                     logger.error("Job completed but no result returned")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5877,9 +5877,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "version": "2.10.44",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.44.tgz",
+      "integrity": "sha512-T3ghW+sl/ZJ8w1v/yQx3qvJ9040DWoLBz8JT/CILbAKcFyG9b2MRe75v6W5uXjv6uH1lumK2Kv46y2zSkcej0Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5925,9 +5925,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -5945,10 +5945,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -6035,9 +6035,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -6815,9 +6815,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.377",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.377.tgz",
-      "integrity": "sha512-cH1jZgJHoezfTnKfKwnScpHywTFVnJUNITDPREFdhNjiuD502+QFpG0Qk7G8jhsV/f+CEAFlIrzP1fT+IMb92g==",
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "dev": true,
       "license": "ISC"
     },
@@ -10393,9 +10393,9 @@
       "optional": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/src/pages/Settings/Translator/options.ts
+++ b/frontend/src/pages/Settings/Translator/options.ts
@@ -19,17 +19,13 @@ export const aiTranslatorModelOptions: SelectorOption<string>[] = [
   },
   { label: "google/gemini-2.5-flash", value: "google/gemini-2.5-flash" },
   {
-    label: "google/gemini-2.5-flash-lite-preview-09-2025",
-    value: "google/gemini-2.5-flash-lite-preview-09-2025",
+    label: "google/gemini-2.5-flash-lite",
+    value: "google/gemini-2.5-flash-lite",
   },
   { label: "google/gemini-2.5-pro", value: "google/gemini-2.5-pro" },
   {
     label: "google/gemini-3-flash-preview",
     value: "google/gemini-3-flash-preview",
-  },
-  {
-    label: "google/gemini-3-pro-preview",
-    value: "google/gemini-3-pro-preview",
   },
   {
     label: "google/gemini-3.1-flash-lite-preview",
@@ -62,8 +58,8 @@ export const aiTranslatorModelOptions: SelectorOption<string>[] = [
   { label: "openrouter/auto", value: "openrouter/auto" },
   { label: "openrouter/free", value: "openrouter/free" },
   { label: "qwen/qwen3.5-plus-02-15", value: "qwen/qwen3.5-plus-02-15" },
-  { label: "x-ai/grok-4-fast", value: "x-ai/grok-4-fast" },
-  { label: "x-ai/grok-4.20-beta", value: "x-ai/grok-4.20-beta" },
+  { label: "x-ai/grok-4.20", value: "x-ai/grok-4.20" },
+  { label: "x-ai/grok-4.6", value: "x-ai/grok-4.6" },
   { label: "z-ai/glm-4.7-flash", value: "z-ai/glm-4.7-flash" },
 ];
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ click-option-group>=0.5.9
 # support must not be picked up unattended. 1.2.71 is the newest release on
 # PyPI today, so this resolves to the latest version.
 cloudscraper<=1.2.71
-cryptography>=49.0.0
+cryptography>=50.0.1
 deathbycaptcha-official==4.7.1
 deep-translator==1.11.4
 dnspython==2.8.0

--- a/site/guides/ai-translation.html
+++ b/site/guides/ai-translation.html
@@ -173,7 +173,7 @@
       </ul>
 
       <div class="note">
-        <strong>Recommendation:</strong> Start with <code class="inline">google/gemini-2.5-flash-lite-preview-09-2025</code>. It handles subtitle translation well and costs fractions of a cent per episode. Switch to Claude Sonnet 4.5 if you need higher quality for difficult content.
+        <strong>Recommendation:</strong> Start with <code class="inline">google/gemini-2.5-flash-lite</code>. It handles subtitle translation well and costs fractions of a cent per episode. Switch to Claude Sonnet 4.5 if you need higher quality for difficult content.
       </div>
 
       <h2 id="batch-translation-from-missing-pages">Batch translation from Missing pages</h2>

--- a/tests/bazarr/fixtures/cryptography49_fernet.json
+++ b/tests/bazarr/fixtures/cryptography49_fernet.json
@@ -1,0 +1,18 @@
+{
+  "source_version": "49.0.0",
+  "master_key": "synthetic-master-key-for-version-compatibility-only",
+  "cases": [
+    {
+      "plaintext": "synthetic-provider-token",
+      "ciphertext": "enc:v1:gAAAAABqm1uaEus9uqCEc7V5GDwndiAh3HvmiIbEEuVCLpudK4OzvCXIt_jOGT-flGv-rNjFnj06Za8vLGX9SM6UNK9POzfHSc012E_Vd2wA_-zEQqis2PQ="
+    },
+    {
+      "plaintext": "synthetic-translator-token",
+      "ciphertext": "enc:v1:gAAAAABqm1uaHS6Ro_bVCFQEdgdCn2veRLwb7Bj4wcK5cJi1z5VPRpY1A-UO1u1qeddWggCYNKMH743Bw25kNLRStuSrDAv_yW90ktfxZKl7ahXKmJwEkZc="
+    },
+    {
+      "plaintext": "synthetic-unicode-árvíztűrő",
+      "ciphertext": "enc:v1:gAAAAABqm1uaQlgBNKC4euTO9bTpCe-MJ0qtKVdFu8O56EwIXx9BtLH-YGq_nQcNZi53xqMy8ft1Cyi2V8SDqqm2SoTgCxLPzcPLW3FZa9uzZXSA2HWlyJk="
+    }
+  ]
+}

--- a/tests/bazarr/test_dependency_loading.py
+++ b/tests/bazarr/test_dependency_loading.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import subliminal
 import yaml
+import pytest
 
 
 def test_pytest_conftest_imports_without_pkg_resources_deprecation_warning():
@@ -234,6 +235,7 @@ def test_startup_requirements_probe_uses_security_patched_dependency_versions():
     requirements = (repo_root / "requirements.txt").read_text()
 
     expected_versions = {
+        "cryptography": ("cryptography", ">=50.0.1"),
         "dynaconf": ("dynaconf", "==3.3.5"),
         "urllib3": ("urllib3", "==2.7.0"),
     }
@@ -261,6 +263,31 @@ def test_startup_requirements_probe_supports_upper_bound_specs():
     assert _satisfies_spec("1.2.58", "<=1.2.58")
     assert _satisfies_spec("1.2.57", "<=1.2.58")
     assert not _satisfies_spec("1.2.59", "<=1.2.58")
+
+
+@pytest.mark.parametrize('installed', ['48.0.0', '49.0.0', '50.0.0', '50.0.1', '50.0.2'])
+def test_cryptography_security_floor_repairs_old_installs_once(monkeypatch, installed):
+    from app import requirements
+
+    monkeypatch.setattr(requirements, 'RUNTIME_IMPORTS', ('cryptography',))
+    installed_version = [installed]
+    monkeypatch.setattr(requirements.metadata, 'version', lambda distribution: installed_version[0])
+    repairs, restarts = [], []
+
+    def install(missing):
+        repairs.append(missing)
+        installed_version[0] = '50.0.1'
+        return True
+
+    monkeypatch.setattr(requirements, 'install_requirements', install)
+    monkeypatch.setattr(requirements, 'restart_after_requirements_install', lambda: restarts.append(True))
+    needs_repair = installed in ['48.0.0', '49.0.0', '50.0.0']
+    assert requirements.missing_runtime_requirements() == (['cryptography'] if needs_repair else [])
+    assert requirements.ensure_requirements() is needs_repair
+    assert repairs == ([['cryptography']] if needs_repair else [])
+    assert restarts == ([True] if needs_repair else [])
+    assert requirements.ensure_requirements() is False
+    assert len(repairs) == len(restarts) == int(needs_repair)
 
 
 def test_startup_requirements_probe_rejects_removed_vendor_origins(monkeypatch):

--- a/tests/bazarr/test_openrouter_model_migration.py
+++ b/tests/bazarr/test_openrouter_model_migration.py
@@ -1,0 +1,37 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.parametrize("retired,replacement", [
+    ("google/gemini-2.5-flash-preview-05-20", "google/gemini-2.5-flash"),
+    ("google/gemini-2.5-flash-lite-preview-06-17", "google/gemini-2.5-flash-lite"),
+    ("google/gemini-2.5-flash-lite-preview-09-2025", "google/gemini-2.5-flash-lite"),
+    ("google/gemini-3-pro-preview", "google/gemini-3.1-pro-preview"),
+    ("  google/gemini-2.5-flash-preview-05-20  ", "google/gemini-2.5-flash"),
+])
+def test_migrate_retired_openrouter_model_rewrites_retired_id(retired, replacement, caplog):
+    from app import config
+
+    settings = SimpleNamespace(translator=SimpleNamespace(openrouter_model=retired))
+
+    with caplog.at_level(logging.WARNING):
+        assert config.migrate_retired_openrouter_model(settings) is True
+
+    assert settings.translator.openrouter_model == replacement
+    assert any(
+        record.levelno == logging.WARNING and retired.strip() in record.message and replacement in record.message
+        for record in caplog.records
+    )
+    assert config.migrate_retired_openrouter_model(settings) is False
+
+
+@pytest.mark.parametrize("model", ["google/gemini-2.5-flash-lite", "custom/model", "  custom/model  ", "", "  "])
+def test_migrate_retired_openrouter_model_leaves_other_values_unchanged(model):
+    from app import config
+
+    settings = SimpleNamespace(translator=SimpleNamespace(openrouter_model=model))
+
+    assert config.migrate_retired_openrouter_model(settings) is False
+    assert settings.translator.openrouter_model == model

--- a/tests/bazarr/test_openrouter_translator.py
+++ b/tests/bazarr/test_openrouter_translator.py
@@ -1,0 +1,244 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pysubs2
+import pytest
+
+from subtitles.tools.translate.services import openrouter_translator as module
+
+
+@pytest.fixture
+def service(tmp_path, monkeypatch):
+    source = tmp_path / 'source.en.srt'
+    source.write_text('1\n00:00:01,000 --> 00:00:02,000\nOne\n\n'
+                      '2\n00:00:03,000 --> 00:00:04,000\nTwo\n\n'
+                      '3\n00:00:05,000 --> 00:00:06,000\nThree\n', encoding='utf-8')
+    monkeypatch.setattr(module.settings.translator, 'translator_info', False)
+    monkeypatch.setattr(module, 'get_title', lambda **kwargs: 'Example')
+    monkeypatch.setattr(module, 'get_translator_auth_headers', lambda: {})
+    monkeypatch.setattr(module, 'language_from_alpha2', lambda code: {'en': 'English', 'hu': 'Hungarian'}[code])
+    monkeypatch.setattr(module, 'language_from_alpha3', lambda code: 'Hungarian')
+    monkeypatch.setattr(module.requests, 'post', lambda *args, **kwargs: SimpleNamespace(
+        status_code=200, json=lambda: {'jobId': 'fixture-job'}))
+    monkeypatch.setattr(module, 'show_progress', lambda **kwargs: None)
+    monkeypatch.setattr(module, 'hide_progress', lambda **kwargs: None)
+    monkeypatch.setattr(module.jobs_queue, 'update_job_progress', lambda **kwargs: None)
+    translator = module.OpenRouterTranslatorService(
+        source_srt_file=str(source), dest_srt_file=str(tmp_path / 'output.hu.srt'),
+        lang_obj=None, to_lang='hun', from_lang='en', media_type='episode',
+        video_path=str(tmp_path / 'video.mkv'), orig_to_lang='hu', forced=False, hi=False,
+        sonarr_series_id=1, sonarr_episode_id=2, radarr_id=None,
+    )
+    monkeypatch.setattr(translator, '_get_api_key_value', lambda: '')
+    return translator
+
+
+@pytest.fixture
+def events(monkeypatch):
+    captured = SimpleNamespace(messages=[], history=[])
+    monkeypatch.setattr(module, 'show_message', captured.messages.append)
+    monkeypatch.setattr(module, 'history_log', lambda **kwargs: captured.history.append(kwargs))
+    monkeypatch.setattr(module, 'history_log_movie', lambda **kwargs: captured.history.append(kwargs))
+    return captured
+
+
+def _response(monkeypatch, status, result=None, **fields):
+    payload = {'status': status, 'result': result, **fields}
+    monkeypatch.setattr(module.requests, 'get', lambda *args, **kwargs: SimpleNamespace(
+        status_code=200, json=lambda: payload))
+
+
+@pytest.mark.parametrize('structured', [True, False])
+@pytest.mark.parametrize('status', ['partial', 'completed'])
+def test_poll_preserves_usable_lines(service, events, monkeypatch, status, structured):
+    lines = [{'position': 2, 'line': 'Három'}, {'position': 0, 'line': 'Egy'}]
+    _response(monkeypatch, status, {'lines': lines} if structured else lines,
+              error='One batch failed')
+
+    assert service._poll_job('http://fixture', 'job', 3) == lines
+    if status == 'partial':
+        assert any('partial' in message.lower() for message in events.messages)
+
+
+@pytest.mark.parametrize('status', ['partial', 'completed'])
+@pytest.mark.parametrize('result', [None, [], {}, {'lines': []}, {'lines': None},
+                                    {'lines': 'invalid'}, 'invalid'])
+def test_poll_rejects_missing_or_empty_lines(service, events, monkeypatch, status, result):
+    _response(monkeypatch, status, result)
+    assert service._poll_job('http://fixture', 'job', 3) is None
+
+
+@pytest.mark.parametrize('status', ['failed', 'cancelled'])
+def test_poll_does_not_return_failed_output(service, events, monkeypatch, status):
+    _response(monkeypatch, status, [{'position': 0, 'line': 'Egy'}], error='Unavailable')
+    assert service._poll_job('http://fixture', 'job', 3) is None
+
+
+@pytest.mark.parametrize('media_type', ['episode', 'movie'])
+def test_partial_translation_writes_ordered_cues_and_records_warning(service, events, monkeypatch, media_type):
+    service.media_type = media_type
+    service.radarr_id = 3 if media_type == 'movie' else None
+    source = Path(service.source_srt_file).read_bytes()
+    _response(monkeypatch, 'partial', {'lines': [
+        {'position': 2, 'line': 'Három'}, {'position': 0, 'line': 'Egy\nMásik'},
+    ]}, error='One batch failed: malformed response')
+
+    assert service.translate(job_id='bazarr-job') == service.dest_srt_file
+
+    output = pysubs2.load(service.dest_srt_file)
+    assert [cue.plaintext for cue in output] == ['Egy\nMásik', 'Two', 'Három']
+    assert [(cue.start, cue.end) for cue in output] == [(1000, 2000), (3000, 4000), (5000, 6000)]
+    assert Path(service.source_srt_file).read_bytes() == source
+    assert len(events.history) == 1
+    message = events.history[0]['result'].message
+    assert 'partial' in message.lower()
+    assert 'source language' in message.lower()
+    assert 'malformed response' in message
+    assert any('partial' in message.lower() for message in events.messages)
+
+
+@pytest.mark.parametrize('lines', [
+    [], [{'position': 0}], [{'position': -1, 'line': 'Invalid'}],
+    [{'position': 3, 'line': 'Invalid'}], [{'position': True, 'line': 'Invalid'}],
+    [{'position': '0', 'line': 'Invalid'}], [{'position': 0, 'line': None}],
+    [{'position': 0, 'line': ''}], [{'position': 0, 'line': '   '}],
+    [{'position': 0, 'line': 'Valid'}, {'position': 0, 'line': 'Duplicate'}],
+    [{'position': 0, 'line': 'Valid'}, {'position': 1, 'line': ['Invalid']}],
+])
+@pytest.mark.parametrize('status', ['partial', 'completed'])
+def test_invalid_results_do_not_overwrite_files(service, events, monkeypatch, status, lines):
+    destination = Path(service.dest_srt_file)
+    destination.write_bytes(b'existing subtitle')
+    source = Path(service.source_srt_file).read_bytes()
+    _response(monkeypatch, status, {'lines': lines})
+
+    assert service.translate() is False
+
+    assert destination.read_bytes() == b'existing subtitle'
+    assert Path(service.source_srt_file).read_bytes() == source
+    assert events.history == []
+
+
+def test_partial_detail_is_bounded_and_cleared_for_next_operation(service, events, monkeypatch):
+    lines = [{'position': 0, 'line': 'Egy'}]
+    _response(monkeypatch, 'partial', lines, error='Failure detail ' + 'x' * 2000)
+    assert service.translate() == service.dest_srt_file
+    assert len(events.history[-1]['result'].message) < 1000
+
+    complete_lines = [{'position': i, 'line': line} for i, line in enumerate(['Egy', 'Kettő', 'Három'])]
+    _response(monkeypatch, 'completed', complete_lines)
+    assert service.translate() == service.dest_srt_file
+    assert 'partial' not in events.history[-1]['result'].message.lower()
+    assert not service.partial_error
+
+    _response(monkeypatch, 'partial', lines, error='Failure detail')
+    assert service.translate() == service.dest_srt_file
+    _response(monkeypatch, 'failed', error='Unavailable')
+    assert service.translate() is False
+    assert not service.partial_error
+
+
+def test_partial_without_error_detail_still_marks_the_saved_output(service, events, monkeypatch):
+    monkeypatch.setattr(module.settings.translator, 'translator_info', True)
+    _response(monkeypatch, 'partial', [{'position': 0, 'line': 'Egy'}], error='   ')
+
+    assert service.translate() == service.dest_srt_file
+    assert 'partially translated' in pysubs2.load(service.dest_srt_file)[-1].plaintext.lower()
+    assert 'partial' in events.history[-1]['result'].message.lower()
+
+
+def test_empty_source_does_not_report_a_saved_translation(service, events):
+    Path(service.source_srt_file).write_text('', encoding='utf-8')
+    assert service.translate() is False
+    assert not Path(service.dest_srt_file).exists()
+    assert events.history == []
+
+
+@pytest.mark.parametrize('valid', [True, False])
+def test_sync_fallback_uses_the_same_result_validation(service, events, monkeypatch, valid):
+    lines = [{'position': 0, 'line': 'Egy'}, {'position': 1, 'line': ''}]
+    if not valid:
+        lines[0]['position'] = 9
+    responses = iter([
+        SimpleNamespace(status_code=404),
+        SimpleNamespace(status_code=200, json=lambda: lines),
+    ])
+    monkeypatch.setattr(module.requests, 'post', lambda *args, **kwargs: next(responses))
+
+    result = service.translate()
+    if valid:
+        assert result == service.dest_srt_file
+        assert [cue.plaintext for cue in pysubs2.load(result)] == ['Egy', 'Two', 'Three']
+        assert 'partial' in events.history[-1]['result'].message.lower()
+    else:
+        assert result is False
+        assert not Path(service.dest_srt_file).exists()
+        assert events.history == []
+
+
+@pytest.mark.parametrize('status', ['partial', 'completed'])
+def test_save_failure_preserves_destination_and_cleans_temporary_file(service, events, monkeypatch, status):
+    destination = Path(service.dest_srt_file)
+    destination.write_bytes(b'existing subtitle')
+    before = set(destination.parent.iterdir())
+    _response(monkeypatch, status, [{'position': 0, 'line': 'Egy'}])
+
+    def fail_save(subtitles, filename, *args, **kwargs):
+        Path(filename).write_bytes(b'incomplete write')
+        raise OSError('write failed')
+
+    monkeypatch.setattr(pysubs2.SSAFile, 'save', fail_save)
+
+    assert service.translate() is False
+    assert destination.read_bytes() == b'existing subtitle'
+    assert set(destination.parent.iterdir()) == before
+    assert events.history == []
+
+
+@pytest.mark.parametrize('synchronous', [False, True])
+def test_missing_or_blank_cues_are_reported_as_partial(service, events, monkeypatch, synchronous):
+    lines = [{'position': 0, 'line': 'Egy'}, {'position': 1, 'line': '  '}]
+    monkeypatch.setattr(module.settings.translator, 'translator_info', True)
+    if synchronous:
+        responses = iter([SimpleNamespace(status_code=404),
+                          SimpleNamespace(status_code=200, json=lambda: lines)])
+        monkeypatch.setattr(module.requests, 'post', lambda *args, **kwargs: next(responses))
+    else:
+        _response(monkeypatch, 'completed', {'lines': lines})
+
+    assert service.translate() == service.dest_srt_file
+    output = pysubs2.load(service.dest_srt_file)
+    assert [cue.plaintext for cue in output[:3]] == ['Egy', 'Two', 'Three']
+    assert 'partially translated' in output[-1].plaintext.lower()
+    assert 'partial' in events.history[-1]['result'].message.lower()
+    assert any('partial' in message.lower() for message in events.messages)
+
+
+def test_long_destination_filename_retains_atomic_saving_and_permissions(service, events, monkeypatch):
+    destination = Path(service.dest_srt_file).with_name('x' * 220 + '.hu.srt')
+    destination.write_bytes(b'existing subtitle')
+    destination.chmod(0o640)
+    service.dest_srt_file = str(destination)
+    before = set(destination.parent.iterdir())
+    lines = [{'position': i, 'line': line} for i, line in enumerate(['Egy', 'Kettő', 'Három'])]
+    _response(monkeypatch, 'completed', lines)
+
+    assert service.translate() == str(destination)
+    assert [cue.plaintext for cue in pysubs2.load(destination)] == ['Egy', 'Kettő', 'Három']
+    assert destination.stat().st_mode & 0o777 == 0o640
+    assert set(destination.parent.iterdir()) == before
+    assert 'partial' not in events.history[-1]['result'].message.lower()
+
+
+def test_existing_staging_file_is_never_overwritten_or_removed(service, events, monkeypatch):
+    destination = Path(service.dest_srt_file)
+    destination.write_bytes(b'existing subtitle')
+    staging = destination.with_name('.bazarr-translate-fixture-collision.srt')
+    staging.write_bytes(b'other operation')
+    monkeypatch.setattr(module.uuid, 'uuid4', lambda: SimpleNamespace(hex='fixture-collision'))
+    _response(monkeypatch, 'completed', [{'position': 0, 'line': 'Egy'}])
+
+    assert service.translate() is False
+    assert staging.read_bytes() == b'other operation'
+    assert destination.read_bytes() == b'existing subtitle'
+    assert not events.history

--- a/tests/bazarr/test_openrouter_translator_partial.py
+++ b/tests/bazarr/test_openrouter_translator_partial.py
@@ -85,7 +85,7 @@ def test_poll_job_returns_completed_lines(structured):
     openrouter_translator.show_message.assert_not_called()
 
 
-@pytest.mark.parametrize("result", [{"lines": "invalid"}, {"model_used": "model"}, "invalid", 42])
+@pytest.mark.parametrize("result", [None, [], {"lines": []}, {"lines": "invalid"}, {"model_used": "model"}, "invalid", 42])
 def test_poll_job_rejects_completed_without_lines(result):
     service = _build_service()
     openrouter_translator.requests.get.return_value.json.return_value = {"status": "completed", "result": result}

--- a/tests/bazarr/test_openrouter_translator_partial.py
+++ b/tests/bazarr/test_openrouter_translator_partial.py
@@ -1,0 +1,245 @@
+import logging
+
+import pytest
+
+from subtitles.tools.translate.services import openrouter_translator
+
+
+def _build_service(source_srt_file="input.srt", dest_srt_file="output.srt", media_type="episode"):
+    return openrouter_translator.OpenRouterTranslatorService(
+        source_srt_file=source_srt_file,
+        dest_srt_file=dest_srt_file,
+        lang_obj=None,
+        to_lang="hun",
+        from_lang="en",
+        media_type=media_type,
+        video_path="/tmp/video.mkv",
+        orig_to_lang="hu",
+        forced=False,
+        hi=False,
+        sonarr_series_id=1,
+        sonarr_episode_id=2,
+        radarr_id=3,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mock_dependencies(mocker):
+    mocker.patch.object(openrouter_translator.requests, "get", return_value=mocker.Mock(status_code=200))
+    mocker.patch.object(openrouter_translator.time, "sleep")
+    for name in (
+        "show_progress", "hide_progress", "show_message", "jobs_queue", "history_log", "history_log_movie",
+        "add_translator_info", "create_process_result",
+    ):
+        mocker.patch.object(openrouter_translator, name)
+
+
+@pytest.mark.parametrize("structured", [True, False])
+def test_poll_job_keeps_partial_lines_and_full_error(structured, caplog):
+    service = _build_service()
+    lines = [{"position": 0, "line": "Szia"}, {"position": 1, "line": "Source text"}]
+    error = "1 of 58 batches failed: " + "Failed to parse JSON. " * 15
+    result = {"lines": lines, "model_used": "google/gemini-2.5-flash-lite", "tokens_used": 100} if structured else lines
+    openrouter_translator.requests.get.return_value.json.return_value = {
+        "status": "partial", "result": result, "error": error,
+    }
+
+    with caplog.at_level(logging.WARNING, logger=openrouter_translator.__name__):
+        assert service._poll_job("http://translator", "job-1", 2, bazarr_job_id="bazarr-job-1") == lines
+
+    assert service.partial_error == error
+    openrouter_translator.hide_progress.assert_called_once_with(id="translate_progress_output.srt")
+    openrouter_translator.show_message.assert_called_once_with(
+        f"Translation completed with untranslated lines: {error[:200]}"
+    )
+    assert (openrouter_translator.__name__, logging.WARNING,
+            f"Translation completed with untranslated lines: {error}") in caplog.record_tuples
+    openrouter_translator.time.sleep.assert_not_called()
+
+
+@pytest.mark.parametrize("result", [None, {}, [], {"lines": []}, {"lines": "invalid"}, "invalid", 42])
+def test_poll_job_rejects_partial_without_lines(result, caplog):
+    service = _build_service()
+    error = "No lines translated"
+    openrouter_translator.requests.get.return_value.json.return_value = {
+        "status": "partial", "result": result, "error": error,
+    }
+
+    assert service._poll_job("http://translator", "job-1", 1) is None
+    openrouter_translator.hide_progress.assert_called_once_with(id="translate_progress_output.srt")
+    openrouter_translator.show_message.assert_called_once_with(f"Translation failed (partial): {error}")
+    assert (openrouter_translator.__name__, logging.ERROR,
+            f"Translation partially failed: {error}") in caplog.record_tuples
+
+
+@pytest.mark.parametrize("structured", [True, False])
+def test_poll_job_returns_completed_lines(structured):
+    service = _build_service()
+    lines = [{"position": 0, "line": "Szia"}]
+    result = {"lines": lines, "model_used": "google/gemini-2.5-flash-lite", "tokens_used": 100} if structured else lines
+    openrouter_translator.requests.get.return_value.json.return_value = {"status": "completed", "result": result}
+
+    assert service._poll_job("http://translator", "job-1", 1) == lines
+    assert service.partial_error is None
+    openrouter_translator.hide_progress.assert_called_once_with(id="translate_progress_output.srt")
+    openrouter_translator.show_message.assert_not_called()
+
+
+@pytest.mark.parametrize("result", [{"lines": "invalid"}, {"model_used": "model"}, "invalid", 42])
+def test_poll_job_rejects_completed_without_lines(result):
+    service = _build_service()
+    openrouter_translator.requests.get.return_value.json.return_value = {"status": "completed", "result": result}
+
+    assert service._poll_job("http://translator", "job-1", 1) is None
+
+
+@pytest.mark.parametrize("media_type", ["episode", "movie"])
+def test_translate_saves_partial_subtitles_and_marks_history(tmp_path, mocker, media_type):
+    source = tmp_path / "input.srt"
+    destination = tmp_path / "output.srt"
+    source.write_text(
+        "1\n00:00:00,000 --> 00:00:02,000\nHello\n\n"
+        "2\n00:00:03,000 --> 00:00:05,000\nSource text\n\n",
+        encoding="utf-8",
+    )
+    service = _build_service(str(source), str(destination), media_type)
+    error = "1 of 2 batches failed: " + "Failed to parse JSON. " * 15
+
+    def _partial_result(lines_list, bazarr_job_id=None):
+        assert lines_list == ["Hello", "Source text"]
+        assert bazarr_job_id == "bazarr-job-1"
+        service.partial_error = error
+        return [{"position": 0, "line": "Szia"}, {"position": 1, "line": "Source text"}]
+
+    mocker.patch.object(service, "_submit_and_poll", side_effect=_partial_result)
+    mocker.patch.object(openrouter_translator, "language_from_alpha2", return_value="English")
+    mocker.patch.object(openrouter_translator, "language_from_alpha3", return_value="Hungarian")
+
+    assert service.translate(job_id="bazarr-job-1") == str(destination)
+    assert destination.read_text(encoding="utf-8") == (
+        "1\n00:00:00,000 --> 00:00:02,000\nSzia\n\n"
+        "2\n00:00:03,000 --> 00:00:05,000\nSource text\n\n"
+    )
+    openrouter_translator.create_process_result.assert_called_once()
+    history_message = openrouter_translator.create_process_result.call_args.args[0]
+    assert history_message.endswith(f" Partial result: {error[:200]}")
+    openrouter_translator.add_translator_info.assert_called_once_with(
+        str(destination), "# Subtitles translated with AI Subtitle Translator #"
+    )
+    result = openrouter_translator.create_process_result.return_value
+    if media_type == "episode":
+        openrouter_translator.history_log.assert_called_once_with(
+            action=6, sonarr_series_id=1, sonarr_episode_id=2, result=result,
+        )
+        openrouter_translator.history_log_movie.assert_not_called()
+    else:
+        openrouter_translator.history_log_movie.assert_called_once_with(action=6, radarr_id=3, result=result)
+        openrouter_translator.history_log.assert_not_called()
+
+
+class _FakeClock:
+    def __init__(self):
+        self.elapsed = 0
+
+    def monotonic(self):
+        return 1000 + self.elapsed
+
+    def advance(self, seconds):
+        self.elapsed += seconds
+
+
+@pytest.fixture
+def poll_clock(mocker, _mock_dependencies):
+    clock = _FakeClock()
+    mocker.patch.object(openrouter_translator.time, "monotonic", side_effect=clock.monotonic)
+    openrouter_translator.time.sleep.side_effect = clock.advance
+    return clock
+
+
+@pytest.mark.parametrize("status", ["processing", "queued"])
+def test_poll_job_completes_after_more_than_thirty_minutes(poll_clock, mocker, status):
+    service = _build_service()
+    lines = [{"position": 0, "line": "Szia"}]
+    response = mocker.Mock(status_code=200)
+
+    def _get_status(*args, **kwargs):
+        if poll_clock.elapsed < 40 * 60:
+            response.json.return_value = {"status": status}
+        else:
+            response.json.return_value = {"status": "completed", "result": {"lines": lines}}
+        return response
+
+    openrouter_translator.requests.get.side_effect = _get_status
+
+    assert service._poll_job("http://translator", "job-1", 1) == lines
+    assert poll_clock.elapsed == 40 * 60
+    openrouter_translator.hide_progress.assert_called_once_with(id="translate_progress_output.srt")
+    openrouter_translator.show_message.assert_not_called()
+
+
+@pytest.mark.parametrize("failure", ["http_500", "request_exception"])
+def test_poll_job_stops_when_status_endpoint_is_unreachable(poll_clock, mocker, caplog, failure):
+    service = _build_service()
+    response = mocker.Mock(status_code=500)
+
+    def _get_status(*args, **kwargs):
+        poll_clock.advance(8)
+        if failure == "request_exception":
+            raise openrouter_translator.requests.exceptions.RequestException("Service unavailable")
+        return response
+
+    openrouter_translator.requests.get.side_effect = _get_status
+
+    assert service._poll_job("http://translator", "job-1", 1) is None
+    assert poll_clock.elapsed == 10 * 60
+    openrouter_translator.hide_progress.assert_called_once_with(id="translate_progress_output.srt")
+    openrouter_translator.show_message.assert_called_once()
+    assert any(
+        record.levelno == logging.ERROR
+        and "job-1" in record.message
+        and "unreachable for 10 minutes" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.parametrize("failure", ["http_500", "request_exception"])
+def test_poll_job_resets_unreachable_clock_after_http_200(poll_clock, mocker, failure):
+    service = _build_service()
+    lines = [{"position": 0, "line": "Szia"}]
+    response = mocker.Mock(status_code=200)
+    failed_response = mocker.Mock(status_code=500)
+
+    def _get_status(*args, **kwargs):
+        if poll_clock.elapsed == 8 * 60:
+            response.json.return_value = {"status": "processing"}
+            return response
+        if poll_clock.elapsed >= 16 * 60:
+            response.json.return_value = {"status": "completed", "result": {"lines": lines}}
+            return response
+        if failure == "request_exception":
+            raise openrouter_translator.requests.exceptions.RequestException("Service unavailable")
+        return failed_response
+
+    openrouter_translator.requests.get.side_effect = _get_status
+
+    assert service._poll_job("http://translator", "job-1", 1) == lines
+    assert poll_clock.elapsed == 16 * 60
+    openrouter_translator.hide_progress.assert_called_once_with(id="translate_progress_output.srt")
+    openrouter_translator.show_message.assert_not_called()
+
+
+def test_poll_job_stops_at_twelve_hour_hard_cap(poll_clock, caplog):
+    service = _build_service()
+    openrouter_translator.requests.get.return_value.json.return_value = {"status": "processing"}
+    openrouter_translator.time.sleep.side_effect = lambda seconds: poll_clock.advance(5 * 60)
+
+    assert service._poll_job("http://translator", "job-1", 1) is None
+    assert poll_clock.elapsed == 12 * 3600
+    openrouter_translator.hide_progress.assert_called_once_with(id="translate_progress_output.srt")
+    openrouter_translator.show_message.assert_called_once()
+    assert any(
+        record.levelno == logging.ERROR
+        and "job-1" in record.message
+        and "hard cap" in record.message
+        for record in caplog.records
+    )

--- a/tests/bazarr/test_openrouter_translator_partial.py
+++ b/tests/bazarr/test_openrouter_translator_partial.py
@@ -1,0 +1,250 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from subtitles.tools.translate.services import openrouter_translator
+
+
+def _build_service(source_srt_file="input.srt", dest_srt_file="output.srt", media_type="episode"):
+    return openrouter_translator.OpenRouterTranslatorService(
+        source_srt_file=source_srt_file,
+        dest_srt_file=dest_srt_file,
+        lang_obj=None,
+        to_lang="hun",
+        from_lang="en",
+        media_type=media_type,
+        video_path="/tmp/video.mkv",
+        orig_to_lang="hu",
+        forced=False,
+        hi=False,
+        sonarr_series_id=1,
+        sonarr_episode_id=2,
+        radarr_id=3,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mock_dependencies(mocker):
+    mocker.patch.object(openrouter_translator.requests, "get", return_value=mocker.Mock(status_code=200))
+    mocker.patch.object(openrouter_translator.time, "sleep")
+    for name in (
+        "show_progress", "hide_progress", "show_message", "jobs_queue", "history_log", "history_log_movie",
+        "add_translator_info", "create_process_result",
+    ):
+        mocker.patch.object(openrouter_translator, name)
+
+
+@pytest.mark.parametrize("structured", [True, False])
+def test_poll_job_keeps_partial_lines_and_bounded_error(structured, caplog):
+    service = _build_service()
+    lines = [{"position": 0, "line": "Szia"}, {"position": 1, "line": "Source text"}]
+    error = "1 of 58 batches failed: " + "Failed to parse JSON. " * 100
+    detail = error.strip()[:500]
+    result = {"lines": lines, "model_used": "google/gemini-2.5-flash-lite", "tokens_used": 100} if structured else lines
+    openrouter_translator.requests.get.return_value.json.return_value = {
+        "status": "partial", "result": result, "error": error,
+    }
+
+    with caplog.at_level(logging.WARNING, logger=openrouter_translator.__name__):
+        assert service._poll_job("http://translator", "job-1", 2, bazarr_job_id="bazarr-job-1") == lines
+
+    assert service.partial_error == detail
+    openrouter_translator.hide_progress.assert_called_once_with(id="translate_progress_output.srt")
+    openrouter_translator.show_message.assert_called_once_with(
+        f"Translation is partial. Some lines may remain in the source language. {detail}"
+    )
+    assert (openrouter_translator.__name__, logging.WARNING,
+            f"Translation partially completed: {detail}") in caplog.record_tuples
+    openrouter_translator.time.sleep.assert_not_called()
+
+
+@pytest.mark.parametrize("result", [None, {}, [], {"lines": []}, {"lines": "invalid"}, "invalid", 42])
+def test_poll_job_rejects_partial_without_lines(result, caplog):
+    service = _build_service()
+    error = "No lines translated"
+    openrouter_translator.requests.get.return_value.json.return_value = {
+        "status": "partial", "result": result, "error": error,
+    }
+
+    assert service._poll_job("http://translator", "job-1", 1) is None
+    openrouter_translator.hide_progress.assert_called_once_with(id="translate_progress_output.srt")
+    openrouter_translator.show_message.assert_called_once_with(f"Translation failed (partial): {error}")
+    assert (openrouter_translator.__name__, logging.ERROR,
+            f"Translation partially failed: {error}") in caplog.record_tuples
+
+
+@pytest.mark.parametrize("structured", [True, False])
+def test_poll_job_returns_completed_lines(structured):
+    service = _build_service()
+    lines = [{"position": 0, "line": "Szia"}]
+    result = {"lines": lines, "model_used": "google/gemini-2.5-flash-lite", "tokens_used": 100} if structured else lines
+    openrouter_translator.requests.get.return_value.json.return_value = {"status": "completed", "result": result}
+
+    assert service._poll_job("http://translator", "job-1", 1) == lines
+    assert service.partial_error is None
+    openrouter_translator.hide_progress.assert_called_once_with(id="translate_progress_output.srt")
+    openrouter_translator.show_message.assert_not_called()
+
+
+@pytest.mark.parametrize("result", [None, [], {"lines": []}, {"lines": "invalid"}, {"model_used": "model"}, "invalid", 42])
+def test_poll_job_rejects_completed_without_lines(result):
+    service = _build_service()
+    openrouter_translator.requests.get.return_value.json.return_value = {"status": "completed", "result": result}
+
+    assert service._poll_job("http://translator", "job-1", 1) is None
+
+
+@pytest.mark.parametrize("media_type", ["episode", "movie"])
+def test_translate_saves_partial_subtitles_and_marks_history(tmp_path, mocker, media_type):
+    source = tmp_path / "input.srt"
+    destination = tmp_path / "output.srt"
+    source.write_text(
+        "1\n00:00:00,000 --> 00:00:02,000\nHello\n\n"
+        "2\n00:00:03,000 --> 00:00:05,000\nSource text\n\n",
+        encoding="utf-8",
+    )
+    service = _build_service(str(source), str(destination), media_type)
+    error = "1 of 2 batches failed: " + "Failed to parse JSON. " * 15
+
+    def _partial_result(lines_list, bazarr_job_id=None):
+        assert lines_list == ["Hello", "Source text"]
+        assert bazarr_job_id == "bazarr-job-1"
+        service._mark_partial(error)
+        return [{"position": 0, "line": "Szia"}, {"position": 1, "line": "Source text"}]
+
+    mocker.patch.object(service, "_submit_and_poll", side_effect=_partial_result)
+    mocker.patch.object(openrouter_translator, "language_from_alpha2", return_value="English")
+    mocker.patch.object(openrouter_translator, "language_from_alpha3", return_value="Hungarian")
+
+    assert service.translate(job_id="bazarr-job-1") == str(destination)
+    assert destination.read_text(encoding="utf-8") == (
+        "1\n00:00:00,000 --> 00:00:02,000\nSzia\n\n"
+        "2\n00:00:03,000 --> 00:00:05,000\nSource text\n\n"
+    )
+    openrouter_translator.create_process_result.assert_called_once()
+    history_message = openrouter_translator.create_process_result.call_args.args[0]
+    assert "partially translated" in history_message
+    assert history_message.endswith(error.strip()[:500])
+    openrouter_translator.add_translator_info.assert_called_once()
+    staged, footer = openrouter_translator.add_translator_info.call_args.args
+    assert Path(staged).parent == destination.parent
+    assert Path(staged).name.startswith(".bazarr-translate-")
+    assert footer == "# Subtitles partially translated with AI Subtitle Translator #"
+    result = openrouter_translator.create_process_result.return_value
+    if media_type == "episode":
+        openrouter_translator.history_log.assert_called_once_with(
+            action=6, sonarr_series_id=1, sonarr_episode_id=2, result=result,
+        )
+        openrouter_translator.history_log_movie.assert_not_called()
+    else:
+        openrouter_translator.history_log_movie.assert_called_once_with(action=6, radarr_id=3, result=result)
+        openrouter_translator.history_log.assert_not_called()
+
+
+class _FakeClock:
+    def __init__(self):
+        self.elapsed = 0
+
+    def monotonic(self):
+        return 1000 + self.elapsed
+
+    def advance(self, seconds):
+        self.elapsed += seconds
+
+
+@pytest.fixture
+def poll_clock(mocker, _mock_dependencies):
+    clock = _FakeClock()
+    mocker.patch.object(openrouter_translator.time, "monotonic", side_effect=clock.monotonic)
+    openrouter_translator.time.sleep.side_effect = clock.advance
+    return clock
+
+
+@pytest.mark.parametrize("status", ["processing", "queued"])
+def test_poll_job_completes_after_more_than_thirty_minutes(poll_clock, mocker, status):
+    service = _build_service()
+    lines = [{"position": 0, "line": "Szia"}]
+    response = mocker.Mock(status_code=200)
+
+    def _get_status(*args, **kwargs):
+        if poll_clock.elapsed < 40 * 60:
+            response.json.return_value = {"status": status}
+        else:
+            response.json.return_value = {"status": "completed", "result": {"lines": lines}}
+        return response
+
+    openrouter_translator.requests.get.side_effect = _get_status
+
+    assert service._poll_job("http://translator", "job-1", 1) == lines
+    assert poll_clock.elapsed == 40 * 60
+    openrouter_translator.hide_progress.assert_called_once_with(id="translate_progress_output.srt")
+    openrouter_translator.show_message.assert_not_called()
+
+
+@pytest.mark.parametrize("failure", ["http_500", "request_exception"])
+def test_poll_job_stops_when_status_endpoint_is_unreachable(poll_clock, mocker, caplog, failure):
+    service = _build_service()
+    response = mocker.Mock(status_code=500)
+
+    def _get_status(*args, **kwargs):
+        poll_clock.advance(8)
+        if failure == "request_exception":
+            raise openrouter_translator.requests.exceptions.RequestException("Service unavailable")
+        return response
+
+    openrouter_translator.requests.get.side_effect = _get_status
+
+    assert service._poll_job("http://translator", "job-1", 1) is None
+    assert poll_clock.elapsed == 10 * 60
+    openrouter_translator.hide_progress.assert_called_once_with(id="translate_progress_output.srt")
+    openrouter_translator.show_message.assert_called_once()
+    assert any(
+        record.levelno == logging.ERROR
+        and "job-1" in record.message
+        and "unreachable for 10 minutes" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.parametrize("failure", ["http_500", "request_exception"])
+def test_poll_job_resets_unreachable_clock_after_http_200(poll_clock, mocker, failure):
+    service = _build_service()
+    lines = [{"position": 0, "line": "Szia"}]
+    response = mocker.Mock(status_code=200)
+    failed_response = mocker.Mock(status_code=500)
+
+    def _get_status(*args, **kwargs):
+        if poll_clock.elapsed == 8 * 60:
+            response.json.return_value = {"status": "processing"}
+            return response
+        if poll_clock.elapsed >= 16 * 60:
+            response.json.return_value = {"status": "completed", "result": {"lines": lines}}
+            return response
+        if failure == "request_exception":
+            raise openrouter_translator.requests.exceptions.RequestException("Service unavailable")
+        return failed_response
+
+    openrouter_translator.requests.get.side_effect = _get_status
+
+    assert service._poll_job("http://translator", "job-1", 1) == lines
+    assert poll_clock.elapsed == 16 * 60
+    openrouter_translator.hide_progress.assert_called_once_with(id="translate_progress_output.srt")
+    openrouter_translator.show_message.assert_not_called()
+
+
+def test_poll_job_stops_at_twelve_hour_hard_cap(poll_clock, caplog):
+    service = _build_service()
+    openrouter_translator.requests.get.return_value.json.return_value = {"status": "processing"}
+    openrouter_translator.time.sleep.side_effect = lambda seconds: poll_clock.advance(5 * 60)
+
+    assert service._poll_job("http://translator", "job-1", 1) is None
+    assert poll_clock.elapsed == 12 * 3600
+    openrouter_translator.hide_progress.assert_called_once_with(id="translate_progress_output.srt")
+    openrouter_translator.show_message.assert_called_once()
+    assert any(
+        record.levelno == logging.ERROR
+        and "job-1" in record.message
+        and "hard cap" in record.message
+        for record in caplog.records
+    )

--- a/tests/bazarr/test_secret_store_crypto.py
+++ b/tests/bazarr/test_secret_store_crypto.py
@@ -6,6 +6,8 @@ bad-cipher diagnostics) lives in commit 5's test_secrets_e2e.py. This file
 covers just the crypto primitives.
 """
 from unittest.mock import MagicMock
+import json
+from pathlib import Path
 
 import pytest
 
@@ -16,6 +18,23 @@ from secret_store.crypto import (
     get_master_key,
     is_encrypted,
 )
+
+
+_OLD_CRYPTOGRAPHY = json.loads(
+    (Path(__file__).with_name('fixtures') / 'cryptography49_fernet.json').read_text(encoding='utf-8')
+)
+
+
+@pytest.mark.parametrize('case', _OLD_CRYPTOGRAPHY['cases'], ids=['provider', 'translator', 'unicode'])
+def test_ciphertext_from_cryptography_49_remains_readable(case):
+    """Persisted synthetic fixtures were encrypted by the actual 49.0.0 wheel."""
+    key = _OLD_CRYPTOGRAPHY['master_key']
+    assert decrypt_secret(case['ciphertext'], master_key=key) == case['plaintext']
+    assert encrypt_secret(case['ciphertext'], master_key=key) == case['ciphertext']
+    with pytest.raises(ValueError, match='tampered|master key'):
+        decrypt_secret(case['ciphertext'], master_key='synthetic-wrong-master-key')
+    with pytest.raises(ValueError, match='tampered|master key'):
+        decrypt_secret(case['ciphertext'][:-2] + 'AA', master_key=key)
 
 
 @pytest.fixture

--- a/tests/bazarr/test_subtitle_destination_path.py
+++ b/tests/bazarr/test_subtitle_destination_path.py
@@ -1,0 +1,110 @@
+# coding=utf-8
+"""A new external subtitle has to land in the configured subtitle folder.
+
+get_external_subtitles_path() is a lookup: it returns a path only for a file that
+already exists. translate and mods used it to build the path of the file they were
+about to WRITE, so in the absolute and relative subfolder modes a first-time
+translation got None and crashed on save. get_subtitle_destination_path() keeps the
+lookup's preference for an existing file and otherwise resolves the configured folder.
+"""
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def subtitle_folder(monkeypatch):
+    from app import config as app_config
+    from subtitles.indexer import utils as indexer_utils
+
+    # Startup modules write the config to disk when first imported. If that first
+    # import happens while these values are patched, the patched folder would be
+    # persisted into the local test config and break every later run.
+    monkeypatch.setattr(app_config, "write_config", lambda: None)
+
+    def _configure(mode, custom=""):
+        monkeypatch.setattr(indexer_utils.settings.general, "subfolder", mode)
+        monkeypatch.setattr(indexer_utils.settings.general, "subfolder_custom", custom)
+
+    return _configure
+
+
+def test_current_mode_writes_next_to_the_video(tmp_path, subtitle_folder):
+    from subtitles.indexer.utils import get_subtitle_destination_path
+
+    subtitle_folder("current")
+    video = tmp_path / "video.mkv"
+
+    assert get_subtitle_destination_path(str(video), "video.hu.srt") == str(tmp_path / "video.hu.srt")
+
+
+def test_absolute_mode_resolves_and_creates_the_custom_folder(tmp_path, subtitle_folder):
+    from subtitles.indexer.utils import get_subtitle_destination_path
+
+    custom = tmp_path / "subs"
+    subtitle_folder("absolute", str(custom))
+    video = tmp_path / "video.mkv"
+
+    destination = get_subtitle_destination_path(str(video), "video.hu.srt")
+
+    assert destination == str(custom / "video.hu.srt")
+    assert custom.is_dir(), "the write target folder has to exist, the way downloads create it"
+
+
+def test_relative_mode_resolves_under_the_video_folder(tmp_path, subtitle_folder):
+    from subtitles.indexer.utils import get_subtitle_destination_path
+
+    subtitle_folder("relative", "Subs")
+    video = tmp_path / "video.mkv"
+
+    assert get_subtitle_destination_path(str(video), "video.hu.srt") == str(tmp_path / "Subs" / "video.hu.srt")
+
+
+def test_an_existing_file_next_to_the_video_keeps_precedence(tmp_path, subtitle_folder):
+    from subtitles.indexer.utils import get_subtitle_destination_path
+
+    subtitle_folder("absolute", str(tmp_path / "subs"))
+    video = tmp_path / "video.mkv"
+    existing = tmp_path / "video.hu.srt"
+    existing.write_text("1\n00:00:00,000 --> 00:00:01,000\nSzia\n", encoding="utf-8")
+
+    assert get_subtitle_destination_path(str(video), "video.hu.srt") == str(existing)
+
+
+def test_translate_passes_a_custom_folder_destination_to_the_translator(tmp_path, monkeypatch, subtitle_folder):
+    from subtitles.tools.translate import main as translate_main
+    from subzero.language import Language
+
+    custom = tmp_path / "subs"
+    subtitle_folder("absolute", str(custom))
+    video = tmp_path / "video.mkv"
+
+    monkeypatch.setattr(translate_main, "validate_translation_params", lambda *a, **kw: None)
+    monkeypatch.setattr(translate_main, "convert_language_codes",
+                        lambda to_lang, forced, hi: (Language("hun"), to_lang))
+    monkeypatch.setattr(translate_main, "get_subtitle_path", lambda *a, **kw: str(tmp_path / "video.hu.srt"))
+    monkeypatch.setattr(translate_main, "alpha3_from_alpha2", lambda code: "hun")
+
+    seen = {}
+    translator = MagicMock()
+    translator.translate.return_value = True
+
+    def _create(kind, **kwargs):
+        seen.update(kwargs)
+        return translator
+
+    monkeypatch.setattr(translate_main.TranslatorFactory, "create_translator", staticmethod(_create))
+
+    with (
+        patch("api.subtitles.subtitles.postprocess_subtitles", lambda *a, **kw: None),
+        patch("subtitles.tools.combine.main.try_combine_for_video", lambda **kw: None),
+    ):
+        translate_main.translate_subtitles_file(
+            video_path=str(video), source_srt_file=str(tmp_path / "video.en.srt"),
+            from_lang="en", to_lang="hu", forced=False, hi=False,
+            media_type="movies", sonarr_series_id=None, sonarr_episode_id=None,
+            radarr_id=9, metadata={}, job_id="job-1")
+
+    assert seen["dest_srt_file"] == os.path.join(str(custom), "video.hu.srt"), (
+        "a first-time translation in absolute subfolder mode must target the custom folder, not None")

--- a/tests/bazarr/test_subtitle_destination_path.py
+++ b/tests/bazarr/test_subtitle_destination_path.py
@@ -1,0 +1,205 @@
+# coding=utf-8
+"""A new external subtitle has to land in the configured subtitle folder.
+
+get_external_subtitles_path() is a lookup: it returns a path only for a file that
+already exists. translate and mods used it to build the path of the file they were
+about to WRITE, so in the absolute and relative subfolder modes a first-time
+translation got None and crashed on save. get_subtitle_destination_path() keeps the
+lookup's preference for an existing file and otherwise resolves the configured folder.
+"""
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def subtitle_folder(monkeypatch):
+    from app import config as app_config
+    from subtitles.indexer import utils as indexer_utils
+
+    # Startup modules write the config to disk when first imported. If that first
+    # import happens while these values are patched, the patched folder would be
+    # persisted into the local test config and break every later run.
+    monkeypatch.setattr(app_config, "write_config", lambda: None)
+
+    def _configure(mode, custom=""):
+        monkeypatch.setattr(indexer_utils.settings.general, "subfolder", mode)
+        monkeypatch.setattr(indexer_utils.settings.general, "subfolder_custom", custom)
+
+    return _configure
+
+
+def test_current_mode_writes_next_to_the_video(tmp_path, subtitle_folder):
+    from subtitles.indexer.utils import get_subtitle_destination_path
+
+    subtitle_folder("current")
+    video = tmp_path / "video.mkv"
+
+    assert get_subtitle_destination_path(str(video), "video.hu.srt") == str(tmp_path / "video.hu.srt")
+
+
+def test_absolute_mode_resolves_and_creates_the_custom_folder(tmp_path, subtitle_folder):
+    from subtitles.indexer.utils import get_subtitle_destination_path
+
+    custom = tmp_path / "subs"
+    subtitle_folder("absolute", str(custom))
+    video = tmp_path / "video.mkv"
+
+    destination = get_subtitle_destination_path(str(video), "video.hu.srt")
+
+    assert destination == str(custom / "video.hu.srt")
+    assert custom.is_dir(), "the write target folder has to exist, the way downloads create it"
+
+
+def test_relative_mode_resolves_under_the_video_folder(tmp_path, subtitle_folder):
+    from subtitles.indexer.utils import get_subtitle_destination_path
+
+    subtitle_folder("relative", "Subs")
+    video = tmp_path / "video.mkv"
+
+    assert get_subtitle_destination_path(str(video), "video.hu.srt") == str(tmp_path / "Subs" / "video.hu.srt")
+
+
+def test_an_existing_file_next_to_the_video_keeps_precedence(tmp_path, subtitle_folder):
+    from subtitles.indexer.utils import get_subtitle_destination_path
+
+    subtitle_folder("absolute", str(tmp_path / "subs"))
+    video = tmp_path / "video.mkv"
+    existing = tmp_path / "video.hu.srt"
+    existing.write_text("1\n00:00:00,000 --> 00:00:01,000\nSzia\n", encoding="utf-8")
+
+    assert get_subtitle_destination_path(str(video), "video.hu.srt") == str(existing)
+
+
+def test_translate_passes_a_custom_folder_destination_to_the_translator(tmp_path, monkeypatch, subtitle_folder):
+    from subtitles.tools.translate import main as translate_main
+    from subzero.language import Language
+
+    custom = tmp_path / "subs"
+    subtitle_folder("absolute", str(custom))
+    video = tmp_path / "video.mkv"
+
+    monkeypatch.setattr(translate_main, "validate_translation_params", lambda *a, **kw: None)
+    monkeypatch.setattr(translate_main, "convert_language_codes",
+                        lambda to_lang, forced, hi: (Language("hun"), to_lang))
+    monkeypatch.setattr(translate_main, "get_subtitle_path", lambda *a, **kw: str(tmp_path / "video.hu.srt"))
+    monkeypatch.setattr(translate_main, "alpha3_from_alpha2", lambda code: "hun")
+
+    seen = {}
+    translator = MagicMock()
+    translator.translate.return_value = True
+
+    def _create(kind, **kwargs):
+        seen.update(kwargs)
+        return translator
+
+    monkeypatch.setattr(translate_main.TranslatorFactory, "create_translator", staticmethod(_create))
+
+    with (
+        patch("api.subtitles.subtitles.postprocess_subtitles", lambda *a, **kw: None),
+        patch("subtitles.tools.combine.main.try_combine_for_video", lambda **kw: None),
+    ):
+        translate_main.translate_subtitles_file(
+            video_path=str(video), source_srt_file=str(tmp_path / "video.en.srt"),
+            from_lang="en", to_lang="hu", forced=False, hi=False,
+            media_type="movies", sonarr_series_id=None, sonarr_episode_id=None,
+            radarr_id=9, metadata={}, job_id="job-1")
+
+    assert seen["dest_srt_file"] == os.path.join(str(custom), "video.hu.srt"), (
+        "a first-time translation in absolute subfolder mode must target the custom folder, not None")
+
+
+@pytest.mark.parametrize("mode", ["absolute", "relative"])
+@pytest.mark.parametrize("status", ["partial", "completed"])
+@pytest.mark.parametrize("failure", [None, "footer", "replace"])
+def test_translation_saves_atomic_results_in_configured_folder(
+        tmp_path, monkeypatch, subtitle_folder, mode, status, failure):
+    import sys
+    from types import SimpleNamespace
+
+    import pysubs2
+
+    from languages import get_languages
+    from subtitles.tools.translate import main as translate_main
+    from subtitles.tools.translate.services import openrouter_translator as service_module
+
+    monkeypatch.setattr(get_languages, "languages_dict", [
+        {"code2": "en", "code3": "eng", "code3b": "eng", "name": "English"},
+        {"code2": "hu", "code3": "hun", "code3b": "hun", "name": "Hungarian"},
+    ], raising=False)
+    video = tmp_path / "video.mkv"
+    video.touch()
+    source = tmp_path / "video.en.srt"
+    source.write_text("1\n00:00:01,000 --> 00:00:02,000\nOne\n\n"
+                      "2\n00:00:03,000 --> 00:00:04,000\nTwo\n", encoding="utf-8")
+    original_source = source.read_bytes()
+    custom = tmp_path / "Subs"
+    destination = custom / "video.hu.srt"
+    subtitle_folder(mode, str(custom) if mode == "absolute" else "Subs")
+    if failure:
+        custom.mkdir()
+        destination.write_bytes(b"existing subtitle")
+
+    monkeypatch.setattr(service_module.settings.translator, "translator_info", True)
+    monkeypatch.setattr(service_module.settings.translator, "translator_type", "openrouter")
+    monkeypatch.setattr(service_module, "get_title", lambda **kwargs: "Example")
+    monkeypatch.setattr(service_module, "get_translator_auth_headers", lambda: {})
+    monkeypatch.setattr(service_module.OpenRouterTranslatorService, "_get_api_key_value", lambda self: "")
+    monkeypatch.setattr(service_module.requests, "post", lambda *args, **kwargs: SimpleNamespace(
+        status_code=200, json=lambda: {"jobId": "fixture-job"}))
+    lines = [{"position": 0, "line": "Egy"}]
+    if status == "completed":
+        lines.append({"position": 1, "line": "Kettő"})
+    monkeypatch.setattr(service_module.requests, "get", lambda *args, **kwargs: SimpleNamespace(
+        status_code=200, json=lambda: {"status": status, "result": {"lines": lines},
+                                      "error": "Some batches failed" if failure else None}))
+    for name in ("show_progress", "hide_progress", "show_message"):
+        monkeypatch.setattr(service_module, name, lambda *args, **kwargs: None)
+    history = []
+    monkeypatch.setattr(service_module, "history_log_movie", lambda **kwargs: history.append(kwargs))
+    monkeypatch.setattr(service_module.jobs_queue, "update_job_progress", lambda **kwargs: None)
+    names = []
+    monkeypatch.setattr(translate_main.jobs_queue, "get_job_name", lambda job_id: "Translating Example")
+    monkeypatch.setattr(translate_main.jobs_queue, "update_job_name",
+                        lambda **kwargs: names.append(kwargs["new_job_name"]))
+    monkeypatch.setattr(translate_main.TranslatorFactory, "create_translator",
+                        staticmethod(lambda kind, **kwargs: service_module.OpenRouterTranslatorService(**kwargs)))
+    postprocessed = []
+
+    def fail_write(*args, **kwargs):
+        raise OSError("synthetic write failure")
+
+    if failure == "footer":
+        monkeypatch.setattr(service_module, "add_translator_info", fail_write)
+    elif failure == "replace":
+        monkeypatch.setattr(service_module.os, "replace", fail_write)
+
+    monkeypatch.setitem(sys.modules, "api.subtitles.subtitles", SimpleNamespace(
+        postprocess_subtitles=lambda *args, **kwargs: postprocessed.append(args[0])))
+    monkeypatch.setitem(sys.modules, "subtitles.tools.combine.main", SimpleNamespace(
+        try_combine_for_video=lambda **kwargs: None))
+    kwargs = dict(video_path=str(video), source_srt_file=str(source), from_lang="en", to_lang="hu",
+                  forced=False, hi=False, media_type="movies", sonarr_series_id=None,
+                  sonarr_episode_id=None, radarr_id=9, metadata={}, job_id="fixture-job", arr_instance_id=3)
+    if failure:
+        with pytest.raises(RuntimeError, match="failed translation result"):
+            translate_main.translate_subtitles_file(**kwargs)
+    else:
+        assert translate_main.translate_subtitles_file(**kwargs) == str(destination)
+
+    assert source.read_bytes() == original_source
+    assert not list(custom.glob(".bazarr-translate-*"))
+    if failure:
+        assert destination.read_bytes() == b"existing subtitle"
+        assert not history
+        assert not postprocessed
+        assert names[-1].startswith("Failed")
+    else:
+        output = pysubs2.load(destination)
+        assert [cue.plaintext for cue in output[:2]] == (["Egy", "Two"] if status == "partial" else ["Egy", "Kettő"])
+        assert [(cue.start, cue.end) for cue in output[:2]] == [(1000, 2000), (3000, 4000)]
+        assert ("partially translated" in output[-1].plaintext.lower()) == (status == "partial")
+        assert ("partial" in history[0]["result"].message.lower()) == (status == "partial")
+        assert names[-1].startswith("Partially translated" if status == "partial" else "Translated")
+        assert postprocessed == [str(destination)]

--- a/tests/bazarr/test_translate_owner_threading.py
+++ b/tests/bazarr/test_translate_owner_threading.py
@@ -27,12 +27,13 @@ def translate_harness(monkeypatch, tmp_path):
                         lambda to_lang, forced, hi: (Language('nld'), to_lang))
     monkeypatch.setattr(translate_main, 'get_subtitle_path',
                         lambda *a, **kw: str(tmp_path / 'video.nl.srt'))
-    monkeypatch.setattr(translate_main, 'get_external_subtitles_path',
+    monkeypatch.setattr(translate_main, 'get_subtitle_destination_path',
                         lambda file, subtitle: str(tmp_path / subtitle))
     monkeypatch.setattr(translate_main, 'alpha3_from_alpha2', lambda code: 'nld')
 
     translator = MagicMock()
     translator.translate.return_value = True
+    translator.partial_error = None
     monkeypatch.setattr(translate_main.TranslatorFactory, 'create_translator',
                         staticmethod(lambda *a, **kw: translator))
     return translate_main
@@ -80,3 +81,27 @@ def test_no_owner_still_works_for_a_single_instance_install(translate_harness):
             radarr_id=9, metadata={}, job_id='job-1')
 
     assert seen['arr_instance_id'] is None
+
+
+@pytest.mark.parametrize('partial', [False, True])
+@pytest.mark.parametrize('current_name', [None, 'Translating Example'])
+def test_translation_job_label_preserves_partial_status(translate_harness, monkeypatch, partial, current_name):
+    translate_main = translate_harness
+    translator = translate_main.TranslatorFactory.create_translator('openrouter')
+    translator.partial_error = 'Some batches failed' if partial else None
+    names = []
+    monkeypatch.setattr(translate_main.jobs_queue, 'get_job_name', lambda job_id: current_name)
+    monkeypatch.setattr(translate_main.jobs_queue, 'update_job_name',
+                        lambda **kwargs: names.append(kwargs['new_job_name']))
+
+    with (
+        patch('api.subtitles.subtitles.postprocess_subtitles', lambda *a, **kw: None),
+        patch('subtitles.tools.combine.main.try_combine_for_video', lambda **kw: None),
+    ):
+        translate_main.translate_subtitles_file(
+            video_path='/local/tv/s/e.mkv', source_srt_file='/local/tv/s/e.en.srt',
+            from_lang='en', to_lang='nl', forced=False, hi=False,
+            media_type='episode', sonarr_series_id=1, sonarr_episode_id=42,
+            radarr_id=None, metadata={}, job_id='job-1', arr_instance_id=3)
+
+    assert names[-1].startswith('Partially translated' if partial else 'Translated')

--- a/tests/bazarr/test_translate_owner_threading.py
+++ b/tests/bazarr/test_translate_owner_threading.py
@@ -27,7 +27,7 @@ def translate_harness(monkeypatch, tmp_path):
                         lambda to_lang, forced, hi: (Language('nld'), to_lang))
     monkeypatch.setattr(translate_main, 'get_subtitle_path',
                         lambda *a, **kw: str(tmp_path / 'video.nl.srt'))
-    monkeypatch.setattr(translate_main, 'get_external_subtitles_path',
+    monkeypatch.setattr(translate_main, 'get_subtitle_destination_path',
                         lambda file, subtitle: str(tmp_path / subtitle))
     monkeypatch.setattr(translate_main, 'alpha3_from_alpha2', lambda code: 'nld')
 

--- a/tests/bazarr/test_translator_model_migration.py
+++ b/tests/bazarr/test_translator_model_migration.py
@@ -1,0 +1,60 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+
+@pytest.mark.parametrize('configured, expected', [
+    (None, 'google/gemini-2.5-flash-lite'),
+    ('google/gemini-2.5-flash-preview-05-20', 'google/gemini-2.5-flash'),
+    ('google/gemini-2.5-flash-lite-preview-06-17', 'google/gemini-2.5-flash-lite'),
+    ('google/gemini-2.5-flash-lite-preview-09-2025', 'google/gemini-2.5-flash-lite'),
+    ('google/gemini-3-pro-preview', 'google/gemini-3.1-pro-preview'),
+    ('google/gemini-2.5-flash', 'google/gemini-2.5-flash'),
+    ('google/gemini-2.5-flash-lite', 'google/gemini-2.5-flash-lite'),
+    ('google/gemini-3.1-pro-preview', 'google/gemini-3.1-pro-preview'),
+    ('x-ai/grok-4-fast', 'x-ai/grok-4-fast'),
+    ('x-ai/grok-4.20-beta', 'x-ai/grok-4.20-beta'),
+    ('custom/my-model', 'custom/my-model'),
+    ('google/gemini-2.5-flash-preview-custom', 'google/gemini-2.5-flash-preview-custom'),
+])
+def test_startup_persists_only_known_model_replacements(tmp_path, configured, expected):
+    config_dir = tmp_path / 'install'
+    (config_dir / 'config').mkdir(parents=True)
+    config_file = config_dir / 'config' / 'config.yaml'
+    translator = {'openrouter_temperature': 0.42, 'translator_type': 'openrouter'}
+    if configured is not None:
+        translator['openrouter_model'] = configured
+    config_file.write_text(yaml.safe_dump({'translator': translator}), encoding='utf-8')
+    repo = Path(__file__).resolve().parents[2]
+    script = '''
+import json
+import os
+import sys
+sys.path[:0] = [os.path.join(sys.argv[1], 'custom_libs'), os.path.join(sys.argv[1], 'bazarr')]
+os.environ['NO_CLI'] = 'true'
+from app.get_args import args
+args.config_dir = sys.argv[2]
+args.no_tasks = True
+from app.config import settings
+print(json.dumps({'model': settings.translator.openrouter_model,
+                  'temperature': settings.translator.openrouter_temperature}))
+'''
+    env = {**os.environ, 'PYTHONDONTWRITEBYTECODE': '1', 'XDG_CACHE_HOME': str(tmp_path / 'cache')}
+    first_contents = None
+    for _startup in range(2):
+        process = subprocess.run([sys.executable, '-c', script, str(repo), str(config_dir)],
+                                 cwd=repo, env=env, capture_output=True, text=True, timeout=30)
+        assert process.returncode == 0, process.stderr
+        assert json.loads(process.stdout) == {'model': expected, 'temperature': 0.42}
+        persisted = yaml.safe_load(config_file.read_text(encoding='utf-8'))
+        assert persisted['translator']['openrouter_model'] == expected
+        assert persisted['translator']['openrouter_temperature'] == 0.42
+        if first_contents is None:
+            first_contents = config_file.read_bytes()
+        else:
+            assert config_file.read_bytes() == first_contents


### PR DESCRIPTION
Save usable partial OpenRouter translation results with explicit incomplete status in history, jobs and subtitle output. Validate cue positions and content, reject empty or malformed results, and preserve existing subtitles if writing or footer generation fails. OpenRouter translation jobs remain eligible to finish for up to 12 hours while the service stays reachable, with a ten-minute limit without a successful status response.

Translation and subtitle modifications keep existing destination paths and use configured custom subtitle folders for new files. Replace four known retired OpenRouter model IDs in defaults, saved settings, the model menu and documentation while preserving other custom selections.

Validation: independent source and integration review; full local frontend, backend, native PostgreSQL and startup CI, with 3,012 tests passing per Python version and 904 frontend tests passing. The exact test-machine image passed guarded model, complete/partial/invalid-result, atomic-write, job-label, long-polling and custom-folder checks, including actual subtitle modifications. Settings, library/history counts and source identities were preserved. These checks use a controlled translator response fixture; they do not establish live model availability or repair the translator service's own response parser.
