### PR TITLE
Align the cryptography security floor and verify stored secrets

### DIFF
--- a/bazarr/app/requirements.py
+++ b/bazarr/app/requirements.py
@@ -108,7 +108,7 @@ RUNTIME_REQUIREMENTS = {
     "charset_normalizer": ("charset-normalizer", "==3.5.1"),
     "click_option_group": ("click-option-group", ">=0.5.6"),
     "cloudscraper": ("cloudscraper", "<=1.2.58"),
-    "cryptography": ("cryptography", ">=48.0.0"),
+    "cryptography": ("cryptography", ">=50.0.1"),
     "dateutil": ("python-dateutil", "==2.9.0"),
     "deathbycaptcha": ("deathbycaptcha-official", "==4.7.1"),
     "deep_translator": ("deep-translator", "==1.11.4"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ click-option-group>=0.5.9
 # support must not be picked up unattended. 1.2.71 is the newest release on
 # PyPI today, so this resolves to the latest version.
 cloudscraper<=1.2.71
-cryptography>=49.0.0
+cryptography>=50.0.1
 deathbycaptcha-official==4.7.1
 deep-translator==1.11.4
 dnspython==2.8.0

--- a/tests/bazarr/fixtures/cryptography49_fernet.json
+++ b/tests/bazarr/fixtures/cryptography49_fernet.json
@@ -1,0 +1,18 @@
+{
+  "source_version": "49.0.0",
+  "master_key": "synthetic-master-key-for-version-compatibility-only",
+  "cases": [
+    {
+      "plaintext": "synthetic-provider-token",
+      "ciphertext": "enc:v1:gAAAAABqm1uaEus9uqCEc7V5GDwndiAh3HvmiIbEEuVCLpudK4OzvCXIt_jOGT-flGv-rNjFnj06Za8vLGX9SM6UNK9POzfHSc012E_Vd2wA_-zEQqis2PQ="
+    },
+    {
+      "plaintext": "synthetic-translator-token",
+      "ciphertext": "enc:v1:gAAAAABqm1uaHS6Ro_bVCFQEdgdCn2veRLwb7Bj4wcK5cJi1z5VPRpY1A-UO1u1qeddWggCYNKMH743Bw25kNLRStuSrDAv_yW90ktfxZKl7ahXKmJwEkZc="
+    },
+    {
+      "plaintext": "synthetic-unicode-árvíztűrő",
+      "ciphertext": "enc:v1:gAAAAABqm1uaQlgBNKC4euTO9bTpCe-MJ0qtKVdFu8O56EwIXx9BtLH-YGq_nQcNZi53xqMy8ft1Cyi2V8SDqqm2SoTgCxLPzcPLW3FZa9uzZXSA2HWlyJk="
+    }
+  ]
+}

--- a/tests/bazarr/test_dependency_loading.py
+++ b/tests/bazarr/test_dependency_loading.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import subliminal
 import yaml
+import pytest
 
 
 def test_pytest_conftest_imports_without_pkg_resources_deprecation_warning():
@@ -234,6 +235,7 @@ def test_startup_requirements_probe_uses_security_patched_dependency_versions():
     requirements = (repo_root / "requirements.txt").read_text()
 
     expected_versions = {
+        "cryptography": ("cryptography", ">=50.0.1"),
         "dynaconf": ("dynaconf", "==3.3.5"),
         "urllib3": ("urllib3", "==2.7.0"),
     }
@@ -261,6 +263,31 @@ def test_startup_requirements_probe_supports_upper_bound_specs():
     assert _satisfies_spec("1.2.58", "<=1.2.58")
     assert _satisfies_spec("1.2.57", "<=1.2.58")
     assert not _satisfies_spec("1.2.59", "<=1.2.58")
+
+
+@pytest.mark.parametrize('installed', ['48.0.0', '49.0.0', '50.0.0', '50.0.1', '50.0.2'])
+def test_cryptography_security_floor_repairs_old_installs_once(monkeypatch, installed):
+    from app import requirements
+
+    monkeypatch.setattr(requirements, 'RUNTIME_IMPORTS', ('cryptography',))
+    installed_version = [installed]
+    monkeypatch.setattr(requirements.metadata, 'version', lambda distribution: installed_version[0])
+    repairs, restarts = [], []
+
+    def install(missing):
+        repairs.append(missing)
+        installed_version[0] = '50.0.1'
+        return True
+
+    monkeypatch.setattr(requirements, 'install_requirements', install)
+    monkeypatch.setattr(requirements, 'restart_after_requirements_install', lambda: restarts.append(True))
+    needs_repair = installed in ['48.0.0', '49.0.0', '50.0.0']
+    assert requirements.missing_runtime_requirements() == (['cryptography'] if needs_repair else [])
+    assert requirements.ensure_requirements() is needs_repair
+    assert repairs == ([['cryptography']] if needs_repair else [])
+    assert restarts == ([True] if needs_repair else [])
+    assert requirements.ensure_requirements() is False
+    assert len(repairs) == len(restarts) == int(needs_repair)
 
 
 def test_startup_requirements_probe_rejects_removed_vendor_origins(monkeypatch):

--- a/tests/bazarr/test_secret_store_crypto.py
+++ b/tests/bazarr/test_secret_store_crypto.py
@@ -6,6 +6,8 @@ bad-cipher diagnostics) lives in commit 5's test_secrets_e2e.py. This file
 covers just the crypto primitives.
 """
 from unittest.mock import MagicMock
+import json
+from pathlib import Path
 
 import pytest
 
@@ -16,6 +18,23 @@ from secret_store.crypto import (
     get_master_key,
     is_encrypted,
 )
+
+
+_OLD_CRYPTOGRAPHY = json.loads(
+    (Path(__file__).with_name('fixtures') / 'cryptography49_fernet.json').read_text(encoding='utf-8')
+)
+
+
+@pytest.mark.parametrize('case', _OLD_CRYPTOGRAPHY['cases'], ids=['provider', 'translator', 'unicode'])
+def test_ciphertext_from_cryptography_49_remains_readable(case):
+    """Persisted synthetic fixtures were encrypted by the actual 49.0.0 wheel."""
+    key = _OLD_CRYPTOGRAPHY['master_key']
+    assert decrypt_secret(case['ciphertext'], master_key=key) == case['plaintext']
+    assert encrypt_secret(case['ciphertext'], master_key=key) == case['ciphertext']
+    with pytest.raises(ValueError, match='tampered|master key'):
+        decrypt_secret(case['ciphertext'], master_key='synthetic-wrong-master-key')
+    with pytest.raises(ValueError, match='tampered|master key'):
+        decrypt_secret(case['ciphertext'][:-2] + 'AA', master_key=key)
 
 
 @pytest.fixture


### PR DESCRIPTION
Require cryptography 50.0.1 or newer in both installation requirements and the startup dependency check. The older runtime floor could accept an installation below the patched version even after requirements.txt was updated.

This includes the dependency update proposed in https://github.com/LavX/bazarr/pull/408 and adds runtime-floor alignment plus regressions for persisted encrypted settings. Secret formats and database schemas are unchanged.

Validation: independent review; 120 focused tests; full local frontend, Python 3.12/3.13/3.14, native PostgreSQL and startup CI, with 2,887 backend tests passing per lane. Actual 49.0.0/50.0.1 environments verified repair behavior and bidirectional synthetic ciphertext compatibility. The exact production image passed isolated test-machine runtime, Fernet, AESGCM, X.509 and TLS checks. Read-only comparison confirmed identical decryption of all 21 existing encrypted settings.
