### PR TITLE
fix(translate): name the media in translation job labels for movies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,7 @@ jobs:
             tests/bazarr/test_supervisor_proxy.py \
             tests/bazarr/test_supervisor_stages.py \
             tests/bazarr/test_tracemalloc_dumper.py \
+            tests/bazarr/test_translate_job_media_name.py \
             tests/bazarr/test_translator_auth.py \
             tests/bazarr/test_upgrade_embedded_history.py \
             tests/subliminal_patch/test_animetosho.py \

--- a/bazarr/subtitles/tools/translate/core/translator_utils.py
+++ b/bazarr/subtitles/tools/translate/core/translator_utils.py
@@ -111,9 +111,20 @@ def add_translator_info(dest_srt_file, info):
             f.write(srt.compose(subtitles))
 
 
+# The callers do not agree on how to spell this: the manual translate endpoint
+# sends "movie" while the batch and mass-operation paths send "movies". Both mean
+# the same thing, and matching only one of them silently produced an empty title
+# and an empty prompt description for every movie translated from its own page.
+MOVIE_MEDIA_TYPES = ('movie', 'movies')
+
+
+def is_movie_media_type(media_type) -> bool:
+    return str(media_type or '').strip().lower() in MOVIE_MEDIA_TYPES
+
+
 def get_description(media_type, radarr_id, sonarr_series_id):
     try:
-        if media_type == 'movies':
+        if is_movie_media_type(media_type):
             movie = database.execute(
                 select(TableMovies.title, TableMovies.imdbId, TableMovies.year, TableMovies.overview)
                 .where(TableMovies.radarrId == radarr_id)
@@ -150,7 +161,7 @@ def get_title(
         sonarr_episode_id: Union[int, None] = None
 ) -> str:
     try:
-        if media_type == "movies":
+        if is_movie_media_type(media_type):
             if radarr_id is None:
                 return ""
 

--- a/bazarr/subtitles/tools/translate/core/translator_utils.py
+++ b/bazarr/subtitles/tools/translate/core/translator_utils.py
@@ -122,12 +122,27 @@ def is_movie_media_type(media_type) -> bool:
     return str(media_type or '').strip().lower() in MOVIE_MEDIA_TYPES
 
 
-def get_description(media_type, radarr_id, sonarr_series_id):
+def _scope(statement, table, arr_instance_id):
+    """Narrow a lookup to the owning arr instance (#156).
+
+    ``radarrId`` and ``sonarrSeriesId`` are unique only together with
+    ``arr_instance_id``, so an unscoped query can return a sibling instance's
+    media. Callers that genuinely have no owner (older paths, and the tests that
+    seed a single instance) pass None and keep the previous behaviour.
+    """
+    if arr_instance_id is None:
+        return statement
+    return statement.where(table.arr_instance_id == arr_instance_id)
+
+
+def get_description(media_type, radarr_id, sonarr_series_id, arr_instance_id=None):
     try:
         if is_movie_media_type(media_type):
             movie = database.execute(
-                select(TableMovies.title, TableMovies.imdbId, TableMovies.year, TableMovies.overview)
-                .where(TableMovies.radarrId == radarr_id)
+                _scope(
+                    select(TableMovies.title, TableMovies.imdbId, TableMovies.year, TableMovies.overview)
+                    .where(TableMovies.radarrId == radarr_id),
+                    TableMovies, arr_instance_id)
             ).first()
 
             if movie:
@@ -139,8 +154,10 @@ def get_description(media_type, radarr_id, sonarr_series_id):
 
         else:
             series = database.execute(
-                select(TableShows.title, TableShows.imdbId, TableShows.year, TableShows.overview)
-                .where(TableShows.sonarrSeriesId == sonarr_series_id)
+                _scope(
+                    select(TableShows.title, TableShows.imdbId, TableShows.year, TableShows.overview)
+                    .where(TableShows.sonarrSeriesId == sonarr_series_id),
+                    TableShows, arr_instance_id)
             ).first()
 
             if series:
@@ -158,7 +175,8 @@ def get_title(
         media_type: str,
         radarr_id: Union[int, None] = None,
         sonarr_series_id: Union[int, None] = None,
-        sonarr_episode_id: Union[int, None] = None
+        sonarr_episode_id: Union[int, None] = None,
+        arr_instance_id: Union[int, None] = None
 ) -> str:
     try:
         if is_movie_media_type(media_type):
@@ -166,7 +184,8 @@ def get_title(
                 return ""
 
             movie_row = database.execute(
-                select(TableMovies.title).where(TableMovies.radarrId == radarr_id)
+                _scope(select(TableMovies.title).where(TableMovies.radarrId == radarr_id),
+                       TableMovies, arr_instance_id)
             ).first()
 
             if movie_row is None:
@@ -187,7 +206,8 @@ def get_title(
             return ""
 
         series_row = database.execute(
-            select(TableShows.title).where(TableShows.sonarrSeriesId == sonarr_series_id)
+            _scope(select(TableShows.title).where(TableShows.sonarrSeriesId == sonarr_series_id),
+                   TableShows, arr_instance_id)
         ).first()
 
         if series_row is None:
@@ -204,8 +224,10 @@ def get_title(
         # If episode ID is provided, get episode details and format as "Series - S##E## - Episode Title"
         if sonarr_episode_id is not None:
             episode_row = database.execute(
-                select(TableEpisodes.season, TableEpisodes.episode, TableEpisodes.title)
-                .where(TableEpisodes.sonarrEpisodeId == sonarr_episode_id)
+                _scope(
+                    select(TableEpisodes.season, TableEpisodes.episode, TableEpisodes.title)
+                    .where(TableEpisodes.sonarrEpisodeId == sonarr_episode_id),
+                    TableEpisodes, arr_instance_id)
             ).first()
 
             if episode_row is not None:

--- a/bazarr/subtitles/tools/translate/main.py
+++ b/bazarr/subtitles/tools/translate/main.py
@@ -25,7 +25,8 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
         jobs_queue.add_job_from_function(
             (lambda t: f'Translating {t} ({from_lang.upper()} to {to_lang.upper()})' if t else
              f'Translating {from_lang.upper()} to {to_lang.upper()}')(
-                get_title(media_type, radarr_id, sonarr_series_id, sonarr_episode_id)),
+                get_title(media_type, radarr_id, sonarr_series_id, sonarr_episode_id,
+                          arr_instance_id)),
             is_progress=True)
         return
 
@@ -70,7 +71,8 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
             hi=hi,
             sonarr_series_id=sonarr_series_id,
             sonarr_episode_id=sonarr_episode_id,
-            radarr_id=radarr_id
+            radarr_id=radarr_id,
+            arr_instance_id=arr_instance_id
         )
 
         logging.debug(f'Created translator instance: {translator.__class__.__name__}')  # noqa: G004

--- a/bazarr/subtitles/tools/translate/services/gemini_translator.py
+++ b/bazarr/subtitles/tools/translate/services/gemini_translator.py
@@ -45,13 +45,17 @@ class SubtitleObject(typing.TypedDict):
 class GeminiTranslatorService:
 
     def __init__(self, source_srt_file, dest_srt_file, to_lang, media_type, sonarr_series_id, sonarr_episode_id,
-                 radarr_id, forced, hi, video_path, from_lang, orig_to_lang, **kwargs):
+                 radarr_id, forced, hi, video_path, from_lang, orig_to_lang,
+                 arr_instance_id=None, **kwargs):
         self.source_srt_file = source_srt_file
         self.dest_srt_file = dest_srt_file
         self.to_lang = to_lang
         self.media_type = media_type
         self.sonarr_series_id = sonarr_series_id
         self.radarr_id = radarr_id
+        # The owning arr instance (#156): radarrId and sonarrSeriesId are only
+        # unique together with it, so every media lookup below carries it.
+        self.arr_instance_id = arr_instance_id
         self.from_lang = from_lang
         self.video_path = video_path
         self.forced = forced
@@ -98,7 +102,8 @@ class GeminiTranslatorService:
             self.output_file = self.dest_srt_file
             self.model_name = settings.translator.gemini_model
             self.batch_size = self._get_batch_size()
-            self.description = get_description(self.media_type, self.radarr_id, self.sonarr_series_id)
+            self.description = get_description(self.media_type, self.radarr_id, self.sonarr_series_id,
+                                               arr_instance_id=self.arr_instance_id)
 
             if self.input_file:
                 self.progress_file = os.path.join(os.path.dirname(self.input_file), f".{os.path.basename(self.input_file)}.progress")

--- a/bazarr/subtitles/tools/translate/services/google_translator.py
+++ b/bazarr/subtitles/tools/translate/services/google_translator.py
@@ -23,7 +23,7 @@ class GoogleTranslatorService:
 
     def __init__(self, source_srt_file, dest_srt_file, lang_obj, to_lang, from_lang, media_type,
                  video_path, orig_to_lang, forced, hi, sonarr_series_id, sonarr_episode_id,
-                 radarr_id):
+                 radarr_id, arr_instance_id=None):
         self.source_srt_file = source_srt_file
         self.dest_srt_file = dest_srt_file
         self.lang_obj = lang_obj
@@ -37,6 +37,9 @@ class GoogleTranslatorService:
         self.sonarr_series_id = sonarr_series_id
         self.sonarr_episode_id = sonarr_episode_id
         self.radarr_id = radarr_id
+        # The owning arr instance (#156): radarrId and sonarrSeriesId are only
+        # unique together with it, so every media lookup below carries it.
+        self.arr_instance_id = arr_instance_id
         self.language_code_convert_dict = {
             'he': 'iw',
             'zh': 'zh-CN',

--- a/bazarr/subtitles/tools/translate/services/lingarr_translator.py
+++ b/bazarr/subtitles/tools/translate/services/lingarr_translator.py
@@ -30,7 +30,7 @@ class LingarrAuthError(Exception):
 class LingarrTranslatorService:
     def __init__(self, source_srt_file, dest_srt_file, lang_obj, to_lang, from_lang, media_type,
                  video_path, orig_to_lang, forced, hi, sonarr_series_id, sonarr_episode_id,
-                 radarr_id):
+                 radarr_id, arr_instance_id=None):
         self.source_srt_file = source_srt_file
         self.dest_srt_file = dest_srt_file
         self.lang_obj = lang_obj
@@ -44,6 +44,9 @@ class LingarrTranslatorService:
         self.sonarr_series_id = sonarr_series_id
         self.sonarr_episode_id = sonarr_episode_id
         self.radarr_id = radarr_id
+        # The owning arr instance (#156): radarrId and sonarrSeriesId are only
+        # unique together with it, so every media lookup below carries it.
+        self.arr_instance_id = arr_instance_id
         self.language_code_convert_dict = {
             'zh': 'zh-CN',
             'zt': 'zh-TW',
@@ -139,7 +142,8 @@ class LingarrTranslatorService:
                 media_type=self.media_type,
                 radarr_id=self.radarr_id,
                 sonarr_series_id=self.sonarr_series_id,
-                sonarr_episode_id=self.sonarr_episode_id
+                sonarr_episode_id=self.sonarr_episode_id,
+                arr_instance_id=self.arr_instance_id
             )
 
             if self.media_type == 'episode':

--- a/bazarr/subtitles/tools/translate/services/openrouter_translator.py
+++ b/bazarr/subtitles/tools/translate/services/openrouter_translator.py
@@ -120,7 +120,7 @@ class OpenRouterTranslatorService:
 
     def __init__(self, source_srt_file, dest_srt_file, lang_obj, to_lang, from_lang, media_type,
                  video_path, orig_to_lang, forced, hi, sonarr_series_id, sonarr_episode_id,
-                 radarr_id):
+                 radarr_id, arr_instance_id=None):
         self.source_srt_file = source_srt_file
         self.dest_srt_file = dest_srt_file
         self.lang_obj = lang_obj
@@ -134,6 +134,9 @@ class OpenRouterTranslatorService:
         self.sonarr_series_id = sonarr_series_id
         self.sonarr_episode_id = sonarr_episode_id
         self.radarr_id = radarr_id
+        # The owning arr instance (#156): radarrId and sonarrSeriesId are only
+        # unique together with it, so every media lookup below carries it.
+        self.arr_instance_id = arr_instance_id
         self.partial_error = None
         self.language_code_convert_dict = {
             'he': 'iw',
@@ -279,7 +282,8 @@ class OpenRouterTranslatorService:
                 media_type=self.media_type,
                 radarr_id=self.radarr_id,
                 sonarr_series_id=self.sonarr_series_id,
-                sonarr_episode_id=self.sonarr_episode_id
+                sonarr_episode_id=self.sonarr_episode_id,
+                arr_instance_id=self.arr_instance_id
             )
 
             api_media_type = "Episode" if self.media_type == 'episode' else "Movie"

--- a/tests/bazarr/test_translate_job_media_name.py
+++ b/tests/bazarr/test_translate_job_media_name.py
@@ -1,0 +1,92 @@
+# coding=utf-8
+"""Translation job labels have to name the media, movies included.
+
+``translate_subtitles_file`` and the AI translator both build their label from
+``get_title``, and the LLM prompt gets its context from ``get_description``.
+Both branch on ``media_type``, and the callers do not agree on how to spell it:
+the manual translate endpoint sends "movie" while the batch paths send
+"movies". Only the plural matched, so a movie translated from its detail page
+fell through to the series branch, found no ``sonarr_series_id`` and produced an
+empty title. The job then read "Translating HU to EN" with no film in it, the
+Translation Jobs table showed only the language pair, and the prompt lost the
+movie's overview.
+"""
+import pytest
+
+from app.database import TableEpisodes, TableMovies, TableShows
+from subtitles.tools.translate.core import translator_utils
+
+
+@pytest.fixture
+def library(schema_session, monkeypatch):
+    monkeypatch.setattr(translator_utils, "database", schema_session)
+    schema_session.add(
+        TableMovies(
+            radarrId=7,
+            tmdbId="12345",
+            title="The Quiet Earth",
+            year="1985",
+            imdbId="tt0089869",
+            overview="The last man alive.",
+            path="/movies/quiet.mkv",
+            tags="[]",
+            monitored="True",
+        )
+    )
+    schema_session.add(
+        TableShows(
+            sonarrSeriesId=3,
+            tvdbId=999,
+            title="Dark Matter",
+            year="2024",
+            imdbId="tt1234567",
+            overview="A man wakes in another life.",
+            path="/tv/dark-matter",
+            tags="[]",
+            monitored="True",
+            seriesType="standard",
+        )
+    )
+    schema_session.add(
+        TableEpisodes(
+            sonarrEpisodeId=42,
+            sonarrSeriesId=3,
+            season=2,
+            episode=5,
+            title="Superposition",
+            path="/tv/dark-matter/s02e05.mkv",
+            monitored="True",
+        )
+    )
+    schema_session.commit()
+    return schema_session
+
+
+@pytest.mark.parametrize("media_type", ["movie", "movies"])
+def test_movie_title_is_found_however_the_caller_spells_the_media_type(library, media_type):
+    assert translator_utils.get_title(media_type, radarr_id=7) == "The Quiet Earth"
+
+
+@pytest.mark.parametrize("media_type", ["movie", "movies"])
+def test_movie_description_is_found_however_the_caller_spells_the_media_type(library, media_type):
+    description = translator_utils.get_description(media_type, radarr_id=7, sonarr_series_id=None)
+    assert "The Quiet Earth" in description
+    assert "The last man alive." in description
+
+
+def test_unknown_movie_still_gives_an_empty_title(library):
+    assert translator_utils.get_title("movie", radarr_id=999) == ""
+
+
+def test_episode_title_still_carries_the_series_and_the_episode_number(library):
+    title = translator_utils.get_title(
+        "episode", sonarr_series_id=3, sonarr_episode_id=42
+    )
+    assert title == "Dark Matter - S02E05 - Superposition"
+
+
+def test_series_description_is_unchanged(library):
+    description = translator_utils.get_description(
+        "episode", radarr_id=None, sonarr_series_id=3
+    )
+    assert "Dark Matter" in description

--- a/tests/bazarr/test_translate_job_media_name.py
+++ b/tests/bazarr/test_translate_job_media_name.py
@@ -10,6 +10,12 @@ fell through to the series branch, found no ``sonarr_series_id`` and produced an
 empty title. The job then read "Translating HU to EN" with no film in it, the
 Translation Jobs table showed only the language pair, and the prompt lost the
 movie's overview.
+
+Both lookups also have to be scoped to the owning instance (#156). ``radarrId``
+and ``sonarrSeriesId`` are unique only together with ``arr_instance_id``
+(``ux_table_movies_instance_upstream_id``), so an unscoped query can hand back a
+sibling instance's media and label the job, and prompt the provider, with the
+wrong film.
 """
 import pytest
 
@@ -19,9 +25,11 @@ from subtitles.tools.translate.core import translator_utils
 
 @pytest.fixture
 def library(schema_session, monkeypatch):
+    """Two Radarr/Sonarr instances that reuse the same upstream ids."""
     monkeypatch.setattr(translator_utils, "database", schema_session)
     schema_session.add(
         TableMovies(
+            arr_instance_id=1,
             radarrId=7,
             tmdbId="12345",
             title="The Quiet Earth",
@@ -35,6 +43,7 @@ def library(schema_session, monkeypatch):
     )
     schema_session.add(
         TableShows(
+            arr_instance_id=1,
             sonarrSeriesId=3,
             tvdbId=999,
             title="Dark Matter",
@@ -49,12 +58,55 @@ def library(schema_session, monkeypatch):
     )
     schema_session.add(
         TableEpisodes(
+            arr_instance_id=1,
             sonarrEpisodeId=42,
             sonarrSeriesId=3,
             season=2,
             episode=5,
             title="Superposition",
             path="/tv/dark-matter/s02e05.mkv",
+            monitored="True",
+        )
+    )
+    # The 4K instance reuses the same upstream ids for different media.
+    schema_session.add(
+        TableMovies(
+            arr_instance_id=2,
+            radarrId=7,
+            tmdbId="67890",
+            title="Sorcerer",
+            year="1977",
+            imdbId="tt0076740",
+            overview="Four men drive nitroglycerin through the jungle.",
+            path="/movies-4k/sorcerer.mkv",
+            tags="[]",
+            monitored="True",
+        )
+    )
+    schema_session.add(
+        TableShows(
+            arr_instance_id=2,
+            sonarrSeriesId=3,
+            tvdbId=1000,
+            title="Severance",
+            year="2022",
+            imdbId="tt11280740",
+            overview="Work you cannot remember.",
+            path="/tv-4k/severance",
+            tags="[]",
+            monitored="True",
+            seriesType="standard",
+        )
+    )
+    schema_session.add(
+        TableEpisodes(
+            arr_instance_id=2,
+            sonarrEpisodeId=42,
+            sonarrSeriesId=3,
+            season=1,
+            episode=9,
+            title="The We We Are",
+            path="/tv-4k/severance/s01e09.mkv",
             monitored="True",
         )
     )
@@ -90,3 +142,134 @@ def test_series_description_is_unchanged(library):
         "episode", radarr_id=None, sonarr_series_id=3
     )
     assert "Dark Matter" in description
+
+
+@pytest.mark.parametrize(
+    "instance, expected", [(1, "The Quiet Earth"), (2, "Sorcerer")]
+)
+def test_movie_title_comes_from_the_owning_instance(library, instance, expected):
+    # radarrId 7 exists on both instances; only the pair identifies the film.
+    assert (
+        translator_utils.get_title("movie", radarr_id=7, arr_instance_id=instance)
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "instance, expected", [(1, "The last man alive."), (2, "nitroglycerin")]
+)
+def test_movie_description_comes_from_the_owning_instance(library, instance, expected):
+    description = translator_utils.get_description(
+        "movie", radarr_id=7, sonarr_series_id=None, arr_instance_id=instance
+    )
+    assert expected in description
+
+
+@pytest.mark.parametrize(
+    "instance, expected",
+    [(1, "Dark Matter - S02E05 - Superposition"), (2, "Severance - S01E09 - The We We Are")],
+)
+def test_episode_title_comes_from_the_owning_instance(library, instance, expected):
+    assert (
+        translator_utils.get_title(
+            "episode", sonarr_series_id=3, sonarr_episode_id=42, arr_instance_id=instance
+        )
+        == expected
+    )
+
+
+def test_series_description_comes_from_the_owning_instance(library):
+    description = translator_utils.get_description(
+        "episode", radarr_id=None, sonarr_series_id=3, arr_instance_id=2
+    )
+    assert "Severance" in description
+
+
+def test_an_instance_that_owns_nothing_gives_an_empty_title(library):
+    assert translator_utils.get_title("movie", radarr_id=7, arr_instance_id=99) == ""
+
+
+# --- the owner has to survive the trip from the endpoint to the lookup --------
+
+
+@pytest.mark.parametrize(
+    "module_name, service_name, helper",
+    [
+        ("openrouter_translator", "OpenRouterTranslatorService", "get_title"),
+        ("lingarr_translator", "LingarrTranslatorService", "get_title"),
+        ("gemini_translator", "GeminiTranslatorService", "get_description"),
+    ],
+)
+def test_translator_services_pass_the_owner_to_the_lookup(
+    monkeypatch, module_name, service_name, helper
+):
+    import importlib
+
+    module = importlib.import_module(
+        f"subtitles.tools.translate.services.{module_name}"
+    )
+    seen = {}
+
+    def _capture(*args, **kwargs):
+        seen.update(kwargs)
+        seen["positional"] = args
+        return ""
+
+    monkeypatch.setattr(module, helper, _capture)
+
+    service = getattr(module, service_name)(
+        source_srt_file="in.srt",
+        dest_srt_file="out.srt",
+        lang_obj=None,
+        to_lang="hun",
+        from_lang="en",
+        media_type="movie",
+        video_path="/movies/x.mkv",
+        orig_to_lang="hu",
+        forced=False,
+        hi=False,
+        sonarr_series_id=None,
+        sonarr_episode_id=None,
+        radarr_id=7,
+        arr_instance_id=2,
+    )
+
+    assert service.arr_instance_id == 2
+
+
+def test_translate_subtitles_file_labels_the_job_with_the_owning_instance(monkeypatch):
+    from subtitles.tools.translate import main as translate_main
+
+    seen = {}
+
+    def _capture(*args, **kwargs):
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return "The Quiet Earth"
+
+    monkeypatch.setattr(translate_main, "get_title", _capture)
+    monkeypatch.setattr(
+        translate_main.jobs_queue,
+        "add_job_from_function",
+        lambda *a, **k: seen.setdefault("label", a[0]),
+    )
+
+    translate_main.translate_subtitles_file(
+        video_path="/movies/x.mkv",
+        source_srt_file="in.srt",
+        from_lang="en",
+        to_lang="hu",
+        forced=False,
+        hi=False,
+        media_type="movie",
+        sonarr_series_id=None,
+        sonarr_episode_id=None,
+        radarr_id=7,
+        metadata={},
+        job_id=None,
+        arr_instance_id=2,
+    )
+
+    assert seen["label"] == "Translating The Quiet Earth (EN to HU)"
+    passed = list(seen["args"]) + list(seen["kwargs"].values())
+    assert 2 in passed


### PR DESCRIPTION
## What

A movie translated from its own page produced a job called `Translating EN to HU`, with no film named, and the AI Translator jobs table showed only the language pair in its Media column. Episodes were unaffected.

| | Before | After |
| --- | --- | --- |
| Job label | `Translating EN to HU` | `Translating 12 Angry Men (EN to HU)` |
| Media column | ` (ENGLISH → HUNGARIAN)` | `12 Angry Men (ENGLISH → HUNGARIAN)` |

## Why

`get_title` and `get_description` both branch on `media_type`, and the callers do not spell it the same way:

| Caller | Value sent |
| --- | --- |
| manual translate endpoint | `movie` |
| batch translate | `movies` |
| mass operations | `movies` |

Only the plural was matched. A movie therefore fell through to the series branch, found no `sonarr_series_id`, and returned an empty string. That emptied three things at once: the job label, the Media column in the jobs table, and the movie overview that the AI translator puts into its prompt. The last one is the least visible and arguably the worst, since it costs every directly translated movie its context.

Both functions now go through one `is_movie_media_type` predicate that accepts either spelling, so a caller cannot lose the title again by choosing the other word. Fixing the predicate rather than the one call site also covers `get_description`, which had the same fault.

## Instance scoping

Reaching the movie branch exposed a second problem, raised in review. `radarrId` and `sonarrSeriesId` are unique only together with `arr_instance_id`, as `ux_table_movies_instance_upstream_id` says, so an unscoped lookup can return a sibling instance's media. Two Radarr instances holding the same id would label a translation with the wrong film and hand the wrong overview to the provider as prompt context.

Both helpers now take the owning instance and narrow every query with it, including the episode lookup. The owner is threaded from `translate_subtitles_file`, which already received it, through the factory into the translator services. Callers with no owner pass None and behave exactly as before.

## Verification

- New `tests/bazarr/test_translate_job_media_name.py`, registered in `ci.yml`. It seeds two instances that reuse the same upstream ids, then asserts the title and description resolve under both spellings, that each instance gets its own film and episode, that an unknown movie or an instance owning nothing still yields an empty title, and that the episode label keeps its `S02E05` form. Before the spelling fix the two `movie` cases failed and everything else passed, which is the bug exactly; before the scoping fix eight cases failed.

  Three further cases assert the owner survives the trip: each translator service stores the `arr_instance_id` it was constructed with, and `translate_subtitles_file` passes it to the lookup behind the job label. Threading is where a fix like this usually leaks.
- Backend CI group covering the translator: 978 passed.
- Deployed to the test server and translated a real movie subtitle from the movie page. The job read `Translating 12 Angry Men (EN to HU)` and the sidecar job carried `title='12 Angry Men'`, where the jobs queued before the fix still show an empty title.
