### PR TITLE
Continue past unusable provider archive candidates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,7 @@ jobs:
             tests/bazarr/test_rar_extraction_production_config.py \
             tests/bazarr/test_provider_hub_auto_install_optin.py \
             tests/bazarr/test_provider_hub_archive_select.py \
+            tests/bazarr/test_provider_hub_archive_candidates.py \
             tests/bazarr/test_archive_member_matching.py \
             tests/bazarr/test_provider_hub_worker_timeout.py \
             tests/bazarr/test_arr_instances_schema.py \

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -389,15 +389,16 @@ def _guard_archive_members(archive) -> None:
         if total > _MAX_ARCHIVE_TOTAL_BYTES:
             raise WorkerProtocolError("download.archive_b64 decompresses past the size limit")
     for name in archive.namelist():
-        _validate_archive_member_name(name)
+        _validate_archive_member_name(name, disk_extracted=isinstance(archive, _SevenZipArchive))
 
 
-def _validate_archive_member_name(name):
+def _validate_archive_member_name(name, disk_extracted=False):
     if not isinstance(name, str) or not name:
         raise WorkerProtocolError("archive member must be a non-empty string")
     normalized = name.replace("\\", "/")
     if (normalized.startswith("/") or ".." in normalized.split("/")
-            or ":" in normalized or "\0" in normalized):
+            or re.match(r"^[A-Za-z]:", normalized) or "\0" in normalized
+            or (disk_extracted and ":" in normalized)):
         raise WorkerProtocolError("archive member has an unsafe path")
 
 
@@ -571,24 +572,28 @@ def _worker_archive_to_content(
         raise WorkerProtocolError("download.season must be a non-negative integer")
     member = payload.get("member")
     if member is not None:
-        _validate_archive_member_name(member)
+        _validate_archive_member_name(member, disk_extracted=isinstance(archive, _SevenZipArchive))
 
     def _episode_pick():
         forced = bool(getattr(getattr(subtitle, "language", None), "forced", False))
-        context = getattr(subtitle, "_requested_archive_context", {})
-        context_season = context.get("season", getattr(subtitle, "season", None))
-        # Archive names may use either numbering scheme from the original search.
-        requested_episodes = (context.get("episode"), context.get("absolute_episode"))
-        episode = tuple(value for value in requested_episodes if type(value) is int and value >= 0)
-        if not episode:
+        context = getattr(subtitle, "_requested_archive_context", None)
+        if context is None:
+            context_season = getattr(subtitle, "season", None)
+            if context_season is None:
+                context_season = season
             episode = payload.get("episode")
             if isinstance(episode, (list, tuple)):
                 episode = episode[0] if episode else None
+        else:
+            # An absent requested number is intentional, including movie searches.
+            context_season = context.get("season")
+            requested_episodes = (context.get("episode"), context.get("absolute_episode"))
+            episode = tuple(value for value in requested_episodes if type(value) is int and value >= 0) or None
         picked = get_subtitle_from_archive(
             archive,
             forced=forced,
             episode=episode,
-            season=context_season if context_season is not None else season,
+            season=context_season,
             episode_title=payload.get("episode_title"),
             get_first_subtitle=bool(payload.get("first_subtitle")),
             extensions=ARCHIVE_MEMBER_EXTENSIONS,
@@ -619,7 +624,7 @@ def _worker_archive_to_content(
             raise WorkerProtocolError("select_archive_member may only name a member when pinning")
         if decision == "pin":
             chosen = result.get("member")
-            _validate_archive_member_name(chosen)
+            _validate_archive_member_name(chosen, disk_extracted=isinstance(archive, _SevenZipArchive))
             if chosen not in offered_members:
                 raise WorkerProtocolError("select_archive_member pinned a member outside the offered subtitles")
             content = fix_line_ending(archive.read(chosen))

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -577,11 +577,13 @@ def _worker_archive_to_content(
         forced = bool(getattr(getattr(subtitle, "language", None), "forced", False))
         context = getattr(subtitle, "_requested_archive_context", {})
         context_season = context.get("season", getattr(subtitle, "season", None))
-        episode = context.get("episode")
-        if episode is None:
+        # Archive names may use either numbering scheme from the original search.
+        requested_episodes = (context.get("episode"), context.get("absolute_episode"))
+        episode = tuple(value for value in requested_episodes if type(value) is int and value >= 0)
+        if not episode:
             episode = payload.get("episode")
-        if isinstance(episode, (list, tuple)):
-            episode = episode[0] if episode else None
+            if isinstance(episode, (list, tuple)):
+                episode = episode[0] if episode else None
         picked = get_subtitle_from_archive(
             archive,
             forced=forced,

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -566,23 +566,31 @@ def _worker_archive_to_content(
     episodes = episode if isinstance(episode, (list, tuple)) else [episode]
     if any(value is not None and (type(value) is not int or value < 0) for value in episodes):
         raise WorkerProtocolError("download.episode must contain non-negative integers")
+    season = payload.get("season")
+    if season is not None and (type(season) is not int or season < 0):
+        raise WorkerProtocolError("download.season must be a non-negative integer")
     member = payload.get("member")
     if member is not None:
         _validate_archive_member_name(member)
 
     def _episode_pick():
         forced = bool(getattr(getattr(subtitle, "language", None), "forced", False))
-        episode = payload.get("episode")
+        context = getattr(subtitle, "_requested_archive_context", {})
+        context_season = context.get("season", getattr(subtitle, "season", None))
+        episode = context.get("episode")
+        if episode is None:
+            episode = payload.get("episode")
         if isinstance(episode, (list, tuple)):
             episode = episode[0] if episode else None
         picked = get_subtitle_from_archive(
             archive,
             forced=forced,
             episode=episode,
+            season=context_season if context_season is not None else season,
             episode_title=payload.get("episode_title"),
             get_first_subtitle=bool(payload.get("first_subtitle")),
             extensions=ARCHIVE_MEMBER_EXTENSIONS,
-            reject_mismatched_single_episode=True,
+            match_episode_context=True,
             log_member_names=False,
         )
         if picked is None:
@@ -600,7 +608,8 @@ def _worker_archive_to_content(
         # cannot list. "defer" => episode pick; "reject" => skip this candidate.
         if select_member_cb is None:
             raise WorkerProtocolError("download.select_member requires a selector")
-        result = select_member_cb(_list_archive_members(archive))
+        offered_members = tuple(_list_archive_members(archive))
+        result = select_member_cb(list(offered_members))
         if not isinstance(result, dict):
             raise WorkerProtocolError("select_archive_member must return an object")
         decision = result.get("decision")
@@ -609,8 +618,8 @@ def _worker_archive_to_content(
         if decision == "pin":
             chosen = result.get("member")
             _validate_archive_member_name(chosen)
-            if chosen not in set(archive.namelist()):
-                raise _archive_rejection(subtitle, archive, "Pinned subtitle member is absent")
+            if chosen not in offered_members:
+                raise WorkerProtocolError("select_archive_member pinned a member outside the offered subtitles")
             content = fix_line_ending(archive.read(chosen))
         elif decision == "defer":
             content = _episode_pick()

--- a/bazarr/provider_hub/protocol.py
+++ b/bazarr/provider_hub/protocol.py
@@ -5,12 +5,15 @@ import base64
 import hashlib
 import logging
 import os
+import re
+import stat
 
 from typing import Any
 
 from subzero.language import Language
 from subliminal.video import Episode, Movie
 from subliminal_patch.core import SUBTITLE_EXTENSIONS
+from subliminal_patch.exceptions import SubtitleCandidateRejected
 from subliminal_patch.subtitle import Subtitle
 
 logger = logging.getLogger(__name__)
@@ -320,6 +323,8 @@ def _format_from_member(name: str | None, content: bytes | None = None) -> str |
 def worker_download_to_content(
     subtitle: HubWorkerSubtitle, payload: dict[str, Any], select_member_cb=None
 ) -> bool:
+    if not isinstance(payload, dict):
+        raise WorkerProtocolError("download must return an object")
     if payload.get("empty"):
         subtitle.content = b""
         return True
@@ -371,6 +376,11 @@ def _guard_archive_members(archive) -> None:
         raise WorkerProtocolError("download.archive_b64 contains too many members")
     total = 0
     for info in infos:
+        is_link = getattr(info, "is_symlink", False)
+        if callable(is_link):
+            is_link = is_link()
+        if is_link or stat.S_ISLNK(getattr(info, "external_attr", 0) >> 16):
+            raise WorkerProtocolError("download.archive_b64 contains a symbolic link")
         # zip/rar expose file_size; py7zr exposes uncompressed.
         size = int(getattr(info, "file_size", 0) or getattr(info, "uncompressed", 0) or 0)
         if size > _MAX_MEMBER_BYTES:
@@ -378,6 +388,39 @@ def _guard_archive_members(archive) -> None:
         total += size
         if total > _MAX_ARCHIVE_TOTAL_BYTES:
             raise WorkerProtocolError("download.archive_b64 decompresses past the size limit")
+    for name in archive.namelist():
+        _validate_archive_member_name(name)
+
+
+def _validate_archive_member_name(name):
+    if not isinstance(name, str) or not name:
+        raise WorkerProtocolError("archive member must be a non-empty string")
+    normalized = name.replace("\\", "/")
+    if (normalized.startswith("/") or ".." in normalized.split("/")
+            or ":" in normalized or "\0" in normalized):
+        raise WorkerProtocolError("archive member has an unsafe path")
+
+
+def _archive_rejection(subtitle, archive, reason):
+    """Describe ordinary mismatch without retaining paths, URLs or archive bytes."""
+    def safe_label(value, limit):
+        return re.sub(r"[^a-zA-Z0-9_. ()-]", "_", str(value or ""))[:limit]
+
+    members = []
+    for name in archive.namelist()[:8]:
+        basename = name.replace("\\", "/").rsplit("/", 1)[-1]
+        basename = basename.split("?", 1)[0].split("#", 1)[0]
+        members.append(safe_label(basename, 80))
+    identifier = str(getattr(subtitle, "worker_id", ""))
+    language = getattr(subtitle, "language", None)
+    return SubtitleCandidateRejected(
+        f"{reason}; provider={safe_label(getattr(subtitle, 'provider_name', ''), 48)} "
+        f"result_sha256={hashlib.sha256(identifier.encode()).hexdigest()[:16]} "
+        f"season={safe_label(getattr(subtitle, 'season', None), 12)} "
+        f"episode={safe_label(getattr(subtitle, 'episode', None), 12)} "
+        f"language={safe_label(getattr(language, 'basename', None), 24)} "
+        f"archive={type(archive).__name__} members={members!r}"
+    )
 
 
 def _list_archive_members(archive):
@@ -516,6 +559,16 @@ def _worker_archive_to_content(
     if archive is None:
         raise WorkerProtocolError("download.archive_b64 is not a zip, rar, or 7z archive")
     _guard_archive_members(archive)
+    for flag in ("select_member", "first_subtitle"):
+        if flag in payload and not isinstance(payload[flag], bool):
+            raise WorkerProtocolError(f"download.{flag} must be a boolean")
+    episode = payload.get("episode")
+    episodes = episode if isinstance(episode, (list, tuple)) else [episode]
+    if any(value is not None and (type(value) is not int or value < 0) for value in episodes):
+        raise WorkerProtocolError("download.episode must contain non-negative integers")
+    member = payload.get("member")
+    if member is not None:
+        _validate_archive_member_name(member)
 
     def _episode_pick():
         forced = bool(getattr(getattr(subtitle, "language", None), "forced", False))
@@ -529,37 +582,43 @@ def _worker_archive_to_content(
             episode_title=payload.get("episode_title"),
             get_first_subtitle=bool(payload.get("first_subtitle")),
             extensions=ARCHIVE_MEMBER_EXTENSIONS,
+            reject_mismatched_single_episode=True,
+            log_member_names=False,
         )
         if picked is None:
-            raise WorkerProtocolError("download.archive_b64 has no usable subtitle member")
+            raise _archive_rejection(subtitle, archive, "No usable subtitle member")
         return picked
 
-    member = payload.get("member")
-    if member:
+    if member is not None:
         if member not in set(archive.namelist()):
-            raise WorkerProtocolError(f"download.member is not in the archive: {member}")
+            raise _archive_rejection(subtitle, archive, "Pinned subtitle member is absent")
         content = fix_line_ending(archive.read(member))
         chosen = member
-    elif payload.get("select_member") and select_member_cb is not None:
+    elif payload.get("select_member"):
         # Host lists the members; the worker language-pins one (tri-state pin/defer/reject).
         # This is the only way to language-select rar/7z, which the stdlib-only worker
-        # cannot list. "defer" => safe episode pick (single-language); "reject" => fail loud.
-        result = select_member_cb(_list_archive_members(archive)) or {}
+        # cannot list. "defer" => episode pick; "reject" => skip this candidate.
+        if select_member_cb is None:
+            raise WorkerProtocolError("download.select_member requires a selector")
+        result = select_member_cb(_list_archive_members(archive))
+        if not isinstance(result, dict):
+            raise WorkerProtocolError("select_archive_member must return an object")
         decision = result.get("decision")
+        if decision in ("defer", "reject") and result.get("member") is not None:
+            raise WorkerProtocolError("select_archive_member may only name a member when pinning")
         if decision == "pin":
             chosen = result.get("member")
+            _validate_archive_member_name(chosen)
             if chosen not in set(archive.namelist()):
-                raise WorkerProtocolError(
-                    f"select_archive_member returned a member not in the archive: {chosen!r}"
-                )
+                raise _archive_rejection(subtitle, archive, "Pinned subtitle member is absent")
             content = fix_line_ending(archive.read(chosen))
         elif decision == "defer":
             content = _episode_pick()
             chosen = payload.get("filename") or ""
+        elif decision == "reject":
+            raise _archive_rejection(subtitle, archive, "No matching subtitle language")
         else:
-            raise WorkerProtocolError(
-                "select_archive_member rejected the archive (no language match)"
-            )
+            raise WorkerProtocolError("select_archive_member returned an invalid decision")
     else:
         content = _episode_pick()
         chosen = payload.get("filename") or ""

--- a/bazarr/provider_hub/registry.py
+++ b/bazarr/provider_hub/registry.py
@@ -147,6 +147,7 @@ class HubProxyProvider(Provider):
             subtitle._requested_archive_context = {
                 "season": request["video"]["season"],
                 "episode": request["video"]["episode"],
+                "absolute_episode": request["video"]["absolute_episode"],
             }
             subtitles.append(subtitle)
         return subtitles

--- a/bazarr/provider_hub/registry.py
+++ b/bazarr/provider_hub/registry.py
@@ -139,10 +139,17 @@ class HubProxyProvider(Provider):
             "languages": [language_to_payload(item) for item in languages],
         }
         result = self._worker().request("search", request, timeout=timeout)
-        return [
-            candidate_from_worker(self.provider_name, item)
-            for item in result.payload.get("candidates", [])
-        ]
+        subtitles = []
+        for item in result.payload.get("candidates", []):
+            subtitle = candidate_from_worker(self.provider_name, item)
+            # Request context belongs to this candidate, separate from provider
+            # display metadata and opaque payloads used for scoring and download.
+            subtitle._requested_archive_context = {
+                "season": request["video"]["season"],
+                "episode": request["video"]["episode"],
+            }
+            subtitles.append(subtitle)
+        return subtitles
 
     def download_subtitle(self, subtitle):
         timeout = self._request_timeout()
@@ -155,14 +162,15 @@ class HubProxyProvider(Provider):
         result = self._worker().request("download", request, timeout=timeout)
 
         def _select_member_cb(members):
+            context = getattr(subtitle, "_requested_archive_context", {})
             response = self._worker().select_archive_member(
                 {
                     "provider": self.provider_name,
                     "provider_payload": subtitle.provider_payload,
                     "language": language_to_payload(subtitle.language),
                     "members": members,
-                    "season": getattr(subtitle, "season", None),
-                    "episode": getattr(subtitle, "episode", None),
+                    "season": context.get("season", getattr(subtitle, "season", None)),
+                    "episode": context.get("episode", getattr(subtitle, "episode", None)),
                     "config": self.config,
                 },
                 timeout=timeout,

--- a/bazarr/provider_hub/registry.py
+++ b/bazarr/provider_hub/registry.py
@@ -164,16 +164,21 @@ class HubProxyProvider(Provider):
 
         def _select_member_cb(members):
             context = getattr(subtitle, "_requested_archive_context", {})
+            selector_payload = {
+                "provider": self.provider_name,
+                "provider_payload": subtitle.provider_payload,
+                "language": language_to_payload(subtitle.language),
+                "members": members,
+                "season": context.get("season", getattr(subtitle, "season", None)),
+                "episode": context.get("episode", getattr(subtitle, "episode", None)),
+                "config": self.config,
+            }
+            if "absolute_episode" in context:
+                selector_payload["absolute_episode"] = context["absolute_episode"]
+            elif hasattr(subtitle, "absolute_episode"):
+                selector_payload["absolute_episode"] = subtitle.absolute_episode
             response = self._worker().select_archive_member(
-                {
-                    "provider": self.provider_name,
-                    "provider_payload": subtitle.provider_payload,
-                    "language": language_to_payload(subtitle.language),
-                    "members": members,
-                    "season": context.get("season", getattr(subtitle, "season", None)),
-                    "episode": context.get("episode", getattr(subtitle, "episode", None)),
-                    "config": self.config,
-                },
+                selector_payload,
                 timeout=timeout,
             )
             return response.payload

--- a/bazarr/provider_hub/worker_runner.py
+++ b/bazarr/provider_hub/worker_runner.py
@@ -78,9 +78,7 @@ def _handle(provider, op, payload):
     if op == "select_archive_member":
         selector = getattr(provider, "select_archive_member", None)
         if selector is None:
-            # Provider asked the host to list members (select_member) but exposes no
-            # selector: reject so the host fails loud rather than risk a wrong member.
-            return {"member": None, "decision": "reject"}
+            raise ValueError("select_archive_member is not implemented")
         provider_payload = dict(payload.get("provider_payload") or {})
         # The host forwards the requested season/episode at the top level of the op payload.
         # Surface them on provider_payload (host context is authoritative) so a selector can
@@ -93,10 +91,12 @@ def _handle(provider, op, payload):
             language=payload.get("language") or {},
             members=payload.get("members") or [],
             config=payload.get("config") or {},
-        ) or {}
+        )
+        if not isinstance(result, dict):
+            raise ValueError("select_archive_member must return an object")
         decision = result.get("decision")
         if decision not in ("pin", "defer", "reject"):
-            decision = "reject"
+            raise ValueError("select_archive_member returned an invalid decision")
         return {"member": result.get("member"), "decision": decision}
     raise ValueError(f"unsupported worker op: {op}")
 

--- a/bazarr/provider_hub/worker_runner.py
+++ b/bazarr/provider_hub/worker_runner.py
@@ -83,9 +83,10 @@ def _handle(provider, op, payload):
         # The host forwards the requested season/episode at the top level of the op payload.
         # Surface them on provider_payload (host context is authoritative) so a selector can
         # disambiguate season-pack members even when the search payload didn't carry them.
+        # An explicit null clears stale context; an absent key preserves legacy payloads.
         for key in ("season", "episode"):
-            if payload.get(key) is not None:
-                provider_payload[key] = payload.get(key)
+            if key in payload:
+                provider_payload[key] = payload[key]
         result = selector(
             provider_payload=provider_payload,
             language=payload.get("language") or {},

--- a/bazarr/provider_hub/worker_runner.py
+++ b/bazarr/provider_hub/worker_runner.py
@@ -80,11 +80,11 @@ def _handle(provider, op, payload):
         if selector is None:
             raise ValueError("select_archive_member is not implemented")
         provider_payload = dict(payload.get("provider_payload") or {})
-        # The host forwards the requested season/episode at the top level of the op payload.
+        # The host forwards relative/absolute episode context at the top level of the op payload.
         # Surface them on provider_payload (host context is authoritative) so a selector can
         # disambiguate season-pack members even when the search payload didn't carry them.
         # An explicit null clears stale context; an absent key preserves legacy payloads.
-        for key in ("season", "episode"):
+        for key in ("season", "episode", "absolute_episode"):
             if key in payload:
                 provider_payload[key] = payload[key]
         result = selector(

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -23,7 +23,7 @@ from subliminal import refiner_manager
 from concurrent.futures import as_completed
 
 from .extensions import provider_registry
-from .exceptions import APIThrottled, MustGetBlacklisted
+from .exceptions import APIThrottled, MustGetBlacklisted, SubtitleCandidateRejected
 from .score import compute_score, MAX_SCORES
 from subliminal.video import VIDEO_EXTENSIONS, Video, Episode, Movie
 from subliminal.core import guessit, ProviderPool, ThreadPoolExecutor, check_video
@@ -709,6 +709,10 @@ class SZProviderPool(ProviderPool):
                     self.post_download_hook(subtitle)
 
                 break
+            except SubtitleCandidateRejected as e:
+                logger.warning('Subtitle candidate rejected: %s', e)
+                return False
+
             except (requests.ConnectionError,
                     requests.exceptions.ProxyError,
                     requests.exceptions.SSLError,

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -875,10 +875,10 @@ class SZProviderPool(ProviderPool):
                 subtitle.score = score
                 downloaded_subtitles.append(subtitle)
 
-            # stop if only one subtitle is requested
-            if only_one:
-                logger.debug('Only one subtitle downloaded')
-                break
+                # stop after one successful download, not one attempted candidate
+                if only_one:
+                    logger.debug('Only one subtitle downloaded')
+                    break
 
         # --- WHISPER FALLBACK PRECONDITIONS ---
         # 1. No regular provider results with at least minimum score

--- a/custom_libs/subliminal_patch/exceptions.py
+++ b/custom_libs/subliminal_patch/exceptions.py
@@ -15,6 +15,13 @@ class APIThrottled(ProviderError):
         self.retry_after = retry_after
 
 
+class SubtitleCandidateRejected(ProviderError):
+    """A valid response has no usable subtitle for this candidate.
+
+    Messages must contain only bounded, non-sensitive diagnostic context.
+    """
+
+
 class ForbiddenError(ProviderError):
     pass
 

--- a/custom_libs/subliminal_patch/providers/utils.py
+++ b/custom_libs/subliminal_patch/providers/utils.py
@@ -114,7 +114,7 @@ def blacklist_on(*exc_types):
 
 
 def _get_matching_sub(
-    sub_names, forced=False, episode=None, episode_title=None, **kwargs
+    sub_names, forced=False, episode=None, episode_title=None, log_member_names=True, **kwargs
 ):
     guess_options = {"single_value": True}
     if episode is not None:
@@ -124,40 +124,44 @@ def _get_matching_sub(
 
     for sub_name in sub_names:
         if not forced and os.path.splitext(sub_name.lower())[0].endswith("forced"):
-            logger.debug("Ignoring forced subtitle: %s", sub_name)
+            if log_member_names:
+                logger.debug("Ignoring forced subtitle: %s", sub_name)
             continue
 
         # If it's a movie then get the first subtitle
         if episode is None and episode_title is None:
-            logger.debug("Movie subtitle found: %s", sub_name)
+            if log_member_names:
+                logger.debug("Movie subtitle found: %s", sub_name)
             matching_subs.append(_MatchingSub(sub_name, 2, "Movie subtitle"))
             break
 
         guess = guessit(sub_name, options=guess_options)
 
         matched_episode_num = guess.get("episode")
-        if not matched_episode_num:
+        if not matched_episode_num and log_member_names:
             logger.debug("No episode number found in file: %s", sub_name)
 
         if episode_title is not None:
-            from_name = _analize_sub_name(sub_name, episode_title)
+            from_name = _analize_sub_name(sub_name, episode_title, log_member_names)
             if from_name is not None:
                 matching_subs.append(from_name)
 
         if episode == matched_episode_num:
-            logger.debug("Episode matched from number: %s", sub_name)
+            if log_member_names:
+                logger.debug("Episode matched from number: %s", sub_name)
             matching_subs.append(_MatchingSub(sub_name, 2, "Episode number matched"))
 
     if matching_subs:
         matching_subs.sort(key=lambda x: x.priority, reverse=True)
-        logger.debug("Matches: %s", matching_subs)
+        if log_member_names:
+            logger.debug("Matches: %s", matching_subs)
         return matching_subs[0].file
     else:
         logger.debug("Nothing matched")
         return None
 
 
-def _analize_sub_name(sub_name: str, title_: str):
+def _analize_sub_name(sub_name: str, title_: str, log_member_names=True):
     titles = re.split(r"[\s_\.\+]?[.-][\s_\.\+]?", os.path.splitext(sub_name)[0])
 
     for title in titles:
@@ -165,9 +169,10 @@ def _analize_sub_name(sub_name: str, title_: str):
         ratio = SequenceMatcher(None, title.lower(), title_.lower()).ratio()
 
         if ratio > 0.85:
-            logger.debug(
-                "Episode title matched: '%s' -> '%s' [%s]", title, sub_name, ratio
-            )
+            if log_member_names:
+                logger.debug(
+                    "Episode title matched: '%s' -> '%s' [%s]", title, sub_name, ratio
+                )
 
             # Avoid false positives with short titles
             if len(title_) > 4 and ratio >= 0.98:
@@ -175,7 +180,8 @@ def _analize_sub_name(sub_name: str, title_: str):
 
             return _MatchingSub(sub_name, 1, "Normal title ratio")
 
-    logger.debug("No episode title matched from file: %s", sub_name)
+    if log_member_names:
+        logger.debug("No episode title matched from file: %s", sub_name)
     return None
 
 
@@ -185,34 +191,55 @@ def get_subtitle_from_archive(
     episode=None,
     get_first_subtitle=False,
     extensions=DEFAULT_ARCHIVE_EXTENSIONS,
+    reject_mismatched_single_episode=False,
+    log_member_names=True,
     **kwargs,
 ):
-    "Get subtitle from Rarfile/Zipfile object. Return None if nothing is found."
+    """Return subtitle bytes, or None if no member matches.
+
+    The host can reject explicitly wrong single-episode files and supply its own
+    sanitized diagnostics. Defaults preserve selection and logging for providers.
+    An explicit first-subtitle request remains authoritative.
+    """
     subs_in_archive = list_subtitle_members(archive, extensions)
 
     if not subs_in_archive:
         # Name the members: without them a user whose download failed here has no
         # way to tell an archive full of the wrong extensions from a broken one.
-        logger.warning(
-            "No subtitles found in archive. Members: %s", _archive_member_names(archive)
-        )
+        if log_member_names:
+            logger.warning(
+                "No subtitles found in archive. Members: %s", _archive_member_names(archive)
+            )
         return None
 
-    logger.debug("Subtitles in archive: %s", subs_in_archive)
+    if log_member_names:
+        logger.debug("Subtitles in archive: %s", subs_in_archive)
 
     if len(subs_in_archive) == 1 or get_first_subtitle:
-        logger.debug("Getting first subtitle in archive: %s", subs_in_archive)
+        if reject_mismatched_single_episode and episode is not None and not get_first_subtitle:
+            guessed_episode = guessit(
+                subs_in_archive[0], options={"type": "episode"}
+            ).get("episode")
+            included_episodes = guessed_episode if isinstance(guessed_episode, list) else [guessed_episode]
+            if guessed_episode is not None and episode not in included_episodes:
+                return None
+        if log_member_names:
+            logger.debug("Getting first subtitle in archive: %s", subs_in_archive)
         return fix_line_ending(archive.read(subs_in_archive[0]))
 
-    matching_sub = _get_matching_sub(subs_in_archive, forced, episode, **kwargs)
+    matching_sub = _get_matching_sub(
+        subs_in_archive, forced, episode, log_member_names=log_member_names, **kwargs
+    )
 
     if matching_sub is not None:
-        logger.info("Using %s from archive", matching_sub)
+        if log_member_names:
+            logger.info("Using %s from archive", matching_sub)
         return fix_line_ending(archive.read(matching_sub))
 
-    logger.warning(
-        "No subtitle in archive matched this episode. Members: %s", subs_in_archive
-    )
+    if log_member_names:
+        logger.warning(
+            "No subtitle in archive matched this episode. Members: %s", subs_in_archive
+        )
     return None
 
 

--- a/custom_libs/subliminal_patch/providers/utils.py
+++ b/custom_libs/subliminal_patch/providers/utils.py
@@ -113,14 +113,20 @@ def blacklist_on(*exc_types):
     return decorator
 
 
+def _contains_number(guessed, requested):
+    return requested in guessed if isinstance(guessed, list) else requested == guessed
+
+
 def _get_matching_sub(
-    sub_names, forced=False, episode=None, episode_title=None, log_member_names=True, **kwargs
+    sub_names, forced=False, episode=None, episode_title=None, log_member_names=True,
+    match_episode_context=False, season=None, **kwargs
 ):
-    guess_options = {"single_value": True}
-    if episode is not None:
+    guess_options = {} if match_episode_context else {"single_value": True}
+    if episode is not None or (match_episode_context and season is not None):
         guess_options["type"] = "episode"  # type: ignore
 
     matching_subs = []
+    movie_selection = episode is None and episode_title is None
 
     for sub_name in sub_names:
         if not forced and os.path.splitext(sub_name.lower())[0].endswith("forced"):
@@ -128,14 +134,19 @@ def _get_matching_sub(
                 logger.debug("Ignoring forced subtitle: %s", sub_name)
             continue
 
-        # If it's a movie then get the first subtitle
-        if episode is None and episode_title is None:
+        guess = {}
+        if not movie_selection or (match_episode_context and season is not None):
+            guess = guessit(sub_name, options=guess_options)
+        if (match_episode_context and season is not None and guess.get("season") is not None
+                and not _contains_number(guess["season"], season)):
+            continue
+
+        # Without episode context, get the first member that passed the season check.
+        if movie_selection:
             if log_member_names:
                 logger.debug("Movie subtitle found: %s", sub_name)
             matching_subs.append(_MatchingSub(sub_name, 2, "Movie subtitle"))
             break
-
-        guess = guessit(sub_name, options=guess_options)
 
         matched_episode_num = guess.get("episode")
         if not matched_episode_num and log_member_names:
@@ -146,7 +157,8 @@ def _get_matching_sub(
             if from_name is not None:
                 matching_subs.append(from_name)
 
-        if episode == matched_episode_num:
+        if (_contains_number(matched_episode_num, episode) if match_episode_context
+                else episode == matched_episode_num):
             if log_member_names:
                 logger.debug("Episode matched from number: %s", sub_name)
             matching_subs.append(_MatchingSub(sub_name, 2, "Episode number matched"))
@@ -191,14 +203,15 @@ def get_subtitle_from_archive(
     episode=None,
     get_first_subtitle=False,
     extensions=DEFAULT_ARCHIVE_EXTENSIONS,
-    reject_mismatched_single_episode=False,
+    match_episode_context=False,
     log_member_names=True,
+    season=None,
     **kwargs,
 ):
     """Return subtitle bytes, or None if no member matches.
 
-    The host can reject explicitly wrong single-episode files and supply its own
-    sanitized diagnostics. Defaults preserve selection and logging for providers.
+    The host can match all included episodes and reject explicit season mismatches
+    while supplying sanitized diagnostics. Defaults preserve provider behavior.
     An explicit first-subtitle request remains authoritative.
     """
     subs_in_archive = list_subtitle_members(archive, extensions)
@@ -216,19 +229,20 @@ def get_subtitle_from_archive(
         logger.debug("Subtitles in archive: %s", subs_in_archive)
 
     if len(subs_in_archive) == 1 or get_first_subtitle:
-        if reject_mismatched_single_episode and episode is not None and not get_first_subtitle:
-            guessed_episode = guessit(
+        if match_episode_context and (episode is not None or season is not None) and not get_first_subtitle:
+            guess = guessit(
                 subs_in_archive[0], options={"type": "episode"}
-            ).get("episode")
-            included_episodes = guessed_episode if isinstance(guessed_episode, list) else [guessed_episode]
-            if guessed_episode is not None and episode not in included_episodes:
-                return None
+            )
+            for key, requested in (("season", season), ("episode", episode)):
+                if requested is not None and guess.get(key) is not None and not _contains_number(guess[key], requested):
+                    return None
         if log_member_names:
             logger.debug("Getting first subtitle in archive: %s", subs_in_archive)
         return fix_line_ending(archive.read(subs_in_archive[0]))
 
     matching_sub = _get_matching_sub(
-        subs_in_archive, forced, episode, log_member_names=log_member_names, **kwargs
+        subs_in_archive, forced, episode, log_member_names=log_member_names,
+        match_episode_context=match_episode_context, season=season, **kwargs
     )
 
     if matching_sub is not None:

--- a/custom_libs/subliminal_patch/providers/utils.py
+++ b/custom_libs/subliminal_patch/providers/utils.py
@@ -114,7 +114,9 @@ def blacklist_on(*exc_types):
 
 
 def _contains_number(guessed, requested):
-    return requested in guessed if isinstance(guessed, list) else requested == guessed
+    guessed_numbers = guessed if isinstance(guessed, (list, tuple)) else (guessed,)
+    requested_numbers = requested if isinstance(requested, (list, tuple)) else (requested,)
+    return any(number in guessed_numbers for number in requested_numbers)
 
 
 def _get_matching_sub(

--- a/tests/bazarr/test_archive_member_matching.py
+++ b/tests/bazarr/test_archive_member_matching.py
@@ -26,6 +26,7 @@ import pytest
 
 import provider_hub.protocol as proto
 from subliminal_patch.core import SUBTITLE_EXTENSIONS
+from subliminal_patch.exceptions import SubtitleCandidateRejected
 from subliminal_patch.providers import utils
 from subliminal_patch.providers.utils import get_archive_from_bytes
 
@@ -173,8 +174,8 @@ def test_failed_extraction_logs_the_member_names(caplog):
     assert "Trailer.mkv" in logged
 
 
-def test_archive_without_any_subtitle_member_still_fails_loudly():
-    with pytest.raises(proto.WorkerProtocolError):
+def test_archive_without_any_subtitle_member_rejects_candidate():
+    with pytest.raises(SubtitleCandidateRejected, match="No usable subtitle member"):
         _download(_zip([("poster.jpg", b"binary")]))
 
 

--- a/tests/bazarr/test_provider_hub.py
+++ b/tests/bazarr/test_provider_hub.py
@@ -445,6 +445,7 @@ def test_worker_download_auto_selects_single_archive_member():
 
 def test_worker_download_rejects_missing_member_and_bad_archive():
     from provider_hub.protocol import WorkerProtocolError, worker_download_to_content
+    from subliminal_patch.exceptions import SubtitleCandidateRejected
 
     candidate = _hub_candidate("sub-bad")
     buffer = io.BytesIO()
@@ -452,7 +453,7 @@ def test_worker_download_rejects_missing_member_and_bad_archive():
         archive.writestr("Show.S01E01.srt", b"1\n00:00:01,000 --> 00:00:02,000\nHi\n")
     archive_bytes = buffer.getvalue()
 
-    with pytest.raises(WorkerProtocolError):
+    with pytest.raises(SubtitleCandidateRejected, match="Pinned subtitle member is absent"):
         worker_download_to_content(
             candidate,
             {

--- a/tests/bazarr/test_provider_hub_archive_candidates.py
+++ b/tests/bazarr/test_provider_hub_archive_candidates.py
@@ -29,6 +29,92 @@ def archive_payload(names, **extra):
             "archive_sha256": hashlib.sha256(body).hexdigest(), "episode": 1, **extra}
 
 
+def formatted_archive_payload(kind, members, **extra):
+    if kind == "zip":
+        return archive_payload(members, **extra)
+    buffer = io.BytesIO()
+    if kind == "rar":
+        import struct
+        import zlib
+
+        def block(block_type, flags, body):
+            header = struct.pack("<BHH", block_type, flags, 7 + len(body)) + body
+            return struct.pack("<H", zlib.crc32(header) & 0xffff) + header
+
+        # Stored RAR4 members exercise the real reader without an external writer.
+        buffer.write(b"Rar!\x1a\x07\x00" + block(0x73, 0, b"\x00" * 6))
+        for name, content in members.items():
+            encoded = name.encode("ascii")
+            header = struct.pack("<LLBLLBBHL", len(content), len(content), 3,
+                                 zlib.crc32(content), 0, 20, 0x30, len(encoded), 0o100644)
+            buffer.write(block(0x74, 0x8000, header + encoded) + content)
+        buffer.write(block(0x7b, 0, b""))
+    else:
+        import py7zr
+
+        assert kind == "7z"
+        with py7zr.SevenZipFile(buffer, "w") as archive:
+            for name, content in members.items():
+                archive.writestr(content, name)
+    body = buffer.getvalue()
+    return {"archive_b64": base64.b64encode(body).decode("ascii"),
+            "archive_sha256": hashlib.sha256(body).hexdigest(), "episode": 1, **extra}
+
+
+def archive_selection(mode, member):
+    if mode == "pin":
+        return {"member": member}, None
+    if mode == "selector":
+        return {"select_member": True}, lambda members: {"decision": "pin", "member": member}
+    if mode == "defer":
+        return {"select_member": True}, lambda members: {"decision": "defer"}
+    assert mode == "automatic"
+    return {}, None
+
+
+@pytest.mark.parametrize("kind", ["zip", "rar"])
+@pytest.mark.parametrize("mode", ["automatic", "defer", "pin", "selector"])
+@pytest.mark.parametrize("colon_subtitle", [False, True])
+def test_streamed_archives_allow_colon_subtitles_and_metadata(kind, mode, colon_subtitle):
+    name = "Show: Pilot.S03E01.srt" if colon_subtitle else "Show.S03E01.srt"
+    members = {"metadata: source.nfo": b"Fixture metadata", name: SRT}
+    extra, selector = archive_selection(mode, name)
+    subtitle = candidate()
+    assert protocol.worker_download_to_content(
+        subtitle, formatted_archive_payload(kind, members, **extra), select_member_cb=selector) is True
+    assert subtitle.content == SRT
+
+
+@pytest.mark.parametrize("mode", ["automatic", "defer", "pin", "selector"])
+@pytest.mark.parametrize("colon_subtitle", [False, True])
+def test_disk_extracted_seven_zip_rejects_all_colon_entries_before_read(monkeypatch, mode, colon_subtitle):
+    name = "Show: Pilot.S03E01.srt" if colon_subtitle else "Show.S03E01.srt"
+    members = {name: SRT} if colon_subtitle else {"metadata: source.nfo": b"Fixture metadata", name: SRT}
+    extra, selector = archive_selection(mode, name)
+    payload = formatted_archive_payload("7z", members, **extra)
+    monkeypatch.setattr(protocol._SevenZipArchive, "read", lambda *a: pytest.fail("unsafe member was read"))
+    with pytest.raises(protocol.WorkerProtocolError, match="unsafe path"):
+        protocol.worker_download_to_content(candidate(), payload, select_member_cb=selector)
+
+
+@pytest.mark.parametrize("mode", ["automatic", "defer", "pin", "selector"])
+def test_disk_extracted_seven_zip_without_colons_still_downloads(mode):
+    name = "Show.S03E01.srt"
+    extra, selector = archive_selection(mode, name)
+    subtitle = candidate()
+    assert protocol.worker_download_to_content(
+        subtitle, formatted_archive_payload("7z", {name: SRT}, **extra), select_member_cb=selector) is True
+    assert subtitle.content == SRT
+
+
+@pytest.mark.parametrize("kind", ["zip", "rar"])
+@pytest.mark.parametrize("name", ["C:/unsafe.srt", "C:unsafe.srt", "../unsafe.srt", "/unsafe.srt",
+                                  "nested/../unsafe.srt", "\\\\server\\unsafe.srt"])
+def test_streamed_archives_keep_drive_absolute_and_traversal_guards(kind, name):
+    with pytest.raises(protocol.WorkerProtocolError, match="unsafe path"):
+        protocol.worker_download_to_content(candidate(), formatted_archive_payload(kind, {name: SRT}))
+
+
 def candidate(identifier="result"):
     subtitle = protocol.HubWorkerSubtitle("fixture", "fixture", identifier, Language("eng"), {})
     subtitle.episode = 1
@@ -267,6 +353,49 @@ def registry_archive_search(payload, display=None, selector=None, season=3, epis
     assert worker.searches[0]["season"] == season and worker.searches[0]["episode"] == episode
     assert worker.searches[0]["absolute_episode"] == absolute_episode
     return provider, worker, subtitles[0]
+
+
+@pytest.mark.parametrize("kind", ["movie", "season_only", "unknown_season"])
+@pytest.mark.parametrize("hint", ["absent", "null", "conflicting"])
+@pytest.mark.parametrize("multiple", [False, True])
+@pytest.mark.parametrize("defer", [False, True])
+def test_stored_request_context_keeps_intentionally_absent_numbers(kind, hint, multiple, defer):
+    video = (core.Movie("/fixtures/Film.mkv", "Film", year=2024) if kind == "movie" else
+             core.Episode("/fixtures/Show.mkv", "Show", 3 if kind == "season_only" else None,
+                          None if kind == "season_only" else 1))
+    members = {"Show.S03E01.srt": SRT}
+    if multiple:
+        members["Show.S04E09.srt"] = SRT.replace(b"Fixture", b"Stale hint")
+    payload = archive_payload(members, select_member=defer)
+    payload.pop("episode")
+    if hint != "absent":
+        payload.update(episode=9 if hint == "conflicting" else None,
+                       season=4 if hint == "conflicting" else None)
+    worker = ArchiveSearchWorker(payload, display={"season": 4, "episode": 9, "absolute_episode": 9})
+    provider = registry.HubProxyProvider(timeout=120, worker_client=worker)
+    provider.provider_name = "fixture"
+    subtitle = provider.list_subtitles(video, {Language("eng")})[0]
+    request = worker.searches[0]
+    assert request["season"] == (3 if kind == "season_only" else None)
+    assert request["episode"] == (1 if kind == "unknown_season" else None)
+    assert request["absolute_episode"] is None
+
+    assert provider.download_subtitle(subtitle) is True
+    assert subtitle.content == SRT
+    if defer:
+        assert [(s["season"], s["episode"]) for s in worker.selections] == [
+            (request["season"], request["episode"])]
+
+
+@pytest.mark.parametrize("hint", [2, [2, 3]])
+def test_legacy_candidate_without_stored_context_keeps_wire_fallback(hint):
+    subtitle = candidate()
+    subtitle.season = subtitle.episode = None
+    assert not hasattr(subtitle, "_requested_archive_context")
+    payload = archive_payload({"Show.S03E01.srt": SRT.replace(b"Fixture", b"Wrong hint"),
+                               "Show.S04E02.srt": SRT}, episode=hint, season=4)
+    assert protocol.worker_download_to_content(subtitle, payload) is True
+    assert subtitle.content == SRT
 
 
 @pytest.mark.parametrize("name", ["Show.S03E01.srt", "49.srt", "Show.E49.srt", "Show.S03E48E49.srt"])

--- a/tests/bazarr/test_provider_hub_archive_candidates.py
+++ b/tests/bazarr/test_provider_hub_archive_candidates.py
@@ -1,0 +1,199 @@
+"""Archive mismatch rejects one download without disabling its provider."""
+import base64
+import hashlib
+import io
+import logging
+import stat
+import zipfile
+
+import pytest
+from subzero.language import Language
+
+from provider_hub import protocol, worker_runner
+from subliminal_patch import core
+from subliminal_patch.providers.utils import get_archive_from_bytes, get_subtitle_from_archive
+
+
+SRT = b"1\n00:00:01,000 --> 00:00:02,000\nFixture\n"
+
+
+def archive_payload(names, **extra):
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for name in names:
+            archive.writestr(name, SRT)
+    body = buffer.getvalue()
+    return {"archive_b64": base64.b64encode(body).decode("ascii"),
+            "archive_sha256": hashlib.sha256(body).hexdigest(), "episode": 1, **extra}
+
+
+def candidate(identifier="result"):
+    subtitle = protocol.HubWorkerSubtitle("fixture", "fixture", identifier, Language("eng"), {})
+    subtitle.episode = 1
+    subtitle.season = 3
+    return subtitle
+
+
+def pool_for(monkeypatch, payload, selector=None):
+    downloads = []
+    throttled = []
+
+    class Provider:
+        def initialize(self):
+            pass
+
+        def terminate(self):
+            pass
+
+        def download_subtitle(self, subtitle):
+            downloads.append(subtitle)
+            result = payload if len(downloads) == 1 else archive_payload(["Show.S03E01.srt"])
+            protocol.worker_download_to_content(subtitle, result, select_member_cb=selector)
+
+    monkeypatch.setattr(core, "provider_registry", {"fixture": Provider})
+    pool = core.SZProviderPool(["fixture"], {}, throttle_callback=lambda *a, **kw: throttled.append(a))
+    return pool, downloads, throttled
+
+
+@pytest.mark.parametrize("payload,selector", [
+    (archive_payload(["Show.S03E03.srt", "Show.S03E03.cyr.srt"]), None),
+    (archive_payload(["Show.S03E03.srt"]), None),
+    (archive_payload(["poster.jpg"]), None),
+    (archive_payload(["Show.S03E01.srt"], member="missing.srt"), None),
+    (archive_payload(["Show.S03E01.srt"], select_member=True),
+     lambda members: {"decision": "pin", "member": "missing.srt"}),
+    (archive_payload(["Show.S03E01.srt"], select_member=True),
+     lambda members: {"decision": "reject", "member": None}),
+    (archive_payload(["Show.S03E03.srt"], select_member=True),
+     lambda members: {"decision": "defer", "member": None}),
+])
+def test_rejected_archive_allows_next_candidate_from_same_provider(monkeypatch, payload, selector):
+    pool, downloads, throttled = pool_for(monkeypatch, payload, selector)
+    rejected, accepted = candidate("first"), candidate("second")
+    assert pool.download_subtitle(rejected) is False
+    assert pool.download_subtitle(accepted) is True
+    assert accepted.content == SRT
+    assert rejected.content is None
+    assert downloads == [rejected, accepted]
+    assert throttled == []
+    assert pool.discarded_providers == set()
+
+
+@pytest.mark.parametrize("names,extra", [
+    (["Show.S03E01.srt"], {}),
+    (["subtitle.srt"], {}),
+    (["Show.S03E03.srt"], {"first_subtitle": True}),
+    (["Show.S03E03.srt"], {"member": "Show.S03E03.srt"}),
+    (["Show.S03E03.srt", "Show.S03E01.srt"], {}),
+])
+def test_legitimate_selection_and_explicit_overrides_still_download(names, extra):
+    subtitle = candidate()
+    assert protocol.worker_download_to_content(subtitle, archive_payload(names, **extra)) is True
+    assert subtitle.content == SRT
+
+
+def test_authoritative_selector_pin_is_not_overridden_by_host_episode():
+    subtitle = candidate()
+    assert protocol.worker_download_to_content(
+        subtitle, archive_payload(["Show.S03E03.srt"], select_member=True),
+        select_member_cb=lambda members: {"decision": "pin", "member": members[0]}) is True
+
+
+def test_legacy_archive_helper_keeps_single_member_behavior():
+    payload = archive_payload(["Show.S03E03.srt"])
+    archive = get_archive_from_bytes(base64.b64decode(payload["archive_b64"]))
+    assert get_subtitle_from_archive(archive, episode=1) == SRT
+
+
+@pytest.mark.parametrize('name', ['Show.S03E01E02.srt', 'Show.S03E01-E02.srt',
+                                  'Show.S03E01-02.srt', 'Show.3x01-02.srt'])
+@pytest.mark.parametrize('episode', [1, 2, 3])
+def test_single_member_with_multiple_episodes_matches_any_included_episode(name, episode):
+    from subliminal_patch.exceptions import SubtitleCandidateRejected
+
+    subtitle = candidate()
+    payload = archive_payload([name], episode=episode)
+    if episode == 3:
+        with pytest.raises(SubtitleCandidateRejected):
+            protocol.worker_download_to_content(subtitle, payload)
+    else:
+        assert protocol.worker_download_to_content(subtitle, payload) is True
+        assert subtitle.content == SRT
+
+
+@pytest.mark.parametrize("response", [None, [], "reject", {}, {"decision": "unknown"},
+                                        {"decision": "pin"}, {"decision": "pin", "member": []},
+                                        {"decision": "reject", "member": []},
+                                        {"decision": "defer", "member": "unexpected.srt"},
+                                        {"decision": "pin", "member": "../unsafe.srt"}])
+def test_malformed_selector_keeps_provider_error_handling(monkeypatch, response):
+    pool, downloads, throttled = pool_for(
+        monkeypatch, archive_payload(["valid.srt"], select_member=True), lambda members: response)
+    assert pool.download_subtitle(candidate()) is False
+    assert pool.download_subtitle(candidate("second")) is False
+    assert len(downloads) == len(throttled) == 1
+    assert pool.discarded_providers == {"fixture"}
+
+
+@pytest.mark.parametrize("response", [None, [], {}, {"decision": "unknown"}])
+def test_runner_does_not_turn_malformed_selector_into_candidate_rejection(response):
+    class Provider:
+        def select_archive_member(self, **kwargs):
+            return response
+
+    with pytest.raises(ValueError):
+        worker_runner._handle(Provider(), "select_archive_member", {})
+
+
+@pytest.mark.parametrize("payload", [
+    [], {"archive_b64": 123}, {"archive_b64": "!invalid!"},
+    archive_payload(["valid.srt"], archive_sha256="0" * 64),
+    {"archive_b64": base64.b64encode(b"invalid archive").decode("ascii")},
+    archive_payload(["valid.srt"], member=[]),
+    archive_payload(["valid.srt"], episode="1"),
+    archive_payload(["valid.srt"], first_subtitle="yes"),
+    archive_payload(["valid.srt"], select_member=True),
+    archive_payload(["../unsafe.srt"]),
+    archive_payload(["/absolute.srt"]),
+])
+def test_protocol_integrity_and_unsafe_payloads_still_discard_provider(monkeypatch, payload):
+    pool, downloads, throttled = pool_for(monkeypatch, payload)
+    assert pool.download_subtitle(candidate()) is False
+    assert len(downloads) == len(throttled) == 1
+    assert pool.discarded_providers == {"fixture"}
+
+
+def test_archive_bomb_is_not_an_ordinary_candidate_rejection(monkeypatch):
+    monkeypatch.setattr(protocol, "_MAX_MEMBER_BYTES", 1)
+    pool, downloads, throttled = pool_for(monkeypatch, archive_payload(["wrong.S03E03.srt"]))
+    assert pool.download_subtitle(candidate()) is False
+    assert len(downloads) == len(throttled) == 1
+    assert pool.discarded_providers == {"fixture"}
+
+
+def test_unsafe_link_is_checked_before_language_or_episode_rejection(monkeypatch):
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        member = zipfile.ZipInfo("Show.S03E03.srt")
+        member.external_attr = (stat.S_IFLNK | 0o777) << 16
+        archive.writestr(member, "private-target")
+    payload = {"archive_b64": base64.b64encode(buffer.getvalue()).decode("ascii"),
+               "episode": 1, "select_member": True}
+    pool, _, throttled = pool_for(monkeypatch, payload, lambda names: {"decision": "reject"})
+    assert pool.download_subtitle(candidate()) is False
+    assert len(throttled) == 1
+    assert pool.discarded_providers == {"fixture"}
+
+
+def test_rejection_diagnostic_is_bounded_and_excludes_paths_urls_and_contents(monkeypatch, caplog):
+    names = [f"private-folder/Show.S03E03.variant{index}.srt" for index in range(30)]
+    pool, _, _ = pool_for(monkeypatch, archive_payload(names))
+    with caplog.at_level(logging.WARNING, logger='subliminal_patch'):
+        assert pool.download_subtitle(candidate("https://user:password@example.invalid/?token=secret")) is False
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "Show.S03E03.variant0.srt" in messages
+    assert "private-folder" not in messages
+    assert "password" not in messages
+    assert "token=secret" not in messages
+    assert "Fixture" not in messages
+    assert len(messages) < 1600

--- a/tests/bazarr/test_provider_hub_archive_candidates.py
+++ b/tests/bazarr/test_provider_hub_archive_candidates.py
@@ -10,7 +10,7 @@ import pytest
 from subzero.language import Language
 
 from provider_hub import protocol, worker_runner
-from subliminal_patch import core
+from subliminal_patch import core, core_persistent
 from subliminal_patch.providers.utils import get_archive_from_bytes, get_subtitle_from_archive
 
 
@@ -197,3 +197,176 @@ def test_rejection_diagnostic_is_bounded_and_excludes_paths_urls_and_contents(mo
     assert "token=secret" not in messages
     assert "Fixture" not in messages
     assert len(messages) < 1600
+
+
+def selection_candidate(identifier, payload=None, selector=None, language="eng", provider="fixture"):
+    subtitle = candidate(identifier)
+    subtitle.provider_name = provider
+    subtitle.language = Language(language)
+    subtitle.matches = {"series", "season", "episode"}
+    subtitle.release_info = identifier
+    subtitle.provider_payload = {"result": payload if payload is not None else archive_payload(["Show.S03E01.srt"]),
+                                 "selector": selector}
+    return subtitle
+
+
+def selection_pool_for(monkeypatch):
+    downloads, throttled = [], []
+
+    class Provider:
+        def initialize(self):
+            pass
+
+        def terminate(self):
+            pass
+
+        def download_subtitle(self, subtitle):
+            downloads.append(subtitle)
+            protocol.worker_download_to_content(subtitle, subtitle.provider_payload["result"],
+                                                select_member_cb=subtitle.provider_payload["selector"])
+
+    monkeypatch.setattr(core, "provider_registry", {"fixture": Provider, "other": Provider})
+    pool = core.SZProviderPool(["fixture", "other"], {}, throttle_callback=lambda *a, **kw: throttled.append(a))
+    return pool, downloads, throttled
+
+
+def select_best(pool, subtitles, only_one=True, languages=None, existing_languages=None):
+    video = core.Episode("/fixtures/Show.S03E01.mkv", "Show", 3, 1,
+                         subtitle_languages=existing_languages or set())
+    listed_languages, sink = [], []
+
+    def list_subtitles(video, languages, **kwargs):
+        listed_languages.append(languages)
+        return subtitles
+
+    pool.list_subtitles_prioritized = list_subtitles
+    result = core_persistent.download_best_subtitles(
+        {video}, languages or {Language("eng")}, pool, only_one=only_one, candidate_sink=sink)
+    return result.get(video, []), listed_languages, sink
+
+
+@pytest.mark.parametrize("only_one", [False, True])
+@pytest.mark.parametrize("payload,selector", [
+    (archive_payload(["Show.S03E03.srt", "Show.S03E03.alt.srt"]), None),
+    (archive_payload(["Show.S03E03.srt"]), None),
+    (archive_payload(["poster.jpg"]), None),
+    (archive_payload(["Show.S03E01.srt"], member="missing.srt"), None),
+    (archive_payload(["Show.S03E01.srt"], select_member=True),
+     lambda members: {"decision": "pin", "member": "missing.srt"}),
+    (archive_payload(["Show.S03E01.srt"], select_member=True),
+     lambda members: {"decision": "reject"}),
+    (archive_payload(["Show.S03E03.srt"], select_member=True),
+     lambda members: {"decision": "defer"}),
+])
+def test_selection_loop_continues_after_archive_rejection(monkeypatch, only_one, payload, selector):
+    pool, downloads, throttled = selection_pool_for(monkeypatch)
+    rejected = selection_candidate("first", payload, selector)
+    accepted = selection_candidate("second")
+
+    result, _, sink = select_best(pool, [rejected, accepted], only_one=only_one)
+
+    assert result == [accepted]
+    assert accepted.content == SRT
+    assert rejected.content is None
+    assert downloads == [rejected, accepted]
+    assert [row["downloaded"] for row in sink] == [False, True]
+    assert throttled == []
+    assert pool.discarded_providers == set()
+
+
+def test_single_subtitle_selection_stops_after_first_success(monkeypatch):
+    pool, downloads, throttled = selection_pool_for(monkeypatch)
+    first, duplicate = selection_candidate("first"), selection_candidate("duplicate")
+    other_language = selection_candidate("other-language", language="fra")
+
+    result, _, sink = select_best(pool, [first, duplicate, other_language],
+                                 languages={Language("eng"), Language("fra")})
+
+    assert result == downloads == [first]
+    assert first.content == SRT
+    assert duplicate.content is other_language.content is None
+    assert [row["downloaded"] for row in sink] == [True, False, False]
+    assert not throttled and not pool.discarded_providers
+
+
+def test_single_subtitle_selection_exhausts_rejected_candidates(monkeypatch):
+    pool, downloads, throttled = selection_pool_for(monkeypatch)
+    subtitles = [selection_candidate(str(index), archive_payload(["Show.S03E03.srt"]))
+                 for index in range(3)]
+
+    result, _, sink = select_best(pool, subtitles)
+
+    assert result == []
+    assert downloads == subtitles
+    assert not any(row["downloaded"] for row in sink)
+    assert not throttled and not pool.discarded_providers
+
+
+def test_single_subtitle_selection_continues_after_invalid_subtitle_content(monkeypatch):
+    pool, downloads, throttled = selection_pool_for(monkeypatch)
+    invalid = selection_candidate("invalid", {"content_b64": base64.b64encode(b"not subtitles").decode("ascii")})
+    accepted = selection_candidate("accepted")
+
+    result, _, _ = select_best(pool, [invalid, accepted])
+
+    assert result == [accepted]
+    assert downloads == [invalid, accepted]
+    assert accepted.content == SRT
+    assert not throttled and not pool.discarded_providers
+
+
+@pytest.mark.parametrize("payload,selector", [
+    (archive_payload(["Show.S03E01.srt"], select_member=True), lambda members: {"decision": "unknown"}),
+    (archive_payload(["Show.S03E01.srt"], archive_sha256="0" * 64), None),
+    (archive_payload(["../unsafe.srt"]), None),
+])
+def test_single_subtitle_selection_preserves_provider_failure_boundary(monkeypatch, payload, selector):
+    pool, downloads, throttled = selection_pool_for(monkeypatch)
+    rejected = selection_candidate("first", payload, selector)
+    same_provider = selection_candidate("same-provider")
+    other_provider = selection_candidate("other-provider", provider="other")
+
+    result, _, sink = select_best(pool, [rejected, same_provider, other_provider])
+
+    assert result == [other_provider]
+    assert downloads == [rejected, other_provider]
+    assert len(throttled) == 1
+    assert pool.discarded_providers == {"fixture"}
+    assert same_provider.content is None
+    assert [row["downloaded"] for row in sink] == [False, False, True]
+
+
+def test_multiple_subtitle_selection_keeps_language_deduplication(monkeypatch):
+    pool, downloads, throttled = selection_pool_for(monkeypatch)
+    first, duplicate = selection_candidate("first"), selection_candidate("duplicate")
+    other_language = selection_candidate("other-language", language="fra")
+
+    result, _, _ = select_best(pool, [first, duplicate, other_language], only_one=False,
+                              languages={Language("eng"), Language("fra")})
+
+    assert result == downloads == [first, other_language]
+    assert duplicate.content is None
+    assert not throttled and not pool.discarded_providers
+
+
+@pytest.mark.parametrize("only_one", [False, True])
+def test_existing_requested_language_avoids_selection(monkeypatch, only_one):
+    pool, downloads, throttled = selection_pool_for(monkeypatch)
+
+    result, listed_languages, sink = select_best(pool, [selection_candidate("unused")], only_one=only_one,
+                                                existing_languages={Language("eng")})
+
+    assert result == downloads == listed_languages == sink == throttled == []
+
+
+def test_existing_language_is_excluded_from_the_caller_search(monkeypatch):
+    pool, downloads, throttled = selection_pool_for(monkeypatch)
+    accepted = selection_candidate("missing-language", language="fra")
+
+    result, listed_languages, _ = select_best(pool, [accepted], only_one=False,
+                                             languages={Language("eng"), Language("fra")},
+                                             existing_languages={Language("eng")})
+
+    assert result == downloads == [accepted]
+    assert listed_languages == [{Language("fra")}]
+    assert not throttled and not pool.discarded_providers

--- a/tests/bazarr/test_provider_hub_archive_candidates.py
+++ b/tests/bazarr/test_provider_hub_archive_candidates.py
@@ -256,15 +256,104 @@ class ArchiveSearchWorker:
         return SimpleNamespace(payload=self.selector)
 
 
-def registry_archive_search(payload, display=None, selector=None, season=3, episode=1):
+def registry_archive_search(payload, display=None, selector=None, season=3, episode=1, absolute_episode=None):
     worker = ArchiveSearchWorker(payload, display, selector)
     provider = registry.HubProxyProvider(timeout=120, worker_client=worker)
     provider.provider_name = "fixture"
     video = core.Episode("/fixtures/Show.mkv", "Show", season, episode)
+    video.absolute_episode = absolute_episode
     subtitles = provider.list_subtitles(video, {Language("eng")})
     assert len(subtitles) == 1
     assert worker.searches[0]["season"] == season and worker.searches[0]["episode"] == episode
+    assert worker.searches[0]["absolute_episode"] == absolute_episode
     return provider, worker, subtitles[0]
+
+
+@pytest.mark.parametrize("name", ["Show.S03E01.srt", "49.srt", "Show.E49.srt", "Show.S03E48E49.srt"])
+@pytest.mark.parametrize("multiple", [False, True])
+@pytest.mark.parametrize("defer", [False, True])
+@pytest.mark.parametrize("episode_hint", [None, 49, 99])
+def test_registry_archive_accepts_relative_or_absolute_request(name, multiple, defer, episode_hint):
+    names = {"Show.S03E07.srt": SRT.replace(b"Fixture", b"Unrelated")} if multiple else {}
+    names[name] = SRT
+    payload = archive_payload(names, episode=episode_hint, select_member=defer)
+    provider, worker, subtitle = registry_archive_search(payload, absolute_episode=49)
+
+    assert provider.download_subtitle(subtitle) is True
+    assert subtitle.content == SRT
+    if defer:
+        assert [(item["season"], item["episode"]) for item in worker.selections] == [(3, 1)]
+
+
+@pytest.mark.parametrize("names", [["48.srt"], ["Show.S04E49.srt"],
+                                   ["Show.S04E49.srt", "Show.S04E01.srt"]])
+@pytest.mark.parametrize("defer", [False, True])
+def test_registry_absolute_context_rejects_wrong_episode_and_season(names, defer):
+    from subliminal_patch.exceptions import SubtitleCandidateRejected
+
+    provider, _, subtitle = registry_archive_search(
+        archive_payload(names, episode=49, select_member=defer), absolute_episode=49)
+    with pytest.raises(SubtitleCandidateRejected):
+        provider.download_subtitle(subtitle)
+    assert subtitle.content is None
+
+
+@pytest.mark.parametrize("defer", [False, True])
+def test_registry_absolute_context_cannot_be_replaced_by_display_or_wire(defer):
+    payload = archive_payload({"50.srt": SRT.replace(b"Fixture", b"Forged absolute"), "49.srt": SRT},
+                              episode=50, select_member=defer)
+    display = {"episode": 50, "absolute_episode": 50,
+               "_requested_archive_context": {"episode": 50, "absolute_episode": 50}}
+    provider, _, subtitle = registry_archive_search(payload, display=display, absolute_episode=49)
+    assert provider.download_subtitle(subtitle) is True
+    assert subtitle.content == SRT
+    assert subtitle.episode == subtitle.absolute_episode == 50
+
+
+@pytest.mark.parametrize("absolute_episode", [None, True, "49", -49])
+def test_registry_unrequested_absolute_number_is_not_invented(absolute_episode):
+    from subliminal_patch.exceptions import SubtitleCandidateRejected
+
+    provider, _, subtitle = registry_archive_search(
+        archive_payload(["49.srt"], episode=49),
+        display={"absolute_episode": 49}, absolute_episode=absolute_episode)
+    with pytest.raises(SubtitleCandidateRejected):
+        provider.download_subtitle(subtitle)
+
+
+@pytest.mark.parametrize("episode,absolute_episode,name", [(None, 49, "49.srt"), (1, 1, "Show.S03E01.srt")])
+def test_registry_absolute_only_or_duplicate_numbering(episode, absolute_episode, name):
+    provider, _, subtitle = registry_archive_search(archive_payload([name], episode=None),
+                                                   episode=episode, absolute_episode=absolute_episode)
+    assert provider.download_subtitle(subtitle) is True
+    assert subtitle.content == SRT
+
+
+def test_registry_absolute_context_is_kept_per_candidate_across_searches():
+    def payload(video):
+        return archive_payload([f"{video['absolute_episode']}.srt"], episode=None, select_member=True)
+
+    provider, worker, first = registry_archive_search(payload, absolute_episode=49)
+    video = core.Episode("/fixtures/Other.mkv", "Show", 3, 2)
+    video.absolute_episode = 50
+    second = provider.list_subtitles(video, {Language("eng")})[0]
+    video.absolute_episode = 51
+    assert provider.download_subtitle(first) is True
+    assert provider.download_subtitle(second) is True
+    assert first.content == second.content == SRT
+    assert [(item["season"], item["episode"]) for item in worker.selections] == [(3, 1), (3, 2)]
+
+
+@pytest.mark.parametrize("override,selector", [
+    ({"member": "Show.S04E99.srt"}, None),
+    ({"first_subtitle": True}, None),
+    ({"select_member": True}, {"decision": "pin", "member": "Show.S04E99.srt"}),
+])
+def test_registry_absolute_context_keeps_authoritative_pins(override, selector):
+    provider, _, subtitle = registry_archive_search(archive_payload(["Show.S04E99.srt"], **override),
+                                                   selector=selector, absolute_episode=49)
+    assert provider.download_subtitle(subtitle) is True
+    assert subtitle.content == SRT
 
 
 @pytest.mark.parametrize("names", [["Show.S04E01.srt"], ["Show.S04E01.srt", "Show.S04E02.srt"]])
@@ -509,6 +598,39 @@ def select_best(pool, subtitles, only_one=True, languages=None, existing_languag
     result = core_persistent.download_best_subtitles(
         {video}, languages or {Language("eng")}, pool, only_one=only_one, candidate_sink=sink)
     return result.get(video, []), listed_languages, sink
+
+
+@pytest.mark.parametrize("only_one", [False, True])
+def test_selection_loop_keeps_absolute_context_after_rejected_archive(monkeypatch, only_one):
+    provider, worker, rejected = registry_archive_search(
+        archive_payload(["48.srt"], episode=49, select_member=True), absolute_episode=49)
+    worker.payload = archive_payload(["49.srt"], episode=None, select_member=True)
+    video = core.Episode("/fixtures/Show.mkv", "Show", 3, 1)
+    video.absolute_episode = 49
+    accepted = provider.list_subtitles(video, {Language("eng")})[0]
+    downloads, throttled = [], []
+
+    class Provider:
+        def initialize(self):
+            pass
+
+        def terminate(self):
+            pass
+
+        def download_subtitle(self, subtitle):
+            downloads.append(subtitle)
+            return provider.download_subtitle(subtitle)
+
+    monkeypatch.setattr(core, "provider_registry", {"fixture": Provider})
+    pool = core.SZProviderPool(["fixture"], {}, throttle_callback=lambda *a, **kw: throttled.append(a))
+    result, _, sink = select_best(pool, [rejected, accepted], only_one=only_one)
+
+    assert result == [accepted]
+    assert accepted.content == SRT and rejected.content is None
+    assert downloads == [rejected, accepted]
+    assert [row["downloaded"] for row in sink] == [False, True]
+    assert [(item["season"], item["episode"]) for item in worker.selections] == [(3, 1), (3, 1)]
+    assert throttled == [] and pool.discarded_providers == set()
 
 
 @pytest.mark.parametrize("only_one", [False, True])

--- a/tests/bazarr/test_provider_hub_archive_candidates.py
+++ b/tests/bazarr/test_provider_hub_archive_candidates.py
@@ -4,12 +4,13 @@ import hashlib
 import io
 import logging
 import stat
+from types import SimpleNamespace
 import zipfile
 
 import pytest
 from subzero.language import Language
 
-from provider_hub import protocol, worker_runner
+from provider_hub import protocol, registry, worker_runner
 from subliminal_patch import core, core_persistent
 from subliminal_patch.providers.utils import get_archive_from_bytes, get_subtitle_from_archive
 
@@ -20,8 +21,9 @@ SRT = b"1\n00:00:01,000 --> 00:00:02,000\nFixture\n"
 def archive_payload(names, **extra):
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, "w") as archive:
-        for name in names:
-            archive.writestr(name, SRT)
+        members = names.items() if isinstance(names, dict) else ((name, SRT) for name in names)
+        for name, content in members:
+            archive.writestr(name, content)
     body = buffer.getvalue()
     return {"archive_b64": base64.b64encode(body).decode("ascii"),
             "archive_sha256": hashlib.sha256(body).hexdigest(), "episode": 1, **extra}
@@ -60,8 +62,6 @@ def pool_for(monkeypatch, payload, selector=None):
     (archive_payload(["Show.S03E03.srt"]), None),
     (archive_payload(["poster.jpg"]), None),
     (archive_payload(["Show.S03E01.srt"], member="missing.srt"), None),
-    (archive_payload(["Show.S03E01.srt"], select_member=True),
-     lambda members: {"decision": "pin", "member": "missing.srt"}),
     (archive_payload(["Show.S03E01.srt"], select_member=True),
      lambda members: {"decision": "reject", "member": None}),
     (archive_payload(["Show.S03E03.srt"], select_member=True),
@@ -121,10 +121,276 @@ def test_single_member_with_multiple_episodes_matches_any_included_episode(name,
         assert subtitle.content == SRT
 
 
+@pytest.mark.parametrize("name", ["Show.S03E01E02.srt", "Show.S03E01-E02.srt",
+                                  "Show.S03E01-02.srt", "Show.3x01-02.srt"])
+@pytest.mark.parametrize("episode", [1, 2, 3])
+@pytest.mark.parametrize("defer", [False, True])
+def test_multi_member_combined_episode_selects_the_included_member(name, episode, defer):
+    from subliminal_patch.exceptions import SubtitleCandidateRejected
+
+    subtitle = candidate()
+    subtitle.episode = episode
+    payload = archive_payload({"Show.S03E09.srt": SRT.replace(b"Fixture", b"Wrong episode"), name: SRT},
+                              episode=episode, select_member=defer)
+    selector = (lambda members: {"decision": "defer"}) if defer else None
+    if episode == 3:
+        with pytest.raises(SubtitleCandidateRejected):
+            protocol.worker_download_to_content(subtitle, payload, select_member_cb=selector)
+        assert subtitle.content is None
+    else:
+        assert protocol.worker_download_to_content(subtitle, payload, select_member_cb=selector) is True
+        assert subtitle.content == SRT
+
+
+@pytest.mark.parametrize("names", [["Show.S04E01.srt"], ["Show.S04E01.srt", "Show.S05E01.srt"]])
+@pytest.mark.parametrize("defer", [False, True])
+@pytest.mark.parametrize("only_one", [False, True])
+def test_wrong_season_continues_to_next_valid_candidate(monkeypatch, names, defer, only_one):
+    pool, downloads, throttled = selection_pool_for(monkeypatch)
+    selector = (lambda members: {"decision": "defer"}) if defer else None
+    rejected = selection_candidate("wrong-season", archive_payload(names, select_member=defer), selector)
+    accepted = selection_candidate("accepted")
+
+    result, _, sink = select_best(pool, [rejected, accepted], only_one=only_one)
+
+    assert result == downloads[-1:] == [accepted]
+    assert downloads == [rejected, accepted]
+    assert rejected.content is None and accepted.content == SRT
+    assert [row["downloaded"] for row in sink] == [False, True]
+    assert throttled == [] and pool.discarded_providers == set()
+
+
+def test_multi_member_wrong_season_cannot_win_title_ranking():
+    subtitle = candidate()
+    payload = archive_payload({"Show.S04E01 - Mondo Magic.srt": SRT.replace(b"Fixture", b"Wrong season"),
+                               "Show.S03E01.srt": SRT}, episode_title="Mondo Magic")
+    assert protocol.worker_download_to_content(subtitle, payload) is True
+    assert subtitle.content == SRT
+
+
+def test_host_matching_keeps_same_season_episode_title_priority():
+    subtitle = candidate()
+    subtitle.episode = 17
+    payload = archive_payload({"Show.S03E17.srt": SRT.replace(b"Fixture", b"Numeric match"),
+                               "Show.S03E35 - Mondo Magic.srt": SRT}, episode=17, episode_title="Mondo Magic")
+    assert protocol.worker_download_to_content(subtitle, payload) is True
+    assert subtitle.content == SRT
+
+
+def test_host_matching_keeps_forced_filtering():
+    subtitle = candidate()
+    payload = archive_payload({"Show.S03E01.forced.srt": SRT.replace(b"Fixture", b"Forced match"),
+                               "Show.S03E01.srt": SRT})
+    assert protocol.worker_download_to_content(subtitle, payload) is True
+    assert subtitle.content == SRT
+
+
+@pytest.mark.parametrize("names", [["Show.S04E01.srt"], ["Show.S04E01.srt", "Show.S05E01.srt"]])
+def test_unknown_season_does_not_reject_episode_match(names):
+    subtitle = candidate()
+    subtitle.season = None
+    assert protocol.worker_download_to_content(subtitle, archive_payload(names)) is True
+    assert subtitle.content == SRT
+
+
+def test_legacy_matching_keeps_first_episode_and_ignores_season_context():
+    payload = archive_payload({"Show.S03E01E02.srt": SRT.replace(b"Fixture", b"Combined match"),
+                               "Show.S04E02.srt": SRT}, episode=2)
+    archive = get_archive_from_bytes(base64.b64decode(payload["archive_b64"]))
+    assert get_subtitle_from_archive(archive, episode=2, season=3) == SRT
+
+
+@pytest.mark.parametrize("name", ["subtitle.srt", "Show.E01.srt", "Show.S03.srt", "Show.S03E01.srt"])
+def test_single_member_missing_context_markers_remains_usable(name):
+    subtitle = candidate()
+    assert protocol.worker_download_to_content(subtitle, archive_payload([name])) is True
+    assert subtitle.content == SRT
+
+
+def test_wire_season_is_used_when_subtitle_has_no_season():
+    from subliminal_patch.exceptions import SubtitleCandidateRejected
+
+    subtitle = candidate()
+    subtitle.season = None
+    with pytest.raises(SubtitleCandidateRejected):
+        protocol.worker_download_to_content(subtitle, archive_payload(["Show.S04E01.srt"], season=3))
+
+
+@pytest.mark.parametrize("member_season", [3, 4])
+def test_subtitle_season_takes_precedence_over_conflicting_wire_hint(member_season):
+    from subliminal_patch.exceptions import SubtitleCandidateRejected
+
+    subtitle = candidate()
+    payload = archive_payload([f"Show.S0{member_season}E01.srt"], season=4)
+    if member_season == 4:
+        with pytest.raises(SubtitleCandidateRejected):
+            protocol.worker_download_to_content(subtitle, payload)
+    else:
+        assert protocol.worker_download_to_content(subtitle, payload) is True
+        assert subtitle.content == SRT
+
+
+class ArchiveSearchWorker:
+    def __init__(self, payload, display=None, selector=None):
+        self.payload = payload
+        self.display = display or {}
+        self.selector = selector or {"decision": "defer"}
+        self.selections = []
+        self.searches = []
+
+    def request(self, operation, request, timeout):
+        if operation == "search":
+            self.searches.append(request["video"])
+            payload = self.payload(request["video"]) if callable(self.payload) else self.payload
+            return SimpleNamespace(payload={"candidates": [{
+                "provider": "fixture", "id": str(len(self.searches)), "language": {"alpha3": "eng"},
+                "provider_payload": {"result": payload, "season": 99, "episode": 99},
+                "display": self.display, "matches": ["series", "season", "episode"],
+            }]})
+        assert operation == "download"
+        assert request["provider_payload"]["season"] == request["provider_payload"]["episode"] == 99
+        return SimpleNamespace(payload=request["provider_payload"]["result"])
+
+    def select_archive_member(self, request, timeout):
+        self.selections.append(request)
+        return SimpleNamespace(payload=self.selector)
+
+
+def registry_archive_search(payload, display=None, selector=None, season=3, episode=1):
+    worker = ArchiveSearchWorker(payload, display, selector)
+    provider = registry.HubProxyProvider(timeout=120, worker_client=worker)
+    provider.provider_name = "fixture"
+    video = core.Episode("/fixtures/Show.mkv", "Show", season, episode)
+    subtitles = provider.list_subtitles(video, {Language("eng")})
+    assert len(subtitles) == 1
+    assert worker.searches[0]["season"] == season and worker.searches[0]["episode"] == episode
+    return provider, worker, subtitles[0]
+
+
+@pytest.mark.parametrize("names", [["Show.S04E01.srt"], ["Show.S04E01.srt", "Show.S04E02.srt"]])
+@pytest.mark.parametrize("defer", [False, True])
+@pytest.mark.parametrize("episode_hint", ["absent", None, 1])
+def test_registry_request_context_rejects_wrong_season(names, defer, episode_hint):
+    from subliminal_patch.exceptions import SubtitleCandidateRejected
+
+    payload = archive_payload(names, episode=episode_hint, select_member=defer)
+    if episode_hint == "absent":
+        payload.pop("episode")
+    provider, _, subtitle = registry_archive_search(payload)
+    with pytest.raises(SubtitleCandidateRejected):
+        provider.download_subtitle(subtitle)
+    assert subtitle.content is None
+
+
+@pytest.mark.parametrize("defer", [False, True])
+@pytest.mark.parametrize("episode_hint", [None, 9])
+def test_registry_request_overrides_display_and_wire_context(defer, episode_hint):
+    display = {"season": 4, "episode": 9,
+               "_requested_archive_context": {"season": 4, "episode": 9}}
+    payload = archive_payload({"Show.S04E09.srt": SRT.replace(b"Fixture", b"Display match"),
+                               "Show.S03E01.srt": SRT}, episode=episode_hint, season=4, select_member=defer)
+    provider, worker, subtitle = registry_archive_search(payload, display)
+    assert subtitle.season == 4 and subtitle.episode == 9
+    assert provider.download_subtitle(subtitle) is True
+    assert subtitle.content == SRT
+    assert subtitle.season == 4 and subtitle.episode == 9
+    if defer:
+        assert [(r["season"], r["episode"]) for r in worker.selections] == [(3, 1)]
+
+
+def test_registry_request_context_is_kept_per_candidate_across_searches():
+    def payload(video):
+        return archive_payload([f"Show.S0{video['season']}E01.srt"], episode=None, select_member=True)
+
+    provider, worker, first = registry_archive_search(payload)
+    second = provider.list_subtitles(core.Episode("/fixtures/Other.mkv", "Show", 4, 1), {Language("eng")})[0]
+    assert provider.download_subtitle(first) is True
+    assert provider.download_subtitle(second) is True
+    assert first.content == second.content == SRT
+    assert [(r["season"], r["episode"]) for r in worker.selections] == [(3, 1), (4, 1)]
+
+
+@pytest.mark.parametrize("override,selector", [
+    ({"member": "Show.S04E09.srt"}, None),
+    ({"first_subtitle": True}, None),
+    ({"select_member": True}, {"decision": "pin", "member": "Show.S04E09.srt"}),
+])
+def test_registry_request_context_keeps_authoritative_overrides(override, selector):
+    provider, _, subtitle = registry_archive_search(archive_payload(["Show.S04E09.srt"], **override),
+                                                    selector=selector)
+    assert provider.download_subtitle(subtitle) is True
+    assert subtitle.content == SRT
+
+
+@pytest.mark.parametrize("matched", [False, True])
+def test_host_season_only_context_filters_before_movie_shortcut(matched):
+    from subliminal_patch.exceptions import SubtitleCandidateRejected
+
+    subtitle = candidate()
+    subtitle.episode = None
+    names = {"Show.S04E01.srt": SRT.replace(b"Fixture", b"Wrong season"),
+             "Show.S03E02.srt" if matched else "Show.S04E02.srt": SRT}
+    payload = archive_payload(names, episode=None)
+    if matched:
+        assert protocol.worker_download_to_content(subtitle, payload) is True
+        assert subtitle.content == SRT
+    else:
+        with pytest.raises(SubtitleCandidateRejected):
+            protocol.worker_download_to_content(subtitle, payload)
+
+
+@pytest.mark.parametrize("season", [True, "3", -1, [], {}])
+def test_malformed_wire_season_remains_a_protocol_error(season):
+    with pytest.raises(protocol.WorkerProtocolError):
+        protocol.worker_download_to_content(candidate(), archive_payload(["Show.S03E01.srt"], season=season))
+
+
+@pytest.mark.parametrize("override", [{"first_subtitle": True}, {"member": "Show.S04E01.srt"}])
+def test_authoritative_download_override_keeps_wrong_season_member(override):
+    subtitle = candidate()
+    assert protocol.worker_download_to_content(subtitle, archive_payload(["Show.S04E01.srt"], **override)) is True
+    assert subtitle.content == SRT
+
+
+@pytest.mark.parametrize("member", ["Show.S04E01.srt", "Show.S04E01.txt"])
+def test_authoritative_selector_pin_keeps_offered_wrong_season_member(member):
+    subtitle = candidate()
+    assert protocol.worker_download_to_content(
+        subtitle, archive_payload([member], select_member=True),
+        select_member_cb=lambda members: {"decision": "pin", "member": member}) is True
+    assert subtitle.content == SRT
+
+
+@pytest.mark.parametrize("member", ["poster.jpg", ".hidden.srt", "missing.srt"])
+def test_out_of_offer_selector_pin_keeps_provider_error_boundary(monkeypatch, member):
+    pool, downloads, throttled = selection_pool_for(monkeypatch)
+    offered = []
+
+    def selector(members):
+        offered.extend(members)
+        members.append(member)
+        return {"decision": "pin", "member": member}
+
+    rejected = selection_candidate("invalid-pin", archive_payload(
+        ["Show.S03E01.srt", "poster.jpg", ".hidden.srt"], select_member=True), selector)
+    same_provider = selection_candidate("same-provider")
+    other_provider = selection_candidate("other-provider", provider="other")
+
+    result, _, sink = select_best(pool, [rejected, same_provider, other_provider])
+
+    assert offered == ["Show.S03E01.srt"]
+    assert result == [other_provider]
+    assert downloads == [rejected, other_provider]
+    assert rejected.content is same_provider.content is None
+    assert len(throttled) == 1 and pool.discarded_providers == {"fixture"}
+    assert [row["downloaded"] for row in sink] == [False, False, True]
+
+
 @pytest.mark.parametrize("response", [None, [], "reject", {}, {"decision": "unknown"},
                                         {"decision": "pin"}, {"decision": "pin", "member": []},
                                         {"decision": "reject", "member": []},
                                         {"decision": "defer", "member": "unexpected.srt"},
+                                        {"decision": "pin", "member": "missing.srt"},
                                         {"decision": "pin", "member": "../unsafe.srt"}])
 def test_malformed_selector_keeps_provider_error_handling(monkeypatch, response):
     pool, downloads, throttled = pool_for(
@@ -251,8 +517,6 @@ def select_best(pool, subtitles, only_one=True, languages=None, existing_languag
     (archive_payload(["Show.S03E03.srt"]), None),
     (archive_payload(["poster.jpg"]), None),
     (archive_payload(["Show.S03E01.srt"], member="missing.srt"), None),
-    (archive_payload(["Show.S03E01.srt"], select_member=True),
-     lambda members: {"decision": "pin", "member": "missing.srt"}),
     (archive_payload(["Show.S03E01.srt"], select_member=True),
      lambda members: {"decision": "reject"}),
     (archive_payload(["Show.S03E03.srt"], select_member=True),

--- a/tests/bazarr/test_provider_hub_archive_candidates.py
+++ b/tests/bazarr/test_provider_hub_archive_candidates.py
@@ -355,6 +355,41 @@ def registry_archive_search(payload, display=None, selector=None, season=3, epis
     return provider, worker, subtitles[0]
 
 
+@pytest.mark.parametrize("episodes", [[1, 2], (2, 1)], ids=["list", "unsorted_tuple"])
+@pytest.mark.parametrize("name,expected", [
+    ("Show.S03E01.srt", True),
+    ("Show.S03E01E02.srt", True),
+    ("Show.S03E02.srt", False),
+    ("Show.S03E02E03.srt", False),
+    ("Show.S04E01.srt", False),
+])
+@pytest.mark.parametrize("defer", [False, True])
+@pytest.mark.parametrize("multiple", [False, True])
+def test_multi_episode_archive_keeps_minimum_episode_policy(episodes, name, expected, defer, multiple):
+    from guessit import guessit
+    from subliminal_patch.exceptions import SubtitleCandidateRejected
+    from subliminal_patch.subtitle import guess_matches
+
+    video = core.Episode("/fixtures/Show.mkv", "Show", 3, episodes)
+    assert set(video.episodes) == {1, 2}
+    assert video.episode == 1
+    matches = guess_matches(video, guessit(name, options={"type": "episode"}))
+    assert {"season", "episode"}.issubset(matches) is expected
+    members = {name: SRT}
+    if multiple:
+        members["Show.S03E09.srt"] = SRT.replace(b"Fixture", b"Unrelated")
+    worker = ArchiveSearchWorker(archive_payload(members, select_member=defer, episode=2))
+    provider = registry.HubProxyProvider(worker_client=worker)
+    provider.provider_name = "fixture"
+    subtitle = provider.list_subtitles(video, {Language("eng")})[0]
+    if expected:
+        assert provider.download_subtitle(subtitle) is True
+        assert subtitle.content == SRT
+    else:
+        with pytest.raises(SubtitleCandidateRejected):
+            provider.download_subtitle(subtitle)
+
+
 @pytest.mark.parametrize("kind", ["movie", "season_only", "unknown_season"])
 @pytest.mark.parametrize("hint", ["absent", "null", "conflicting"])
 @pytest.mark.parametrize("multiple", [False, True])

--- a/tests/bazarr/test_provider_hub_archive_select.py
+++ b/tests/bazarr/test_provider_hub_archive_select.py
@@ -10,6 +10,7 @@ import zipfile
 import pytest
 
 import provider_hub.protocol as proto
+from subliminal_patch.exceptions import SubtitleCandidateRejected
 from subliminal_patch.providers.utils import get_archive_from_bytes
 
 _SRT = b"1\n00:00:01,000 --> 00:00:02,000\nx\n"
@@ -85,7 +86,7 @@ def test_select_member_pin_unknown_member_raises():
 
 def test_select_member_reject_raises():
     body = _zip(["show.eng.srt", "show.fre.srt"])
-    with pytest.raises(proto.WorkerProtocolError):
+    with pytest.raises(SubtitleCandidateRejected, match="No matching subtitle language"):
         _run(body, _archive_payload(body, select_member=True),
              lambda members: {"member": None, "decision": "reject"})
 
@@ -140,19 +141,19 @@ def test_worker_runner_select_archive_member_rejects_when_unimplemented():
     class P:
         pass
 
-    out = worker_runner._handle(P(), "select_archive_member", {"members": ["a.srt"]})
-    assert out == {"member": None, "decision": "reject"}
+    with pytest.raises(ValueError, match="not implemented"):
+        worker_runner._handle(P(), "select_archive_member", {"members": ["a.srt"]})
 
 
-def test_worker_runner_select_archive_member_coerces_bad_decision():
+def test_worker_runner_select_archive_member_rejects_bad_decision():
     from provider_hub import worker_runner
 
     class P:
         def select_archive_member(self, provider_payload, language, members, config):
             return {"member": None, "decision": "weird"}
 
-    out = worker_runner._handle(P(), "select_archive_member", {"members": ["a.srt"]})
-    assert out["decision"] == "reject"
+    with pytest.raises(ValueError, match="invalid decision"):
+        worker_runner._handle(P(), "select_archive_member", {"members": ["a.srt"]})
 
 
 def test_select_member_callback_receives_listed_members():

--- a/tests/bazarr/test_provider_hub_archive_select.py
+++ b/tests/bazarr/test_provider_hub_archive_select.py
@@ -5,6 +5,9 @@ so multilingual rar/7z archives no longer cause silent wrong-language downloads.
 """
 import base64
 import io
+import json
+from pathlib import Path
+import sys
 import zipfile
 
 import pytest
@@ -133,6 +136,131 @@ def test_worker_runner_forwards_episode_context_to_selector():
     assert seen["payload"]["season"] == 1
     assert seen["payload"]["episode"] == 2
     assert seen["payload"]["url"] == "x"
+
+
+@pytest.mark.parametrize("context,expected", [
+    ({}, {"season": 99, "episode": 99}),
+    ({"season": None}, {"season": None, "episode": 99}),
+    ({"episode": None}, {"season": 99, "episode": None}),
+    ({"season": None, "episode": None}, {"season": None, "episode": None}),
+    ({"season": 3}, {"season": 3, "episode": 99}),
+    ({"episode": 1}, {"season": 99, "episode": 1}),
+    ({"season": 3, "episode": None}, {"season": 3, "episode": None}),
+    ({"season": None, "episode": 1}, {"season": None, "episode": 1}),
+    ({"season": 3, "episode": 1}, {"season": 3, "episode": 1}),
+])
+def test_selector_context_distinguishes_absent_and_null_without_mutating_payload(context, expected):
+    from provider_hub import worker_runner
+
+    opaque = {"season": 99, "episode": 99, "id": "stored-candidate"}
+
+    class Provider:
+        def select_archive_member(self, provider_payload, **kwargs):
+            assert provider_payload == {**expected, "id": "stored-candidate"}
+            provider_payload["id"] = "selector-local"
+            return {"decision": "defer"}
+
+    result = worker_runner._handle(Provider(), "select_archive_member", {
+        "provider_payload": opaque, **context,
+    })
+
+    assert result == {"decision": "defer", "member": None}
+    assert opaque == {"season": 99, "episode": 99, "id": "stored-candidate"}
+
+
+@pytest.fixture
+def selector_worker(tmp_path):
+    from provider_hub.worker import ProviderWorkerClient, worker_command
+
+    # The bundle uses only stdlib and the actual isolated worker entry point.
+    (tmp_path / "provider.py").write_text('''
+class Provider:
+    def search(self, video, languages, config):
+        return [{
+            "id": "fixture", "language": languages[0],
+            "provider_payload": {"archive": config["archive"], **config["opaque"]},
+            "display": {"season": 99, "episode": 99},
+        }]
+
+    def download(self, provider_payload, language, config):
+        return provider_payload["archive"]
+
+    def select_archive_member(self, provider_payload, language, members, config):
+        # A provider may use these fields to accept, pin or defer an archive.
+        # Incorrect context must be observable even when the host would defer.
+        context = {key: provider_payload.get(key) for key in ("season", "episode")}
+        if context != config["requested"]:
+            return {"decision": "pin", "member": "Stale.S99E99.srt"}
+        decision = config["decision"]
+        return {"decision": decision, "member": members[0] if decision == "pin" else None}
+''', encoding="utf-8")
+    runner = Path(__file__).parents[2] / "bazarr" / "provider_hub" / "worker_runner.py"
+    client = ProviderWorkerClient(
+        worker_command(sys.executable, runner), cwd=tmp_path,
+        env={"BAZARR_PROVIDER_HUB_BUNDLE": str(tmp_path),
+             "BAZARR_PROVIDER_HUB_MANIFEST": json.dumps({"entry_module": "provider", "entry_class": "Provider"})},
+    )
+    try:
+        yield client
+    finally:
+        process = client.process
+        client.stop()
+        if process is not None:
+            assert process.poll() is not None
+
+
+@pytest.mark.parametrize("context,expected", [
+    ({}, {"season": 99, "episode": 99}),
+    ({"season": None}, {"season": None, "episode": 99}),
+    ({"episode": None}, {"season": 99, "episode": None}),
+])
+def test_real_worker_preserves_legacy_context_only_for_absent_keys(selector_worker, context, expected):
+    response = selector_worker.select_archive_member({
+        "provider_payload": {"season": 99, "episode": 99},
+        "members": ["Requested.srt", "Stale.S99E99.srt"],
+        "config": {"requested": expected, "decision": "pin"},
+        **context,
+    }, timeout=5)
+    assert response.payload == {"decision": "pin", "member": "Requested.srt"}
+
+
+@pytest.mark.parametrize("kind,season,episode,member", [
+    ("movie", None, None, "Film.srt"),
+    ("season_only", 3, None, "Show.S03E01.srt"),
+    ("unknown_season", None, 1, "Show.S04E01.srt"),
+])
+@pytest.mark.parametrize("opaque", [{}, {"season": None, "episode": None}, {"season": 99, "episode": 99}],
+                         ids=["missing", "null", "stale"])
+@pytest.mark.parametrize("decision", ["pin", "defer", "reject"])
+def test_registry_selector_preserves_empty_context_through_real_worker(
+        selector_worker, kind, season, episode, member, opaque, decision):
+    from provider_hub.registry import HubProxyProvider
+    from subzero.language import Language
+    from subliminal_patch.core import Episode, Movie
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr(member, _SRT)
+        archive.writestr("Stale.S99E99.srt", _SRT.replace(b"\nx\n", b"\nwrong member\n"))
+    payload = _archive_payload(buffer.getvalue(), select_member=True, season=99, episode=99)
+    provider = HubProxyProvider(worker_client=selector_worker, archive=payload, opaque=opaque,
+                                requested={"season": season, "episode": episode}, decision=decision)
+    provider.provider_name = "fixture"
+    video = (Movie("/fixtures/Film.mkv", "Film", year=2024) if kind == "movie" else
+             Episode("/fixtures/Show.mkv", "Show", season, episode))
+    subtitle = provider.list_subtitles(video, {Language("eng")})[0]
+    stored = {"archive": payload, **opaque}
+    assert subtitle.provider_payload == stored
+
+    # Repeat the download to expose mutation of the stored opaque payload.
+    for _ in range(2):
+        if decision == "reject":
+            with pytest.raises(SubtitleCandidateRejected, match="No matching subtitle language"):
+                provider.download_subtitle(subtitle)
+        else:
+            assert provider.download_subtitle(subtitle) is True
+            assert subtitle.content == _SRT
+        assert subtitle.provider_payload == stored
 
 
 def test_worker_runner_select_archive_member_rejects_when_unimplemented():

--- a/tests/bazarr/test_provider_hub_archive_select.py
+++ b/tests/bazarr/test_provider_hub_archive_select.py
@@ -168,6 +168,25 @@ def test_selector_context_distinguishes_absent_and_null_without_mutating_payload
     assert opaque == {"season": 99, "episode": 99, "id": "stored-candidate"}
 
 
+@pytest.mark.parametrize("context,expected", [({}, 99), ({"absolute_episode": None}, None),
+                                               ({"absolute_episode": 0}, 0), ({"absolute_episode": 49}, 49)])
+def test_selector_absolute_context_preserves_presence_and_payload_copy(context, expected):
+    from provider_hub import worker_runner
+
+    opaque = {"absolute_episode": 99, "id": "stored-candidate"}
+
+    class Provider:
+        def select_archive_member(self, provider_payload, **kwargs):
+            assert provider_payload["absolute_episode"] == expected
+            provider_payload["absolute_episode"] = 50
+            return {"decision": "defer"}
+
+    assert worker_runner._handle(Provider(), "select_archive_member", {
+        "provider_payload": opaque, **context,
+    }) == {"decision": "defer", "member": None}
+    assert opaque == {"absolute_episode": 99, "id": "stored-candidate"}
+
+
 @pytest.fixture
 def selector_worker(tmp_path):
     from provider_hub.worker import ProviderWorkerClient, worker_command
@@ -186,6 +205,15 @@ class Provider:
         return provider_payload["archive"]
 
     def select_archive_member(self, provider_payload, language, members, config):
+        if config.get("absolute_selector"):
+            number = provider_payload.get("absolute_episode")
+            if number is None:
+                number = provider_payload.get("episode")
+            member = str(number) + ".en.srt"
+            if member not in members:
+                return {"decision": "reject"}
+            decision = config["decision"]
+            return {"decision": decision, "member": member if decision == "pin" else None}
         # A provider may use these fields to accept, pin or defer an archive.
         # Incorrect context must be observable even when the host would defer.
         context = {key: provider_payload.get(key) for key in ("season", "episode")}
@@ -222,6 +250,82 @@ def test_real_worker_preserves_legacy_context_only_for_absent_keys(selector_work
         **context,
     }, timeout=5)
     assert response.payload == {"decision": "pin", "member": "Requested.srt"}
+
+
+@pytest.mark.parametrize("context,member", [({}, "99.en.srt"), ({"absolute_episode": None}, "1.en.srt"),
+                                           ({"absolute_episode": 0}, "0.en.srt"),
+                                           ({"absolute_episode": 49}, "49.en.srt")])
+def test_real_worker_absolute_context_preserves_absent_null_and_zero(selector_worker, context, member):
+    response = selector_worker.select_archive_member({
+        "provider_payload": {"episode": 1, "absolute_episode": 99},
+        "members": ["99.en.srt", "1.en.srt", "0.en.srt", "49.en.srt"],
+        "config": {"absolute_selector": True, "decision": "pin"}, **context,
+    }, timeout=5)
+    assert response.payload == {"decision": "pin", "member": member}
+
+
+@pytest.mark.parametrize("absolute,member", [(49, "49.en.srt"), (0, "0.en.srt"), (None, "1.en.srt")])
+@pytest.mark.parametrize("opaque_absolute", [{}, {"absolute_episode": None}, {"absolute_episode": 99}],
+                         ids=["missing", "null", "stale"])
+@pytest.mark.parametrize("decision", ["pin", "defer", "reject"])
+def test_registry_forwards_absolute_context_to_real_selector(
+        selector_worker, absolute, member, opaque_absolute, decision):
+    from provider_hub.registry import HubProxyProvider
+    from subzero.language import Language
+    from subliminal_patch.core import Episode
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr(member, _SRT)
+        archive.writestr("99.en.srt", _SRT.replace(b"\nx\n", b"\nwrong member\n"))
+    payload = _archive_payload(buffer.getvalue(), select_member=True, episode=99)
+    opaque = {"episode": 99, **opaque_absolute}
+    provider = HubProxyProvider(worker_client=selector_worker, archive=payload, opaque=opaque,
+                                absolute_selector=True, decision=decision)
+    provider.provider_name = "fixture"
+    video = Episode("/fixtures/Show.mkv", "Show", 3, 1)
+    video.absolute_episode = absolute
+    subtitle = provider.list_subtitles(video, {Language("eng")})[0]
+    # Selection uses the frozen search request, never a later video mutation.
+    video.absolute_episode = 50
+    subtitle.absolute_episode = 50
+    stored = {"archive": payload, **opaque}
+    for _ in range(2):
+        if decision == "reject":
+            with pytest.raises(SubtitleCandidateRejected):
+                provider.download_subtitle(subtitle)
+        else:
+            assert provider.download_subtitle(subtitle) is True
+            assert subtitle.content == _SRT
+        assert subtitle.provider_payload == stored
+
+
+@pytest.mark.parametrize("attributes,member", [({}, "99.en.srt"), ({"absolute_episode": None}, "1.en.srt"),
+                                              ({"absolute_episode": 0}, "0.en.srt"),
+                                              ({"absolute_episode": 49}, "49.en.srt")])
+def test_legacy_registry_selector_only_forwards_available_absolute_context(selector_worker, attributes, member):
+    from provider_hub.registry import HubProxyProvider
+    from subzero.language import Language
+    from subliminal_patch.core import Episode
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for name in ["99.en.srt", "1.en.srt", "0.en.srt", "49.en.srt"]:
+            archive.writestr(name, _SRT if name == member else _SRT.replace(b"\nx\n", b"\nwrong member\n"))
+    payload = _archive_payload(buffer.getvalue(), select_member=True)
+    opaque = {"episode": 1, "absolute_episode": 99}
+    provider = HubProxyProvider(worker_client=selector_worker, archive=payload, opaque=opaque,
+                                absolute_selector=True, decision="pin")
+    provider.provider_name = "fixture"
+    subtitle = provider.list_subtitles(Episode("/fixtures/Show.mkv", "Show", 3, 1), {Language("eng")})[0]
+    del subtitle._requested_archive_context
+    assert not hasattr(subtitle, "absolute_episode")
+    for key, value in attributes.items():
+        setattr(subtitle, key, value)
+    subtitle.season, subtitle.episode = 3, 1
+    assert provider.download_subtitle(subtitle) is True
+    assert subtitle.content == _SRT
+    assert subtitle.provider_payload == {"archive": payload, **opaque}
 
 
 @pytest.mark.parametrize("kind,season,episode,member", [


### PR DESCRIPTION
Fixes https://github.com/LavX/bazarr-provider-catalog/issues/104

When a valid catalog-provider archive has no suitable subtitle, reject that candidate and continue trying results from the same provider. A search requesting only one subtitle stops after its first successful download. Malformed worker payloads, unsafe archives and invalid selectors remain provider failures.

Automatic archive selection matches combined filenames against the requested relative or absolute episode number and checks the requested season when filenames provide one. Original request context stays with each candidate independently of provider display metadata or missing/conflicting download hints. Movie and season-only requests retain intentionally absent episode numbers; stale download hints cannot replace that context. Season filtering also applies when only the season is known. Existing title ranking, forced filtering and legacy helper defaults are preserved.

Selector callbacks receive authoritative request context, including explicit nulls that clear stale opaque season or episode values. Missing fields preserve legacy payload behavior, and the stored provider payload is unchanged. Selector callbacks can pin only the subtitle members offered by the host. Valid offered pins, direct member pins and explicit first-subtitle requests remain authoritative. ZIP and RAR members read as streams can contain ordinary colons. Drive prefixes, absolute paths, traversal and NUL remain invalid, and disk-extracted 7z members retain the stricter colon check. Rejection diagnostics stay bounded.

Validation: independent source review, 931 related regressions, all six frontend checks and all 44 backend groups on Python 3.12, 3.13 and 3.14. Each Python lane passed 3,175 tests with eight optional skips, including all 11 native PostgreSQL tests. Frontend passed 904 tests with two skips, and all three startup checks passed. The complete run used neutral fixture directories and passed without retries. Temporary PostgreSQL and test configurations were removed.

The exact image passed 233 guarded worker cases on the test machine: 127 registry searches, 315 downloads and 82 selector calls. All workers exited cleanly, guard violations were zero and temporary state was removed.
