### PR TITLE
fix(upload): show saved subtitles before background synchronization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
             tests/bazarr/test_processing_sync_substep.py \
             tests/bazarr/test_mass_download_path_mapping.py \
             tests/bazarr/test_processing_postprocessing.py \
+            tests/bazarr/test_upload_background_sync.py \
             tests/bazarr/test_sync_progress_report.py \
             tests/bazarr/test_subsync_engines.py \
             tests/bazarr/test_autosubsync_diagnostics.py \

--- a/bazarr/subtitles/sync.py
+++ b/bazarr/subtitles/sync.py
@@ -5,7 +5,7 @@ import logging
 import gc
 
 from app.config import settings
-from app.jobs_queue import jobs_queue
+from app.jobs_queue import jobs_queue, JobCancelled
 from subtitles.tools.subsyncer import SubSyncer
 from subtitles.tools.subsync_engines import (
     DEFAULT_ENABLED_ENGINES,
@@ -18,6 +18,7 @@ from subtitles.tools.subsync_engines import (
     REASON_MISSING_ENGINE,
     REASON_OUTPUT_EXISTS,
     REASON_RESULT_REJECTED,
+    REASON_SOURCE_CHANGED,
     is_sync_engine_output,
     normalize_enabled_engines,
 )
@@ -38,6 +39,7 @@ _ENGINE_OUTCOME_SENTENCES = {
                              "when it cannot confidently align a file. {message}"),
     REASON_RESULT_REJECTED: "{label} result rejected: {message}",
     REASON_ENGINE_FAILED: "{label} failed: {message}",
+    REASON_SOURCE_CHANGED: "The uploaded subtitle was replaced or deleted. Sync was skipped.",
 }
 _ENGINE_MESSAGE_LIMIT = 160
 
@@ -251,7 +253,8 @@ def sync_subtitles(video_path,
                    callback=None,
                    track_job_progress=True,
                    arr_instance_id=None,
-                   owns_job_progress=True):
+                   owns_job_progress=True,
+                   source_version=None):
     # The audio-sync settings resolve against the owning instance (#227); a None
     # owner / unset override yields the global value, so legacy paths are
     # unchanged. The use_subsync gate is evaluated inline via the module-level
@@ -322,12 +325,14 @@ def sync_subtitles(video_path,
             'arr_instance_id': arr_instance_id,
         }
         sync_result = None
+        if source_version is not None:
+            sync_kwargs['source_version'] = source_version
         try:
             sync_result = subsync.sync(**sync_kwargs)
             if sync_result and sync_result.success:
-                if callback:
+                if callback and source_version is None:
                     callback()
-                elif getattr(sync_result, 'output_mode', None) == OUTPUT_MODE_KEEP_ALL:
+                elif not callback and getattr(sync_result, 'output_mode', None) == OUTPUT_MODE_KEEP_ALL:
                     _index_keep_all_outputs(
                         video_path,
                         sonarr_series_id=sonarr_series_id,
@@ -335,6 +340,8 @@ def sync_subtitles(video_path,
                         radarr_id=radarr_id,
                         arr_instance_id=arr_instance_id,
                     )
+        except JobCancelled:
+            raise
         except Exception:
             logging.exception(f'BAZARR an unhandled exception occurs during the synchronization process for this '  # noqa: G004
                               f'subtitle file: {srt_path}')
@@ -342,6 +349,8 @@ def sync_subtitles(video_path,
         else:
             return bool(sync_result and sync_result.success)
         finally:
+            if callback and source_version is not None:
+                callback()
             report(_sync_outcome_message(sync_result), value='max',
                    name=_sync_complete_job_name(srt_path, sync_result))
             del subsync

--- a/bazarr/subtitles/tools/delete.py
+++ b/bazarr/subtitles/tools/delete.py
@@ -15,6 +15,7 @@ from utilities.autopulse_webhook import call_external_webhook
 from subtitles.indexer.series import store_subtitles
 from subtitles.indexer.movies import store_subtitles_movie
 from subtitles.processing import ProcessSubtitlesResult
+from subtitles.tools.subsync_engines import subtitle_write_lock
 from sonarr.history import history_log
 from radarr.history import history_log_movie
 from sonarr.notify import notify_sonarr
@@ -81,64 +82,64 @@ def delete_subtitles(media_type, language, forced, hi, media_path, subtitles_pat
                                     hearing_impaired=None)
 
     if media_type == 'series':
-        try:
-            os.remove(pr(subtitles_path))
-        except OSError:
-            logging.exception(f'BAZARR cannot delete subtitles file: {subtitles_path}')  # noqa: G004
+        with subtitle_write_lock(media_path, os.path.dirname(pr(subtitles_path))):
+            try:
+                os.remove(pr(subtitles_path))
+            except OSError:
+                logging.exception(f'BAZARR cannot delete subtitles file: {subtitles_path}')  # noqa: G004
+                store_subtitles(prr(media_path), media_path, arr_instance_id=arr_instance_id)
+                return False
             store_subtitles(prr(media_path), media_path, arr_instance_id=arr_instance_id)
-            return False
-        else:
-            history_log(0, sonarr_series_id, sonarr_episode_id, result, arr_instance_id=arr_instance_id)
-            store_subtitles(prr(media_path), media_path, arr_instance_id=arr_instance_id)
-            # Route the rescan at the OWNING instance's Sonarr (#156); None
-            # owner = default server (legacy single-instance), unchanged.
-            notify_sonarr(sonarr_series_id,
-                          arr_client=client_for_instance(database, arr_instance_id, enabled_only=False))
-            event_stream(type='series', action='update', payload=sonarr_series_id)
-            event_stream(type='episode-wanted', action='update', payload=sonarr_episode_id)
+        history_log(0, sonarr_series_id, sonarr_episode_id, result, arr_instance_id=arr_instance_id)
+        # Route the rescan at the OWNING instance's Sonarr (#156); None
+        # owner = default server (legacy single-instance), unchanged.
+        notify_sonarr(sonarr_series_id,
+                      arr_client=client_for_instance(database, arr_instance_id, enabled_only=False))
+        event_stream(type='series', action='update', payload=sonarr_series_id)
+        event_stream(type='episode-wanted', action='update', payload=sonarr_episode_id)
 
-            if settings.general.use_plex and settings.plex.update_series_library:
-                plex_refresh_item(metadata.imdbId, is_movie=False, season=metadata.season,
-                                  episode=metadata.episode)
-            if settings.general.use_jellyfin and settings.jellyfin.update_series_library:
-                jellyfin_refresh_item(metadata.imdbId, is_movie=False, season=metadata.season,
-                                      episode=metadata.episode, tvdb_id=metadata.tvdbId)
+        if settings.general.use_plex and settings.plex.update_series_library:
+            plex_refresh_item(metadata.imdbId, is_movie=False, season=metadata.season,
+                              episode=metadata.episode)
+        if settings.general.use_jellyfin and settings.jellyfin.update_series_library:
+            jellyfin_refresh_item(metadata.imdbId, is_movie=False, season=metadata.season,
+                                  episode=metadata.episode, tvdb_id=metadata.tvdbId)
 
-            # Call external webhook after all processing is complete
-            call_external_webhook(
-                subtitle_path=subtitles_path,
-                media_path=media_path,
-                language=language_log,
-                media_type=media_type
-            )
+        # Call external webhook after all processing is complete
+        call_external_webhook(
+            subtitle_path=subtitles_path,
+            media_path=media_path,
+            language=language_log,
+            media_type=media_type
+        )
 
-            return True
+        return True
     else:
-        try:
-            os.remove(pr(subtitles_path))
-        except OSError:
-            logging.exception(f'BAZARR cannot delete subtitles file: {subtitles_path}')  # noqa: G004
+        with subtitle_write_lock(media_path, os.path.dirname(pr(subtitles_path))):
+            try:
+                os.remove(pr(subtitles_path))
+            except OSError:
+                logging.exception(f'BAZARR cannot delete subtitles file: {subtitles_path}')  # noqa: G004
+                store_subtitles_movie(prr(media_path), media_path, arr_instance_id=arr_instance_id)
+                return False
             store_subtitles_movie(prr(media_path), media_path, arr_instance_id=arr_instance_id)
-            return False
-        else:
-            history_log_movie(0, radarr_id, result, arr_instance_id=arr_instance_id)
-            store_subtitles_movie(prr(media_path), media_path, arr_instance_id=arr_instance_id)
-            notify_radarr(radarr_id,
-                          arr_client=client_for_instance(database, arr_instance_id, enabled_only=False))
-            event_stream(type='movie-wanted', action='update', payload=radarr_id)
+        history_log_movie(0, radarr_id, result, arr_instance_id=arr_instance_id)
+        notify_radarr(radarr_id,
+                      arr_client=client_for_instance(database, arr_instance_id, enabled_only=False))
+        event_stream(type='movie-wanted', action='update', payload=radarr_id)
 
-            if settings.general.use_plex and settings.plex.update_movie_library:
-                plex_refresh_item(metadata.imdbId, is_movie=True)
-            if settings.general.use_jellyfin and settings.jellyfin.update_movie_library:
-                jellyfin_refresh_item(metadata.imdbId, is_movie=True,
-                                      tmdb_id=metadata.tmdbId)
+        if settings.general.use_plex and settings.plex.update_movie_library:
+            plex_refresh_item(metadata.imdbId, is_movie=True)
+        if settings.general.use_jellyfin and settings.jellyfin.update_movie_library:
+            jellyfin_refresh_item(metadata.imdbId, is_movie=True,
+                                  tmdb_id=metadata.tmdbId)
 
-            # Call external webhook after all processing is complete
-            call_external_webhook(
-                subtitle_path=subtitles_path,
-                media_path=media_path,
-                language=language_log,
-                media_type=media_type
-            )
-            
-            return True
+        # Call external webhook after all processing is complete
+        call_external_webhook(
+            subtitle_path=subtitles_path,
+            media_path=media_path,
+            language=language_log,
+            media_type=media_type
+        )
+
+        return True

--- a/bazarr/subtitles/tools/subsync_engines.py
+++ b/bazarr/subtitles/tools/subsync_engines.py
@@ -4,7 +4,44 @@ import logging
 import os
 import tempfile
 from dataclasses import dataclass, field
+from contextlib import nullcontext
 from pathlib import Path
+from threading import Lock, RLock
+from weakref import WeakValueDictionary
+
+
+_subtitle_write_locks = WeakValueDictionary()
+_subtitle_write_locks_guard = Lock()
+
+
+def subtitle_write_lock(video_path, subtitle_directory):
+    """Coordinate one media destination, including its subtitle language variants.
+
+    The saver can change HI tags and format extensions. The target directory and
+    video stem identify their shared destination without predicting those names.
+    Weak references release idle locks once all participating operations finish.
+    """
+    key = (os.path.normcase(os.path.realpath(subtitle_directory)),
+           os.path.normcase(os.path.splitext(os.path.basename(video_path))[0]))
+    with _subtitle_write_locks_guard:
+        lock = _subtitle_write_locks.get(key)
+        if lock is None:
+            lock = RLock()
+            _subtitle_write_locks[key] = lock
+        return lock
+
+
+def subtitle_source_version(path):
+    """Identify the saved file a queued upload sync is allowed to replace."""
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return None
+    return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns)
+
+
+class SubtitleSourceChanged(Exception):
+    """The upload was replaced or deleted while its sync was queued or running."""
 
 
 SYNC_ENGINES = ('ffsubsync', 'autosubsync', 'alass')
@@ -46,6 +83,7 @@ REASON_FAILURE_THRESHOLD = 'failure_threshold'
 REASON_ENGINE_DECLINED = 'engine_declined'
 REASON_RESULT_REJECTED = 'result_rejected'
 REASON_ENGINE_FAILED = 'engine_failed'
+REASON_SOURCE_CHANGED = 'source_changed'
 
 ENGINE_LABELS = {
     'ffsubsync': 'FFsubsync',
@@ -409,7 +447,8 @@ class SubsyncEngineRunner:
 
         return output_stat.st_size > 0 and output_stat.st_mtime_ns >= source_stat.st_mtime_ns
 
-    def run(self, srt_path, output_mode, enabled_engines, execute_engine, force_sync=False):
+    def run(self, srt_path, output_mode, enabled_engines, execute_engine, force_sync=False,
+            source_version=None, before_publish=None, publication_lock=None):
         output_mode = normalize_output_mode(output_mode)
         result = SyncRunResult(source_path=srt_path, output_mode=output_mode)
 
@@ -423,9 +462,15 @@ class SubsyncEngineRunner:
             return result
 
         for engine in normalize_enabled_engines(enabled_engines):
+            if source_version is not None and subtitle_source_version(srt_path) != source_version:
+                result.results.append(SyncEngineResult(
+                    engine=engine, status=RESULT_SKIPPED, reason=REASON_SOURCE_CHANGED,
+                    message='The uploaded subtitle was replaced or deleted.',
+                ))
+                break
             final_engine_output_path = engine_output_path(srt_path, engine)
             output_path = (
-                final_engine_output_path if output_mode == OUTPUT_MODE_KEEP_ALL
+                final_engine_output_path if output_mode == OUTPUT_MODE_KEEP_ALL and source_version is None
                 else temporary_engine_output_path(srt_path, engine)
             )
 
@@ -462,10 +507,19 @@ class SubsyncEngineRunner:
 
                 generated_path = str(output_path)
                 final_output_path = output_path
-                if output_mode == OUTPUT_MODE_OVERWRITE:
-                    os.replace(str(output_path), srt_path)
-                    final_output_path = Path(srt_path)
-                    generated_path = None
+                with publication_lock or nullcontext():
+                    if before_publish:
+                        before_publish()
+                    if source_version is not None and subtitle_source_version(srt_path) != source_version:
+                        raise SubtitleSourceChanged()
+                    if output_mode == OUTPUT_MODE_OVERWRITE:
+                        os.replace(str(output_path), srt_path)
+                        final_output_path = Path(srt_path)
+                        generated_path = None
+                    elif source_version is not None:
+                        os.replace(str(output_path), str(final_engine_output_path))
+                        final_output_path = final_engine_output_path
+                        generated_path = str(final_engine_output_path)
 
                 self.failure_store.record_success(srt_path, engine)
                 result.results.append(SyncEngineResult(
@@ -479,6 +533,14 @@ class SubsyncEngineRunner:
                 if output_mode == OUTPUT_MODE_OVERWRITE:
                     break
 
+            except SubtitleSourceChanged:
+                if output_path.is_file():
+                    output_path.unlink()
+                result.results.append(SyncEngineResult(
+                    engine=engine, status=RESULT_SKIPPED, reason=REASON_SOURCE_CHANGED,
+                    message='The uploaded subtitle was replaced or deleted.',
+                ))
+                break
             except MissingSyncEngineError as exc:
                 logging.warning('BAZARR %s sync engine skipped: %s', engine, exc)
                 result.results.append(SyncEngineResult(
@@ -519,6 +581,11 @@ class SubsyncEngineRunner:
                 ))
 
             except Exception as exc:
+                if before_publish:
+                    from app.jobs_queue import JobCancelled
+                    if isinstance(exc, JobCancelled):
+                        self._discard_engine_output(srt_path, engine, output_path, exc, record=False)
+                        raise
                 logging.exception('BAZARR %s sync engine failed for %s', engine, srt_path)
                 self._discard_engine_output(srt_path, engine, output_path, exc)
                 result.results.append(SyncEngineResult(

--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -22,6 +22,7 @@ from subtitles.tools.subsync_engines import (
     normalize_enabled_engines,
     normalize_output_mode,
     validate_engine_result,
+    subtitle_write_lock,
 )
 from languages.get_languages import audio_language_from_name, language_from_alpha2
 from utilities.path_mappings import path_mappings
@@ -523,7 +524,7 @@ class SubSyncer:
     def sync(self, video_path, srt_path, srt_lang, hi, forced,
              max_offset_seconds, no_fix_framerate, gss, reference=None, sonarr_series_id=None, sonarr_episode_id=None,
              radarr_id=None, progress_callback=None, job_id=None, force_sync=False, output_mode=None,
-             enabled_engines=None, write_history=True, arr_instance_id=None):
+             enabled_engines=None, write_history=True, arr_instance_id=None, source_version=None):
         self.reference = video_path
         self.srtin = srt_path
         self.progress_callback = progress_callback
@@ -586,12 +587,17 @@ class SubSyncer:
             return raw_result
 
         runner = SubsyncEngineRunner()
+        source_options = {'source_version': source_version} if source_version is not None else {}
+        if source_version is not None:
+            source_options['before_publish'] = lambda: self._report_progress('Saving synchronized subtitle', None, None)
+            source_options['publication_lock'] = subtitle_write_lock(video_path, os.path.dirname(srt_path))
         self.sync_result = runner.run(
             srt_path=self.srtin,
             output_mode=output_mode,
             enabled_engines=enabled_engines,
             execute_engine=execute_engine,
             force_sync=force_sync,
+            **source_options,
         )
 
         if settings.subsync.debug:

--- a/bazarr/subtitles/upload.py
+++ b/bazarr/subtitles/upload.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import logging
+from functools import partial
 
 from subzero.language import Language
 from subliminal_patch.core import save_subtitles
@@ -28,14 +29,22 @@ from app.jobs_queue import jobs_queue
 from app.event_handler import event_stream
 from app.notifier import send_notifications
 from app.notifier import send_notifications_movie
-from subtitles.indexer.series import store_subtitles
-from subtitles.indexer.movies import store_subtitles_movie
 from subtitles.processing import ProcessSubtitlesResult
+from subtitles.tools.subsync_engines import subtitle_source_version, subtitle_write_lock
 
-from .sync import sync_subtitles
+from .sync import sync_subtitles, _index_keep_all_outputs
 from .post_processing import postprocessing
 from plex.operations import plex_set_movie_added_date_now, plex_set_episode_added_date_now, plex_refresh_item
 from jellyfin.operations import jellyfin_refresh_item
+
+
+def _refresh_uploaded_subtitles(video_path, subtitle_path, sonarr_series_id=None, sonarr_episode_id=None,
+                                radarr_id=None, arr_instance_id=None):
+    # Keep the scan and its database update together with save/delete operations.
+    with subtitle_write_lock(video_path, os.path.dirname(subtitle_path)):
+        _index_keep_all_outputs(video_path, sonarr_series_id=sonarr_series_id,
+                               sonarr_episode_id=sonarr_episode_id, radarr_id=radarr_id,
+                               arr_instance_id=arr_instance_id)
 
 
 def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, filename, audio_language, job_id=None,
@@ -133,14 +142,18 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
     try:
         # ensure that formats must be a tuple of strings
         sub_format = (sub.format,) if isinstance(sub.format, str) else sub.format
-        saved_subtitles = save_subtitles(path,
-                                         [sub],
-                                         single=single,
-                                         tags=None,  # fixme
-                                         directory=get_target_folder(path),
-                                         chmod=chmod,
-                                         formats=sub_format if use_original_format else ("srt",),
-                                         path_decoder=force_unicode)
+        subtitle_directory = get_target_folder(path)
+        write_lock = subtitle_write_lock(path, subtitle_directory or os.path.dirname(path))
+        with write_lock:
+            saved_subtitles = save_subtitles(path,
+                                            [sub],
+                                            single=single,
+                                            tags=None,  # fixme
+                                            directory=subtitle_directory,
+                                            chmod=chmod,
+                                            formats=sub_format if use_original_format else ("srt",),
+                                            path_decoder=force_unicode)
+            source_version = subtitle_source_version(saved_subtitles[0].storage_path) if saved_subtitles else None
     except Exception as e:
         logging.exception(f'BAZARR Error saving Subtitles file to disk for this file {path}: {repr(e)}')  # noqa: G004
         return
@@ -185,14 +198,18 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
                              uploaded_language_code3, audio_language['name'], audio_language['code2'],
                              audio_language['code3'], 100, "1", "manual", "user", "unknown", sonarrSeriesId,
                              sonarrEpisodeId or radarrId,)
-        postprocessing(command, path)
-        set_chmod(subtitles_path=subtitle_path)
+        with write_lock:
+            if subtitle_source_version(subtitle_path) == source_version:
+                postprocessing(command, path)
+                set_chmod(subtitles_path=subtitle_path)
+                source_version = subtitle_source_version(subtitle_path)
+
+    refresh_subtitles = partial(_refresh_uploaded_subtitles, path, subtitle_path, sonarr_series_id=sonarrSeriesId,
+                                sonarr_episode_id=sonarrEpisodeId, radarr_id=radarrId,
+                                arr_instance_id=arr_instance_id)
+    refresh_subtitles()
 
     if media_type == 'series':
-        sync_subtitles(video_path=path, srt_path=subtitle_path, srt_lang=uploaded_language_code2, percent_score=100,
-                       sonarr_series_id=episode_metadata.sonarrSeriesId, forced=forced, hi=hi,
-                       sonarr_episode_id=episode_metadata.sonarrEpisodeId, job_id=job_id,
-                       arr_instance_id=arr_instance_id)
         # Reverse-map through the owning instance's path_mappings (#156); None
         # owner => global mapping (the default/single-instance path), unchanged.
         reversed_path = path_mappings.path_replace_reverse_instance(path, arr_instance_id, "series")
@@ -205,9 +222,6 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
         event_stream(type='series', action='update', payload=episode_metadata.sonarrSeriesId)
         event_stream(type='episode-wanted', action='delete', payload=episode_metadata.sonarrEpisodeId)
     else:
-        sync_subtitles(video_path=path, srt_path=subtitle_path, srt_lang=uploaded_language_code2, percent_score=100,
-                       radarr_id=movie_metadata.radarrId, forced=forced, hi=hi, job_id=job_id,
-                       arr_instance_id=arr_instance_id)
         # Reverse-map through the owning instance's path_mappings (#156); None
         # owner => global mapping (the default/single-instance path), unchanged.
         reversed_path = path_mappings.path_replace_reverse_instance(path, arr_instance_id, "movie")
@@ -242,7 +256,6 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
             if not settings.general.dont_notify_manual_actions:
                 send_notifications(sonarrSeriesId, sonarrEpisodeId, result.message,
                                    arr_instance_id=arr_instance_id)
-            store_subtitles(result.path, path, arr_instance_id=arr_instance_id)
             if settings.general.use_plex:
                 if settings.plex.update_series_library:
                     plex_refresh_item(episode_metadata.imdbId, is_movie=False,
@@ -258,7 +271,6 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
                               arr_instance_id=arr_instance_id)
             if not settings.general.dont_notify_manual_actions:
                 send_notifications_movie(radarrId, result.message, arr_instance_id=arr_instance_id)
-            store_subtitles_movie(result.path, path, arr_instance_id=arr_instance_id)
             if settings.general.use_plex:
                 if settings.plex.update_movie_library:
                     plex_refresh_item(movie_metadata.imdbId, is_movie=True)
@@ -267,5 +279,12 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
             if settings.general.use_jellyfin and settings.jellyfin.update_movie_library:
                 jellyfin_refresh_item(movie_metadata.imdbId, is_movie=True,
                                       tmdb_id=movie_metadata.tmdbId)
+
+    if source_version is not None:
+        sync_subtitles(video_path=path, srt_path=subtitle_path, srt_lang=uploaded_language_code2,
+                       percent_score=100, forced=forced, hi=hi, sonarr_series_id=sonarrSeriesId,
+                       sonarr_episode_id=sonarrEpisodeId, radarr_id=radarrId,
+                       arr_instance_id=arr_instance_id, callback=refresh_subtitles,
+                       source_version=source_version)
 
     return '', 204

--- a/tests/bazarr/test_upload_background_sync.py
+++ b/tests/bazarr/test_upload_background_sync.py
@@ -1,0 +1,571 @@
+"""Manual uploads remain visible while their separate sync job is running."""
+
+from io import BytesIO
+import ast
+from pathlib import Path
+from threading import Event, Thread
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.fixture
+def upload_flow(monkeypatch, tmp_path):
+    from app import jobs_queue as queue_module
+    from app.config import settings
+    from arr_instances import resolution
+    from languages import get_languages
+    from subtitles import manual, processing, sync, upload
+    from subtitles.indexer import movies, series
+    from subtitles.tools import delete, subsyncer
+    from subtitles.tools.subsync_engines import InMemorySubsyncFailureStore, SubsyncEngineRunner
+
+    queue = queue_module.JobsQueue()
+    events, indexes, history, notifications, sync_history, engine_calls = [], [], [], [], [], []
+    real_indexers = {"series": series.store_subtitles, "movie": movies.store_subtitles_movie}
+    controls = SimpleNamespace(fail=False)
+    engine_started, release_engine = Event(), Event()
+    video = tmp_path / "Video.mkv"
+    video.touch()
+    metadata = SimpleNamespace(sonarrSeriesId=10, sonarrEpisodeId=20, radarrId=30,
+                               profileId=1, imdbId="tt1", tvdbId=1, tmdbId=1,
+                               season=1, episode=1)
+    db = Mock()
+    db.execute.return_value.first.return_value = metadata
+    monkeypatch.setattr(get_languages, "languages_dict", [
+        {"code2": "en", "code3": "eng", "code3b": "eng", "name": "English"},
+    ], raising=False)
+    monkeypatch.setattr(upload, "database", db)
+    monkeypatch.setattr(delete, "database", db)
+    monkeypatch.setattr(upload, "get_profiles_list", lambda _: {"originalFormat": False})
+    monkeypatch.setattr(upload, "get_audio_profile_languages", lambda _: [])
+    monkeypatch.setattr(upload, "client_for_instance", lambda *a, **k: None)
+    monkeypatch.setattr(delete, "client_for_instance", lambda *a, **k: None)
+    monkeypatch.setattr(delete, "call_external_webhook", lambda **k: None)
+    monkeypatch.setattr(upload, "get_target_folder", lambda _: None)
+    monkeypatch.setattr(manual, "clear_mismatch_after_manual_save", lambda *a: None)
+    monkeypatch.setattr(processing, "_postprocessing_config", lambda *a: (False, "", False, 0))
+    monkeypatch.setattr(resolution, "_subtitle_settings_cache", {7: {}, 8: {}})
+    monkeypatch.setattr(upload.path_mappings, "path_replace_reverse_instance", lambda path, *a: path)
+    monkeypatch.setattr(upload.path_mappings, "path_replace_instance", lambda path, *a: path)
+    monkeypatch.setattr("utilities.media_ids.local_episode_id", lambda episode_id, owner: 2000 + owner)
+    for name, value in {"single_language": False, "chmod_enabled": False, "utf8_encode": True,
+                        "dont_notify_manual_actions": False, "use_plex": False, "use_jellyfin": False}.items():
+        monkeypatch.setattr(settings.general, name, value)
+    for name, value in {"use_subsync": True, "use_subsync_threshold": False,
+                        "use_subsync_movie_threshold": False, "enabled_engines": ["ffsubsync"],
+                        "output_mode": "overwrite", "debug": False}.items():
+        monkeypatch.setattr(settings.subsync, name, value)
+
+    def event(**kwargs):
+        if kwargs.get("type") in ("movie", "series", "episode"):
+            assert indexes, "media events must follow the first subtitle index"
+        events.append(kwargs)
+
+    def index(mapped_path, path, arr_instance_id=None):
+        indexes.append((arr_instance_id, {p.name: p.read_text() for p in Path(path).parent.glob("*.srt")}))
+
+    for module in (queue_module, upload, sync):
+        monkeypatch.setattr(module, "jobs_queue", queue)
+    for module in (queue_module, upload, delete):
+        monkeypatch.setattr(module, "event_stream", event)
+    monkeypatch.setattr("app.event_handler.event_stream", event)
+    monkeypatch.setattr(series, "store_subtitles", index)
+    monkeypatch.setattr(movies, "store_subtitles_movie", index)
+    monkeypatch.setattr(delete, "store_subtitles", index)
+    monkeypatch.setattr(delete, "store_subtitles_movie", index)
+    for name in ("history_log", "history_log_movie"):
+        monkeypatch.setattr(upload, name, lambda *a, **k: history.append((a, k)))
+        monkeypatch.setattr(delete, name, lambda *a, **k: None)
+    for name in ("notify_sonarr", "notify_radarr", "send_notifications", "send_notifications_movie"):
+        monkeypatch.setattr(upload, name, lambda *a, **k: notifications.append((a, k)))
+    for name in ("notify_sonarr", "notify_radarr"):
+        monkeypatch.setattr(delete, name, lambda *a, **k: None)
+    monkeypatch.setattr(subsyncer.SubSyncer, "_log_sync_history", lambda *a, **k: sync_history.append(k))
+    monkeypatch.setattr(subsyncer, "SubsyncEngineRunner", lambda: SubsyncEngineRunner(InMemorySubsyncFailureStore()))
+
+    def engine(self, output_path, **kwargs):
+        engine_calls.append(kwargs)
+        source = Path(self.srtin).read_text()
+        engine_started.set()
+        assert release_engine.wait(5), "test did not release sync engine"
+        output_path.write_text("1\n00:00:03,000 --> 00:00:04,000\nSynced " + source)
+        if controls.fail:
+            raise RuntimeError("controlled sync failure")
+        return {"offset_seconds": 0, "framerate_scale_factor": 1}
+
+    monkeypatch.setattr(subsyncer.SubSyncer, "_run_ffsubsync_engine", engine)
+
+    def submit(media_type, content="Uploaded", owner=7, **kwargs):
+        return upload.manual_upload_subtitle(
+            path=str(video), language="en", forced=kwargs.pop("forced", False),
+            hi=kwargs.pop("hi", False), media_type=media_type,
+            subtitle=BytesIO(f"1\n00:00:01,000 --> 00:00:02,000\n{content}\n".encode()),
+            filename="upload.srt", audio_language=[],
+            sonarrSeriesId=10 if media_type == "series" else None,
+            sonarrEpisodeId=20 if media_type == "series" else None,
+            radarrId=30 if media_type == "movie" else None,
+            arr_instance_id=owner, **kwargs)
+
+    threads = []
+
+    def start(job_id=None):
+        job = next(job for job in queue.jobs_pending_queue if job_id is None or job.job_id == job_id)
+        queue.jobs_pending_queue.remove(job)
+        queue.jobs_running_queue.append(job)
+        thread = Thread(target=queue._run_job, args=(job,))
+        threads.append(thread)
+        thread.start()
+        return job, thread
+
+    def remove(media_type):
+        return delete.delete_subtitles(media_type=media_type, language="en", forced=False, hi=False,
+                                       media_path=str(video), subtitles_path=str(video.with_suffix(".en.srt")),
+                                       sonarr_series_id=10, sonarr_episode_id=20, radarr_id=30, arr_instance_id=7)
+
+    yield SimpleNamespace(submit=submit, start=start, queue=queue, events=events, indexes=indexes,
+                          history=history, notifications=notifications, engine_started=engine_started,
+                          release_engine=release_engine, video=video, remove=remove, controls=controls,
+                          sync_history=sync_history, engine_calls=engine_calls, real_indexers=real_indexers)
+    release_engine.set()
+    for thread in threads:
+        thread.join(5)
+        assert not thread.is_alive()
+
+
+@pytest.mark.parametrize("media_type", ["movie", "series"])
+def test_saved_upload_is_visible_and_upload_completes_before_sync(upload_flow, media_type):
+    flow = upload_flow
+    upload_id = flow.submit(media_type)
+    upload_job, upload_thread = flow.start()
+    upload_thread.join(1)
+
+    assert (flow.video.parent / "Video.en.srt").is_file()
+    assert upload_job.status != "failed"
+    assert flow.indexes, "the saved subtitle is still hidden while sync is pending/running"
+    assert upload_job.status == "completed"
+    assert upload_job.job_returned_value == ("", 204)
+    assert len(flow.history) == 1
+    assert len(flow.queue.jobs_pending_queue) == 1
+    sync_job, sync_thread = flow.start()
+    assert flow.engine_started.wait(2)
+    assert sync_job.job_id != upload_id
+    assert sync_job.is_progress
+    assert sync_job.status == "running"
+    assert "Uploaded" in flow.indexes[-1][1]["Video.en.srt"]
+    flow.release_engine.set()
+    sync_thread.join(3)
+    assert sync_job.status == "completed"
+    assert "Synced" in flow.indexes[-1][1]["Video.en.srt"]
+    assert len(flow.history) == 1
+    assert len(flow.notifications) == 2
+    assert len(flow.sync_history) == 1
+
+
+@pytest.mark.parametrize("media_type", ["movie", "series"])
+@pytest.mark.parametrize("output_mode", ["overwrite", "keep_all"])
+@pytest.mark.parametrize("running", [False, True], ids=["queued", "running"])
+@pytest.mark.parametrize("change", ["upload", "delete"])
+def test_stale_sync_does_not_replace_a_new_upload_or_restore_a_deleted_file(
+        upload_flow, monkeypatch, media_type, output_mode, running, change):
+    from app.config import settings
+
+    monkeypatch.setattr(settings.subsync, "output_mode", output_mode)
+    flow = upload_flow
+    flow.submit(media_type)
+    job, thread = flow.start()
+    thread.join(2)
+    assert job.status == "completed"
+    sync_id = flow.queue.jobs_pending_queue[0].job_id
+    if running:
+        sync_job, sync_thread = flow.start(sync_id)
+        assert flow.engine_started.wait(2)
+
+    source = flow.video.parent / "Video.en.srt"
+    if change == "upload":
+        second_upload_id = flow.submit(media_type, content="New upload")
+        second_job, second_thread = flow.start(second_upload_id)
+        second_thread.join(2)
+        assert second_job.status == "completed"
+        assert "New upload" in source.read_text()
+    else:
+        source.unlink()
+
+    flow.release_engine.set()
+    if not running:
+        sync_job, sync_thread = flow.start(sync_id)
+    sync_thread.join(2)
+    assert sync_job.status == "completed"
+    if not running:
+        assert not flow.engine_started.is_set(), "outdated queued sync should skip its engines"
+    assert not (flow.video.parent / "Video.en.ffsubsync.srt").exists()
+    if change == "upload":
+        assert "New upload" in source.read_text()
+        assert "Synced" not in source.read_text()
+        latest_sync, latest_thread = flow.start()
+        latest_thread.join(2)
+        assert latest_sync.status == "completed"
+        output = source if output_mode == "overwrite" else source.with_name("Video.en.ffsubsync.srt")
+        assert "Synced" in output.read_text()
+        assert "New upload" in output.read_text()
+    else:
+        assert not source.exists()
+    assert not list(flow.video.parent.glob(".bazarr-sync-*"))
+
+
+@pytest.mark.parametrize("media_type", ["movie", "series"])
+def test_delete_during_sync_publication_cannot_be_undone(upload_flow, monkeypatch, media_type):
+    from subtitles.tools import subsync_engines
+
+    flow = upload_flow
+    flow.submit(media_type)
+    upload_job, upload_thread = flow.start()
+    upload_thread.join(2)
+    assert upload_job.status == "completed"
+    publishing, publish = Event(), Event()
+    real_replace = subsync_engines.os.replace
+
+    def paused_replace(source, destination):
+        publishing.set()
+        assert publish.wait(5)
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(subsync_engines.os, "replace", paused_replace)
+    flow.release_engine.set()
+    sync_job, sync_thread = flow.start()
+    assert publishing.wait(2)
+    deletion = Thread(target=flow.remove, args=(media_type,))
+    deletion.start()
+    try:
+        deletion.join(0.1)
+        assert deletion.is_alive(), "deletion must serialize with the checked output publication"
+    finally:
+        publish.set()
+        sync_thread.join(2)
+        deletion.join(2)
+    assert not deletion.is_alive()
+    assert not flow.video.with_suffix(".en.srt").exists()
+
+
+@pytest.mark.parametrize("media_type", ["movie", "series"])
+@pytest.mark.parametrize("outcome", ["failure", "cancel", "disabled", "forced", "threshold"])
+def test_optional_sync_failure_or_skip_keeps_the_successful_upload(upload_flow, monkeypatch, media_type, outcome):
+    from app.config import settings
+
+    flow = upload_flow
+    if outcome == "disabled":
+        monkeypatch.setattr(settings.subsync, "use_subsync", False)
+    if outcome == "threshold":
+        threshold = "subsync_threshold" if media_type == "series" else "subsync_movie_threshold"
+        monkeypatch.setattr(settings.subsync, "use_" + threshold, True)
+        monkeypatch.setattr(settings.subsync, threshold, 99)
+    flow.controls.fail = outcome == "failure"
+    flow.submit(media_type, forced=outcome == "forced")
+    upload_job, upload_thread = flow.start()
+    upload_thread.join(2)
+    assert upload_job.status == "completed"
+    before = flow.indexes[-1]
+    if outcome == "disabled":
+        assert not flow.queue.jobs_pending_queue
+    else:
+        sync_job, sync_thread = flow.start()
+        if outcome in ("cancel", "failure"):
+            assert flow.engine_started.wait(2)
+            if outcome == "cancel":
+                assert flow.queue.cancel_running_job(sync_job.job_id)
+        flow.release_engine.set()
+        sync_thread.join(2)
+        assert sync_job.status == "completed"
+        if outcome == "cancel":
+            assert sync_job.progress_message == "Cancelled by user"
+        assert sync_job.job_returned_value is not True
+    assert flow.indexes[-1] == before
+    assert len(flow.history) == 1
+    assert len(flow.notifications) == 2
+    assert not flow.sync_history
+    assert not list(flow.video.parent.glob(".bazarr-sync-*"))
+
+
+@pytest.mark.parametrize("media_type", ["movie", "series"])
+def test_upload_preserves_postprocessing_hi_and_notification_policy(upload_flow, monkeypatch, media_type):
+    from app.config import settings
+    from subtitles import processing, upload
+
+    flow = upload_flow
+    monkeypatch.setattr(settings.general, "dont_notify_manual_actions", True)
+    monkeypatch.setattr(processing, "_postprocessing_config", lambda kind, owner: (True, "process", False, 0))
+    monkeypatch.setattr(upload, "pp_replace", lambda *args: "process")
+    monkeypatch.setattr(upload, "set_chmod", lambda **kwargs: None)
+
+    def postprocess(command, video_path):
+        assert command == "process"
+        flow.video.with_suffix(".en.hi.srt").write_text("1\n00:00:01,000 --> 00:00:02,000\nProcessed\n")
+
+    monkeypatch.setattr(upload, "postprocessing", postprocess)
+    flow.submit(media_type, hi=True)
+    upload_job, upload_thread = flow.start()
+    upload_thread.join(2)
+    assert upload_job.status == "completed"
+    assert "Processed" in flow.indexes[-1][1]["Video.en.hi.srt"]
+    flow.release_engine.set()
+    sync_job, sync_thread = flow.start()
+    sync_thread.join(2)
+    assert sync_job.status == "completed"
+    assert "Synced" in flow.indexes[-1][1]["Video.en.hi.srt"]
+    assert "Processed" in flow.indexes[-1][1]["Video.en.hi.srt"]
+    assert len(flow.notifications) == 1
+    assert flow.sync_history[0]["hi"] is True
+
+
+@pytest.mark.parametrize("media_type", ["movie", "series"])
+def test_real_index_and_settings_stay_with_the_upload_owner(upload_flow, schema_session, monkeypatch, media_type):
+    from app.config import settings
+    from app.database import TableEpisodes, TableMovies, TableShows, select
+    from arr_instances import resolution
+    from subzero.language import Language
+    from subtitles import upload
+    from subtitles.indexer import movies, series
+    from subtitles.tools import subsyncer
+
+    flow = upload_flow
+    module = series if media_type == "series" else movies
+    table = TableEpisodes if media_type == "series" else TableMovies
+    for owner in (7, 8):
+        if media_type == "series":
+            schema_session.add(TableShows(id=owner, arr_instance_id=owner, sonarrSeriesId=10,
+                                          title="Show", path=str(flow.video.parent), profileId=None))
+            schema_session.flush()
+            row = TableEpisodes(id=owner, arr_instance_id=owner, series_id=owner,
+                                sonarrSeriesId=10, sonarrEpisodeId=20, title="Episode", path=str(flow.video),
+                                season=1, episode=1, subtitles="[]")
+        else:
+            row = TableMovies(id=owner, arr_instance_id=owner, radarrId=30, title="Movie",
+                              path=str(flow.video), tmdbId=str(owner), profileId=None, subtitles="[]")
+        schema_session.add(row)
+    schema_session.commit()
+    monkeypatch.setattr(upload, "database", schema_session)
+    monkeypatch.setattr(module, "database", schema_session)
+    monkeypatch.setattr(settings.general, "use_embedded_subs", False)
+    monkeypatch.setattr(settings.general, "subfolder", "current")
+    monkeypatch.setattr(module, "get_language_set", lambda: {Language.fromietf("en")})
+    monkeypatch.setattr(module.core, "CUSTOM_PATHS", [])
+    missing = "list_missing_subtitles" if media_type == "series" else "list_missing_subtitles_movies"
+    monkeypatch.setattr(module, missing, lambda *a, **k: None)
+    monkeypatch.setattr(module, "event_stream", lambda **kwargs: None)
+    real_index = flow.real_indexers[media_type]
+
+    def index(*args, **kwargs):
+        result = real_index(*args, **kwargs)
+        flow.indexes.append((kwargs["arr_instance_id"], result))
+        return result
+
+    monkeypatch.setattr(module, "store_subtitles" if media_type == "series" else "store_subtitles_movie", index)
+    resolution._subtitle_settings_cache[7] = {"subsync": {"use_subsync": False}}
+    resolution._subtitle_settings_cache[8] = {"subsync": {
+        "use_subsync": True, "enabled_engines": ["alass"], "max_offset_seconds": 17,
+        "use_subsync_threshold": True, "subsync_threshold": 100,
+        "use_subsync_movie_threshold": True, "subsync_movie_threshold": 100,
+    }}
+    monkeypatch.setattr(settings.subsync, "use_subsync", False)
+    monkeypatch.setattr(settings.subsync, "output_mode", "keep_all")
+    external_calls = []
+
+    def external(self, engine, output_path, video_path):
+        external_calls.append(engine)
+        output_path.write_text("1\n00:00:03,000 --> 00:00:04,000\nSynced\n")
+        return {"offset_seconds": 16, "framerate_scale_factor": 1}
+
+    monkeypatch.setattr(subsyncer.SubSyncer, "_run_external_engine", external)
+    flow.submit(media_type, owner=8)
+
+    def run_next():
+        job = flow.queue.jobs_pending_queue.popleft()
+        flow.queue.jobs_running_queue.append(job)
+        assert flow.queue._run_job(job)
+        return job
+
+    upload_job = run_next()
+    assert upload_job.job_returned_value == ("", 204)
+    before = ast.literal_eval(schema_session.execute(select(table.subtitles).where(table.id == 8)).scalar())
+    assert len(before) == 1 and before[0][0] == "en"
+    assert schema_session.execute(select(table.subtitles).where(table.id == 7)).scalar() == "[]"
+    sync_job = run_next()
+    assert sync_job.job_returned_value is True
+    after = ast.literal_eval(schema_session.execute(select(table.subtitles).where(table.id == 8)).scalar())
+    assert {row[0] for row in after} == {"en", "en:sync-alass"}
+    assert schema_session.execute(select(table.subtitles).where(table.id == 7)).scalar() == "[]"
+    assert external_calls == ["alass"]
+    assert all(row[0] == 8 for row in flow.indexes)
+    assert flow.history[0][1]["arr_instance_id"] == 8
+    assert flow.sync_history[0]["arr_instance_id"] == 8
+
+
+def test_unrelated_upload_finishes_while_other_media_postprocessing_is_blocked(upload_flow, monkeypatch):
+    from subtitles import processing, upload
+
+    flow = upload_flow
+    blocked, unblock, second_entered = Event(), Event(), Event()
+
+    def config(kind, owner):
+        if owner == 8:
+            second_entered.set()
+        return (owner == 7, 'controlled', False, 0)
+
+    def postprocess(command, video_path):
+        blocked.set()
+        assert unblock.wait(5), 'probe failed to release postprocessing'
+
+    monkeypatch.setattr(processing, '_postprocessing_config', config)
+    monkeypatch.setattr(upload, 'pp_replace', lambda *args: 'controlled')
+    monkeypatch.setattr(upload, 'postprocessing', postprocess)
+    monkeypatch.setattr(upload, 'set_chmod', lambda **kwargs: None)
+    flow.submit('movie', owner=7)
+    first_job, first_thread = flow.start()
+    assert blocked.wait(2)
+    other_video = flow.video.with_name('Unrelated.mkv')
+    other_video.touch()
+    second_id = upload.manual_upload_subtitle(
+        path=str(other_video), language='en', forced=False, hi=False, media_type='movie',
+        subtitle=BytesIO(b'1\n00:00:01,000 --> 00:00:02,000\nOther media\n'),
+        filename='other.srt', audio_language=[], radarrId=31, arr_instance_id=8)
+    second_job, second_thread = flow.start(second_id)
+    try:
+        assert second_entered.wait(2), 'second upload did not start'
+        second_thread.join(0.25)
+        completed_before_release = second_job.status == 'completed'
+        saved_before_release = other_video.with_suffix('.en.srt').exists()
+    finally:
+        unblock.set()
+        first_thread.join(2)
+        second_thread.join(2)
+    assert not first_thread.is_alive() and not second_thread.is_alive()
+    assert first_job.status == second_job.status == 'completed'
+    assert completed_before_release and saved_before_release, 'unrelated upload was blocked by another media postprocessing lock'
+
+
+@pytest.mark.parametrize("output_mode", ["overwrite", "keep_all"])
+def test_cancel_while_finished_engine_waits_for_publication_preserves_upload(upload_flow, monkeypatch, output_mode):
+    from app.config import settings
+    monkeypatch.setattr(settings.subsync, "output_mode", output_mode)
+    from subtitles.tools import subsync_engines, subsyncer
+
+    flow = upload_flow
+    flow.submit('movie')
+    upload_job, upload_thread = flow.start()
+    upload_thread.join(2)
+    assert upload_job.status == 'completed'
+    original = flow.video.with_suffix('.en.srt').read_bytes()
+    finished_checkpoint = Event()
+    real_report = subsyncer.SubSyncer._report_progress
+
+    def report(self, message, value, total):
+        result = real_report(self, message, value, total)
+        if message.startswith('Finished '):
+            finished_checkpoint.set()
+        return result
+
+    monkeypatch.setattr(subsyncer.SubSyncer, '_report_progress', report)
+    with subsync_engines.subtitle_write_lock(str(flow.video), str(flow.video.parent)):
+        flow.release_engine.set()
+        sync_job, sync_thread = flow.start()
+        assert finished_checkpoint.wait(2), 'engine did not reach publication boundary'
+        assert flow.video.with_suffix('.en.srt').read_bytes() == original
+        assert flow.queue.cancel_running_job(sync_job.job_id)
+    sync_thread.join(2)
+    assert not sync_thread.is_alive()
+    assert sync_job.progress_message == 'Cancelled by user'
+    assert flow.video.with_suffix('.en.srt').read_bytes() == original
+    assert not flow.video.with_suffix('.en.ffsubsync.srt').exists()
+    assert not list(flow.video.parent.glob('.bazarr-sync-*'))
+    assert not flow.sync_history
+
+
+@pytest.mark.parametrize("media_type", ["movie", "series"])
+def test_sync_reindex_cannot_restore_a_listing_after_successful_delete(upload_flow, monkeypatch, media_type):
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.sql.dml import Update
+    from app.config import settings
+    from app.database import Base, TableEpisodes, TableMovies, TableShows, select
+    from subzero.language import Language
+    from subtitles import upload
+    from subtitles.indexer import movies, series
+    from subtitles.tools import delete
+
+    flow = upload_flow
+    module = series if media_type == "series" else movies
+    table = TableEpisodes if media_type == "series" else TableMovies
+    engine = create_engine(f"sqlite:///{flow.video.parent / 'index.sqlite'}")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    with Session.begin() as session:
+        if media_type == "series":
+            session.add(TableShows(id=7, arr_instance_id=7, sonarrSeriesId=10,
+                                   title="Show", path=str(flow.video.parent), profileId=None))
+            session.flush()
+            session.add(TableEpisodes(id=7, arr_instance_id=7, series_id=7, sonarrSeriesId=10,
+                                      sonarrEpisodeId=20, title="Episode", path=str(flow.video),
+                                      season=1, episode=1, subtitles="[]"))
+        else:
+            session.add(TableMovies(id=7, arr_instance_id=7, radarrId=30, title="Movie",
+                                    path=str(flow.video), tmdbId="1", profileId=None, subtitles="[]"))
+    before_commit, commit = Event(), Event()
+    controls = {"armed": False}
+
+    class Database:
+        def execute(self, statement, *args, **kwargs):
+            if controls["armed"] and isinstance(statement, Update):
+                controls["armed"] = False
+                before_commit.set()
+                assert commit.wait(5)
+            with Session.begin() as session:
+                result = session.execute(statement, *args, **kwargs)
+                return result.freeze()() if statement.is_select else result
+
+    db = Database()
+    for item in (upload, delete, module):
+        monkeypatch.setattr(item, "database", db)
+    monkeypatch.setattr(settings.general, "use_embedded_subs", False)
+    monkeypatch.setattr(settings.general, "subfolder", "current")
+    monkeypatch.setattr(module, "get_language_set", lambda: {Language.fromietf("en")})
+    missing = "list_missing_subtitles" if media_type == "series" else "list_missing_subtitles_movies"
+    monkeypatch.setattr(module, missing, lambda *a, **k: None)
+    monkeypatch.setattr(module, "event_stream", lambda **k: None)
+
+    def index(*args, **kwargs):
+        result = flow.real_indexers[media_type](*args, **kwargs)
+        flow.indexes.append((kwargs["arr_instance_id"], result))
+        return result
+
+    index_name = "store_subtitles" if media_type == "series" else "store_subtitles_movie"
+    monkeypatch.setattr(module, index_name, index)
+    monkeypatch.setattr(delete, index_name, index)
+    deletion = None
+    try:
+        flow.submit(media_type)
+        upload_job, upload_thread = flow.start()
+        upload_thread.join(2)
+        assert upload_job.status == "completed"
+        assert len(ast.literal_eval(db.execute(select(table.subtitles)).scalar())) == 1
+        controls["armed"] = True
+        flow.release_engine.set()
+        sync_job, sync_thread = flow.start()
+        assert before_commit.wait(2)
+        deleted = []
+        deletion = Thread(target=lambda: deleted.append(flow.remove(media_type)))
+        deletion.start()
+        deletion.join(0.2)
+        commit.set()
+        sync_thread.join(2)
+        deletion.join(2)
+        assert not deletion.is_alive() and not sync_thread.is_alive()
+        assert sync_job.status == "completed"
+        assert deleted == [True]
+        assert not flow.video.with_suffix(".en.srt").exists()
+        assert ast.literal_eval(db.execute(select(table.subtitles)).scalar()) == []
+    finally:
+        commit.set()
+        if deletion:
+            deletion.join(2)
+        engine.dispose()


### PR DESCRIPTION
With automatic synchronization enabled, a saved movie or episode subtitle stayed absent from the subtitle list until synchronization finished. Index and announce the saved upload first, then queue synchronization as a separate progress job and refresh the indexed files when it finishes.

Keep a successful upload visible when optional synchronization fails, is cancelled, or is skipped. Coordinate saving, publication, indexing, and deletion per media destination so stale synchronization cannot overwrite a newer upload or restore a deleted subtitle. Preserve instance ownership, upload metadata, postprocessing, and notification policy.

Validation:

- The exact standalone source passed full local CI with Node 24.20.0: frontend formatting, lint, types, build, and 918 tests; 3,741 backend tests on each of Python 3.12, 3.13, and 3.14; all 11 native PostgreSQL cases per Python lane; Ruff and startup checks. Two frontend and eight backend skips per lane remain. All stage exit codes were zero.
- Independent source review passed. The 39 focused regressions cover immediate visibility, background completion, cancellation, failure, skips, instance ownership, and concurrent upload/delete behavior.
- A combined test candidate carrying the identical upload source passed 32 API/queue/index/publication fixture cases with a controlled synchronization engine, six served UI cases, and 49 normal-start checks. These fixture checks do not establish real audio alignment.
- A normal upload was manually verified in the deployed test UI: the subtitle appeared immediately while synchronization continued in the background.
- All 1,427 standalone source/test files were rechecked against the completed CI manifest before and after committing. The PR merges cleanly with current development; the shared workflow retains both upload and routing regressions. Local standalone CI and combined test-machine acceptance are distinct from the GitHub PR checks.
