### PR TITLE
Fix subtitle sync races and prepare Bazarr+ v2.6.2

### DIFF
--- a/bazarr/api/subtitles/content.py
+++ b/bazarr/api/subtitles/content.py
@@ -21,6 +21,7 @@ from sonarr.history import history_log
 from subtitles.indexer.movies import store_subtitles_movie
 from subtitles.indexer.series import store_subtitles
 from subtitles.processing import ProcessSubtitlesResult
+from subtitles.tools.subsync_engines import subtitle_mutation, subtitle_write_locks
 from utilities.helper import get_target_folder
 from utilities.path_mappings import path_mappings
 
@@ -813,13 +814,6 @@ def _save_subtitle_content(media_type, media_id, language_code, arr_instance_id=
 
     subtitle_path, metadata = result
 
-    # Optimistic locking via ETag (optional but recommended)
-    if_match = request.headers.get('If-Match')
-    if if_match:
-        current_etag = generate_etag(subtitle_path)
-        if if_match.strip('"') != current_etag:
-            return 'Subtitle file has been modified since last read', 412
-
     data = request.get_json()
     if not data or 'content' not in data:
         return 'Request body must include "content" field', 400
@@ -838,8 +832,19 @@ def _save_subtitle_content(media_type, media_id, language_code, arr_instance_id=
     if len(encoded) > MAX_FILE_SIZE:
         return f'Content too large ({len(encoded)} bytes, max {MAX_FILE_SIZE})', 413
 
+    video_path = path_mappings.path_replace_instance(
+        metadata['mediaPath'], metadata.get('arrInstanceId', arr_instance_id), media_type)
     try:
-        _write_bytes_atomically(subtitle_path, encoded)
+        with subtitle_write_locks(video_path, subtitle_path):
+            if not os.path.isfile(subtitle_path):
+                return 'Subtitle file or directory not found', 404
+            if_match = request.headers.get('If-Match')
+            if if_match and if_match.strip('"') != generate_etag(subtitle_path):
+                return 'Subtitle file has been modified since last read', 412
+            with subtitle_mutation(video_path, subtitle_path):
+                _write_bytes_atomically(subtitle_path, encoded)
+                _apply_subtitle_chmod(subtitle_path)
+            new_etag = generate_etag(subtitle_path)
     except FileNotFoundError:
         return 'Subtitle file or directory not found', 404
     except PermissionError:
@@ -849,11 +854,7 @@ def _save_subtitle_content(media_type, media_id, language_code, arr_instance_id=
             return 'No space left on device', 507
         raise
 
-    _apply_subtitle_chmod(subtitle_path)
-
     _refresh_media_subtitles(media_type, media_id, metadata)
-
-    new_etag = generate_etag(subtitle_path)
     response = make_response('', 204)
     response.headers['ETag'] = f'"{new_etag}"'
     return response
@@ -900,15 +901,20 @@ def promote_sync_subtitle(media_type, media_id, target_language, source_language
     if os.path.realpath(source_path) == os.path.realpath(target_path):
         return 'Source and target subtitles are the same file', 400
 
+    video_path = path_mappings.path_replace_instance(
+        metadata['mediaPath'], metadata.get('arrInstanceId', arr_instance_id), media_type)
     try:
-        file_size = os.path.getsize(source_path)
-        if file_size > MAX_FILE_SIZE:
-            return f'Subtitle file too large ({file_size} bytes, max {MAX_FILE_SIZE})', 413
-
-        with open(source_path, 'rb') as source_file:
-            data = source_file.read()
-
-        _write_bytes_atomically(target_path, data)
+        with subtitle_write_locks(video_path, source_path, target_path):
+            file_size = os.path.getsize(source_path)
+            if file_size > MAX_FILE_SIZE:
+                return f'Subtitle file too large ({file_size} bytes, max {MAX_FILE_SIZE})', 413
+            if not os.path.isfile(target_path):
+                return 'Subtitle file or directory not found', 404
+            with open(source_path, 'rb') as source_file:
+                data = source_file.read()
+            with subtitle_mutation(video_path, target_path):
+                _write_bytes_atomically(target_path, data)
+                _apply_subtitle_chmod(target_path)
     except FileNotFoundError:
         return 'Subtitle file or directory not found', 404
     except PermissionError:
@@ -918,7 +924,7 @@ def promote_sync_subtitle(media_type, media_id, target_language, source_language
             return 'No space left on device', 507
         raise
 
-    _apply_subtitle_chmod(target_path)
+    _refresh_media_subtitles(media_type, media_id, metadata)
     _log_promoted_sync_history(
         media_type=media_type,
         media_id=media_id,
@@ -927,7 +933,6 @@ def promote_sync_subtitle(media_type, media_id, target_language, source_language
         target_path=target_path,
         metadata=metadata,
     )
-    _refresh_media_subtitles(media_type, media_id, metadata)
 
     return {
         'sourceLanguage': source_language,
@@ -1096,24 +1101,20 @@ def _create_subtitle(media_type, media_id, arr_instance_id=None):
             subtitle_path.startswith(target_folder_real + os.sep)):
         return 'Invalid subtitle path', 400
 
-    # Check for existing file
-    if os.path.isfile(subtitle_path):
-        return 'Subtitle file already exists', 409
-
     # Encode content
     encoded = content.encode('utf-8')
     if len(encoded) > MAX_FILE_SIZE:
         return f'Content too large ({len(encoded)} bytes, max {MAX_FILE_SIZE})', 413
 
-    # Write atomically
+    # Check and create under the same mutation lock as replacements.
     try:
-        fd, tmp_path = tempfile.mkstemp(dir=target_folder)
-        try:
-            os.write(fd, encoded)
-        finally:
-            os.close(fd)
+        with subtitle_write_locks(video_path, subtitle_path):
+            if os.path.isfile(subtitle_path):
+                return 'Subtitle file already exists', 409
+            with subtitle_mutation(video_path, subtitle_path):
+                _write_bytes_atomically(subtitle_path, encoded)
+                _apply_subtitle_chmod(subtitle_path)
 
-        os.replace(tmp_path, subtitle_path)
     except FileNotFoundError:
         return 'Target directory not found', 404
     except PermissionError:
@@ -1122,14 +1123,6 @@ def _create_subtitle(media_type, media_id, arr_instance_id=None):
         if e.errno == 28:  # ENOSPC
             return 'No space left on device', 507
         raise
-
-    # Apply chmod if configured
-    if settings.general.chmod_enabled:
-        try:
-            chmod_value = int(settings.general.chmod, 8)
-            os.chmod(subtitle_path, chmod_value)
-        except Exception:
-            pass
 
     # Force re-scan subtitles from disk using the media (video) path
     if media_type == 'episode':

--- a/bazarr/api/subtitles/content.py
+++ b/bazarr/api/subtitles/content.py
@@ -924,15 +924,17 @@ def promote_sync_subtitle(media_type, media_id, target_language, source_language
             return 'No space left on device', 507
         raise
 
-    _refresh_media_subtitles(media_type, media_id, metadata)
-    _log_promoted_sync_history(
-        media_type=media_type,
-        media_id=media_id,
-        target_language=target_language,
-        source_language=source_language,
-        target_path=target_path,
-        metadata=metadata,
-    )
+    try:
+        _refresh_media_subtitles(media_type, media_id, metadata)
+    finally:
+        _log_promoted_sync_history(
+            media_type=media_type,
+            media_id=media_id,
+            target_language=target_language,
+            source_language=source_language,
+            target_path=target_path,
+            metadata=metadata,
+        )
 
     return {
         'sourceLanguage': source_language,

--- a/bazarr/subtitles/download.py
+++ b/bazarr/subtitles/download.py
@@ -4,11 +4,13 @@
 import os
 import sys
 import logging
+from functools import partial
 import subliminal
 import ast
 
 from subzero.language import Language
 from subliminal_patch.core import save_subtitles
+from subtitles.tools.subsync_engines import subtitle_write_locks, subtitle_mutation, write_subtitle_file
 from subliminal_patch.core_persistent import download_best_subtitles
 
 from app.config import settings
@@ -149,21 +151,29 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
                             fld = get_target_folder(path)
                             chmod = int(settings.general.chmod, 8) if not sys.platform.startswith(
                                 'win') and settings.general.chmod_enabled else None
-                            if is_upgrade and previous_subtitles_to_delete:
-                                try:
-                                    # delete previously downloaded subtitles in case of an upgrade to prevent edge loop
-                                    # issue.
-                                    os.remove(previous_subtitles_to_delete)
-                                except (OSError, FileNotFoundError):
-                                    pass
-                            saved_subtitles = save_subtitles(video.original_path, subtitles,
-                                                             single=settings.general.single_language,
-                                                             tags=None,  # fixme
-                                                             directory=fld,
-                                                             chmod=chmod,
-                                                             formats=subtitle_formats,
-                                                             path_decoder=force_unicode
-                                                             )
+                            with subtitle_write_locks(path, os.path.join(fld or os.path.dirname(path), '.destination'),
+                                                      previous_subtitles_to_delete or path):
+                                written_paths = []
+                                saved_subtitles = save_subtitles(video.original_path, subtitles,
+                                                                 single=settings.general.single_language,
+                                                                 tags=None,  # fixme
+                                                                 directory=fld,
+                                                                 chmod=chmod,
+                                                                 formats=subtitle_formats,
+                                                                 path_decoder=force_unicode,
+                                                                 write_subtitle=partial(write_subtitle_file, path, written_paths=written_paths)
+                                                                 )
+                                if is_upgrade and previous_subtitles_to_delete and written_paths and (
+                                        os.path.normcase(os.path.realpath(previous_subtitles_to_delete)) not in
+                                        {os.path.normcase(os.path.realpath(written)) for written in written_paths}):
+                                    try:
+                                        with subtitle_mutation(path, previous_subtitles_to_delete):
+                                            os.remove(previous_subtitles_to_delete)
+                                    except OSError:
+                                        logging.exception('BAZARR unable to remove superseded subtitle: %s',
+                                                          previous_subtitles_to_delete)
+                                saved_subtitles = [saved for saved in saved_subtitles if saved.storage_path in written_paths]
+
                         except Exception as e:
                             logging.exception(
                                 f'BAZARR Error saving Subtitles file to disk for this file {path}: {repr(e)}')  # noqa: G004

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -13,7 +13,8 @@ from app.database import get_profiles_list, get_profile_cutoff, TableMovies, Tab
     get_audio_profile_languages, database, update, select
 from languages.get_languages import alpha2_from_alpha3, get_language_set
 from app.config import settings
-from utilities.helper import get_subtitle_destination_folder
+from utilities.helper import get_subtitle_destination_folder, get_target_folder
+from subtitles.tools.subsync_engines import subtitle_write_locks
 from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import embedded_subs_reader
 from app.event_handler import event_stream
@@ -102,88 +103,91 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True, arr_inst
                         f"BAZARR error when trying to analyze this {os.path.splitext(reversed_path)[1]} file: "  # noqa: G004
                         f"{reversed_path}")
 
-        try:
-            dest_folder = get_subtitle_destination_folder()
-            core.CUSTOM_PATHS = [dest_folder] if dest_folder else []
+        destination = os.path.join(get_target_folder(reversed_path, create=False) or os.path.dirname(reversed_path),
+                                   '.destination')
+        with subtitle_write_locks(reversed_path, destination):
+            try:
+                dest_folder = get_subtitle_destination_folder()
+                core.CUSTOM_PATHS = [dest_folder] if dest_folder else []
 
-            # get previously indexed subtitles that haven't changed:
-            item = database.execute(
-                scoped(select(TableMovies.subtitles)
-                       .where(TableMovies.path == original_path),
-                       TableMovies.arr_instance_id, owner_instance_id))\
-                .first()
-            if not item:
-                previously_indexed_subtitles_to_exclude = []
-            else:
-                previously_indexed_subtitles = ast.literal_eval(item.subtitles) if item.subtitles else []
-                previously_indexed_subtitles_to_exclude = [x for x in previously_indexed_subtitles
-                                                           if len(x) == 3 and
-                                                           x[1] and
-                                                           os.path.isfile(_pr(x[1])) and
-                                                           os.stat(_pr(x[1])).st_size == x[2]]
-
-            subtitles = search_external_subtitles(reversed_path, languages=get_language_set(),
-                                                  only_one=settings.general.single_language)
-            full_dest_folder_path = os.path.dirname(reversed_path)
-            if dest_folder:
-                if settings.general.subfolder == "absolute":
-                    full_dest_folder_path = dest_folder
-                elif settings.general.subfolder == "relative":
-                    full_dest_folder_path = os.path.join(os.path.dirname(reversed_path), dest_folder)
-            subtitles = add_sync_engine_outputs(full_dest_folder_path, subtitles,
-                                                video_path=reversed_path)
-            subtitles = add_combined_outputs(full_dest_folder_path, subtitles,
-                                             video_filename=os.path.basename(reversed_path))
-            subtitles = guess_external_subtitles(full_dest_folder_path, subtitles, "movie",
-                                                 previously_indexed_subtitles_to_exclude)
-        except Exception as e:
-            logging.exception(f"BAZARR unable to index external subtitles for this file {reversed_path}: {repr(e)}")  # noqa: G004
-        else:
-            for subtitle, language in subtitles.items():
-                valid_language = False
-                if language:
-                    if hasattr(language, 'alpha3'):
-                        valid_language = alpha2_from_alpha3(language.alpha3)
+                # get previously indexed subtitles that haven't changed:
+                item = database.execute(
+                    scoped(select(TableMovies.subtitles)
+                           .where(TableMovies.path == original_path),
+                           TableMovies.arr_instance_id, owner_instance_id))\
+                    .first()
+                if not item:
+                    previously_indexed_subtitles_to_exclude = []
                 else:
-                    logging.debug(f"Skipping subtitles because we are unable to define language: {subtitle}")  # noqa: G004
-                    continue
+                    previously_indexed_subtitles = ast.literal_eval(item.subtitles) if item.subtitles else []
+                    previously_indexed_subtitles_to_exclude = [x for x in previously_indexed_subtitles
+                                                               if len(x) == 3 and
+                                                               x[1] and
+                                                               os.path.isfile(_pr(x[1])) and
+                                                               os.stat(_pr(x[1])).st_size == x[2]]
 
-                if not valid_language:
-                    logging.debug(f'{language.alpha3} is an unsupported language code.')  # noqa: G004
-                    continue
-
-                subtitle_path = get_external_subtitles_path(reversed_path, subtitle)
-
-                try:
-                    subtitle_size = os.stat(subtitle_path).st_size
-                except FileNotFoundError:
-                    logging.debug(f"BAZARR skipping missing subtitle file: {subtitle_path}")  # noqa: G004
-                    continue
-
-                custom = CustomLanguage.found_external(subtitle, subtitle_path)
-
-                if custom is not None:
-                    actual_subtitles.append([custom, _prr(subtitle_path),
-                                             subtitle_size])
-
-                elif str(language.basename) != 'und':
-                    if language.forced:
-                        language_str = f'{language}:forced'
-                    elif language.hi:
-                        language_str = f'{language}:hi'
+                subtitles = search_external_subtitles(reversed_path, languages=get_language_set(),
+                                                      only_one=settings.general.single_language)
+                full_dest_folder_path = os.path.dirname(reversed_path)
+                if dest_folder:
+                    if settings.general.subfolder == "absolute":
+                        full_dest_folder_path = dest_folder
+                    elif settings.general.subfolder == "relative":
+                        full_dest_folder_path = os.path.join(os.path.dirname(reversed_path), dest_folder)
+                subtitles = add_sync_engine_outputs(full_dest_folder_path, subtitles,
+                                                    video_path=reversed_path)
+                subtitles = add_combined_outputs(full_dest_folder_path, subtitles,
+                                                 video_filename=os.path.basename(reversed_path))
+                subtitles = guess_external_subtitles(full_dest_folder_path, subtitles, "movie",
+                                                     previously_indexed_subtitles_to_exclude)
+            except Exception as e:
+                logging.exception(f"BAZARR unable to index external subtitles for this file {reversed_path}: {repr(e)}")  # noqa: G004
+            else:
+                for subtitle, language in subtitles.items():
+                    valid_language = False
+                    if language:
+                        if hasattr(language, 'alpha3'):
+                            valid_language = alpha2_from_alpha3(language.alpha3)
                     else:
-                        language_str = str(language)
-                    language_str = subtitle_language_with_sync_modifier(language_str, subtitle)
-                    language_str = subtitle_language_with_combined_modifier(language_str, subtitle)
-                    logging.debug(f"BAZARR external subtitles detected: {language_str}")  # noqa: G004
-                    actual_subtitles.append([language_str, _prr(subtitle_path),
-                                             subtitle_size])
+                        logging.debug(f"Skipping subtitles because we are unable to define language: {subtitle}")  # noqa: G004
+                        continue
 
-        database.execute(
-            scoped(update(TableMovies)
-                   .values(subtitles=str(actual_subtitles))
-                   .where(TableMovies.path == original_path),
-                   TableMovies.arr_instance_id, owner_instance_id))
+                    if not valid_language:
+                        logging.debug(f'{language.alpha3} is an unsupported language code.')  # noqa: G004
+                        continue
+
+                    subtitle_path = get_external_subtitles_path(reversed_path, subtitle)
+
+                    try:
+                        subtitle_size = os.stat(subtitle_path).st_size
+                    except FileNotFoundError:
+                        logging.debug(f"BAZARR skipping missing subtitle file: {subtitle_path}")  # noqa: G004
+                        continue
+
+                    custom = CustomLanguage.found_external(subtitle, subtitle_path)
+
+                    if custom is not None:
+                        actual_subtitles.append([custom, _prr(subtitle_path),
+                                                 subtitle_size])
+
+                    elif str(language.basename) != 'und':
+                        if language.forced:
+                            language_str = f'{language}:forced'
+                        elif language.hi:
+                            language_str = f'{language}:hi'
+                        else:
+                            language_str = str(language)
+                        language_str = subtitle_language_with_sync_modifier(language_str, subtitle)
+                        language_str = subtitle_language_with_combined_modifier(language_str, subtitle)
+                        logging.debug(f"BAZARR external subtitles detected: {language_str}")  # noqa: G004
+                        actual_subtitles.append([language_str, _prr(subtitle_path),
+                                                 subtitle_size])
+
+            database.execute(
+                scoped(update(TableMovies)
+                       .values(subtitles=str(actual_subtitles))
+                       .where(TableMovies.path == original_path),
+                       TableMovies.arr_instance_id, owner_instance_id))
         matching_movies = database.execute(
             scoped(select(TableMovies.radarrId, TableMovies.arr_instance_id)
                    .where(TableMovies.path == original_path),

--- a/bazarr/subtitles/indexer/movies.py
+++ b/bazarr/subtitles/indexer/movies.py
@@ -14,7 +14,7 @@ from app.database import get_profiles_list, get_profile_cutoff, TableMovies, Tab
 from languages.get_languages import alpha2_from_alpha3, get_language_set
 from app.config import settings
 from utilities.helper import get_subtitle_destination_folder, get_target_folder
-from subtitles.tools.subsync_engines import subtitle_write_locks
+from subtitles.tools.subsync_engines import SyncOutputOwnerIndex, subtitle_write_locks
 from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import embedded_subs_reader
 from app.event_handler import event_stream
@@ -32,7 +32,7 @@ from arr_instances.resolution import scoped
 gc.enable()
 
 
-def store_subtitles_movie(original_path, reversed_path, use_cache=True, arr_instance_id=None):
+def store_subtitles_movie(original_path, reversed_path, use_cache=True, arr_instance_id=None, ownership_index=None):
     logging.debug(f'BAZARR started subtitles indexing for this file: {reversed_path}')  # noqa: G004
     actual_subtitles = []
     # The owning instance decides everything below: which per-instance
@@ -135,7 +135,7 @@ def store_subtitles_movie(original_path, reversed_path, use_cache=True, arr_inst
                     elif settings.general.subfolder == "relative":
                         full_dest_folder_path = os.path.join(os.path.dirname(reversed_path), dest_folder)
                 subtitles = add_sync_engine_outputs(full_dest_folder_path, subtitles,
-                                                    video_path=reversed_path)
+                                                    video_path=reversed_path, ownership_index=ownership_index)
                 subtitles = add_combined_outputs(full_dest_folder_path, subtitles,
                                                  video_filename=os.path.basename(reversed_path))
                 subtitles = guess_external_subtitles(full_dest_folder_path, subtitles, "movie",
@@ -442,12 +442,13 @@ def movies_full_scan_subtitles(job_id=None, use_cache=None, wait_for_completion=
         .all()
 
     jobs_queue.update_job_progress(job_id=job_id, progress_max=len(movies), progress_message='Indexing')
+    ownership_index = SyncOutputOwnerIndex()
     for i, movie in enumerate(movies, start=1):
         jobs_queue.update_job_progress(job_id=job_id, progress_value=i, progress_message=movie.title)
         store_subtitles_movie(movie.path,
                               path_mappings.path_replace_instance(movie.path,
                                                                   movie.arr_instance_id, 'movie'),
-                              use_cache=use_cache, arr_instance_id=movie.arr_instance_id)
+                              use_cache=use_cache, arr_instance_id=movie.arr_instance_id, ownership_index=ownership_index)
 
     logging.info('BAZARR All existing movie subtitles indexed from disk.')
 
@@ -465,8 +466,9 @@ def movies_scan_subtitles(no, arr_instance_id=None):
             TableMovies.arr_instance_id, arr_instance_id)) \
         .all()
 
+    ownership_index = SyncOutputOwnerIndex()
     for movie in movies:
         store_subtitles_movie(movie.path,
                               path_mappings.path_replace_instance(movie.path,
                                                                   movie.arr_instance_id, 'movie'),
-                              use_cache=False, arr_instance_id=movie.arr_instance_id)
+                              use_cache=False, arr_instance_id=movie.arr_instance_id, ownership_index=ownership_index)

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -13,7 +13,7 @@ from app.database import get_profiles_list, get_profile_cutoff, TableEpisodes, T
 from languages.get_languages import alpha2_from_alpha3, get_language_set
 from app.config import settings
 from utilities.helper import get_subtitle_destination_folder, get_target_folder
-from subtitles.tools.subsync_engines import subtitle_write_locks
+from subtitles.tools.subsync_engines import SyncOutputOwnerIndex, subtitle_write_locks
 from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import embedded_subs_reader
 from app.event_handler import event_stream
@@ -31,7 +31,7 @@ from arr_instances.resolution import scoped
 gc.enable()
 
 
-def store_subtitles(original_path, reversed_path, use_cache=True, arr_instance_id=None):
+def store_subtitles(original_path, reversed_path, use_cache=True, arr_instance_id=None, ownership_index=None):
     logging.debug(f'BAZARR started subtitles indexing for this file: {reversed_path}')  # noqa: G004
     actual_subtitles = []
     # The owning instance decides everything below: which per-instance
@@ -135,7 +135,7 @@ def store_subtitles(original_path, reversed_path, use_cache=True, arr_instance_i
                     elif settings.general.subfolder == "relative":
                         full_dest_folder_path = os.path.join(os.path.dirname(reversed_path), dest_folder)
                 subtitles = add_sync_engine_outputs(full_dest_folder_path, subtitles,
-                                                    video_path=reversed_path)
+                                                    video_path=reversed_path, ownership_index=ownership_index)
                 subtitles = add_combined_outputs(full_dest_folder_path, subtitles,
                                                  video_filename=os.path.basename(reversed_path))
                 subtitles = guess_external_subtitles(full_dest_folder_path, subtitles, "series",
@@ -463,6 +463,7 @@ def series_full_scan_subtitles(job_id=None, use_cache=None, wait_for_completion=
     ).all()
 
     jobs_queue.update_job_progress(job_id=job_id, progress_max=len(episodes), progress_message='Indexing')
+    ownership_index = SyncOutputOwnerIndex()
     for i, episode in enumerate(episodes, start=1):
         jobs_queue.update_job_progress(
             job_id=job_id, progress_value=i,
@@ -470,7 +471,7 @@ def series_full_scan_subtitles(job_id=None, use_cache=None, wait_for_completion=
         store_subtitles(episode.path,
                         path_mappings.path_replace_instance(episode.path,
                                                             episode.arr_instance_id, 'series'),
-                        use_cache=use_cache, arr_instance_id=episode.arr_instance_id)
+                        use_cache=use_cache, arr_instance_id=episode.arr_instance_id, ownership_index=ownership_index)
 
     logging.info('BAZARR All existing episode subtitles indexed from disk.')
 
@@ -488,8 +489,9 @@ def series_scan_subtitles(no, arr_instance_id=None):
             TableEpisodes.arr_instance_id, arr_instance_id))\
         .all()
 
+    ownership_index = SyncOutputOwnerIndex()
     for episode in episodes:
         store_subtitles(episode.path,
                         path_mappings.path_replace_instance(episode.path,
                                                             episode.arr_instance_id, 'series'),
-                        use_cache=False, arr_instance_id=episode.arr_instance_id)
+                        use_cache=False, arr_instance_id=episode.arr_instance_id, ownership_index=ownership_index)

--- a/bazarr/subtitles/indexer/series.py
+++ b/bazarr/subtitles/indexer/series.py
@@ -12,7 +12,8 @@ from app.database import get_profiles_list, get_profile_cutoff, TableEpisodes, T
     get_audio_profile_languages, database, update, select
 from languages.get_languages import alpha2_from_alpha3, get_language_set
 from app.config import settings
-from utilities.helper import get_subtitle_destination_folder
+from utilities.helper import get_subtitle_destination_folder, get_target_folder
+from subtitles.tools.subsync_engines import subtitle_write_locks
 from utilities.path_mappings import path_mappings
 from utilities.video_analyzer import embedded_subs_reader
 from app.event_handler import event_stream
@@ -102,87 +103,90 @@ def store_subtitles(original_path, reversed_path, use_cache=True, arr_instance_i
                         "BAZARR error when trying to analyze this %s file: %s" % (os.path.splitext(reversed_path)[1],  # noqa: G002
                                                                                   reversed_path))
                     pass
-        try:
-            dest_folder = get_subtitle_destination_folder()
-            core.CUSTOM_PATHS = [dest_folder] if dest_folder else []
+        destination = os.path.join(get_target_folder(reversed_path, create=False) or os.path.dirname(reversed_path),
+                                   '.destination')
+        with subtitle_write_locks(reversed_path, destination):
+            try:
+                dest_folder = get_subtitle_destination_folder()
+                core.CUSTOM_PATHS = [dest_folder] if dest_folder else []
 
-            # get previously indexed subtitles that haven't changed:
-            item = database.execute(
-                scoped(select(TableEpisodes.subtitles)
-                       .where(TableEpisodes.path == original_path),
-                       TableEpisodes.arr_instance_id, owner_instance_id)) \
-                .first()
-            if not item:
-                previously_indexed_subtitles_to_exclude = []
-            else:
-                previously_indexed_subtitles = ast.literal_eval(item.subtitles) if item.subtitles else []
-                previously_indexed_subtitles_to_exclude = [x for x in previously_indexed_subtitles
-                                                           if len(x) == 3 and
-                                                           x[1] and
-                                                           os.path.isfile(_pr(x[1])) and
-                                                           os.stat(_pr(x[1])).st_size == x[2]]
-
-            subtitles = search_external_subtitles(reversed_path, languages=get_language_set(),
-                                                  only_one=settings.general.single_language)
-            full_dest_folder_path = os.path.dirname(reversed_path)
-            if dest_folder:
-                if settings.general.subfolder == "absolute":
-                    full_dest_folder_path = dest_folder
-                elif settings.general.subfolder == "relative":
-                    full_dest_folder_path = os.path.join(os.path.dirname(reversed_path), dest_folder)
-            subtitles = add_sync_engine_outputs(full_dest_folder_path, subtitles,
-                                                video_path=reversed_path)
-            subtitles = add_combined_outputs(full_dest_folder_path, subtitles,
-                                             video_filename=os.path.basename(reversed_path))
-            subtitles = guess_external_subtitles(full_dest_folder_path, subtitles, "series",
-                                                 previously_indexed_subtitles_to_exclude)
-        except Exception as e:
-            logging.exception(f"BAZARR unable to index external subtitles for this file {reversed_path}: {repr(e)}")  # noqa: G004
-        else:
-            for subtitle, language in subtitles.items():
-                valid_language = False
-                if language:
-                    if hasattr(language, 'alpha3'):
-                        valid_language = alpha2_from_alpha3(language.alpha3)
+                # get previously indexed subtitles that haven't changed:
+                item = database.execute(
+                    scoped(select(TableEpisodes.subtitles)
+                           .where(TableEpisodes.path == original_path),
+                           TableEpisodes.arr_instance_id, owner_instance_id)) \
+                    .first()
+                if not item:
+                    previously_indexed_subtitles_to_exclude = []
                 else:
-                    logging.debug(f"Skipping subtitles because we are unable to define language: {subtitle}")  # noqa: G004
-                    continue
+                    previously_indexed_subtitles = ast.literal_eval(item.subtitles) if item.subtitles else []
+                    previously_indexed_subtitles_to_exclude = [x for x in previously_indexed_subtitles
+                                                               if len(x) == 3 and
+                                                               x[1] and
+                                                               os.path.isfile(_pr(x[1])) and
+                                                               os.stat(_pr(x[1])).st_size == x[2]]
 
-                if not valid_language:
-                    logging.debug(f'{language.alpha3} is an unsupported language code.')  # noqa: G004
-                    continue
-
-                subtitle_path = get_external_subtitles_path(reversed_path, subtitle)
-
-                try:
-                    subtitle_size = os.stat(subtitle_path).st_size
-                except FileNotFoundError:
-                    logging.debug(f"BAZARR skipping missing subtitle file: {subtitle_path}")  # noqa: G004
-                    continue
-
-                custom = CustomLanguage.found_external(subtitle, subtitle_path)
-                if custom is not None:
-                    actual_subtitles.append([custom, _prr(subtitle_path),
-                                             subtitle_size])
-
-                elif str(language.basename) != 'und':
-                    if language.forced:
-                        language_str = f'{language}:forced'
-                    elif language.hi:
-                        language_str = f'{language}:hi'
+                subtitles = search_external_subtitles(reversed_path, languages=get_language_set(),
+                                                      only_one=settings.general.single_language)
+                full_dest_folder_path = os.path.dirname(reversed_path)
+                if dest_folder:
+                    if settings.general.subfolder == "absolute":
+                        full_dest_folder_path = dest_folder
+                    elif settings.general.subfolder == "relative":
+                        full_dest_folder_path = os.path.join(os.path.dirname(reversed_path), dest_folder)
+                subtitles = add_sync_engine_outputs(full_dest_folder_path, subtitles,
+                                                    video_path=reversed_path)
+                subtitles = add_combined_outputs(full_dest_folder_path, subtitles,
+                                                 video_filename=os.path.basename(reversed_path))
+                subtitles = guess_external_subtitles(full_dest_folder_path, subtitles, "series",
+                                                     previously_indexed_subtitles_to_exclude)
+            except Exception as e:
+                logging.exception(f"BAZARR unable to index external subtitles for this file {reversed_path}: {repr(e)}")  # noqa: G004
+            else:
+                for subtitle, language in subtitles.items():
+                    valid_language = False
+                    if language:
+                        if hasattr(language, 'alpha3'):
+                            valid_language = alpha2_from_alpha3(language.alpha3)
                     else:
-                        language_str = str(language)
-                    language_str = subtitle_language_with_sync_modifier(language_str, subtitle)
-                    language_str = subtitle_language_with_combined_modifier(language_str, subtitle)
-                    logging.debug(f"BAZARR external subtitles detected: {language_str}")  # noqa: G004
-                    actual_subtitles.append([language_str, _prr(subtitle_path),
-                                             subtitle_size])
+                        logging.debug(f"Skipping subtitles because we are unable to define language: {subtitle}")  # noqa: G004
+                        continue
 
-        database.execute(
-            scoped(update(TableEpisodes)
-                   .values(subtitles=str(actual_subtitles))
-                   .where(TableEpisodes.path == original_path),
-                   TableEpisodes.arr_instance_id, owner_instance_id))
+                    if not valid_language:
+                        logging.debug(f'{language.alpha3} is an unsupported language code.')  # noqa: G004
+                        continue
+
+                    subtitle_path = get_external_subtitles_path(reversed_path, subtitle)
+
+                    try:
+                        subtitle_size = os.stat(subtitle_path).st_size
+                    except FileNotFoundError:
+                        logging.debug(f"BAZARR skipping missing subtitle file: {subtitle_path}")  # noqa: G004
+                        continue
+
+                    custom = CustomLanguage.found_external(subtitle, subtitle_path)
+                    if custom is not None:
+                        actual_subtitles.append([custom, _prr(subtitle_path),
+                                                 subtitle_size])
+
+                    elif str(language.basename) != 'und':
+                        if language.forced:
+                            language_str = f'{language}:forced'
+                        elif language.hi:
+                            language_str = f'{language}:hi'
+                        else:
+                            language_str = str(language)
+                        language_str = subtitle_language_with_sync_modifier(language_str, subtitle)
+                        language_str = subtitle_language_with_combined_modifier(language_str, subtitle)
+                        logging.debug(f"BAZARR external subtitles detected: {language_str}")  # noqa: G004
+                        actual_subtitles.append([language_str, _prr(subtitle_path),
+                                                 subtitle_size])
+
+            database.execute(
+                scoped(update(TableEpisodes)
+                       .values(subtitles=str(actual_subtitles))
+                       .where(TableEpisodes.path == original_path),
+                       TableEpisodes.arr_instance_id, owner_instance_id))
         matching_episodes = database.execute(
             scoped(select(TableEpisodes.sonarrEpisodeId, TableEpisodes.sonarrSeriesId,
                           TableEpisodes.arr_instance_id)

--- a/bazarr/subtitles/indexer/utils.py
+++ b/bazarr/subtitles/indexer/utils.py
@@ -13,7 +13,7 @@ from constants import MAXIMUM_SUBTITLE_SIZE
 from app.config import settings
 from utilities.path_mappings import path_mappings
 from languages.custom_lang import CustomLanguage
-from subtitles.tools.subsync_engines import SYNC_ENGINES, sync_engine_from_output_path
+from subtitles.tools.subsync_engines import SYNC_ENGINES, sync_engine_from_output_path, sync_output_owner_is_unique
 
 import re as _re_combine
 
@@ -156,12 +156,24 @@ def add_sync_engine_outputs(dest_folder, subtitles, video_filename=None, video_p
                            for entry in media_files
                            if entry.is_file() and entry.name.lower().endswith(core.VIDEO_EXTENSIONS)}
 
+    ownership = {}
     for subtitle in os.listdir(dest_folder):
-        if subtitle in subtitles or not sync_engine_from_subtitle_name(subtitle):
+        if not sync_engine_from_subtitle_name(subtitle):
             continue
 
         subtitle_path = os.path.join(dest_folder, subtitle)
         if not os.path.isfile(subtitle_path):
+            continue
+
+        if video_path is not None:
+            stem, extension = os.path.splitext(subtitle)
+            source_path = os.path.join(dest_folder, stem.rsplit('.', 1)[0] + extension)
+            if source_path not in ownership:
+                ownership[source_path] = sync_output_owner_is_unique(video_path, source_path)
+            if not ownership[source_path]:
+                subtitles.pop(subtitle, None)
+                continue
+        if subtitle in subtitles:
             continue
 
         if video_stem is not None:

--- a/bazarr/subtitles/indexer/utils.py
+++ b/bazarr/subtitles/indexer/utils.py
@@ -139,7 +139,7 @@ def _language_code_from_sync_engine_output(subtitle, video_filename=None):
     return ':'.join([language] + variants)
 
 
-def add_sync_engine_outputs(dest_folder, subtitles, video_filename=None, video_path=None):
+def add_sync_engine_outputs(dest_folder, subtitles, video_filename=None, video_path=None, ownership_index=None):
     """Add generated outputs belonging to the video, regardless of save preferences."""
     if not os.path.isdir(dest_folder):
         return subtitles
@@ -169,7 +169,8 @@ def add_sync_engine_outputs(dest_folder, subtitles, video_filename=None, video_p
             stem, extension = os.path.splitext(subtitle)
             source_path = os.path.join(dest_folder, stem.rsplit('.', 1)[0] + extension)
             if source_path not in ownership:
-                ownership[source_path] = sync_output_owner_is_unique(video_path, source_path)
+                ownership[source_path] = sync_output_owner_is_unique(video_path, source_path,
+                                                                    ownership_index=ownership_index)
             if not ownership[source_path]:
                 subtitles.pop(subtitle, None)
                 continue

--- a/bazarr/subtitles/manual.py
+++ b/bazarr/subtitles/manual.py
@@ -4,10 +4,12 @@
 import os
 import sys
 import logging
+from functools import partial
 import subliminal
 
 from subzero.language import Language
 from subliminal_patch.core import save_subtitles
+from subtitles.tools.subsync_engines import subtitle_write_locks, write_subtitle_file
 from subliminal_patch.core_persistent import list_all_subtitles, download_subtitles
 from subliminal_patch.score import compute_score, DEFAULT_SCORES
 
@@ -196,13 +198,18 @@ def manual_download_subtitle(path, audio_language, hi, forced, subtitle, provide
             try:
                 chmod = int(settings.general.chmod, 8) if not sys.platform.startswith(
                     'win') and settings.general.chmod_enabled else None
-                saved_subtitles = save_subtitles(video.original_path, [subtitle],
-                                                 single=settings.general.single_language,
-                                                 tags=None,  # fixme
-                                                 directory=get_target_folder(path),
-                                                 chmod=chmod,
-                                                 formats=(subtitle.format,),
-                                                 path_decoder=force_unicode)
+                with subtitle_write_locks(path, os.path.join(get_target_folder(path) or os.path.dirname(path), '.destination')):
+                    written_paths = []
+                    saved_subtitles = save_subtitles(video.original_path, [subtitle],
+                                                     single=settings.general.single_language,
+                                                     tags=None,  # fixme
+                                                     directory=get_target_folder(path),
+                                                     chmod=chmod,
+                                                     formats=(subtitle.format,),
+                                                     path_decoder=force_unicode,
+                                                     write_subtitle=partial(write_subtitle_file, path, written_paths=written_paths))
+                    saved_subtitles = [saved for saved in saved_subtitles if saved.storage_path in written_paths]
+
             except Exception as e:
                 logging.exception(f'BAZARR Error saving Subtitles file to disk for this file {path}: {repr(e)}')  # noqa: G004
                 return 'Error saving Subtitles file to disk'

--- a/bazarr/subtitles/post_processing.py
+++ b/bazarr/subtitles/post_processing.py
@@ -6,9 +6,23 @@ import logging
 import subprocess
 
 from locale import getpreferredencoding
+from utilities.helper import get_target_folder
+from subtitles.tools.subsync_engines import subtitle_write_locks, subtitle_mutation
 
 
-def postprocessing(command, path):
+def postprocessing(command, path, subtitle_path=None):
+    # Configured commands can mutate subtitles in place. This is the one boundary
+    # that must hold this media's mutation locks while the external command runs.
+    destination = os.path.join(get_target_folder(path, create=False) or os.path.dirname(path), '.destination')
+    with subtitle_write_locks(path, path, destination, subtitle_path or path) as states:
+        watched_paths = {watched for state in states.values() for watched in state.revisions}
+        if subtitle_path:
+            watched_paths.add(subtitle_path)
+        with subtitle_mutation(path, *watched_paths):
+            return _postprocessing_locked(command, path)
+
+
+def _postprocessing_locked(command, path):
     try:
         encoding = getpreferredencoding()
         if os.name == 'nt':

--- a/bazarr/subtitles/processing.py
+++ b/bazarr/subtitles/processing.py
@@ -333,7 +333,7 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
 
         if not use_pp_threshold or (use_pp_threshold and percent_score < pp_threshold):
             logging.debug(f"BAZARR Using post-processing command: {command}")  # noqa: G004
-            postprocessing(command, path)
+            postprocessing(command, path, subtitle_path=downloaded_path)
             set_chmod(subtitles_path=downloaded_path)
         else:
             logging.debug(f"BAZARR post-processing skipped because subtitles score isn't below this "  # noqa: G004

--- a/bazarr/subtitles/sync.py
+++ b/bazarr/subtitles/sync.py
@@ -19,8 +19,12 @@ from subtitles.tools.subsync_engines import (
     REASON_OUTPUT_EXISTS,
     REASON_RESULT_REJECTED,
     REASON_SOURCE_CHANGED,
+    REASON_DESTINATION_CHANGED,
+    REASON_DESTINATION_AMBIGUOUS,
     is_sync_engine_output,
     normalize_enabled_engines,
+    release_subtitle_publication,
+    release_unqueued_subtitle_publication,
 )
 
 
@@ -40,6 +44,8 @@ _ENGINE_OUTCOME_SENTENCES = {
     REASON_RESULT_REJECTED: "{label} result rejected: {message}",
     REASON_ENGINE_FAILED: "{label} failed: {message}",
     REASON_SOURCE_CHANGED: "The uploaded subtitle was replaced or deleted. Sync was skipped.",
+    REASON_DESTINATION_CHANGED: "The synchronized subtitle destination was changed or deleted. Sync was skipped.",
+    REASON_DESTINATION_AMBIGUOUS: "The synchronized subtitle destination has no unique media owner. Sync was skipped.",
 }
 _ENGINE_MESSAGE_LIMIT = 160
 
@@ -254,109 +260,134 @@ def sync_subtitles(video_path,
                    track_job_progress=True,
                    arr_instance_id=None,
                    owns_job_progress=True,
-                   source_version=None):
-    # The audio-sync settings resolve against the owning instance (#227); a None
-    # owner / unset override yields the global value, so legacy paths are
-    # unchanged. The use_subsync gate is evaluated inline via the module-level
-    # helper so NO non-signature local is created before add_job_from_function
-    # below, which re-passes the frame's locals as kwargs on re-invocation.
-    if (not _resolve_subsync_overrides(
-            arr_instance_id, bool(sonarr_episode_id), enabled_engines, max_offset_seconds)[0]
-            and not force_sync):
-        logging.debug('BAZARR automatic syncing is disabled in settings. Skipping sync routine.')
-        return False
-
-    if is_sync_engine_output(srt_path):
-        logging.debug('BAZARR generated sync output cannot be synchronized again. Skipping: %s', srt_path)
-        _report_progress(job_id, track_job_progress, owns_job_progress, 'Sync skipped',
-                         value='max', name=f"Skipped sync for {srt_path}")
-        return False
-
-    if not job_id and track_job_progress:
-        jobs_queue.add_job_from_function(
-            f"Syncing {srt_path}",
-            is_progress=True,
-            progress_max=_sync_progress_total(enabled_engines),
-        )
-        return False
-
-    # Past the enqueue point it is safe to bind locals. Resolve the per-instance
-    # overrides for the real run (the use_subsync gate already passed above).
-    (_, use_subsync_threshold, subsync_threshold,
-     enabled_engines, max_offset_seconds) = _resolve_subsync_overrides(
-        arr_instance_id, bool(sonarr_episode_id), enabled_engines, max_offset_seconds)
-    progress_total = _sync_progress_total(enabled_engines)
-
-    def report(message, value=None, total=None, name=None):
-        _report_progress(job_id, track_job_progress, owns_job_progress, message, value, total, name)
-
-    report('Preparing synchronization', value=0, total=progress_total, name=f"Syncing {srt_path}")
-
-    def update_progress(message, value, total):
-        report(message, value=value, total=total)
-
-    if forced:
-        logging.debug('BAZARR cannot sync forced subtitles. Skipping sync routine.')
-        report('Sync skipped', value='max', name=f"Skipped sync for {srt_path}")
-        return False
-
-    logging.debug(f'BAZARR automatic syncing is enabled in settings. We\'ll try to sync this '  # noqa: G004
-                  f'subtitles: {srt_path}.')
-    if not use_subsync_threshold or (use_subsync_threshold and percent_score <= float(subsync_threshold)):
-        subsync = SubSyncer()
-        sync_kwargs = {
-            'video_path': video_path,
-            'srt_path': srt_path,
-            'srt_lang': srt_lang,
-            'forced': forced,
-            'hi': hi,
-            'max_offset_seconds': max_offset_seconds,
-            'no_fix_framerate': no_fix_framerate,
-            'gss': gss,
-            'reference': reference,
-            'sonarr_series_id': sonarr_series_id,
-            'sonarr_episode_id': sonarr_episode_id,
-            'radarr_id': radarr_id,
-            'job_id': job_id,
-            'force_sync': force_sync,
-            'output_mode': output_mode,
-            'enabled_engines': enabled_engines,
-            'progress_callback': update_progress if track_job_progress else None,
-            'arr_instance_id': arr_instance_id,
-        }
-        sync_result = None
-        if source_version is not None:
-            sync_kwargs['source_version'] = source_version
-        try:
-            sync_result = subsync.sync(**sync_kwargs)
-            if sync_result and sync_result.success:
-                if callback and source_version is None:
-                    callback()
-                elif not callback and getattr(sync_result, 'output_mode', None) == OUTPUT_MODE_KEEP_ALL:
-                    _index_keep_all_outputs(
-                        video_path,
-                        sonarr_series_id=sonarr_series_id,
-                        sonarr_episode_id=sonarr_episode_id,
-                        radarr_id=radarr_id,
-                        arr_instance_id=arr_instance_id,
-                    )
-        except JobCancelled:
-            raise
-        except Exception:
-            logging.exception(f'BAZARR an unhandled exception occurs during the synchronization process for this '  # noqa: G004
-                              f'subtitle file: {srt_path}')
+                   source_version=None,
+                   on_success=None):
+    try:
+        # The audio-sync settings resolve against the owning instance (#227); a None
+        # owner / unset override yields the global value, so legacy paths are
+        # unchanged. The use_subsync gate is evaluated inline via the module-level
+        # helper so NO non-signature local is created before add_job_from_function
+        # below, which re-passes the frame's locals as kwargs on re-invocation.
+        if (not _resolve_subsync_overrides(
+                arr_instance_id, bool(sonarr_episode_id), enabled_engines, max_offset_seconds)[0]
+                and not force_sync):
+            logging.debug('BAZARR automatic syncing is disabled in settings. Skipping sync routine.')
+            release_subtitle_publication(source_version)
             return False
-        else:
-            return bool(sync_result and sync_result.success)
-        finally:
-            if callback and source_version is not None:
-                callback()
-            report(_sync_outcome_message(sync_result), value='max',
-                   name=_sync_complete_job_name(srt_path, sync_result))
-            del subsync
-            gc.collect()
 
-    logging.debug(f"BAZARR subsync skipped because subtitles score isn't below this "  # noqa: G004
-                  f"threshold value: {subsync_threshold}%")
-    report('Sync skipped', value='max', name=f"Skipped sync for {srt_path}")
-    return False
+        if is_sync_engine_output(srt_path):
+            logging.debug('BAZARR generated sync output cannot be synchronized again. Skipping: %s', srt_path)
+            _report_progress(job_id, track_job_progress, owns_job_progress, 'Sync skipped',
+                             value='max', name=f"Skipped sync for {srt_path}")
+            release_subtitle_publication(source_version)
+            return False
+
+        if not job_id and track_job_progress:
+            if not jobs_queue.add_job_from_function(
+                f"Syncing {srt_path}",
+                is_progress=True,
+                progress_max=_sync_progress_total(enabled_engines),
+            ):
+                release_unqueued_subtitle_publication(source_version, jobs_queue)
+            return False
+
+    except BaseException:
+        if job_id:
+            release_subtitle_publication(source_version)
+        else:
+            release_unqueued_subtitle_publication(source_version, jobs_queue)
+        raise
+
+    try:
+        # Past the enqueue point it is safe to bind locals. Resolve the per-instance
+        # overrides for the real run (the use_subsync gate already passed above).
+        (_, use_subsync_threshold, subsync_threshold,
+         enabled_engines, max_offset_seconds) = _resolve_subsync_overrides(
+            arr_instance_id, bool(sonarr_episode_id), enabled_engines, max_offset_seconds)
+        progress_total = _sync_progress_total(enabled_engines)
+
+        def report(message, value=None, total=None, name=None):
+            _report_progress(job_id, track_job_progress, owns_job_progress, message, value, total, name)
+
+        report('Preparing synchronization', value=0, total=progress_total, name=f"Syncing {srt_path}")
+
+        def update_progress(message, value, total):
+            report(message, value=value, total=total)
+
+        if forced:
+            logging.debug('BAZARR cannot sync forced subtitles. Skipping sync routine.')
+            report('Sync skipped', value='max', name=f"Skipped sync for {srt_path}")
+            release_subtitle_publication(source_version)
+            return False
+
+        logging.debug(f'BAZARR automatic syncing is enabled in settings. We\'ll try to sync this '  # noqa: G004
+                      f'subtitles: {srt_path}.')
+        if not use_subsync_threshold or (use_subsync_threshold and percent_score <= float(subsync_threshold)):
+            subsync = SubSyncer()
+            sync_kwargs = {
+                'video_path': video_path,
+                'srt_path': srt_path,
+                'srt_lang': srt_lang,
+                'forced': forced,
+                'hi': hi,
+                'max_offset_seconds': max_offset_seconds,
+                'no_fix_framerate': no_fix_framerate,
+                'gss': gss,
+                'reference': reference,
+                'sonarr_series_id': sonarr_series_id,
+                'sonarr_episode_id': sonarr_episode_id,
+                'radarr_id': radarr_id,
+                'job_id': job_id,
+                'force_sync': force_sync,
+                'output_mode': output_mode,
+                'enabled_engines': enabled_engines,
+                'progress_callback': update_progress if track_job_progress else None,
+                'arr_instance_id': arr_instance_id,
+            }
+            sync_result = None
+            if source_version is not None:
+                sync_kwargs['source_version'] = source_version
+            try:
+                sync_result = subsync.sync(**sync_kwargs)
+                if sync_result and sync_result.success:
+                    if callback and source_version is None:
+                        callback()
+                    elif not callback and getattr(sync_result, 'output_mode', None) == OUTPUT_MODE_KEEP_ALL:
+                        _index_keep_all_outputs(
+                            video_path,
+                            sonarr_series_id=sonarr_series_id,
+                            sonarr_episode_id=sonarr_episode_id,
+                            radarr_id=radarr_id,
+                            arr_instance_id=arr_instance_id,
+                        )
+            except JobCancelled:
+                raise
+            except Exception:
+                logging.exception(f'BAZARR an unhandled exception occurs during the synchronization process for this '  # noqa: G004
+                                  f'subtitle file: {srt_path}')
+                return False
+            else:
+                return bool(sync_result and sync_result.success)
+            finally:
+                try:
+                    try:
+                        if callback and source_version is not None:
+                            callback()
+                    finally:
+                        if on_success and (sync_result or getattr(subsync, 'sync_result', None)) and (
+                            sync_result or subsync.sync_result).success:
+                            on_success()
+                    report(_sync_outcome_message(sync_result), value='max',
+                           name=_sync_complete_job_name(srt_path, sync_result))
+                finally:
+                    release_subtitle_publication(source_version)
+                    del subsync
+                    gc.collect()
+
+        logging.debug(f"BAZARR subsync skipped because subtitles score isn't below this "  # noqa: G004
+                      f"threshold value: {subsync_threshold}%")
+        report('Sync skipped', value='max', name=f"Skipped sync for {srt_path}")
+        release_subtitle_publication(source_version)
+        return False
+    finally:
+        release_subtitle_publication(source_version)

--- a/bazarr/subtitles/tools/combine/main.py
+++ b/bazarr/subtitles/tools/combine/main.py
@@ -3,7 +3,9 @@
 import logging
 import os
 import re
+import stat
 from dataclasses import dataclass
+from subtitles.tools.subsync_engines import staged_subtitle_write, subtitle_mutation, sync_output_owner_is_unique
 
 from .composer import compose
 from .naming import compose_combined_filename, external_subtitles_dir
@@ -84,6 +86,8 @@ def try_combine_for_video(video_path, media_type, sonarr_series_id=None,
         # inside this video's external-subtitles directory. Re-assert it here so a
         # crafted code can never steer makedirs/open/remove outside that folder.
         safe_root = os.path.realpath(external_subtitles_dir(video_path))
+        if os.path.islink(out_path) or not sync_output_owner_is_unique(video_path, out_path):
+            return CombineResult(status="skipped", reason="combined output has no unique regular-file owner")
         out_path = os.path.realpath(out_path)
         if os.path.commonpath([safe_root, out_path]) != safe_root:
             return CombineResult(
@@ -92,35 +96,19 @@ def try_combine_for_video(video_path, media_type, sonarr_series_id=None,
             )
 
         try:
-            content = compose(
-                primary_path=sources.primary,
-                secondary_paths=sources.secondaries,
-                format=rule["format"],
-            )
-        except Exception as e:
-            logging.exception("BAZARR combine compose failed for %s", video_path)
-            return CombineResult(status="failed", error=str(e))
-
-        try:
-            # Create the destination directory (mirrors how Bazarr's
-            # get_target_folder makedirs the configured subtitle subfolder) so a
-            # first-time combine into a not-yet-created absolute/relative folder
-            # succeeds instead of failing on open().
             out_dir = os.path.dirname(out_path)
             if out_dir:
                 os.makedirs(out_dir, exist_ok=True)
-            with open(out_path, "wb") as fh:
-                fh.write(content)
-        except OSError as e:
-            logging.exception("BAZARR combine write failed for %s", out_path)
+            with staged_subtitle_write(
+                    video_path, out_path, source_paths=(sources.primary, *sources.secondaries),
+                    after_publish=lambda: _remove_stale_combined_siblings(out_path, video_path)) as temporary:
+                content = compose(primary_path=sources.primary, secondary_paths=sources.secondaries,
+                                  format=rule["format"])
+                with open(temporary, "wb") as fh:
+                    fh.write(content)
+        except Exception as e:
+            logging.exception("BAZARR combine could not publish %s", out_path)
             return CombineResult(status="failed", error=str(e))
-
-        # A combined output is one logical subtitle. Drop any sibling combined
-        # file in a different subtitle format (left over when the profile format
-        # changes or a rebuild switches format) before re-indexing, so the same
-        # combined language is not indexed twice and the editor does not load a
-        # stale positioned ASS as overlapping cues.
-        _remove_stale_combined_siblings(out_path, video_path)
 
         _post_write(out_path, video_path, media_type,
                      sonarr_episode_id, radarr_id)
@@ -173,19 +161,22 @@ def _remove_stale_combined_siblings(out_path, video_path):
     crafted output path can never steer os.remove outside that folder."""
     safe_dir = os.path.realpath(external_subtitles_dir(video_path))
     out_real = os.path.realpath(out_path)
-    if os.path.dirname(out_real) != safe_dir:
+    if os.path.dirname(out_real) != safe_dir or not sync_output_owner_is_unique(video_path, out_path):
         return
     root, _ext = os.path.splitext(out_real)
     for ext in _COMBINED_OUTPUT_EXTS:
-        sibling = os.path.realpath(root + ext)
+        sibling = root + ext
         if sibling == out_real:
             continue
         try:
             if os.path.commonpath([safe_dir, sibling]) != safe_dir:
                 continue
-            if os.path.isfile(sibling):
-                os.remove(sibling)
+            if stat.S_ISREG(os.lstat(sibling).st_mode):
+                with subtitle_mutation(video_path, sibling):
+                    os.remove(sibling)
                 logging.info("BAZARR combine removed stale sibling %s", sibling)
+        except FileNotFoundError:
+            continue
         except OSError:
             logging.exception(
                 "BAZARR combine could not remove stale sibling %s", sibling)

--- a/bazarr/subtitles/tools/delete.py
+++ b/bazarr/subtitles/tools/delete.py
@@ -15,13 +15,29 @@ from utilities.autopulse_webhook import call_external_webhook
 from subtitles.indexer.series import store_subtitles
 from subtitles.indexer.movies import store_subtitles_movie
 from subtitles.processing import ProcessSubtitlesResult
-from subtitles.tools.subsync_engines import subtitle_write_lock
+from subtitles.tools.subsync_engines import (subtitle_write_lock, subtitle_write_locks,
+                                            quarantine_sync_outputs_after_mutation)
 from sonarr.history import history_log
 from radarr.history import history_log_movie
 from sonarr.notify import notify_sonarr
 from radarr.notify import notify_radarr
 from plex.operations import plex_refresh_item
 from jellyfin.operations import jellyfin_refresh_item
+
+
+def _delete_subtitle_file(media_path, subtitle_path):
+    with subtitle_write_locks(media_path, subtitle_path):
+        state = subtitle_write_lock(media_path, os.path.dirname(subtitle_path))
+        try:
+            os.remove(subtitle_path)
+        except OSError as exc:
+            if isinstance(exc, FileNotFoundError):
+                state.changed(subtitle_path)
+            logging.exception('BAZARR cannot delete subtitles file: %s', subtitle_path)
+            return False
+        state.changed(subtitle_path)
+        quarantine_sync_outputs_after_mutation(media_path, subtitle_path)
+        return True
 
 
 def delete_subtitles(media_type, language, forced, hi, media_path, subtitles_path, sonarr_series_id=None,
@@ -82,14 +98,10 @@ def delete_subtitles(media_type, language, forced, hi, media_path, subtitles_pat
                                     hearing_impaired=None)
 
     if media_type == 'series':
-        with subtitle_write_lock(media_path, os.path.dirname(pr(subtitles_path))):
-            try:
-                os.remove(pr(subtitles_path))
-            except OSError:
-                logging.exception(f'BAZARR cannot delete subtitles file: {subtitles_path}')  # noqa: G004
-                store_subtitles(prr(media_path), media_path, arr_instance_id=arr_instance_id)
-                return False
-            store_subtitles(prr(media_path), media_path, arr_instance_id=arr_instance_id)
+        removed = _delete_subtitle_file(media_path, pr(subtitles_path))
+        store_subtitles(prr(media_path), media_path, arr_instance_id=arr_instance_id)
+        if not removed:
+            return False
         history_log(0, sonarr_series_id, sonarr_episode_id, result, arr_instance_id=arr_instance_id)
         # Route the rescan at the OWNING instance's Sonarr (#156); None
         # owner = default server (legacy single-instance), unchanged.
@@ -115,14 +127,10 @@ def delete_subtitles(media_type, language, forced, hi, media_path, subtitles_pat
 
         return True
     else:
-        with subtitle_write_lock(media_path, os.path.dirname(pr(subtitles_path))):
-            try:
-                os.remove(pr(subtitles_path))
-            except OSError:
-                logging.exception(f'BAZARR cannot delete subtitles file: {subtitles_path}')  # noqa: G004
-                store_subtitles_movie(prr(media_path), media_path, arr_instance_id=arr_instance_id)
-                return False
-            store_subtitles_movie(prr(media_path), media_path, arr_instance_id=arr_instance_id)
+        removed = _delete_subtitle_file(media_path, pr(subtitles_path))
+        store_subtitles_movie(prr(media_path), media_path, arr_instance_id=arr_instance_id)
+        if not removed:
+            return False
         history_log_movie(0, radarr_id, result, arr_instance_id=arr_instance_id)
         notify_radarr(radarr_id,
                       arr_client=client_for_instance(database, arr_instance_id, enabled_only=False))

--- a/bazarr/subtitles/tools/mods.py
+++ b/bazarr/subtitles/tools/mods.py
@@ -13,6 +13,8 @@ from app.jobs_queue import jobs_queue
 from languages.custom_lang import CustomLanguage
 from languages.get_languages import alpha3_from_alpha2
 from subtitles.indexer.utils import get_subtitle_destination_path
+from utilities.helper import get_target_folder
+from subtitles.tools.subsync_engines import subtitle_write_locks, subtitle_mutation
 
 
 def has_remove_hi(mods):
@@ -145,6 +147,12 @@ def apply_subtitle_mods(language, subtitle_path, mods, video_path,
 
 
 def subtitles_apply_mods(language, subtitle_path, mods, video_path, arr_instance_id=None):
+    destination = os.path.join(get_target_folder(video_path, create=False) or os.path.dirname(video_path), '.destination')
+    with subtitle_write_locks(video_path, subtitle_path, destination):
+        return _apply_mods_locked(language, subtitle_path, mods, video_path, arr_instance_id)
+
+
+def _apply_mods_locked(language, subtitle_path, mods, video_path, arr_instance_id):
     # The mod list is user-chosen here, so only the keep-lyrics preference is
     # instance-relevant: resolve it against the media's owning instance (#227).
     # A None owner keeps the legacy global-only behaviour (single-instance).
@@ -187,11 +195,12 @@ def subtitles_apply_mods(language, subtitle_path, mods, video_path, arr_instance
         else:
             modded_subtitles_path = subtitle_path
 
-        if os.path.exists(subtitle_path):
-            os.remove(subtitle_path)
+        with subtitle_mutation(video_path, subtitle_path, modded_subtitles_path):
+            if os.path.exists(subtitle_path):
+                os.remove(subtitle_path)
 
-        if os.path.exists(modded_subtitles_path):
-            os.remove(modded_subtitles_path)
+            if os.path.exists(modded_subtitles_path):
+                os.remove(modded_subtitles_path)
 
-        with open(modded_subtitles_path, 'wb') as f:
-            f.write(content)
+            with open(modded_subtitles_path, 'wb') as f:
+                f.write(content)

--- a/bazarr/subtitles/tools/subsync_engines.py
+++ b/bazarr/subtitles/tools/subsync_engines.py
@@ -196,7 +196,67 @@ def write_subtitle_file(video_path, destination, content, written_paths=None):
             handle.write(content)
 
 
-def sync_output_owner_is_unique(video_path, source_path):
+def _normalized_media_stem(path):
+    return unicodedata.normalize('NFC', os.path.splitext(os.path.basename(path))[0].lower())
+
+
+class SyncOutputOwnerIndex:
+    """Lazily map library owners once for one sequential subtitle scan.
+
+    Only indexers share this snapshot. File mutations and queued publications
+    use fresh ownership checks so a completed scan cannot authorize a later write.
+    """
+
+    def __init__(self):
+        self._loaded = False
+        self._owners = {}
+
+    @staticmethod
+    def _load_owners():
+        from app.database import database, select, TableEpisodes, TableMovies
+        from app.config import settings
+        from utilities.path_mappings import path_mappings
+
+        subfolder = settings.general.subfolder
+        custom_folder = settings.general.subfolder_custom
+        absolute_folder = (os.path.normcase(os.path.realpath(custom_folder))
+                           if subfolder == 'absolute' else None)
+        owners = {}
+        for table, media_type in ((TableEpisodes, 'episode'), (TableMovies, 'movie')):
+            for row in database.execute(select(table.path, table.arr_instance_id)).all():
+                if not row.path:
+                    continue
+                mapped = os.path.normcase(os.path.realpath(path_mappings.path_replace_instance(
+                    row.path, row.arr_instance_id, media_type)))
+                folders = {os.path.dirname(mapped)}
+                if subfolder == 'absolute':
+                    folders.add(absolute_folder)
+                elif subfolder == 'relative':
+                    folders.add(os.path.normcase(os.path.realpath(os.path.join(
+                        os.path.dirname(mapped), custom_folder))))
+                stem = _normalized_media_stem(mapped)
+                for folder in folders:
+                    owners.setdefault((folder, stem), set()).add(mapped)
+        return owners
+
+    def is_unique(self, video, directory, conflicting_stems):
+        if not self._loaded:
+            # A failed build leaves an empty index, never a partial ownership
+            # claim or repeated full-library retries during the same scan.
+            self._loaded = True
+            self._owners = self._load_owners()
+        owned = False
+        expected_owner = {video}
+        for stem in conflicting_stems:
+            owners = self._owners.get((directory, stem))
+            if owners:
+                if owners != expected_owner:
+                    return False
+                owned = True
+        return owned
+
+
+def sync_output_owner_is_unique(video_path, source_path, ownership_index=None):
     """Prove ownership before moving or replacing an exact generated variant."""
     from subliminal_patch.core import VIDEO_EXTENSIONS
 
@@ -204,9 +264,7 @@ def sync_output_owner_is_unique(video_path, source_path):
     directory = os.path.normcase(os.path.realpath(os.path.dirname(source_path)))
     media_directory = os.path.dirname(video)
 
-    def stem(path):
-        return unicodedata.normalize('NFC', os.path.splitext(os.path.basename(path))[0].lower())
-
+    stem = _normalized_media_stem
     if stem(source_path) != stem(video) and not stem(source_path).startswith(stem(video) + '.'):
         return False
     conflicting_stems = {stem(video), stem(source_path)}
@@ -219,30 +277,11 @@ def sync_output_owner_is_unique(video_path, source_path):
         if directory == media_directory:
             return video in local_videos
 
-        # Separate media directories can share one absolute subtitle folder. The
-        # local scan cannot establish ownership there, so include mapped DB paths.
-        from app.database import database, select, TableEpisodes, TableMovies
-        from app.config import settings
-        from utilities.path_mappings import path_mappings
-
-        owners = set()
-        for table, media_type in ((TableEpisodes, 'episode'), (TableMovies, 'movie')):
-            for row in database.execute(select(table.path, table.arr_instance_id)).all():
-                if not row.path:
-                    continue
-                mapped = os.path.normcase(os.path.realpath(path_mappings.path_replace_instance(
-                    row.path, row.arr_instance_id, media_type)))
-                if stem(mapped) not in conflicting_stems:
-                    continue
-                folders = {os.path.dirname(mapped)}
-                if settings.general.subfolder == 'absolute':
-                    folders.add(os.path.normcase(os.path.realpath(settings.general.subfolder_custom)))
-                elif settings.general.subfolder == 'relative':
-                    folders.add(os.path.normcase(os.path.realpath(os.path.join(
-                        os.path.dirname(mapped), settings.general.subfolder_custom))))
-                if directory in folders:
-                    owners.add(mapped)
-        return owners == {video}
+        # Separate media directories can share a custom subtitle folder. Keep
+        # all mapped owners, amortizing that lookup only within an explicit scan.
+        if ownership_index is None:
+            ownership_index = SyncOutputOwnerIndex()
+        return ownership_index.is_unique(video, directory, conflicting_stems)
     except (OSError, ValueError):
         return False
     except Exception:

--- a/bazarr/subtitles/tools/subsync_engines.py
+++ b/bazarr/subtitles/tools/subsync_engines.py
@@ -2,9 +2,13 @@
 
 import logging
 import os
+import stat
+import shutil
 import tempfile
+import unicodedata
+import uuid
 from dataclasses import dataclass, field
-from contextlib import nullcontext
+from contextlib import contextmanager, ExitStack, nullcontext
 from pathlib import Path
 from threading import Lock, RLock
 from weakref import WeakValueDictionary
@@ -12,6 +16,26 @@ from weakref import WeakValueDictionary
 
 _subtitle_write_locks = WeakValueDictionary()
 _subtitle_write_locks_guard = Lock()
+
+
+class _SubtitleWriteState:
+    def __init__(self):
+        self.lock = RLock()
+        self.revisions = {}
+
+    def __enter__(self):
+        self.lock.acquire()
+        return self
+
+    def __exit__(self, *exc):
+        self.lock.release()
+
+    def changed(self, path):
+        key = os.path.normcase(os.path.realpath(path))
+        self.revisions[key] = self.revisions.get(key, 0) + 1
+
+    def revision(self, path):
+        return self.revisions.setdefault(os.path.normcase(os.path.realpath(path)), 0)
 
 
 def subtitle_write_lock(video_path, subtitle_directory):
@@ -26,7 +50,7 @@ def subtitle_write_lock(video_path, subtitle_directory):
     with _subtitle_write_locks_guard:
         lock = _subtitle_write_locks.get(key)
         if lock is None:
-            lock = RLock()
+            lock = _SubtitleWriteState()
             _subtitle_write_locks[key] = lock
         return lock
 
@@ -40,8 +64,236 @@ def subtitle_source_version(path):
     return (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns)
 
 
+class SubtitlePublication:
+    """Hold a media coordinator while a queued sync watches exact destinations."""
+
+    def __init__(self, video_path, source_path, source_version):
+        self.state = subtitle_write_lock(video_path, os.path.dirname(source_path))
+        self.source_path = source_path
+        self.source_version = source_version
+        with self.state:
+            self.source_revision = self.state.revision(source_path)
+            self.owns_destinations = sync_output_owner_is_unique(video_path, source_path)
+            self.destinations = {
+                str(path): (self.state.revision(path), subtitle_source_version(path))
+                for path in (engine_output_path(source_path, engine) for engine in SYNC_ENGINES)
+            }
+
+    def source_unchanged(self):
+        return (self.state is not None and self.source_version is not None
+                and self.state.revision(self.source_path) == self.source_revision
+                and subtitle_source_version(self.source_path) == self.source_version)
+
+    def destination_owned(self, path):
+        return self.owns_destinations and not os.path.islink(path)
+
+    def destination_unchanged(self, path):
+        expected = self.destinations.get(str(path))
+        return (self.state is not None and self.destination_owned(path) and expected is not None
+                and expected == (self.state.revision(path), subtitle_source_version(path)))
+
+    def release(self):
+        self.state = None
+
+
+def source_is_unchanged(path, version):
+    if isinstance(version, SubtitlePublication):
+        return version.source_unchanged()
+    return subtitle_source_version(path) == version
+
+
+def release_subtitle_publication(version):
+    if isinstance(version, SubtitlePublication):
+        version.release()
+
+
+def release_unqueued_subtitle_publication(version, queue):
+    if not isinstance(version, SubtitlePublication):
+        return
+    # Duplicate submission can pass the very same snapshot as the queued job.
+    # Its coordinator belongs to that job until the running call finishes.
+    with queue._queue_lock:
+        if any(job.kwargs.get('source_version') is version
+               for job in (*queue.jobs_pending_queue, *queue.jobs_running_queue)):
+            return
+    release_subtitle_publication(version)
+
+
+@contextmanager
+def subtitle_write_locks(video_path, *paths):
+    """Acquire participating subtitle directories in stable order."""
+    directories = sorted({os.path.normcase(os.path.realpath(os.path.dirname(path))) for path in (video_path, *paths)})
+    with ExitStack() as stack:
+        states = {directory: stack.enter_context(subtitle_write_lock(video_path, directory))
+                  for directory in directories}
+        yield states
+
+
+@contextmanager
+def subtitle_mutation(video_path, *paths, invalidate_outputs=True):
+    """Coordinate exact local writes and invalidate pending publications.
+
+    Network and engine work stays outside. Indexers share this coordinator for
+    their external-file scan and database update.
+    """
+    with subtitle_write_locks(video_path, *paths) as states:
+        versions = {path: subtitle_source_version(path) for path in paths}
+        try:
+            yield
+        finally:
+            for path, version in versions.items():
+                if subtitle_source_version(path) != version:
+                    directory = os.path.normcase(os.path.realpath(os.path.dirname(path)))
+                    states[directory].changed(path)
+                    if invalidate_outputs:
+                        quarantine_sync_outputs_after_mutation(video_path, path)
+
+
+@contextmanager
+def staged_subtitle_write(video_path, destination, before_publish=None, allow_empty=False,
+                          source_paths=(), after_publish=None):
+    """Compute privately, then publish only while source and destination are current."""
+    with subtitle_write_locks(video_path, destination, *source_paths) as states:
+        def version(path):
+            directory = os.path.normcase(os.path.realpath(os.path.dirname(path)))
+            return (states[directory].revision(path), subtitle_source_version(path))
+
+        destination_version = version(destination)
+        source_versions = {path: version(path) for path in source_paths}
+    temporary = os.path.join(os.path.dirname(destination), f'.bazarr-write-{uuid.uuid4().hex}{Path(destination).suffix}')
+    fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o666)
+    os.close(fd)
+    try:
+        yield temporary
+        if allow_empty and os.path.isfile(temporary) and os.path.getsize(temporary) == 0:
+            return
+        if not os.path.isfile(temporary) or os.path.getsize(temporary) == 0:
+            raise OSError('Subtitle writer did not produce a nonempty file')
+        with subtitle_write_locks(video_path, destination, *source_paths):
+            with subtitle_mutation(video_path, destination):
+                if before_publish:
+                    before_publish()
+                if destination_version != version(destination):
+                    raise SubtitleDestinationChanged('Subtitle changed during processing')
+                if any(expected[1] is None or expected != version(path) for path, expected in source_versions.items()):
+                    raise SubtitleSourceChanged('Source subtitle changed during processing')
+                if os.path.isfile(destination):
+                    shutil.copymode(destination, temporary)
+                os.replace(temporary, destination)
+                if after_publish:
+                    after_publish()
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def write_subtitle_file(video_path, destination, content, written_paths=None):
+    """Write one saver output atomically and record that exact successful path."""
+    with staged_subtitle_write(video_path, destination,
+                              after_publish=(lambda: written_paths.append(destination))
+                              if written_paths is not None else None) as temporary:
+        with open(temporary, 'wb') as handle:
+            handle.write(content)
+
+
+def sync_output_owner_is_unique(video_path, source_path):
+    """Prove ownership before moving or replacing an exact generated variant."""
+    from subliminal_patch.core import VIDEO_EXTENSIONS
+
+    video = os.path.normcase(os.path.realpath(video_path))
+    directory = os.path.normcase(os.path.realpath(os.path.dirname(source_path)))
+    media_directory = os.path.dirname(video)
+
+    def stem(path):
+        return unicodedata.normalize('NFC', os.path.splitext(os.path.basename(path))[0].lower())
+
+    if stem(source_path) != stem(video) and not stem(source_path).startswith(stem(video) + '.'):
+        return False
+    conflicting_stems = {stem(video), stem(source_path)}
+    try:
+        with os.scandir(media_directory) as entries:
+            local_videos = {os.path.normcase(os.path.realpath(entry.path)) for entry in entries
+                            if entry.is_file() and entry.name.lower().endswith(VIDEO_EXTENSIONS)}
+        if any(path != video and stem(path) in conflicting_stems for path in local_videos):
+            return False
+        if directory == media_directory:
+            return video in local_videos
+
+        # Separate media directories can share one absolute subtitle folder. The
+        # local scan cannot establish ownership there, so include mapped DB paths.
+        from app.database import database, select, TableEpisodes, TableMovies
+        from app.config import settings
+        from utilities.path_mappings import path_mappings
+
+        owners = set()
+        for table, media_type in ((TableEpisodes, 'episode'), (TableMovies, 'movie')):
+            for row in database.execute(select(table.path, table.arr_instance_id)).all():
+                if not row.path:
+                    continue
+                mapped = os.path.normcase(os.path.realpath(path_mappings.path_replace_instance(
+                    row.path, row.arr_instance_id, media_type)))
+                if stem(mapped) not in conflicting_stems:
+                    continue
+                folders = {os.path.dirname(mapped)}
+                if settings.general.subfolder == 'absolute':
+                    folders.add(os.path.normcase(os.path.realpath(settings.general.subfolder_custom)))
+                elif settings.general.subfolder == 'relative':
+                    folders.add(os.path.normcase(os.path.realpath(os.path.join(
+                        os.path.dirname(mapped), settings.general.subfolder_custom))))
+                if directory in folders:
+                    owners.add(mapped)
+        return owners == {video}
+    except (OSError, ValueError):
+        return False
+    except Exception:
+        logging.exception('BAZARR unable to verify generated subtitle ownership')
+        return False
+
+
+def quarantine_sync_outputs(video_path, source_path):
+    """Preserve proven generated siblings under names no subtitle scan accepts."""
+    if is_sync_engine_output(source_path) or not sync_output_owner_is_unique(video_path, source_path):
+        return
+    from subtitles.indexer.utils import add_sync_engine_outputs
+
+    directory = os.path.dirname(source_path)
+    with subtitle_write_lock(video_path, directory) as state:
+        owned = add_sync_engine_outputs(directory, {}, video_path=video_path)
+        for engine in SYNC_ENGINES:
+            output = engine_output_path(source_path, engine)
+            if output.name not in owned:
+                continue
+            try:
+                if not stat.S_ISREG(output.lstat().st_mode):
+                    continue
+            except FileNotFoundError:
+                continue
+            fd, quarantine = tempfile.mkstemp(prefix=f'.bazarr-sync-obsolete-{output.name[:40]}-', suffix='.bak', dir=directory)
+            os.close(fd)
+            try:
+                os.replace(output, quarantine)
+            except BaseException:
+                os.unlink(quarantine)
+                raise
+            state.changed(output)
+
+
+def quarantine_sync_outputs_after_mutation(video_path, source_path):
+    """Report cleanup failure separately from an already completed file change."""
+    try:
+        quarantine_sync_outputs(video_path, source_path)
+    except OSError as exc:
+        logging.error(
+            'BAZARR subtitle change completed for %s, but obsolete generated subtitle cleanup failed (%s). '
+            'Previous generated files may remain available.', source_path, type(exc).__name__)
+
+
 class SubtitleSourceChanged(Exception):
     """The upload was replaced or deleted while its sync was queued or running."""
+
+
+class SubtitleDestinationChanged(Exception):
+    """A user changed or deleted this engine's destination after enqueueing."""
 
 
 SYNC_ENGINES = ('ffsubsync', 'autosubsync', 'alass')
@@ -84,6 +336,8 @@ REASON_ENGINE_DECLINED = 'engine_declined'
 REASON_RESULT_REJECTED = 'result_rejected'
 REASON_ENGINE_FAILED = 'engine_failed'
 REASON_SOURCE_CHANGED = 'source_changed'
+REASON_DESTINATION_CHANGED = 'destination_changed'
+REASON_DESTINATION_AMBIGUOUS = 'destination_ambiguous'
 
 ENGINE_LABELS = {
     'ffsubsync': 'FFsubsync',
@@ -448,9 +702,9 @@ class SubsyncEngineRunner:
         return output_stat.st_size > 0 and output_stat.st_mtime_ns >= source_stat.st_mtime_ns
 
     def run(self, srt_path, output_mode, enabled_engines, execute_engine, force_sync=False,
-            source_version=None, before_publish=None, publication_lock=None):
+            source_version=None, before_publish=None, publication_lock=None, after_publish=None):
         output_mode = normalize_output_mode(output_mode)
-        result = SyncRunResult(source_path=srt_path, output_mode=output_mode)
+        result = self.result = SyncRunResult(source_path=srt_path, output_mode=output_mode)
 
         if is_sync_engine_output(srt_path):
             result.results.append(SyncEngineResult(
@@ -462,17 +716,24 @@ class SubsyncEngineRunner:
             return result
 
         for engine in normalize_enabled_engines(enabled_engines):
-            if source_version is not None and subtitle_source_version(srt_path) != source_version:
+            if source_version is not None and not source_is_unchanged(srt_path, source_version):
                 result.results.append(SyncEngineResult(
                     engine=engine, status=RESULT_SKIPPED, reason=REASON_SOURCE_CHANGED,
                     message='The uploaded subtitle was replaced or deleted.',
                 ))
                 break
             final_engine_output_path = engine_output_path(srt_path, engine)
-            output_path = (
-                final_engine_output_path if output_mode == OUTPUT_MODE_KEEP_ALL and source_version is None
-                else temporary_engine_output_path(srt_path, engine)
-            )
+            output_path = temporary_engine_output_path(srt_path, engine)
+
+            if (output_mode == OUTPUT_MODE_KEEP_ALL and isinstance(source_version, SubtitlePublication)
+                    and not source_version.destination_unchanged(final_engine_output_path)):
+                result.results.append(SyncEngineResult(
+                    engine=engine, status=RESULT_SKIPPED,
+                    reason=(REASON_DESTINATION_CHANGED if source_version.destination_owned(final_engine_output_path)
+                            else REASON_DESTINATION_AMBIGUOUS),
+                    message='The synchronized subtitle destination changed or its owner is ambiguous.',
+                ))
+                continue
 
             if self.failure_store.should_skip(srt_path, engine) and not force_sync:
                 result.results.append(SyncEngineResult(
@@ -507,19 +768,26 @@ class SubsyncEngineRunner:
 
                 generated_path = str(output_path)
                 final_output_path = output_path
-                with publication_lock or nullcontext():
+                with publication_lock or nullcontext() as state:
                     if before_publish:
                         before_publish()
-                    if source_version is not None and subtitle_source_version(srt_path) != source_version:
+                    if source_version is not None and not source_is_unchanged(srt_path, source_version):
                         raise SubtitleSourceChanged()
+                    if (output_mode == OUTPUT_MODE_KEEP_ALL and isinstance(source_version, SubtitlePublication)
+                            and not source_version.destination_unchanged(final_engine_output_path)):
+                        raise SubtitleDestinationChanged()
                     if output_mode == OUTPUT_MODE_OVERWRITE:
                         os.replace(str(output_path), srt_path)
                         final_output_path = Path(srt_path)
                         generated_path = None
-                    elif source_version is not None:
+                    else:
                         os.replace(str(output_path), str(final_engine_output_path))
                         final_output_path = final_engine_output_path
                         generated_path = str(final_engine_output_path)
+                    if hasattr(state, 'changed'):
+                        state.changed(final_output_path)
+                    if after_publish:
+                        after_publish()
 
                 self.failure_store.record_success(srt_path, engine)
                 result.results.append(SyncEngineResult(
@@ -541,6 +809,16 @@ class SubsyncEngineRunner:
                     message='The uploaded subtitle was replaced or deleted.',
                 ))
                 break
+            except SubtitleDestinationChanged:
+                if output_path.is_file():
+                    output_path.unlink()
+                result.results.append(SyncEngineResult(
+                    engine=engine, status=RESULT_SKIPPED,
+                    reason=(REASON_DESTINATION_CHANGED if source_version.destination_owned(final_engine_output_path)
+                            else REASON_DESTINATION_AMBIGUOUS),
+                    message='The synchronized subtitle destination changed or its owner is ambiguous.',
+                ))
+                continue
             except MissingSyncEngineError as exc:
                 logging.warning('BAZARR %s sync engine skipped: %s', engine, exc)
                 result.results.append(SyncEngineResult(

--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -23,6 +23,9 @@ from subtitles.tools.subsync_engines import (
     normalize_output_mode,
     validate_engine_result,
     subtitle_write_lock,
+    SubtitlePublication,
+    subtitle_source_version,
+    quarantine_sync_outputs_after_mutation,
 )
 from languages.get_languages import audio_language_from_name, language_from_alpha2
 from utilities.path_mappings import path_mappings
@@ -587,18 +590,33 @@ class SubSyncer:
             return raw_result
 
         runner = SubsyncEngineRunner()
-        source_options = {'source_version': source_version} if source_version is not None else {}
-        if source_version is not None:
-            source_options['before_publish'] = lambda: self._report_progress('Saving synchronized subtitle', None, None)
-            source_options['publication_lock'] = subtitle_write_lock(video_path, os.path.dirname(srt_path))
-        self.sync_result = runner.run(
-            srt_path=self.srtin,
-            output_mode=output_mode,
-            enabled_engines=enabled_engines,
-            execute_engine=execute_engine,
-            force_sync=force_sync,
-            **source_options,
-        )
+        publication_lock = subtitle_write_lock(video_path, os.path.dirname(srt_path))
+        publication = source_version
+        if publication is None:
+            with publication_lock:
+                publication = SubtitlePublication(video_path, srt_path, subtitle_source_version(srt_path))
+
+        def publish():
+            self._report_progress('Saving synchronized subtitle', None, None)
+
+        try:
+            self.sync_result = runner.run(
+                srt_path=self.srtin,
+                output_mode=output_mode,
+                enabled_engines=enabled_engines,
+                execute_engine=execute_engine,
+                force_sync=force_sync,
+                source_version=publication,
+                before_publish=publish,
+                publication_lock=publication_lock,
+                after_publish=(lambda: quarantine_sync_outputs_after_mutation(video_path, srt_path))
+                if output_mode == OUTPUT_MODE_OVERWRITE and source_version is None else None,
+            )
+        finally:
+            # Preserve successful destinations even if a later engine is cancelled.
+            self.sync_result = getattr(runner, 'result', self.sync_result)
+            if source_version is None:
+                publication.release()
 
         if settings.subsync.debug:
             return self.sync_result

--- a/bazarr/subtitles/tools/translate/services/gemini_translator.py
+++ b/bazarr/subtitles/tools/translate/services/gemini_translator.py
@@ -12,6 +12,7 @@ import logging
 
 import srt
 import pysubs2
+from subtitles.tools.subsync_engines import staged_subtitle_write
 import requests
 import unicodedata as ud
 from collections import Counter
@@ -23,7 +24,7 @@ from sonarr.history import history_log
 from radarr.history import history_log_movie
 from utilities.path_mappings import path_mappings  # noqa: F401
 from subtitles.processing import ProcessSubtitlesResult  # noqa: F401
-from app.jobs_queue import jobs_queue
+from app.jobs_queue import JobCancelled, jobs_queue
 from languages.get_languages import alpha3_from_alpha2, language_from_alpha2, language_from_alpha3  # noqa: F401
 from ..core.translator_utils import add_translator_info, get_description, create_process_result
 
@@ -99,7 +100,6 @@ class GeminiTranslatorService:
             self.gemini_api_key = self.current_api_key
             self.target_language = language_from_alpha3(self.to_lang)
             self.input_file = self.source_srt_file
-            self.output_file = self.dest_srt_file
             self.model_name = settings.translator.gemini_model
             self.batch_size = self._get_batch_size()
             self.description = get_description(self.media_type, self.radarr_id, self.sonarr_series_id,
@@ -108,15 +108,23 @@ class GeminiTranslatorService:
             if self.input_file:
                 self.progress_file = os.path.join(os.path.dirname(self.input_file), f".{os.path.basename(self.input_file)}.progress")
 
-            self._check_saved_progress()
-
             try:
-                self._translate_with_gemini()
-                add_translator_info(self.dest_srt_file, f"# Subtitles translated with {settings.translator.gemini_model} # ")
+                with staged_subtitle_write(self.video_path, self.dest_srt_file,
+                                       source_paths=(self.source_srt_file,),
+                                           before_publish=lambda: jobs_queue.update_job_progress(job_id=job_id)) as temporary:
+                    self.output_file = temporary
+                    self._check_saved_progress()
+                    self._translate_with_gemini()
+                    add_translator_info(temporary, f"# Subtitles translated with {settings.translator.gemini_model} # ")
+            except JobCancelled:
+                raise
             except Exception as e:
                 jobs_queue.update_job_progress(job_id=job_id, progress_message=f'Gemini translation error: {str(e)}')
                 raise
 
+        except JobCancelled:
+            self._clear_progress()
+            raise
         except Exception as e:
             logger.error(f'BAZARR encountered an error translating with Gemini: {str(e)}')  # noqa: G004
             raise
@@ -182,6 +190,8 @@ class GeminiTranslatorService:
 
                 if saved_line > 1 and self.start_line == 1:
                     os.remove(self.output_file)
+        except JobCancelled:
+            raise
         except Exception as e:
             jobs_queue.update_job_progress(job_id=self.job_id, progress_message=f"Error reading progress file: {e}")
 
@@ -197,7 +207,7 @@ class GeminiTranslatorService:
             jobs_queue.update_job_progress(job_id=self.job_id, progress_message=f"Failed to save progress: {e}")
 
     def _clear_progress(self):
-        """Clear the progress file on successful completion"""
+        """Remove saved progress after completion, failure, or cancellation."""
         if self.progress_file and os.path.exists(self.progress_file):
             try:
                 os.remove(self.progress_file)
@@ -367,6 +377,7 @@ class GeminiTranslatorService:
         }
 
         try:
+            jobs_queue.update_job_progress(job_id=self.job_id)
             response = requests.request("POST", url, headers=headers, data=payload)
             response.raise_for_status()  # Raise an exception for bad status codes
 
@@ -403,6 +414,8 @@ class GeminiTranslatorService:
 
             return self.current_progress
 
+        except JobCancelled:
+            raise
         except Exception as e:
             response = getattr(e, "response", None)
             if self._is_rate_limited_response(response):
@@ -543,15 +556,20 @@ class GeminiTranslatorService:
                     # Clear progress file on successful completion
                     self._clear_progress()
 
+        except JobCancelled:
+            raise
         except Exception as e:
             logger.error(f'BAZARR encountered an error translating with Gemini: {str(e)}')  # noqa: G004
             jobs_queue.update_job_progress(job_id=self.job_id, progress_value=total,
                                            progress_message=f'Gemini translation failed: {str(e)}')
-            self._clear_progress()
-            if self.output_file and os.path.exists(self.output_file):
-                try:
-                    if os.path.getsize(self.output_file) == 0:
-                        os.remove(self.output_file)
-                except OSError:
-                    pass
-            raise e
+            raise
+        finally:
+            try:
+                self._clear_progress()
+            finally:
+                if self.output_file and os.path.exists(self.output_file):
+                    try:
+                        if os.path.getsize(self.output_file) == 0:
+                            os.remove(self.output_file)
+                    except OSError:
+                        pass

--- a/bazarr/subtitles/tools/translate/services/google_translator.py
+++ b/bazarr/subtitles/tools/translate/services/google_translator.py
@@ -2,6 +2,7 @@
 
 import logging
 import pysubs2
+from subtitles.tools.subsync_engines import staged_subtitle_write
 
 from retry.api import retry
 from app.config import settings  # noqa: F401
@@ -48,67 +49,71 @@ class GoogleTranslatorService:
 
     def translate(self, job_id):
         try:
-            subs = pysubs2.load(self.source_srt_file, encoding='utf-8')
-            subs.remove_miscellaneous_events()
-            lines_list = [x.plaintext for x in subs]
-            lines_list_len = len(lines_list)
+            with staged_subtitle_write(self.video_path, self.dest_srt_file,
+                                       source_paths=(self.source_srt_file,),
+                                       before_publish=lambda: jobs_queue.update_job_progress(job_id=job_id),
+                                       allow_empty=True) as temporary:
+                subs = pysubs2.load(self.source_srt_file, encoding='utf-8')
+                subs.remove_miscellaneous_events()
+                lines_list = [x.plaintext for x in subs]
+                lines_list_len = len(lines_list)
 
-            jobs_queue.update_job_progress(job_id=job_id, progress_max=lines_list_len,
-                                           progress_message=self.source_srt_file)
+                jobs_queue.update_job_progress(job_id=job_id, progress_max=lines_list_len,
+                                               progress_message=self.source_srt_file)
 
-            translated_lines = []
-            logger.debug(f'starting translation for {self.source_srt_file}')  # noqa: G004
+                translated_lines = []
+                logger.debug(f'starting translation for {self.source_srt_file}')  # noqa: G004
 
-            def translate_line(line_id, subtitle_line):
+                def translate_line(line_id, subtitle_line):
+                    try:
+                        translated_text = self._translate_text(subtitle_line, job_id)
+                        translated_lines.append({'id': line_id, 'line': translated_text})
+                    except TranslationNotFound:
+                        logger.debug(f'Unable to translate line {subtitle_line}')  # noqa: G004
+                        translated_lines.append({'id': line_id, 'line': subtitle_line})
+                    finally:
+                        jobs_queue.update_job_progress(job_id=job_id, progress_value=len(translated_lines))
+
+                logger.debug(f'BAZARR is sending {lines_list_len} blocks to Google Translate')  # noqa: G004
+                pool = ThreadPoolExecutor(max_workers=10)
+                futures = []
+                for i, line in enumerate(lines_list):
+                    future = pool.submit(translate_line, i, line)
+                    futures.append(future)
+                pool.shutdown(wait=True)
+                for future in futures:
+                    try:
+                        future.result()
+                    except Exception as e:
+                        logger.error(f"Error in translation task: {e}")  # noqa: G004
+
+                for i, line in enumerate(translated_lines):
+                    lines_list[line['id']] = line['line']
+
+                logger.debug(f'BAZARR saving translated subtitles to {self.dest_srt_file}')  # noqa: G004
+                for i, line in enumerate(subs):
+                    try:
+                        if lines_list[i]:
+                            line.plaintext = lines_list[i]
+                        else:
+                            # we assume that there was nothing to translate if Google returns None. ex.: "♪♪"
+                            continue
+                    except IndexError:
+                        logger.error(f'BAZARR is unable to translate malformed subtitles: {self.source_srt_file}')  # noqa: G004
+                        jobs_queue.update_job_progress(job_id=job_id,
+                                                       progress_message=f'Translation failed: Unable to translate '
+                                                                        f'malformed subtitles for {self.source_srt_file}')
+                        raise
+
                 try:
-                    translated_text = self._translate_text(subtitle_line, job_id)
-                    translated_lines.append({'id': line_id, 'line': translated_text})
-                except TranslationNotFound:
-                    logger.debug(f'Unable to translate line {subtitle_line}')  # noqa: G004
-                    translated_lines.append({'id': line_id, 'line': subtitle_line})
-                finally:
-                    jobs_queue.update_job_progress(job_id=job_id, progress_value=len(translated_lines))
-
-            logger.debug(f'BAZARR is sending {lines_list_len} blocks to Google Translate')  # noqa: G004
-            pool = ThreadPoolExecutor(max_workers=10)
-            futures = []
-            for i, line in enumerate(lines_list):
-                future = pool.submit(translate_line, i, line)
-                futures.append(future)
-            pool.shutdown(wait=True)
-            for future in futures:
-                try:
-                    future.result()
-                except Exception as e:
-                    logger.error(f"Error in translation task: {e}")  # noqa: G004
-
-            for i, line in enumerate(translated_lines):
-                lines_list[line['id']] = line['line']
-
-            logger.debug(f'BAZARR saving translated subtitles to {self.dest_srt_file}')  # noqa: G004
-            for i, line in enumerate(subs):
-                try:
-                    if lines_list[i]:
-                        line.plaintext = lines_list[i]
-                    else:
-                        # we assume that there was nothing to translate if Google returns None. ex.: "♪♪"
-                        continue
-                except IndexError:
-                    logger.error(f'BAZARR is unable to translate malformed subtitles: {self.source_srt_file}')  # noqa: G004
+                    subs.save(temporary)
+                    add_translator_info(temporary, f"# Subtitles translated with Google Translate # ")  # noqa: F541
+                except OSError:
+                    logger.error(f'BAZARR is unable to save translated subtitles to {self.dest_srt_file}')  # noqa: G004
                     jobs_queue.update_job_progress(job_id=job_id,
-                                                   progress_message=f'Translation failed: Unable to translate '
-                                                                    f'malformed subtitles for {self.source_srt_file}')
-                    raise
-
-            try:
-                subs.save(self.dest_srt_file)
-                add_translator_info(self.dest_srt_file, f"# Subtitles translated with Google Translate # ")  # noqa: F541
-            except OSError:
-                logger.error(f'BAZARR is unable to save translated subtitles to {self.dest_srt_file}')  # noqa: G004
-                jobs_queue.update_job_progress(job_id=job_id,
-                                               progress_message=f'Translation failed: Unable to save translated '
-                                                                f'subtitles to {self.dest_srt_file}')
-                raise OSError
+                                                   progress_message=f'Translation failed: Unable to save translated '
+                                                                    f'subtitles to {self.dest_srt_file}')
+                    raise OSError
 
             message = f"{language_from_alpha2(self.from_lang)} subtitles translated to {language_from_alpha3(self.to_lang)}."
             result = create_process_result(message, self.video_path, self.orig_to_lang, self.forced, self.hi, self.dest_srt_file, self.media_type)

--- a/bazarr/subtitles/tools/translate/services/lingarr_translator.py
+++ b/bazarr/subtitles/tools/translate/services/lingarr_translator.py
@@ -2,6 +2,7 @@
 
 import logging
 import pysubs2
+from subtitles.tools.subsync_engines import staged_subtitle_write
 import requests
 
 from retry.api import retry
@@ -55,44 +56,48 @@ class LingarrTranslatorService:
 
     def translate(self, job_id=None):
         try:
-            jobs_queue.update_job_progress(job_id=job_id, progress_max=1, progress_message=self.source_srt_file)
+            with staged_subtitle_write(self.video_path, self.dest_srt_file,
+                                       source_paths=(self.source_srt_file,),
+                                       before_publish=lambda: jobs_queue.update_job_progress(job_id=job_id),
+                                       allow_empty=True) as temporary:
+                jobs_queue.update_job_progress(job_id=job_id, progress_max=1, progress_message=self.source_srt_file)
 
-            subs = pysubs2.load(self.source_srt_file, encoding='utf-8')
-            lines_list = [x.plaintext for x in subs]
-            lines_list_len = len(lines_list)
+                subs = pysubs2.load(self.source_srt_file, encoding='utf-8')
+                lines_list = [x.plaintext for x in subs]
+                lines_list_len = len(lines_list)
 
-            if lines_list_len == 0:
-                logger.debug('No lines to translate in subtitle file')
-                return self.dest_srt_file
+                if lines_list_len == 0:
+                    logger.debug('No lines to translate in subtitle file')
+                    return self.dest_srt_file
 
-            logger.debug(f'Starting translation for {self.source_srt_file}')  # noqa: G004
-            translated_lines = self._translate_content(lines_list, job_id=job_id)
+                logger.debug(f'Starting translation for {self.source_srt_file}')  # noqa: G004
+                translated_lines = self._translate_content(lines_list, job_id=job_id)
 
-            if translated_lines is None:
-                logger.error(f'Translation failed for {self.source_srt_file}')  # noqa: G004
-                jobs_queue.update_job_progress(job_id=job_id,
-                                               progress_message=f'Translation failed for {self.source_srt_file}')
-                raise RuntimeError(f'Translation failed for {self.source_srt_file}')
+                if translated_lines is None:
+                    logger.error(f'Translation failed for {self.source_srt_file}')  # noqa: G004
+                    jobs_queue.update_job_progress(job_id=job_id,
+                                                   progress_message=f'Translation failed for {self.source_srt_file}')
+                    raise RuntimeError(f'Translation failed for {self.source_srt_file}')
 
-            logger.debug(f'BAZARR saving Lingarr translated subtitles to {self.dest_srt_file}')  # noqa: G004
-            translation_map = {}
-            for item in translated_lines:
-                if isinstance(item, dict) and 'position' in item and 'line' in item:
-                    translation_map[item['position']] = item['line']
+                logger.debug(f'BAZARR saving Lingarr translated subtitles to {self.dest_srt_file}')  # noqa: G004
+                translation_map = {}
+                for item in translated_lines:
+                    if isinstance(item, dict) and 'position' in item and 'line' in item:
+                        translation_map[item['position']] = item['line']
 
-            for i, line in enumerate(subs):
-                if i in translation_map and translation_map[i]:
-                    line.text = translation_map[i]
+                for i, line in enumerate(subs):
+                    if i in translation_map and translation_map[i]:
+                        line.text = translation_map[i]
 
-            try:
-                subs.save(self.dest_srt_file)
-                add_translator_info(self.dest_srt_file, f"# Subtitles translated with Lingarr # ")  # noqa: F541
-            except OSError:
-                logger.error(f'BAZARR is unable to save translated subtitles to {self.dest_srt_file}')  # noqa: G004
-                jobs_queue.update_job_progress(job_id=job_id,
-                                               progress_message=f'Translation failed: Unable to save translated '
-                                                                f'subtitles to {self.dest_srt_file}')
-                raise OSError
+                try:
+                    subs.save(temporary)
+                    add_translator_info(temporary, f"# Subtitles translated with Lingarr # ")  # noqa: F541
+                except OSError:
+                    logger.error(f'BAZARR is unable to save translated subtitles to {self.dest_srt_file}')  # noqa: G004
+                    jobs_queue.update_job_progress(job_id=job_id,
+                                                   progress_message=f'Translation failed: Unable to save translated '
+                                                                    f'subtitles to {self.dest_srt_file}')
+                    raise OSError
 
             message = (f"{language_from_alpha2(self.from_lang)} subtitles translated to "
                        f"{language_from_alpha3(self.to_lang)} using Lingarr.")

--- a/bazarr/subtitles/tools/translate/services/openrouter_translator.py
+++ b/bazarr/subtitles/tools/translate/services/openrouter_translator.py
@@ -3,10 +3,8 @@
 import re
 import time
 import logging
-import os
-import shutil
-import uuid
 import pysubs2
+from subtitles.tools.subsync_engines import staged_subtitle_write, SubtitleDestinationChanged
 import requests
 from typing import Optional, List, Dict, Any
 
@@ -18,7 +16,7 @@ from languages.get_languages import language_from_alpha2, language_from_alpha3
 from radarr.history import history_log_movie
 from sonarr.history import history_log
 from app.event_handler import show_progress, hide_progress, show_message
-from app.jobs_queue import jobs_queue
+from app.jobs_queue import jobs_queue, JobCancelled
 
 from ..core.translator_utils import add_translator_info, create_process_result, get_title
 from .auth import get_translator_auth_headers
@@ -174,59 +172,47 @@ class OpenRouterTranslatorService:
     def translate(self, job_id=None):
         self.partial_error = None
         try:
-            subs = pysubs2.load(self.source_srt_file, encoding='utf-8')
-            lines_list: List[str] = [x.plaintext for x in subs]
-            lines_list_len = len(lines_list)
+            with staged_subtitle_write(self.video_path, self.dest_srt_file,
+                                       source_paths=(self.source_srt_file,),
+                                       before_publish=lambda: jobs_queue.update_job_progress(job_id=job_id),
+                                       allow_empty=True) as temporary:
+                subs = pysubs2.load(self.source_srt_file, encoding='utf-8')
+                lines_list: List[str] = [x.plaintext for x in subs]
+                lines_list_len = len(lines_list)
 
-            if lines_list_len == 0:
-                logger.debug('No lines to translate in subtitle file')
-                return False
+                if lines_list_len == 0:
+                    logger.debug('No lines to translate in subtitle file')
+                    return False
 
-            logger.debug(f'Starting AI translation for {self.source_srt_file}')  # noqa: G004
+                logger.debug(f'Starting AI translation for {self.source_srt_file}')  # noqa: G004
 
-            # Submit job and poll for completion
-            translated_lines = self._submit_and_poll(lines_list, bazarr_job_id=job_id)
+                # Submit job and poll for completion
+                translated_lines = self._submit_and_poll(lines_list, bazarr_job_id=job_id)
 
-            if translated_lines is None:
-                logger.error(f'Translation failed for {self.source_srt_file}')  # noqa: G004
-                show_message(f'Translation failed for {self.source_srt_file}')
-                return False
+                if translated_lines is None:
+                    logger.error(f'Translation failed for {self.source_srt_file}')  # noqa: G004
+                    show_message(f'Translation failed for {self.source_srt_file}')
+                    return False
 
-            # Process results
-            logger.debug(f'BAZARR saving AI translated subtitles to {self.dest_srt_file}')  # noqa: G004
-            translation_map = {}
-            for item in translated_lines:
-                if isinstance(item, dict) and 'position' in item and 'line' in item:
-                    translation_map[item['position']] = item['line']
+                # Process results
+                logger.debug(f'BAZARR saving AI translated subtitles to {self.dest_srt_file}')  # noqa: G004
+                translation_map = {}
+                for item in translated_lines:
+                    if isinstance(item, dict) and 'position' in item and 'line' in item:
+                        translation_map[item['position']] = item['line']
 
-            missing_lines = sum(bool(source.strip()) and not translation_map.get(i, '').strip()
-                                for i, source in enumerate(lines_list))
-            if missing_lines and not self.partial_error:
-                self._mark_partial(f'No translated text was returned for {missing_lines} of {lines_list_len} cues.')
+                missing_lines = sum(bool(source.strip()) and not translation_map.get(i, '').strip()
+                                    for i, source in enumerate(lines_list))
+                if missing_lines and not self.partial_error:
+                    self._mark_partial(f'No translated text was returned for {missing_lines} of {lines_list_len} cues.')
 
-            for i, line in enumerate(subs):
-                if i in translation_map and translation_map[i].strip():
-                    line.text = translation_map[i]
+                for i, line in enumerate(subs):
+                    if i in translation_map and translation_map[i].strip():
+                        line.text = translation_map[i]
 
-            temporary_file = os.path.join(os.path.dirname(self.dest_srt_file),
-                                          f'.bazarr-translate-{uuid.uuid4().hex}.srt')
-            temporary_file_created = False
-            try:
-                with open(temporary_file, 'x', encoding='utf-8'):
-                    temporary_file_created = True
-                subs.save(temporary_file)
+                subs.save(temporary)
                 translated = 'partially translated' if self.partial_error else 'translated'
-                add_translator_info(temporary_file, f"# Subtitles {translated} with AI Subtitle Translator #")
-                if os.path.exists(self.dest_srt_file):
-                    shutil.copymode(self.dest_srt_file, temporary_file)
-                os.replace(temporary_file, self.dest_srt_file)
-            except OSError:
-                logger.error(f'BAZARR is unable to save translated subtitles to {self.dest_srt_file}')  # noqa: G004
-                show_message(f'Translation failed: Unable to save translated subtitles to {self.dest_srt_file}')
-                raise
-            finally:
-                if temporary_file_created and os.path.exists(temporary_file):
-                    os.remove(temporary_file)
+                add_translator_info(temporary, f"# Subtitles {translated} with AI Subtitle Translator #")
 
             message = f"{language_from_alpha2(self.from_lang)} subtitles {translated} to {language_from_alpha3(self.to_lang)} using AI Subtitle Translator."
             if self.partial_error:
@@ -245,6 +231,8 @@ class OpenRouterTranslatorService:
 
             return self.dest_srt_file
 
+        except (JobCancelled, SubtitleDestinationChanged):
+            raise
         except Exception as e:
             logger.error(f'BAZARR encountered an error during AI translation: {str(e)}')  # noqa: G004
             show_message(f'AI translation failed: {str(e)}')

--- a/bazarr/subtitles/upload.py
+++ b/bazarr/subtitles/upload.py
@@ -310,12 +310,11 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
 
     refresh_consumers = partial(_refresh_upload_consumers, media_type,
                                 episode_metadata if media_type == 'series' else movie_metadata, arr_instance_id)
+    refresh_consumers()
     if source_publication is not None:
         sync_subtitles(video_path=path, srt_path=subtitle_path, srt_lang=uploaded_language_code2,
                        percent_score=100, forced=forced, hi=hi, sonarr_series_id=sonarrSeriesId,
                        sonarr_episode_id=sonarrEpisodeId, radarr_id=radarrId,
                        arr_instance_id=arr_instance_id, callback=refresh_subtitles,
                        source_version=source_publication, on_success=refresh_consumers)
-    refresh_consumers()
-
     return '', 204

--- a/bazarr/subtitles/upload.py
+++ b/bazarr/subtitles/upload.py
@@ -30,7 +30,8 @@ from app.event_handler import event_stream
 from app.notifier import send_notifications
 from app.notifier import send_notifications_movie
 from subtitles.processing import ProcessSubtitlesResult
-from subtitles.tools.subsync_engines import subtitle_source_version, subtitle_write_lock
+from subtitles.tools.subsync_engines import (SubtitlePublication, write_subtitle_file,
+                                            subtitle_source_version, subtitle_write_locks)
 
 from .sync import sync_subtitles, _index_keep_all_outputs
 from .post_processing import postprocessing
@@ -40,11 +41,45 @@ from jellyfin.operations import jellyfin_refresh_item
 
 def _refresh_uploaded_subtitles(video_path, subtitle_path, sonarr_series_id=None, sonarr_episode_id=None,
                                 radarr_id=None, arr_instance_id=None):
-    # Keep the scan and its database update together with save/delete operations.
-    with subtitle_write_lock(video_path, os.path.dirname(subtitle_path)):
-        _index_keep_all_outputs(video_path, sonarr_series_id=sonarr_series_id,
-                               sonarr_episode_id=sonarr_episode_id, radarr_id=radarr_id,
-                               arr_instance_id=arr_instance_id)
+    _index_keep_all_outputs(video_path, sonarr_series_id=sonarr_series_id,
+                            sonarr_episode_id=sonarr_episode_id, radarr_id=radarr_id,
+                            arr_instance_id=arr_instance_id)
+
+
+def _notify_upload(consumer, callback, *args, **kwargs):
+    try:
+        callback(*args, **kwargs)
+    except Exception as exc:
+        logging.warning('BAZARR upload notification failed for %s (%s)', consumer, type(exc).__name__)
+
+
+def _refresh_upload_consumers(media_type, metadata, arr_instance_id):
+    callbacks = []
+    if media_type == 'series':
+        callbacks.append(('Sonarr', lambda: notify_sonarr(
+            metadata.sonarrSeriesId,
+            arr_client=client_for_instance(database, arr_instance_id, enabled_only=False))))
+        if settings.general.use_plex and settings.plex.update_series_library:
+            callbacks.append(('Plex', lambda: plex_refresh_item(
+                metadata.imdbId, is_movie=False, season=metadata.season, episode=metadata.episode)))
+        if settings.general.use_jellyfin and settings.jellyfin.update_series_library:
+            callbacks.append(('Jellyfin', lambda: jellyfin_refresh_item(
+                metadata.imdbId, is_movie=False, season=metadata.season, episode=metadata.episode,
+                tvdb_id=metadata.tvdbId)))
+    else:
+        callbacks.append(('Radarr', lambda: notify_radarr(
+            metadata.radarrId,
+            arr_client=client_for_instance(database, arr_instance_id, enabled_only=False))))
+        if settings.general.use_plex and settings.plex.update_movie_library:
+            callbacks.append(('Plex', lambda: plex_refresh_item(metadata.imdbId, is_movie=True)))
+        if settings.general.use_jellyfin and settings.jellyfin.update_movie_library:
+            callbacks.append(('Jellyfin', lambda: jellyfin_refresh_item(
+                metadata.imdbId, is_movie=True, tmdb_id=metadata.tmdbId)))
+    for consumer, callback in callbacks:
+        try:
+            callback()
+        except Exception as exc:
+            logging.warning('BAZARR upload refresh failed for %s (%s)', consumer, type(exc).__name__)
 
 
 def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, filename, audio_language, job_id=None,
@@ -96,6 +131,8 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
             .first()
 
         if episode_metadata:
+            sonarrSeriesId = episode_metadata.sonarrSeriesId
+            sonarrEpisodeId = episode_metadata.sonarrEpisodeId
             use_original_format = bool(get_profiles_list(episode_metadata.profileId)["originalFormat"])
         else:
             return
@@ -108,6 +145,7 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
             .first()
 
         if movie_metadata:
+            radarrId = movie_metadata.radarrId
             use_original_format = bool(get_profiles_list(movie_metadata.profileId)["originalFormat"])
         else:
             return
@@ -143,8 +181,8 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
         # ensure that formats must be a tuple of strings
         sub_format = (sub.format,) if isinstance(sub.format, str) else sub.format
         subtitle_directory = get_target_folder(path)
-        write_lock = subtitle_write_lock(path, subtitle_directory or os.path.dirname(path))
-        with write_lock:
+        with subtitle_write_locks(path, os.path.join(subtitle_directory or os.path.dirname(path), '.destination')):
+            written_paths = []
             saved_subtitles = save_subtitles(path,
                                             [sub],
                                             single=single,
@@ -152,8 +190,12 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
                                             directory=subtitle_directory,
                                             chmod=chmod,
                                             formats=sub_format if use_original_format else ("srt",),
-                                            path_decoder=force_unicode)
+                                            path_decoder=force_unicode,
+                                            write_subtitle=partial(write_subtitle_file, path, written_paths=written_paths))
+            saved_subtitles = [saved for saved in saved_subtitles if saved.storage_path in written_paths]
             source_version = subtitle_source_version(saved_subtitles[0].storage_path) if saved_subtitles else None
+            source_publication = (SubtitlePublication(path, saved_subtitles[0].storage_path, source_version)
+                                  if source_version is not None else None)
     except Exception as e:
         logging.exception(f'BAZARR Error saving Subtitles file to disk for this file {path}: {repr(e)}')  # noqa: G004
         return
@@ -198,11 +240,13 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
                              uploaded_language_code3, audio_language['name'], audio_language['code2'],
                              audio_language['code3'], 100, "1", "manual", "user", "unknown", sonarrSeriesId,
                              sonarrEpisodeId or radarrId,)
-        with write_lock:
+        with subtitle_write_locks(path, subtitle_path):
             if subtitle_source_version(subtitle_path) == source_version:
-                postprocessing(command, path)
+                postprocessing(command, path, subtitle_path=subtitle_path)
                 set_chmod(subtitles_path=subtitle_path)
                 source_version = subtitle_source_version(subtitle_path)
+                source_publication.release()
+                source_publication = SubtitlePublication(path, subtitle_path, source_version)
 
     refresh_subtitles = partial(_refresh_uploaded_subtitles, path, subtitle_path, sonarr_series_id=sonarrSeriesId,
                                 sonarr_episode_id=sonarrEpisodeId, radarr_id=radarrId,
@@ -217,8 +261,6 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
             subtitle_path, arr_instance_id, "series")
         # Route the rescan at the OWNING instance's server (#156). None owner =
         # default server (legacy single-instance), unchanged.
-        notify_sonarr(episode_metadata.sonarrSeriesId,
-                      arr_client=client_for_instance(database, arr_instance_id, enabled_only=False))
         event_stream(type='series', action='update', payload=episode_metadata.sonarrSeriesId)
         event_stream(type='episode-wanted', action='delete', payload=episode_metadata.sonarrEpisodeId)
     else:
@@ -227,8 +269,6 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
         reversed_path = path_mappings.path_replace_reverse_instance(path, arr_instance_id, "movie")
         reversed_subtitles_path = path_mappings.path_replace_reverse_instance(
             subtitle_path, arr_instance_id, "movie")
-        notify_radarr(movie_metadata.radarrId,
-                      arr_client=client_for_instance(database, arr_instance_id, enabled_only=False))
         event_stream(type='movie', action='update', payload=movie_metadata.radarrId)
         event_stream(type='movie-wanted', action='delete', payload=movie_metadata.radarrId)
 
@@ -254,37 +294,28 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
             history_log(4, sonarrSeriesId, sonarrEpisodeId, result, fake_provider=provider,
                         fake_score=MAX_SCORES['episode'], arr_instance_id=arr_instance_id)
             if not settings.general.dont_notify_manual_actions:
-                send_notifications(sonarrSeriesId, sonarrEpisodeId, result.message,
+                _notify_upload("user", send_notifications, sonarrSeriesId, sonarrEpisodeId, result.message,
                                    arr_instance_id=arr_instance_id)
             if settings.general.use_plex:
-                if settings.plex.update_series_library:
-                    plex_refresh_item(episode_metadata.imdbId, is_movie=False,
-                                      season=episode_metadata.season, episode=episode_metadata.episode)
                 if settings.plex.set_episode_added:
-                    plex_set_episode_added_date_now(episode_metadata)
-            if settings.general.use_jellyfin and settings.jellyfin.update_series_library:
-                jellyfin_refresh_item(episode_metadata.imdbId, is_movie=False,
-                                      season=episode_metadata.season, episode=episode_metadata.episode,
-                                      tvdb_id=episode_metadata.tvdbId)
+                    _notify_upload("Plex added date", plex_set_episode_added_date_now, episode_metadata)
         else:
             history_log_movie(4, radarrId, result, fake_provider=provider, fake_score=MAX_SCORES['movie'],
                               arr_instance_id=arr_instance_id)
             if not settings.general.dont_notify_manual_actions:
-                send_notifications_movie(radarrId, result.message, arr_instance_id=arr_instance_id)
+                _notify_upload("user", send_notifications_movie, radarrId, result.message, arr_instance_id=arr_instance_id)
             if settings.general.use_plex:
-                if settings.plex.update_movie_library:
-                    plex_refresh_item(movie_metadata.imdbId, is_movie=True)
                 if settings.plex.set_movie_added:
-                    plex_set_movie_added_date_now(movie_metadata)
-            if settings.general.use_jellyfin and settings.jellyfin.update_movie_library:
-                jellyfin_refresh_item(movie_metadata.imdbId, is_movie=True,
-                                      tmdb_id=movie_metadata.tmdbId)
+                    _notify_upload("Plex added date", plex_set_movie_added_date_now, movie_metadata)
 
-    if source_version is not None:
+    refresh_consumers = partial(_refresh_upload_consumers, media_type,
+                                episode_metadata if media_type == 'series' else movie_metadata, arr_instance_id)
+    if source_publication is not None:
         sync_subtitles(video_path=path, srt_path=subtitle_path, srt_lang=uploaded_language_code2,
                        percent_score=100, forced=forced, hi=hi, sonarr_series_id=sonarrSeriesId,
                        sonarr_episode_id=sonarrEpisodeId, radarr_id=radarrId,
                        arr_instance_id=arr_instance_id, callback=refresh_subtitles,
-                       source_version=source_version)
+                       source_version=source_publication, on_success=refresh_consumers)
+    refresh_consumers()
 
     return '', 204

--- a/custom_libs/subliminal_patch/core.py
+++ b/custom_libs/subliminal_patch/core.py
@@ -1471,7 +1471,7 @@ SUBTITLE_FORMAT_EXTENSIONS = {
 
 
 def save_subtitles(file_path, subtitles, single=False, directory=None, chmod=None, formats=("srt",),
-                   tags=None, path_decoder=None, debug_mods=False):
+                   tags=None, path_decoder=None, debug_mods=False, write_subtitle=None):
     """Save subtitles on filesystem.
 
     Subtitles are saved in the order of the list. If a subtitle with a language has already been saved, other subtitles
@@ -1486,6 +1486,7 @@ def save_subtitles(file_path, subtitles, single=False, directory=None, chmod=Non
     :type subtitles: list of :class:`~subliminal.subtitle.Subtitle`
     :param bool single: save a single subtitle, default is to save one subtitle per language.
     :param str directory: path to directory where to save the subtitles, default is next to the video.
+    :param write_subtitle: optional callback receiving each exact destination and encoded content
     :return: the saved subtitles
     :rtype: list of :class:`~subliminal.subtitle.Subtitle`
 
@@ -1543,11 +1544,13 @@ def save_subtitles(file_path, subtitles, single=False, directory=None, chmod=Non
             logger.debug(u"Saving %r to %r", subtitle, subtitle_path)
             content = subtitle.get_modified_content(format=format, debug=debug_mods)
             if content:
-                if os.path.exists(subtitle_path):
-                    os.remove(subtitle_path)
-
-                with open(subtitle_path, 'wb') as f:
-                    f.write(content)
+                if write_subtitle is not None:
+                    write_subtitle(subtitle_path, content)
+                else:
+                    if os.path.exists(subtitle_path):
+                        os.remove(subtitle_path)
+                    with open(subtitle_path, 'wb') as f:
+                        f.write(content)
                 subtitle.storage_path = subtitle_path
             else:
                 logger.error(u"Something went wrong when getting modified subtitle for %s", subtitle)

--- a/docs/release-notes/v2.6.2-clockwork.md
+++ b/docs/release-notes/v2.6.2-clockwork.md
@@ -1,0 +1,140 @@
+# Bazarr+ v2.6.2 (Clockwork)
+
+Codename: **Clockwork**
+
+A stability patch for subtitle uploads, searches, disk scans and translation. Uploaded subtitles appear before automatic sync finishes. Downloads keep their server ownership, sync outputs stay with the correct video, and useful partial OpenRouter translations are saved with an honest incomplete status. OpenRouter routing choices now stay consistent with the model field, and Provider Hub distinguishes a bad subtitle candidate from a provider-wide failure.
+
+---
+
+## Headline: Keep useful subtitle work and continue past unusable candidates
+
+### Partial translations are recoverable
+
+The OpenRouter translator service can return useful lines even when some batches fail. Bazarr previously discarded that partial result. It now saves valid translated lines, retains the source text where translation is missing, and marks the result as partially translated in history, job status and the subtitle footer. An empty or malformed result still fails. Saving uses a temporary file, so an unsuccessful write or footer update preserves any existing subtitle.
+
+The host also waits for long-running OpenRouter translation jobs while the service remains reachable, with a 12-hour overall limit and a 10-minute limit without a successful status response. This does not repair a translator service's own model or response-parsing errors.
+
+The separately deployed translator service reference advances to v1.3.4. The included service updates tolerate more malformed model replies, let batch sizes recover after failures, and report how many lines were actually translated. They align the prompt with JSON object mode, retry incomplete replies at the minimum batch size, and account for usage from failed or retried batches. Version 1.3.4 adds provider routing. Updating Bazarr alone does not replace a running translator service.
+
+### Uploads stay visible while sync runs
+
+A successful subtitle upload previously waited for automatic synchronization before appearing in the media's subtitle list. It now appears as soon as the upload is finalized, and synchronization runs as a separate progress job. Its completion refreshes the list, including saved outputs from multiple engines. A failed, skipped or cancelled sync leaves the uploaded subtitle available.
+
+Queued and running sync work also checks whether its source was replaced or deleted. An older sync result cannot overwrite a newer upload or restore a subtitle the user removed. Existing synchronization settings, instance ownership and upload history are retained.
+
+If older synchronized outputs cannot be moved aside after a new subtitle is saved, Bazarr reports the cleanup failure separately and keeps the completed save available. Those older outputs may remain listed until cleanup succeeds.
+
+### OpenRouter routing matches the saved settings
+
+Settings now offer fastest, cheapest, lowest-latency and OpenRouter-default routing, with separate `:nitro` and `:floor` shortcut choices. Typing either shortcut into the model field moves it into the routing selector when editing finishes and keeps the plain model ID for model details. Stacked routing shortcuts adopt the last one; other model variants remain unchanged. Lookalike text such as `:floorplan` is not rewritten.
+
+When the settings Save bar is visible, Enter, Ctrl+S and Cmd+S now include the focused field's latest edit before saving, including fields that apply changes when focus leaves them. Previously a keyboard save could retain the earlier value even though the field showed the new text. Ctrl+S and Cmd+S still require a pending settings change before starting a save.
+
+Full routing support requires translator service v1.3.4. Older or unrecognized service versions receive compatible plain routing choices where possible. Routing can affect provider selection and cost when a model has multiple providers; it does not guarantee a particular price or completion time.
+
+### An unusable archive does not disable the provider
+
+A valid catalog-provider archive can contain no subtitle for the requested episode or language. That now rejects the candidate and lets the search continue, including when only one successful subtitle is requested. Automatic archive selection handles filenames covering multiple episodes and relative or absolute episode numbers. It checks the requested season when filenames provide one. Selector callbacks are limited to the offered subtitle files. Corrupt archives, invalid selectors and unsafe archive paths still follow the provider-failure path.
+
+Provider workers also retain recognized authentication, quota, rate-limit and service errors. These reach Bazarr's matching pause policy instead of all becoming a generic worker error. OpenSubtitles.com download-quota errors use the existing six-hour pause; this change does not claim to know the account's exact quota-reset time.
+
+---
+
+## Other Improvements & Fixes
+
+- Dropping files into an open movie or series upload dialog no longer opens a second dialog. This also prevents extra dialogs while an archive is being expanded. Existing file selections are retained, and closing once dismisses the upload dialog.
+- Disk scans associate saved sync-engine outputs with their actual video. Case differences, Unicode normalization, language tags and sibling videos with dotted names are handled without duplicating or assigning another video's subtitles. Existing language-tagged files remain discoverable after single-language naming is enabled.
+- History preserves an explicitly supplied Sonarr or Radarr owner when a media lookup fails, avoiding the reported non-null ownership error.
+- Global search shows the owning instance name when multiple Sonarr instances or multiple Radarr instances are configured for that media kind.
+- Movie translation jobs now show the movie title, and Gemini receives its overview. Translations started from a media page use the owning Sonarr or Radarr instance for title and overview lookups, so matching upstream IDs on another server do not supply the wrong context.
+- Cancelling a Gemini translation no longer retries the request. Cancellation at the initial or final progress update also removes temporary progress files, while the existing destination subtitle is preserved.
+- Translator status cards remain visible when idle. Available counts show zero, and unavailable counts keep a placeholder while loading or reconnecting.
+- Automatic translation checks eligibility before logging that a source score is too low, including when automatic translation is disabled.
+- Translation and subtitle modifications retain an existing file's directory. New files use the configured subtitle folder, including relative and absolute custom folders.
+- Four retired OpenRouter model IDs are replaced in saved settings only when one of those known IDs is selected. New installations default to `google/gemini-2.5-flash-lite`; other custom selections are preserved. The model menu and translation guide are updated too. Grok menu suggestions are refreshed separately; saved Grok model IDs are not automatically migrated.
+- Startup dependency checks now agree with the versions selected in `requirements.txt`, preventing unnecessary repeated repair-and-restart attempts on otherwise compliant source installations.
+
+### Provider catalog updates
+
+Provider bundles have a separate release channel from the application. At preparation time, catalog `beta` includes OpenSubtitles.com 0.1.9 regional-language matching, anonymous OpenSubtitles.org 0.1.12 episode search and Anubis clearance, Titlovi 0.1.8 season-pack eligibility, and SubDL 0.1.4 error classification. Promotion to catalog `main` is still pending. Installing this application version alone does not replace those bundles. SubDL distinguishes documented exhausted-quota responses from other HTTP 429 rate limits and ordinary service failures.
+
+Anonymous OpenSubtitles.org and OpenSubtitles.com regional-language searches were verified through search, download-link creation and nonempty subtitle streams. Titlovi's season-pack correction passed local tests, but live download verification remains limited by the configured account's disabled API access. SubDL movie search and download passed; its episode control returned zero results with both the prior and updated versions, so episode downloads remain unverified. Current Subsource catalog searches and downloads passed; the reported failures came from the retired built-in implementation.
+
+---
+
+## CI / Docker
+
+The regression suites run in the standard Python 3.12, 3.13 and 3.14 matrix, including native PostgreSQL checks. Coverage includes upload visibility and synchronization races, settings submission, translation routing, provider error handling, ownership and runtime dependency checks. Release acceptance checks the combined production image, startup, the served UI and release-tour navigation, with provider canaries recorded separately. Frontend builds use Node 24.20.0 LTS, satisfying the installed dependencies' runtime requirements. Existing CI and Docker build workflows read this shared version pin. No Docker base-image change is included.
+
+---
+
+## Dependency Updates
+
+- Raise the cryptography security floor to 50.0.1 in both installation and runtime checks. Existing encrypted settings and ciphertext compatibility were verified.
+- Update the frontend's transitive Browserslist dependency from 4.28.4 to 4.28.7 with its required metadata packages.
+- Update GuessIt from 3.8.0 to 4.4.0 for subtitle filename parsing, and align its startup version check.
+- Update SQLAlchemy from 2.0.51 to 2.0.52, and align its startup version check.
+- Update Mantine from 9.5.2 to 9.6.0, including its react-dropzone 20 upload dependency.
+- Align the remaining stale runtime declarations with the dependencies already selected by the installation requirements. Version checks also distinguish prereleases from the required final and post-release versions.
+
+---
+
+## Database Migrations
+
+No schema changes. There are no new database migrations in this patch. Existing library and history data are preserved.
+
+---
+
+## Included Pull Requests
+
+- LavX/bazarr#407: Update GuessIt and its runtime version check.
+- LavX/bazarr#409: Update Mantine and verify upload compatibility.
+- LavX/bazarr#410: Update SQLAlchemy and its runtime version check.
+- LavX/bazarr#411: Preserve explicit history ownership when media lookup fails.
+- LavX/bazarr#412: Check automatic-translation eligibility before source-score logging.
+- LavX/bazarr#413: Show instance names in global search.
+- LavX/bazarr#414: Preserve Provider Hub semantic errors across the worker boundary.
+- LavX/bazarr#415: Scope sync-engine output discovery to the owning video.
+- LavX/bazarr#416: Preserve partial translations, wait for long jobs, and respect subtitle destinations.
+- LavX/bazarr#417: Update the Browserslist security dependency.
+- LavX/bazarr#418: Continue past unusable provider archive candidates.
+- LavX/bazarr#419: Align the cryptography security floor and verify encrypted-setting compatibility.
+- LavX/bazarr#420: Align startup dependency declarations and correct version comparisons.
+- LavX/bazarr#421: Update the translator service reference to v1.3.1.
+- LavX/bazarr#422: Update the translator service reference to v1.3.2.
+- LavX/bazarr#423: Update the translator service reference to v1.3.4.
+- LavX/bazarr#424: Keep nested subtitle drops in one upload dialog.
+- LavX/bazarr#425: Configure OpenRouter provider routing and compatibility with older services.
+- LavX/bazarr#426: Normalize routing shortcuts and commit edited settings before keyboard saves.
+- LavX/bazarr#427: Name movie translation jobs and scope media context to the owning server.
+- LavX/bazarr#428: Show uploaded subtitles immediately and synchronize them in a separate job.
+
+Catalog changes: [OpenSubtitles.com](https://github.com/LavX/bazarr-provider-catalog/pull/109), [Titlovi](https://github.com/LavX/bazarr-provider-catalog/pull/110), [SubDL](https://github.com/LavX/bazarr-provider-catalog/pull/111), and [OpenSubtitles.org](https://github.com/LavX/bazarr-provider-catalog/pull/112).
+
+---
+
+## Upgrade / Migration Notes
+
+- Update and restart normally. Back up your configuration and database before upgrading.
+- Review subtitles marked partially translated: some cues may remain in the source language. A saved partial result is not a complete translation.
+- Update the separately deployed translator service to v1.3.4 for the parsing, retry, usage-accounting and routing changes. Updating Bazarr alone does not replace a running translator service.
+- Review Provider Routing in Settings > AI Translator. Fastest remains the default; choosing Cheapest or `:floor` can select different providers. Existing model variants remain valid, and editing a trailing `:nitro` or `:floor` moves that choice into the routing selector.
+- If you used one of the retired OpenRouter model IDs, check the replacement in Settings > AI Translator. Other custom model IDs are retained.
+- Run Scan Disk to refresh existing sync-output entries after upgrading. Keep all engine outputs still intentionally saves one file per engine, and this fix does not delete files. Unrelated videos with identical basenames remain ambiguous in a shared absolute subtitle folder; use separate subtitle folders for those files.
+- Update provider bundles separately through Subtitle Hub when their catalog updates are available. OpenSubtitles.org's scraper supports anonymous downloads; OpenSubtitles.com and Titlovi have their own account requirements.
+- SQLite and PostgreSQL remain supported. Native Windows dependency execution was not part of this release's test-machine checks.
+
+---
+
+## Docker
+
+```bash
+docker pull ghcr.io/lavx/bazarr:2.6.2
+docker pull ghcr.io/lavx/bazarr:latest
+```
+
+After upgrading, confirm that the UI loads and `/api/system/status` reports `2.6.2`.
+
+---
+
+**Full Changelog:** https://github.com/LavX/bazarr/compare/v2.6.1...v2.6.2

--- a/docs/release-notes/v2.6.2-clockwork.md
+++ b/docs/release-notes/v2.6.2-clockwork.md
@@ -108,6 +108,7 @@ No schema changes. There are no new database migrations in this patch. Existing 
 - LavX/bazarr#426: Normalize routing shortcuts and commit edited settings before keyboard saves.
 - LavX/bazarr#427: Name movie translation jobs and scope media context to the owning server.
 - LavX/bazarr#428: Show uploaded subtitles immediately and synchronize them in a separate job.
+- LavX/bazarr#429: Protect subtitle changes during background sync, stop cancelled Gemini requests, keep translator status cards visible, and prepare this release.
 
 Catalog changes: [OpenSubtitles.com](https://github.com/LavX/bazarr-provider-catalog/pull/109), [Titlovi](https://github.com/LavX/bazarr-provider-catalog/pull/110), [SubDL](https://github.com/LavX/bazarr-provider-catalog/pull/111), and [OpenSubtitles.org](https://github.com/LavX/bazarr-provider-catalog/pull/112).
 

--- a/frontend/src/components/TranslatorStatus.tsx
+++ b/frontend/src/components/TranslatorStatus.tsx
@@ -215,7 +215,7 @@ const JobRow: FunctionComponent<JobRowProps> = ({ job }) => {
 
 interface StatCardProps {
   label: string;
-  value: number;
+  value: number | undefined;
   color: string;
 }
 
@@ -230,8 +230,13 @@ const StatCard: FunctionComponent<StatCardProps> = ({
     className={classes.statCard}
     style={{ borderLeftColor: `var(--bz-stat-${color})` }}
   >
-    <Text size="2rem" fw={700} lh={1}>
-      {value}
+    <Text
+      size="2rem"
+      fw={700}
+      lh={1}
+      aria-label={value == null ? "Count unavailable" : undefined}
+    >
+      {value ?? "-"}
     </Text>
     <Text
       size="xs"
@@ -272,17 +277,46 @@ export const TranslatorStatusPanel: FunctionComponent<
     void refetchJobs();
   }, [refetchStatus, refetchJobs]);
 
+  const availableStatus = statusError ? undefined : status;
+  const queueStats = (
+    <SimpleGrid cols={{ base: 2, sm: 4 }}>
+      <StatCard
+        label="Pending"
+        value={availableStatus?.bazarr_queue?.pending}
+        color="queued"
+      />
+      <StatCard
+        label="Processing"
+        value={availableStatus?.queue.processing}
+        color="processing"
+      />
+      <StatCard
+        label="Completed"
+        value={availableStatus?.queue.completed}
+        color="completed"
+      />
+      <StatCard
+        label="Failed"
+        value={availableStatus?.queue.failed}
+        color="failed"
+      />
+    </SimpleGrid>
+  );
+
   // Show loading state on first load
   if (statusLoading && !status) {
     return (
-      <Card withBorder mt="md" p="md">
-        <Group justify="center" py="md">
-          <FontAwesomeIcon icon={faSpinner} spin aria-hidden="true" />
-          <Text c="var(--bz-text-tertiary)">
-            Connecting to AI Subtitle Translator...
-          </Text>
-        </Group>
-      </Card>
+      <Stack gap="md" mt="md">
+        <Card withBorder p="md">
+          <Group justify="center" py="md">
+            <FontAwesomeIcon icon={faSpinner} spin aria-hidden="true" />
+            <Text c="var(--bz-text-tertiary)">
+              Connecting to AI Subtitle Translator...
+            </Text>
+          </Group>
+        </Card>
+        {queueStats}
+      </Stack>
     );
   }
 
@@ -293,26 +327,30 @@ export const TranslatorStatusPanel: FunctionComponent<
         : "The translation service isn't responding. Check that it's running at the configured URL, then hit retry.";
 
     return (
-      <Alert
-        color="yellow"
-        title="AI Subtitle Translator Unavailable"
-        mt="md"
-        icon={
-          <FontAwesomeIcon icon={faExclamationTriangle} aria-hidden="true" />
-        }
-      >
-        <Text size="sm" mb="sm">
-          {errorMessage}
-        </Text>
-        <Button
-          size="xs"
-          variant="light"
-          leftSection={<FontAwesomeIcon icon={faRefresh} aria-hidden="true" />}
-          onClick={handleRetry}
+      <Stack gap="md" mt="md">
+        <Alert
+          color="yellow"
+          title="AI Subtitle Translator Unavailable"
+          icon={
+            <FontAwesomeIcon icon={faExclamationTriangle} aria-hidden="true" />
+          }
         >
-          Retry Connection
-        </Button>
-      </Alert>
+          <Text size="sm" mb="sm">
+            {errorMessage}
+          </Text>
+          <Button
+            size="xs"
+            variant="light"
+            leftSection={
+              <FontAwesomeIcon icon={faRefresh} aria-hidden="true" />
+            }
+            onClick={handleRetry}
+          >
+            Retry Connection
+          </Button>
+        </Alert>
+        {queueStats}
+      </Stack>
     );
   }
 
@@ -350,42 +388,7 @@ export const TranslatorStatusPanel: FunctionComponent<
       </Card>
 
       {/* Queue Stats */}
-      {status &&
-        (status.queue.processing > 0 ||
-          status.queue.completed > 0 ||
-          status.queue.failed > 0 ||
-          (status.bazarr_queue?.pending ?? 0) > 0) && (
-          <SimpleGrid cols={{ base: 2, sm: 4 }}>
-            {(status.bazarr_queue?.pending ?? 0) > 0 && (
-              <StatCard
-                label="Pending"
-                value={status.bazarr_queue!.pending}
-                color="queued"
-              />
-            )}
-            {status.queue.processing > 0 && (
-              <StatCard
-                label="Processing"
-                value={status.queue.processing}
-                color="processing"
-              />
-            )}
-            {status.queue.completed > 0 && (
-              <StatCard
-                label="Completed"
-                value={status.queue.completed}
-                color="completed"
-              />
-            )}
-            {status.queue.failed > 0 && (
-              <StatCard
-                label="Failed"
-                value={status.queue.failed}
-                color="failed"
-              />
-            )}
-          </SimpleGrid>
-        )}
+      {queueStats}
 
       {/* Jobs Table */}
       <Card withBorder>

--- a/frontend/src/data/whatsNew.ts
+++ b/frontend/src/data/whatsNew.ts
@@ -32,7 +32,7 @@ export interface WhatsNewSlide {
  * cutting a release. Kept as an explicit token so the wizard never has to parse the
  * fork's `version + YYMMDD` runtime string.
  */
-export const latestWhatsNewVersion = "2.6.1";
+export const latestWhatsNewVersion = "2.6.2";
 
 // v2.6.0 feature slides; v2.6.1 (a patch on the same line) leads with its
 // fix and keeps the whole Clockwork tour behind it.
@@ -87,6 +87,116 @@ const clockworkSlides: WhatsNewSlide[] = [
 ];
 
 export const whatsNew: Record<string, WhatsNewSlide[]> = {
+  "2.6.2": [
+    {
+      title: "Uploaded subtitles appear before sync finishes",
+      body: "A saved upload is listed immediately while automatic sync runs as a separate job. Failed or cancelled sync leaves the uploaded subtitle available, and older sync work cannot replace a newer upload.",
+      icon: faDownload,
+      cta: { label: "Open your series", to: "/series" },
+    },
+    {
+      title: "One upload dialog for each batch",
+      body: "Dropping files into an open upload dialog keeps the existing selection without opening another dialog, including while an archive is expanding. Closing once dismisses it.",
+      icon: faFileZipper,
+      cta: { label: "Open your movies", to: "/movies" },
+    },
+    {
+      title: "Choose how OpenRouter routes your translations",
+      body: "Pick fastest, cheapest, lowest latency or OpenRouter's default. Typed :nitro and :floor shortcuts move into the routing selector when editing finishes, keeping model details and the saved choice consistent. Full shortcut support needs translator service 1.3.4.",
+      icon: faSliders,
+      cta: { label: "Open Translator settings", to: "/settings/translator" },
+    },
+    {
+      title: "Keyboard saves keep your latest settings edit",
+      body: "When the Save bar is visible, Enter and Ctrl+S or Cmd+S now include the latest text in the focused field, including fields that finish editing when focus moves away.",
+      icon: faSliders,
+      cta: { label: "Open Translator settings", to: "/settings/translator" },
+    },
+    {
+      title: "History keeps the right server",
+      body: "Downloads keep their Sonarr or Radarr owner even if the media lookup fails, so a missing lookup no longer prevents the history entry from being saved.",
+      icon: faClockRotateLeft,
+      cta: { label: "Open History", to: "/history/series" },
+    },
+    {
+      title: "Disk scans keep sync outputs with their video",
+      body: "Keep all still stores one file per sync engine. Disk scans now keep those outputs with the owning video, including existing language-tagged files after a single-language naming change.",
+      icon: faSliders,
+      cta: { label: "Open Subtitles settings", to: "/settings/subtitles" },
+    },
+    {
+      title: "Movie translation jobs show the movie title",
+      body: "Movie translations now show the movie's name in the job list, and Gemini receives its overview. Starting a translation from a media page also keeps title and overview lookups with that media's Sonarr or Radarr server.",
+      icon: faWandMagicSparkles,
+      cta: { label: "Open your movies", to: "/movies" },
+    },
+    {
+      title: "Recover useful OpenRouter translation results",
+      body: "Usable partial OpenRouter translations are saved and marked incomplete. Missing translations retain their source text, so review incomplete files. Empty or invalid results still fail, and failed saves preserve the previous subtitle.",
+      icon: faWandMagicSparkles,
+      cta: { label: "Open Translator settings", to: "/settings/translator" },
+    },
+    {
+      title: "Long OpenRouter translation jobs can finish",
+      body: "OpenRouter translation jobs can keep running for up to 12 hours. Ten minutes without a successful status response still stops the wait.",
+      icon: faClockRotateLeft,
+      cta: { label: "Open Translator settings", to: "/settings/translator" },
+    },
+    {
+      title: "Translation and edits respect subtitle folders",
+      body: "Existing subtitles stay in their current location. New translated or modified subtitles use your configured subtitle folder, including relative and absolute custom folders.",
+      icon: faFileZipper,
+      cta: { label: "Open Subtitles settings", to: "/settings/subtitles" },
+    },
+    {
+      title: "Cancelled Gemini jobs stop retrying",
+      body: "Cancelling a Gemini translation no longer retries the request. The existing subtitle stays in place, and temporary progress files are cleaned up.",
+      icon: faWandMagicSparkles,
+      cta: { label: "Open Translator settings", to: "/settings/translator" },
+    },
+    {
+      title: "Updated translation model choices",
+      body: "Four known retired Gemini IDs in OpenRouter settings migrate to replacements. Other saved IDs stay unchanged. Removed Grok menu suggestions are not migrated automatically.",
+      icon: faWandMagicSparkles,
+      cta: { label: "Open Translator settings", to: "/settings/translator" },
+    },
+    {
+      title: "One unusable archive no longer stops the search",
+      body: "If a catalog-provider archive has no suitable subtitle, Bazarr tries the next candidate without disabling that provider. The search also continues when only one successful subtitle is requested.",
+      icon: faDownload,
+      cta: { label: "Open Subtitle Hub", to: "/subtitle-hub" },
+    },
+    {
+      title: "Provider errors keep their meaning",
+      body: "Provider Hub now preserves quota, login, rate-limit and service errors across its workers, so Bazarr applies the matching pause instead of treating them all as a generic failure.",
+      icon: faStore,
+      cta: { label: "Open Subtitle Hub", to: "/subtitle-hub" },
+    },
+    {
+      title: "See which server owns a search result",
+      body: "When you have multiple Sonarr or multiple Radarr instances, global search shows the owning instance beside that media type\u2019s results.",
+      icon: faServer,
+      cta: { label: "Open your series", to: "/series" },
+    },
+    {
+      title: "Fewer misleading translation messages",
+      body: "Automatic translation checks whether it is enabled and eligible before reporting that a source score is too low.",
+      icon: faWandMagicSparkles,
+      cta: { label: "Open Translator settings", to: "/settings/translator" },
+    },
+    {
+      title: "Dependency checks match installed versions",
+      body: "Source installs no longer request repeated repairs for dependencies that already satisfy the installation requirements. This patch also updates filename parsing, database access, shared UI components and security dependencies.",
+      icon: faShieldHalved,
+      cta: { label: "Open System Status", to: "/system/status" },
+    },
+    {
+      title: "Provider fixes are delivered separately",
+      body: "Reviewed OpenSubtitles.org, OpenSubtitles.com, Titlovi and SubDL updates are in catalog beta. Stable availability follows promotion to main; update the bundles in Subtitle Hub when available.",
+      icon: faStore,
+      cta: { label: "Open Subtitle Hub", to: "/subtitle-hub" },
+    },
+  ],
   "2.6.1": [
     {
       title: "History shows your events again",

--- a/package_info
+++ b/package_info
@@ -1,7 +1,7 @@
 # Bazarr+ Package Information
 
 # Package version identifier (shown in System Status)
-packageversion=Bazarr+ v2.6.1
+packageversion=Bazarr+ v2.6.2
 
 # Package author (shown in System Status)
 packageauthor=LavX

--- a/site/index.html
+++ b/site/index.html
@@ -36,7 +36,7 @@
     "name": "Bazarr+",
     "applicationCategory": "MultimediaApplication",
     "operatingSystem": "Docker, Linux, Windows, macOS",
-    "softwareVersion": "2.6.1",
+    "softwareVersion": "2.6.2",
     "license": "https://www.gnu.org/licenses/gpl-3.0.html",
     "url": "https://lavx.github.io/bazarr/",
     "codeRepository": "https://github.com/LavX/bazarr",
@@ -597,12 +597,14 @@
         <li class="near">
           <h3>Shipped</h3>
           <span class="horizon-when">The v2 line so far</span>
-          <p>Eleven releases on the v2 line so far, most recently
-            <strong>v2.6 &ldquo;Clockwork&rdquo;</strong>: a correctness pass across the whole surface,
-            subtitle downloads including whole-season bundles, sync results held to the offset you
-            configured, and databases from upstream Bazarr adopted instead of refused. Before it,
-            <strong>v2.5 &ldquo;Murmuration&rdquo;</strong> brought many Sonarr and Radarr instances
-            managed as one, per-instance subtitle settings and archive uploads.</p>
+          <p><strong>v2.6.2 &ldquo;Clockwork&rdquo;</strong> keeps subtitle history and sync outputs
+            with the right media, saves useful partial OpenRouter translations with an incomplete
+            status, lists uploads before background sync finishes, and adds explicit OpenRouter
+            routing choices. Searches continue past unusable archives from catalog providers. The v2.6 line also
+            brought whole-season subtitle downloads, stricter sync validation, and adoption of
+            upstream Bazarr databases. Before it, <strong>v2.5 &ldquo;Murmuration&rdquo;</strong>
+            brought many Sonarr and Radarr instances managed as one, per-instance subtitle settings
+            and archive uploads.</p>
           <p><a class="inline" href="https://github.com/LavX/bazarr/releases" rel="noopener">Every release, with full notes</a></p>
         </li>
 

--- a/tests/bazarr/test_combine_main.py
+++ b/tests/bazarr/test_combine_main.py
@@ -153,7 +153,7 @@ class TestTryCombine:
         mock_resolve.return_value = make_sources(
             tmp_path, "en_hu_sibling_en.srt", "en_hu_sibling_hu.srt"
         )
-        mock_filename.return_value = str(tmp_path / "out.srt")
+        mock_filename.return_value = str(tmp_path / "Movie.en.combined-hu.srt")
         mock_compose.side_effect = ValueError("bad SRT")
 
         result = try_combine_for_video(

--- a/tests/bazarr/test_gemini_translator.py
+++ b/tests/bazarr/test_gemini_translator.py
@@ -1,4 +1,9 @@
 import time
+import json
+import sys
+from pathlib import Path
+from threading import Event, Thread
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -160,3 +165,167 @@ def test_translate_with_gemini_does_not_leave_output_file_on_failure(tmp_path, m
         service._translate_with_gemini()
 
     assert not output_file.exists()
+
+
+@pytest.fixture
+def queued_gemini(tmp_path, monkeypatch):
+    from app import jobs_queue as queue_module
+
+    monkeypatch.setattr(queue_module.JobsQueue, "_flush_progress_loop", lambda self: None)
+    monkeypatch.setattr(queue_module, "event_stream", lambda **kwargs: None)
+    queue = queue_module.JobsQueue()
+    monkeypatch.setattr(gemini_translator, "jobs_queue", queue)
+    source = tmp_path / "Video.en.srt"
+    source.write_text("1\n00:00:01,000 --> 00:00:02,000\nSource text\n", encoding="utf-8")
+    destination = tmp_path / "Video.hu.srt"
+    destination.write_text("Previous destination", encoding="utf-8")
+    video = tmp_path / "Video.mkv"
+    video.touch()
+    service = gemini_translator.GeminiTranslatorService(
+        str(source), str(destination), "hun", "movie", None, None, 7, False, False,
+        str(video), "en", "hu", arr_instance_id=2)
+    monkeypatch.setattr(service, "_get_configured_api_keys", lambda: ["fixture-one", "fixture-two"])
+    monkeypatch.setattr(service, "_get_batch_size", lambda: 1)
+    monkeypatch.setattr(gemini_translator, "get_description", lambda *args, **kwargs: "")
+    monkeypatch.setattr(gemini_translator, "language_from_alpha2", lambda value: "English")
+    monkeypatch.setattr(gemini_translator, "language_from_alpha3", lambda value: "Hungarian")
+    monkeypatch.setattr(gemini_translator, "create_process_result", lambda *args, **kwargs: None)
+    history = []
+    monkeypatch.setattr(gemini_translator, "history_log_movie", lambda **kwargs: history.append(kwargs))
+    dispatch = ModuleType("gemini_cancellation_fixture")
+    dispatch.translate = service.translate
+    monkeypatch.setitem(sys.modules, dispatch.__name__, dispatch)
+    queue.feed_jobs_pending_queue("Translation", dispatch.__name__, "translate", is_progress=True)
+    job = queue.jobs_pending_queue.popleft()
+    queue.jobs_running_queue.append(job)
+    worker = Thread(target=queue._run_job, args=(job,))
+    release = Event()
+    fixture = SimpleNamespace(queue=queue, job=job, service=service, source=source, destination=destination,
+                              worker=worker, entered=Event(), release=release, calls=[], history=history)
+    yield fixture
+    release.set()
+    if worker.ident:
+        worker.join(3)
+        assert not worker.is_alive()
+
+
+def _gemini_response(status=200):
+    response = gemini_translator.requests.Response()
+    response.status_code = status
+    response.headers["Retry-After"] = "7"
+    content = ({"candidates": [{"content": {"parts": [{"text": json.dumps([
+        {"index": "0", "content": "Translated text"}])}]}}]} if status == 200 else
+               {"error": {"status": "RESOURCE_EXHAUSTED"}})
+    response._content = json.dumps(content).encode()
+    return response
+
+
+def _record_cancellation_state(fixture, record_property):
+    record_property("transport_calls", len(fixture.calls))
+    record_property("progress_files_remaining", len(list(fixture.source.parent.glob("*.progress"))))
+    record_property("temporary_files_remaining", len(list(fixture.source.parent.glob(".bazarr-write-*"))))
+    record_property("job_cancelled", fixture.job.cancelled)
+    assert fixture.job.cancelled
+    assert fixture.job.status == "completed"
+    assert fixture.job.progress_message == "Cancelled by user"
+    assert fixture.destination.read_text() == "Previous destination"
+    assert "Source text" in fixture.source.read_text()
+    assert not fixture.history
+    assert not list(fixture.source.parent.glob(".bazarr-write-*"))
+    assert not list(fixture.source.parent.glob("*.progress"))
+
+
+@pytest.mark.parametrize("response_kind", ["success", "transient-error", "rate-limit"])
+def test_cancelled_response_does_not_retry_translation(queued_gemini, monkeypatch, record_property, response_kind):
+    fixture = queued_gemini
+
+    def transport(*args, **kwargs):
+        fixture.calls.append(True)
+        fixture.entered.set()
+        assert fixture.release.wait(3)
+        if response_kind == "transient-error":
+            raise gemini_translator.requests.ConnectionError("synthetic transport failure")
+        return _gemini_response(429 if response_kind == "rate-limit" else 200)
+
+    monkeypatch.setattr(gemini_translator.requests, "request", transport)
+    fixture.worker.start()
+    assert fixture.entered.wait(3)
+    assert fixture.queue.cancel_running_job(fixture.job.job_id)
+    fixture.release.set()
+    fixture.worker.join(3)
+    assert not fixture.worker.is_alive()
+    _record_cancellation_state(fixture, record_property)
+    assert len(fixture.calls) == 1
+
+
+@pytest.mark.parametrize("phase", ["initial-progress", "final-progress"])
+def test_cancellation_at_progress_boundary_clears_progress(queued_gemini, monkeypatch, record_property, phase):
+    fixture = queued_gemini
+    original = fixture.queue.update_job_progress
+
+    def progress(*args, **kwargs):
+        if ((phase == "initial-progress" and "progress_max" in kwargs) or
+                (phase == "final-progress" and "progress_value" in kwargs
+                 and kwargs.get("progress_message") == str(fixture.source))):
+            assert Path(fixture.service.progress_file).is_file()
+            assert fixture.queue.cancel_running_job(fixture.job.job_id)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(fixture.queue, "update_job_progress", progress)
+    monkeypatch.setattr(gemini_translator.requests, "request",
+                        lambda *args, **kwargs: fixture.calls.append(True) or _gemini_response())
+    fixture.worker.start()
+    fixture.worker.join(3)
+    assert not fixture.worker.is_alive()
+    _record_cancellation_state(fixture, record_property)
+    assert len(fixture.calls) == (0 if phase == "initial-progress" else 1)
+
+
+def test_already_cancelled_batch_does_not_send_request(queued_gemini, monkeypatch, record_property):
+    from app.jobs_queue import JobCancelled
+
+    fixture = queued_gemini
+    service = fixture.service
+    service.job_id = fixture.job.job_id
+    service.current_api_key = "fixture"
+    service.target_language = "Hungarian"
+    assert fixture.queue.cancel_running_job(fixture.job.job_id)
+    monkeypatch.setattr(gemini_translator.requests, "request",
+                        lambda *args, **kwargs: fixture.calls.append(True) or _gemini_response())
+    batch = [{"index": "0", "content": "Source text"}]
+    translated = list(gemini_translator.srt.parse(fixture.source.read_text()))
+    with pytest.raises(JobCancelled):
+        service._process_batch(batch, translated, 1)
+    record_property("transport_calls", len(fixture.calls))
+    assert not fixture.calls
+
+
+@pytest.mark.parametrize("failure", ["transient", "rate-limit", "exhausted"])
+def test_ordinary_request_retries_keep_existing_behavior(queued_gemini, monkeypatch, failure):
+    fixture = queued_gemini
+    keys = []
+
+    def transport(*args, **kwargs):
+        fixture.calls.append(True)
+        keys.append(fixture.service.current_api_key)
+        if failure == "exhausted" or (failure == "transient" and len(fixture.calls) == 1):
+            raise gemini_translator.requests.ConnectionError("synthetic transport failure")
+        return _gemini_response(429 if failure == "rate-limit" and len(fixture.calls) == 1 else 200)
+
+    monkeypatch.setattr(gemini_translator.requests, "request", transport)
+    fixture.worker.start()
+    fixture.worker.join(3)
+    assert not fixture.worker.is_alive()
+    assert len(fixture.calls) == (4 if failure == "exhausted" else 2)
+    assert not fixture.job.cancelled
+    assert fixture.job.status == ("failed" if failure == "exhausted" else "completed")
+    assert len(fixture.history) == (0 if failure == "exhausted" else 1)
+    if failure == "exhausted":
+        assert fixture.destination.read_text() == "Previous destination"
+    else:
+        assert "Translated text" in fixture.destination.read_text()
+    assert "Source text" in fixture.source.read_text()
+    assert not list(fixture.source.parent.glob("*.progress"))
+    assert not list(fixture.source.parent.glob(".bazarr-write-*"))
+    if failure == "rate-limit":
+        assert keys[0] != keys[1]

--- a/tests/bazarr/test_indexer_owner_scope.py
+++ b/tests/bazarr/test_indexer_owner_scope.py
@@ -88,6 +88,7 @@ def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, t
                                                  media_type, subfolder, naming, single_language):
     from app import database as database_module
     from subzero.language import Language
+    from subtitles.tools.subsync_engines import SyncOutputOwnerIndex
     import subtitles.indexer.movies as mv
     import subtitles.indexer.series as se
 
@@ -166,12 +167,13 @@ def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, t
 
     first_scan = {}
     for scan in range(3):
+        ownership_index = SyncOutputOwnerIndex()
         if scan == 2:
             schema_session.execute(update(table).values(subtitles='[]'))
             schema_session.commit()
         for row_id, stem in enumerate(stems, 1):
             video = str(media_folder / f'{stem}.mkv')
-            actual = store(video, video, arr_instance_id=1)
+            actual = store(video, video, arr_instance_id=1, ownership_index=ownership_index)
             assert len(actual) == len(expected[row_id])
             assert {path: (set(language.split(':')), size) for language, path, size in actual} == {
                 path: (set(language.split(':')), size) for language, path, size in expected[row_id]}
@@ -180,6 +182,198 @@ def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, t
                 first_scan[row_id] = sorted(actual)
             else:
                 assert sorted(actual) == first_scan[row_id]
+
+
+@pytest.mark.parametrize('media_type', ['series', 'movie'])
+@pytest.mark.parametrize('subfolder', ['relative', 'absolute'])
+@pytest.mark.parametrize('library_size', [8, 32])
+def test_full_scan_amortizes_sync_output_ownership(schema_session, monkeypatch, tmp_path,
+                                                 media_type, subfolder, library_size):
+    from app import database as database_module
+    from subzero.language import Language
+    import subtitles.indexer.movies as mv
+    import subtitles.indexer.series as se
+
+    module = se if media_type == 'series' else mv
+    table = TableEpisodes if media_type == 'series' else TableMovies
+    full_scan = se.series_full_scan_subtitles if media_type == 'series' else mv.movies_full_scan_subtitles
+    mapping_calls = []
+    owner_queries = []
+    execute = schema_session.execute
+
+    def counted_execute(statement, *args, **kwargs):
+        if getattr(statement, 'is_select', False):
+            columns = list(statement.selected_columns)
+            if [column.name for column in columns] == ['path', 'arr_instance_id']:
+                owner_queries.append(columns[0].table.name)
+        return execute(statement, *args, **kwargs)
+
+    def mapped(path, instance, kind):
+        mapping_calls.append((instance, kind))
+        assert instance == 7
+        assert kind in ('episode', 'series', 'movie')
+        return str(tmp_path / 'media' / path.removeprefix('/remote/'))
+
+    monkeypatch.setattr(schema_session, 'execute', counted_execute)
+    monkeypatch.setattr(module, 'database', schema_session)
+    monkeypatch.setattr(database_module, 'database', schema_session)
+    monkeypatch.setattr(module.path_mappings, 'path_replace_instance', mapped)
+    monkeypatch.setattr(module.path_mappings, 'path_replace_reverse_instance', lambda path, *a: path)
+    monkeypatch.setattr(module.settings.general, 'use_embedded_subs', False)
+    monkeypatch.setattr(module.settings.general, 'single_language', False)
+    monkeypatch.setattr(module.settings.general, 'subfolder', subfolder)
+    monkeypatch.setattr(module.settings.general, 'subfolder_custom',
+                        '../subs' if subfolder == 'relative' else str(tmp_path / 'subs'))
+    monkeypatch.setattr(module.core, 'CUSTOM_PATHS', [])
+    monkeypatch.setattr(module, 'get_language_set', lambda: {Language.fromietf('en')})
+    monkeypatch.setattr(module, 'alpha2_from_alpha3', lambda code: Language(code).alpha2)
+    monkeypatch.setattr(module, 'event_stream', lambda **kw: None)
+    missing = 'list_missing_subtitles' if media_type == 'series' else 'list_missing_subtitles_movies'
+    monkeypatch.setattr(module, missing, lambda **kw: None)
+    monkeypatch.setattr(module.jobs_queue, 'update_job_progress', lambda **kw: None)
+    monkeypatch.setattr(module.jobs_queue, 'update_job_name', lambda **kw: None)
+    if media_type == 'series':
+        schema_session.add(TableShows(id=1, arr_instance_id=7, sonarrSeriesId=10,
+                                      title='Show', path='/remote', profileId=None))
+        schema_session.flush()
+
+    expected = {}
+    for row_id in range(1, library_size + 1):
+        filename = f'Video{row_id:04}.mkv'
+        remote = f'/remote/{row_id}/{filename}'
+        video = tmp_path / 'media' / str(row_id) / filename
+        video.parent.mkdir(parents=True)
+        video.touch()
+        folder = tmp_path / 'media' / 'subs' if subfolder == 'relative' else tmp_path / 'subs'
+        folder.mkdir(exist_ok=True)
+        output = folder / f'Video{row_id:04}.en.ffsubsync.srt'
+        output.write_text('1\n00:00:00,000 --> 00:00:01,000\nAn English subtitle.\n')
+        indexed_path = video.parent / '..' / 'subs' / output.name if subfolder == 'relative' else output
+        expected[row_id] = [['en:sync-ffsubsync', str(indexed_path), output.stat().st_size]]
+        if media_type == 'series':
+            row = TableEpisodes(id=row_id, arr_instance_id=7, series_id=1, sonarrSeriesId=10,
+                                sonarrEpisodeId=row_id, title=filename, path=remote, season=1,
+                                episode=row_id, subtitles='[]')
+        else:
+            row = TableMovies(id=row_id, arr_instance_id=7, radarrId=row_id, title=filename,
+                              path=remote, tmdbId=str(row_id), subtitles='[]')
+        schema_session.add(row)
+    schema_session.commit()
+
+    full_scan(job_id=1, use_cache=False)
+
+    counts = {'library_size': library_size, 'owner_queries': len(owner_queries),
+              'path_mappings': len(mapping_calls)}
+    print(f'Ownership scan counts: {counts}')
+    for row_id, subtitles in expected.items():
+        assert ast.literal_eval(_subs(schema_session, table, row_id)) == subtitles
+    assert len(owner_queries) == 2, counts
+    assert len(mapping_calls) <= 8 * library_size, counts
+
+    # A new scan must see another media type claiming the same generated name.
+    conflict = tmp_path / 'media' / 'conflict' / 'Video0001.en.mkv'
+    conflict.parent.mkdir()
+    conflict.touch()
+    if media_type == 'series':
+        row = TableMovies(id=1, arr_instance_id=7, radarrId=1, title='Conflict', tmdbId='1',
+                          path='/remote/conflict/Video0001.en.mkv', subtitles='[]')
+    else:
+        schema_session.add(TableShows(id=1, arr_instance_id=7, sonarrSeriesId=10,
+                                      title='Show', path='/remote', profileId=None))
+        schema_session.flush()
+        row = TableEpisodes(id=1, arr_instance_id=7, series_id=1, sonarrSeriesId=10,
+                            sonarrEpisodeId=1, title='Conflict', season=1, episode=1,
+                            path='/remote/conflict/Video0001.en.mkv', subtitles='[]')
+    schema_session.add(row)
+    schema_session.commit()
+    owner_queries.clear()
+    full_scan(job_id=2, use_cache=False)
+    assert len(owner_queries) == 2, 'independent scans must rebuild their ownership snapshot'
+    assert ast.literal_eval(_subs(schema_session, table, 1)) == []
+    for row_id in range(2, library_size + 1):
+        assert ast.literal_eval(_subs(schema_session, table, row_id)) == expected[row_id]
+
+
+@pytest.mark.parametrize('subfolder', ['relative', 'absolute'])
+@pytest.mark.parametrize('collision', [False, True])
+def test_scan_owner_index_preserves_instance_mapping_and_normalized_conflicts(
+        schema_session, monkeypatch, tmp_path, subfolder, collision):
+    from app import database as database_module
+    from app.config import settings
+    from subtitles.tools.subsync_engines import SyncOutputOwnerIndex, sync_output_owner_is_unique
+    from utilities.path_mappings import path_mappings
+
+    video = tmp_path / 'one' / '\u00c9pisode.mkv'
+    other = tmp_path / 'two' / 'e\u0301PISODE.en.mkv'
+    folder = tmp_path / 'subs'
+    for path in (video, other):
+        path.parent.mkdir()
+        path.touch()
+    folder.mkdir()
+    source = folder / 'e\u0301pisode.en.srt'
+    source.touch()
+    monkeypatch.setattr(settings.general, 'subfolder', subfolder)
+    monkeypatch.setattr(settings.general, 'subfolder_custom', '../subs' if subfolder == 'relative' else str(folder))
+    monkeypatch.setattr(database_module, 'database', schema_session)
+    for owner in (7, 8):
+        schema_session.add(TableMovies(id=owner, arr_instance_id=owner, radarrId=1,
+                                      title='Mapped video', path='/same/remote.mkv', tmdbId=str(owner)))
+    schema_session.commit()
+    mappings = []
+
+    def mapped(path, owner, media_type):
+        assert (path, media_type) == ('/same/remote.mkv', 'movie')
+        mappings.append(owner)
+        return str(other if collision and owner == 8 else video)
+
+    monkeypatch.setattr(path_mappings, 'path_replace_instance', mapped)
+    index = SyncOutputOwnerIndex()
+    for _ in range(2):
+        assert sync_output_owner_is_unique(str(video), str(source), ownership_index=index) is (not collision)
+    assert sorted(mappings) == [7, 8]
+
+    # Standalone mutation checks must not inherit the earlier scan snapshot.
+    monkeypatch.setattr(path_mappings, 'path_replace_instance', lambda path, owner, kind: str(other if owner == 8 else video))
+    assert sync_output_owner_is_unique(str(video), str(source)) is False
+
+
+def test_scan_owner_index_fails_closed_after_incomplete_library_read(schema_session, monkeypatch, tmp_path):
+    from app import database as database_module
+    from app.config import settings
+    from subtitles.tools.subsync_engines import SyncOutputOwnerIndex, sync_output_owner_is_unique
+    from utilities.path_mappings import path_mappings
+
+    video = tmp_path / 'Video.mkv'
+    video.touch()
+    folder = tmp_path / 'subs'
+    folder.mkdir()
+    source = folder / 'Video.en.srt'
+    source.touch()
+    monkeypatch.setattr(settings.general, 'subfolder', 'relative')
+    monkeypatch.setattr(settings.general, 'subfolder_custom', 'subs')
+    monkeypatch.setattr(database_module, 'database', schema_session)
+    monkeypatch.setattr(path_mappings, 'path_replace_instance', lambda path, *args: path)
+    schema_session.add(TableShows(id=1, arr_instance_id=7, sonarrSeriesId=10, title='Show', path=str(tmp_path)))
+    schema_session.flush()
+    schema_session.add(TableEpisodes(id=1, arr_instance_id=7, series_id=1, sonarrSeriesId=10,
+                                    sonarrEpisodeId=1, title='Video', path=str(video), season=1, episode=1))
+    schema_session.commit()
+    execute = schema_session.execute
+    queries = []
+
+    def fail_movie_read(statement, *args, **kwargs):
+        queries.append(statement)
+        if list(statement.selected_columns)[0].table.name == 'table_movies':
+            raise RuntimeError('controlled owner lookup failure')
+        return execute(statement, *args, **kwargs)
+
+    monkeypatch.setattr(schema_session, 'execute', fail_movie_read)
+    index = SyncOutputOwnerIndex()
+    assert sync_output_owner_is_unique(str(video), str(source), ownership_index=index) is False
+    assert len(queries) == 2
+    monkeypatch.setattr(schema_session, 'execute', execute)
+    assert sync_output_owner_is_unique(str(video), str(source), ownership_index=index) is False
+    assert sync_output_owner_is_unique(str(video), str(source), ownership_index=SyncOutputOwnerIndex()) is True
 
 
 def test_only_the_owning_episode_row_is_indexed(two_series_rows):

--- a/tests/bazarr/test_indexer_owner_scope.py
+++ b/tests/bazarr/test_indexer_owner_scope.py
@@ -86,6 +86,7 @@ def _subs(session, table, row_id):
 ])
 def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, tmp_path,
                                                  media_type, subfolder, naming, single_language):
+    from app import database as database_module
     from subzero.language import Language
     import subtitles.indexer.movies as mv
     import subtitles.indexer.series as se
@@ -111,6 +112,7 @@ def test_sync_outputs_belong_to_the_indexed_video(schema_session, monkeypatch, t
     monkeypatch.setattr(module.settings.general, 'subfolder_custom', custom_folder)
     monkeypatch.setattr(module.core, 'CUSTOM_PATHS', [])
     monkeypatch.setattr(module, 'database', schema_session)
+    monkeypatch.setattr(database_module, 'database', schema_session)
     monkeypatch.setattr(module, 'get_language_set', lambda: {Language.fromietf('en')})
     monkeypatch.setattr(module, 'alpha2_from_alpha3', lambda code: Language(code).alpha2)
     monkeypatch.setattr(module.path_mappings, 'path_replace_instance', lambda p, *a: p)

--- a/tests/bazarr/test_openrouter_translator.py
+++ b/tests/bazarr/test_openrouter_translator.py
@@ -233,9 +233,10 @@ def test_long_destination_filename_retains_atomic_saving_and_permissions(service
 def test_existing_staging_file_is_never_overwritten_or_removed(service, events, monkeypatch):
     destination = Path(service.dest_srt_file)
     destination.write_bytes(b'existing subtitle')
-    staging = destination.with_name('.bazarr-translate-fixture-collision.srt')
+    staging = destination.with_name('.bazarr-write-fixture-collision.srt')
     staging.write_bytes(b'other operation')
-    monkeypatch.setattr(module.uuid, 'uuid4', lambda: SimpleNamespace(hex='fixture-collision'))
+    from subtitles.tools import subsync_engines
+    monkeypatch.setattr(subsync_engines.uuid, 'uuid4', lambda: SimpleNamespace(hex='fixture-collision'))
     _response(monkeypatch, 'completed', [{'position': 0, 'line': 'Egy'}])
 
     assert service.translate() is False

--- a/tests/bazarr/test_openrouter_translator_partial.py
+++ b/tests/bazarr/test_openrouter_translator_partial.py
@@ -129,7 +129,7 @@ def test_translate_saves_partial_subtitles_and_marks_history(tmp_path, mocker, m
     openrouter_translator.add_translator_info.assert_called_once()
     staged, footer = openrouter_translator.add_translator_info.call_args.args
     assert Path(staged).parent == destination.parent
-    assert Path(staged).name.startswith(".bazarr-translate-")
+    assert Path(staged).name.startswith(".bazarr-write-")
     assert footer == "# Subtitles partially translated with AI Subtitle Translator #"
     result = openrouter_translator.create_process_result.return_value
     if media_type == "episode":

--- a/tests/bazarr/test_release_type_mismatch.py
+++ b/tests/bazarr/test_release_type_mismatch.py
@@ -1013,8 +1013,11 @@ def test_the_search_clears_the_record_when_the_language_finally_lands(search, tm
         storage_path = str(written_file)
         matches = set()
 
-    search.monkeypatch.setattr(search.module, "save_subtitles",
-                               lambda *args, **kwargs: [_Written()])
+    def save(*args, **kwargs):
+        kwargs['write_subtitle'](str(written_file), b'1\n')
+        return [_Written()]
+
+    search.monkeypatch.setattr(search.module, "save_subtitles", save)
     search.monkeypatch.setattr(search.module, "process_subtitle", lambda **kwargs: None)
 
     search.run()

--- a/tests/bazarr/test_subsync_engines.py
+++ b/tests/bazarr/test_subsync_engines.py
@@ -412,7 +412,7 @@ def test_successful_sync_without_history_does_not_log_error(monkeypatch, tmp_pat
     _write(subtitle, 'original')
 
     class FakeRunner:
-        def run(self, srt_path, output_mode, enabled_engines, execute_engine, force_sync=False):
+        def run(self, srt_path, output_mode, enabled_engines, execute_engine, force_sync=False, **source_options):
             result = SyncRunResult(source_path=srt_path, output_mode=output_mode)
             result.results = [
                 SyncEngineResult(
@@ -663,6 +663,7 @@ def test_subsyncer_reports_engine_progress(monkeypatch, tmp_path):
 
     subtitle = tmp_path / 'Movie.hu.srt'
     _write(subtitle, 'original')
+    (tmp_path / 'Movie.mkv').touch()
     progress = []
 
     def fake_engine(self, output_path, **kwargs):
@@ -692,6 +693,7 @@ def test_subsyncer_reports_engine_progress(monkeypatch, tmp_path):
         ('Preparing synchronization', 0, 1),
         ('Running FFsubsync (1/1)', 0, 1),
         ('Finished FFsubsync (1/1)', 1, 1),
+        ('Saving synchronized subtitle', None, None),
     ]
 
 
@@ -842,7 +844,7 @@ def test_sync_output_keeps_complete_actual_owner_stem(tmp_path, stem):
 ])
 @pytest.mark.parametrize('sibling_kind', ['media', 'directory', 'non-media', 'absent'])
 def test_tagged_sync_output_defers_only_to_an_actual_media_owner(
-        tmp_path, video_stem, subtitle_stem, sibling_stem, sibling_kind):
+        tmp_path, monkeypatch, video_stem, subtitle_stem, sibling_stem, sibling_kind):
     from subtitles.indexer.utils import add_sync_engine_outputs
 
     media_folder = tmp_path / 'media'
@@ -862,6 +864,19 @@ def test_tagged_sync_output_defers_only_to_an_actual_media_owner(
     subtitle = f'{subtitle_stem}.en.ffsubsync.srt'
     _write(subtitle_folder / subtitle, 'subtitle')
 
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+    from app import database as db_module
+    from app.config import settings
+    from utilities.path_mappings import path_mappings
+    monkeypatch.setattr(settings.general, 'subfolder', 'absolute')
+    monkeypatch.setattr(settings.general, 'subfolder_custom', str(subtitle_folder))
+    rows = [SimpleNamespace(path=str(path), arr_instance_id=None) for path in media_folder.iterdir()
+            if path.is_file() and path.suffix.lower() in ('.mkv', '.mp4')]
+    db = Mock()
+    db.execute.return_value.all.return_value = rows
+    monkeypatch.setattr(db_module, 'database', db)
+    monkeypatch.setattr(path_mappings, 'path_replace_instance', lambda path, *args: path)
     result = add_sync_engine_outputs(str(subtitle_folder), {}, video_path=str(video))
 
     if sibling_kind == 'media':

--- a/tests/bazarr/test_subtitle_content_sync_outputs.py
+++ b/tests/bazarr/test_subtitle_content_sync_outputs.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from types import SimpleNamespace
 
 from flask import Flask
+import pytest
 
 import app.database  # noqa: F401
 
@@ -221,6 +222,72 @@ def test_promote_sync_output_overwrites_target_atomically(tmp_path, monkeypatch)
     assert history_calls[0][1]['result'].subs_path == str(original)
     assert 'ffsubsync' in history_calls[0][1]['result'].message
     assert events == [{'type': 'movie', 'payload': 1203}]
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+@pytest.mark.parametrize('failure', ['index', 'event', 'history'])
+def test_promotion_preserves_confirmation_and_refresh_attempts_on_failure(schema_session, tmp_path, monkeypatch,
+                                                                        media_type, failure):
+    from app.database import TableHistory, TableHistoryMovie, select
+    from radarr import history as movie_history
+    from sonarr import history as episode_history
+
+    content = _real_module('api.subtitles.content')
+    video = tmp_path / 'Video.mkv'
+    original = tmp_path / 'Video.en.srt'
+    generated = tmp_path / 'Video.en.alass.srt'
+    video.touch()
+    original.write_text('original subtitle')
+    generated.write_text('selected subtitle')
+    metadata = {'mediaPath': str(video), 'mediaId': 10, 'mediaUpstreamId': 20,
+                'episodeId': 30, 'episodeUpstreamId': 40, 'arrInstanceId': 7}
+    media_id = 40 if media_type == 'episode' else 20
+    table = TableHistory if media_type == 'episode' else TableHistoryMovie
+    refreshed = []
+
+    monkeypatch.setattr(content, 'resolve_subtitle_path',
+                        lambda kind, item_id, lang, **kw: (str(generated if ':sync-' in lang else original), metadata))
+    monkeypatch.setattr(content, 'database', schema_session)
+    for module in (movie_history, episode_history):
+        monkeypatch.setattr(module, 'database', schema_session)
+        monkeypatch.setattr(module, 'event_stream', lambda **kw: None)
+    for name in ('path_replace_reverse', 'path_replace_reverse_movie'):
+        monkeypatch.setattr(content.path_mappings, name, lambda path: path)
+    monkeypatch.setattr(content.path_mappings, 'path_replace_instance', lambda path, *a: path)
+    monkeypatch.setattr(content, '_active_sync_job_for_path', lambda path: None)
+
+    def refresh_step(step):
+        refreshed.append(step)
+        if step == failure:
+            raise RuntimeError('controlled refresh failure')
+
+    for name in ('store_subtitles', 'store_subtitles_movie'):
+        monkeypatch.setattr(content, name, lambda *a, **kw: refresh_step('index'))
+    monkeypatch.setattr(content, 'event_stream', lambda **kw: refresh_step('event'))
+    if failure == 'history':
+        execute = schema_session.execute
+
+        def fail_history_insert(statement, *args, **kwargs):
+            if getattr(statement, 'is_insert', False):
+                raise RuntimeError('controlled refresh failure')
+            return execute(statement, *args, **kwargs)
+
+        monkeypatch.setattr(schema_session, 'execute', fail_history_insert)
+
+    with pytest.raises(RuntimeError, match='controlled refresh failure'):
+        content.promote_sync_subtitle(media_type, media_id, 'en', 'en:sync-alass', arr_instance_id=7)
+
+    assert original.read_text() == 'selected subtitle'
+    rows = schema_session.execute(select(table)).scalars().all()
+    if failure == 'history':
+        assert refreshed == (['index', 'event', 'event'] if media_type == 'episode' else ['index', 'event'])
+        assert rows == []
+        return
+    assert len(rows) == 1, 'a completed publication lost its action-5 confirmation'
+    assert (rows[0].action, rows[0].arr_instance_id, rows[0].subtitles_path) == (5, 7, str(original))
+    status, code = content.get_subtitle_sync_status(media_type, media_id, 'en', arr_instance_id=7)
+    assert code == 200
+    assert status['confirmed'] is True
 
 
 def test_promote_sync_output_rejects_different_base_language(monkeypatch):

--- a/tests/bazarr/test_subtitle_destination_path.py
+++ b/tests/bazarr/test_subtitle_destination_path.py
@@ -173,7 +173,8 @@ def test_translation_saves_atomic_results_in_configured_folder(
     if failure == "footer":
         monkeypatch.setattr(service_module, "add_translator_info", fail_write)
     elif failure == "replace":
-        monkeypatch.setattr(service_module.os, "replace", fail_write)
+        from subtitles.tools import subsync_engines
+        monkeypatch.setattr(subsync_engines.os, "replace", fail_write)
 
     monkeypatch.setitem(sys.modules, "api.subtitles.subtitles", SimpleNamespace(
         postprocess_subtitles=lambda *args, **kwargs: postprocessed.append(args[0])))

--- a/tests/bazarr/test_upload_background_sync.py
+++ b/tests/bazarr/test_upload_background_sync.py
@@ -136,6 +136,54 @@ def upload_flow(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize("media_type", ["movie", "series"])
+@pytest.mark.parametrize("failure", ["settings", "enqueue"])
+def test_saved_upload_refreshes_consumers_when_sync_setup_fails(upload_flow, monkeypatch, media_type, failure):
+    from app.config import settings
+    from subtitles import sync, upload
+
+    flow = upload_flow
+    refreshes = []
+    monkeypatch.setattr(settings.general, 'use_plex', True)
+    monkeypatch.setattr(settings.general, 'use_jellyfin', True)
+    for service in (settings.plex, settings.jellyfin):
+        monkeypatch.setattr(service, 'update_movie_library', True)
+        monkeypatch.setattr(service, 'update_series_library', True)
+    monkeypatch.setattr(settings.plex, 'set_episode_added', False)
+    monkeypatch.setattr(settings.plex, 'set_movie_added', False)
+
+    def consumer(name):
+        def refresh(*args, **kwargs):
+            assert flow.indexes, 'consumers must see an indexed source publication'
+            refreshes.append((name, args, kwargs))
+        return refresh
+
+    for name in ('notify_sonarr', 'notify_radarr', 'plex_refresh_item', 'jellyfin_refresh_item'):
+        monkeypatch.setattr(upload, name, consumer(name))
+
+    def fail(*args, **kwargs):
+        raise RuntimeError('controlled sync setup failure')
+
+    if failure == 'settings':
+        monkeypatch.setattr(sync, '_resolve_subsync_overrides', fail)
+    else:
+        monkeypatch.setattr(flow.queue, 'add_job_from_function', fail)
+
+    with pytest.raises(RuntimeError, match='controlled sync setup failure'):
+        flow.submit(media_type, job_id='existing-upload-job')
+
+    assert 'Uploaded' in flow.video.with_suffix('.en.srt').read_text()
+    assert flow.indexes
+    assert len(flow.history) == 1
+    assert not flow.queue.jobs_pending_queue
+    assert [name for name, args, kwargs in refreshes] == [
+        'notify_sonarr' if media_type == 'series' else 'notify_radarr',
+        'plex_refresh_item', 'jellyfin_refresh_item']
+    assert refreshes[0][1] == (10 if media_type == 'series' else 30,)
+    assert refreshes[1][2]['is_movie'] == (media_type == 'movie')
+    assert refreshes[2][2]['is_movie'] == (media_type == 'movie')
+
+
+@pytest.mark.parametrize("media_type", ["movie", "series"])
 def test_saved_upload_is_visible_and_upload_completes_before_sync(upload_flow, media_type):
     flow = upload_flow
     upload_id = flow.submit(media_type)

--- a/tests/bazarr/test_upload_background_sync.py
+++ b/tests/bazarr/test_upload_background_sync.py
@@ -21,6 +21,7 @@ def upload_flow(monkeypatch, tmp_path):
     from subtitles.tools import delete, subsyncer
     from subtitles.tools.subsync_engines import InMemorySubsyncFailureStore, SubsyncEngineRunner
 
+    monkeypatch.setattr(queue_module.JobsQueue, "_flush_progress_loop", lambda self: None)
     queue = queue_module.JobsQueue()
     events, indexes, history, notifications, sync_history, engine_calls = [], [], [], [], [], []
     real_indexers = {"series": series.store_subtitles, "movie": movies.store_subtitles_movie}
@@ -103,7 +104,7 @@ def upload_flow(monkeypatch, tmp_path):
             hi=kwargs.pop("hi", False), media_type=media_type,
             subtitle=BytesIO(f"1\n00:00:01,000 --> 00:00:02,000\n{content}\n".encode()),
             filename="upload.srt", audio_language=[],
-            sonarrSeriesId=10 if media_type == "series" else None,
+            sonarrSeriesId=kwargs.pop("sonarrSeriesId", 10 if media_type == "series" else None),
             sonarrEpisodeId=20 if media_type == "series" else None,
             radarrId=30 if media_type == "movie" else None,
             arr_instance_id=owner, **kwargs)
@@ -159,7 +160,8 @@ def test_saved_upload_is_visible_and_upload_completes_before_sync(upload_flow, m
     assert sync_job.status == "completed"
     assert "Synced" in flow.indexes[-1][1]["Video.en.srt"]
     assert len(flow.history) == 1
-    assert len(flow.notifications) == 2
+    assert sum("arr_client" in kwargs for _, kwargs in flow.notifications) == 2
+    assert sum("arr_instance_id" in kwargs for _, kwargs in flow.notifications) == 1
     assert len(flow.sync_history) == 1
 
 
@@ -298,7 +300,7 @@ def test_upload_preserves_postprocessing_hi_and_notification_policy(upload_flow,
     monkeypatch.setattr(upload, "pp_replace", lambda *args: "process")
     monkeypatch.setattr(upload, "set_chmod", lambda **kwargs: None)
 
-    def postprocess(command, video_path):
+    def postprocess(command, video_path, subtitle_path=None):
         assert command == "process"
         flow.video.with_suffix(".en.hi.srt").write_text("1\n00:00:01,000 --> 00:00:02,000\nProcessed\n")
 
@@ -314,7 +316,8 @@ def test_upload_preserves_postprocessing_hi_and_notification_policy(upload_flow,
     assert sync_job.status == "completed"
     assert "Synced" in flow.indexes[-1][1]["Video.en.hi.srt"]
     assert "Processed" in flow.indexes[-1][1]["Video.en.hi.srt"]
-    assert len(flow.notifications) == 1
+    assert sum("arr_client" in kwargs for _, kwargs in flow.notifications) == 2
+    assert not any("arr_instance_id" in kwargs for _, kwargs in flow.notifications)
     assert flow.sync_history[0]["hi"] is True
 
 
@@ -412,7 +415,7 @@ def test_unrelated_upload_finishes_while_other_media_postprocessing_is_blocked(u
             second_entered.set()
         return (owner == 7, 'controlled', False, 0)
 
-    def postprocess(command, video_path):
+    def postprocess(command, video_path, subtitle_path=None):
         blocked.set()
         assert unblock.wait(5), 'probe failed to release postprocessing'
 
@@ -569,3 +572,1119 @@ def test_sync_reindex_cannot_restore_a_listing_after_successful_delete(upload_fl
         if deletion:
             deletion.join(2)
         engine.dispose()
+
+
+@pytest.mark.parametrize("media_type", ["movie", "series"])
+@pytest.mark.parametrize("output_mode", ["overwrite", "keep_all"])
+def test_review_sync_publication_refreshes_external_consumers(upload_flow, monkeypatch, media_type, output_mode):
+    from app.config import settings
+    from subtitles import upload
+
+    flow = upload_flow
+    monkeypatch.setattr(settings.subsync, "output_mode", output_mode)
+    monkeypatch.setattr(settings.general, "use_plex", True)
+    monkeypatch.setattr(settings.general, "use_jellyfin", True)
+    for name in ("update_series_library", "update_movie_library"):
+        monkeypatch.setattr(settings.plex, name, True)
+        monkeypatch.setattr(settings.jellyfin, name, True)
+    monkeypatch.setattr(settings.plex, "set_movie_added", False)
+    monkeypatch.setattr(settings.plex, "set_episode_added", False)
+    refreshes = []
+
+    def refresh(consumer, *args, **kwargs):
+        refreshes.append((consumer, {path.name: path.read_text() for path in flow.video.parent.glob("*.srt")}))
+
+    for name in ("notify_sonarr", "notify_radarr", "plex_refresh_item", "jellyfin_refresh_item"):
+        monkeypatch.setattr(upload, name, lambda *args, _consumer=name, **kwargs: refresh(_consumer, *args, **kwargs))
+    flow.submit(media_type)
+    upload_job, upload_thread = flow.start()
+    upload_thread.join(2)
+    assert upload_job.status == "completed"
+    assert len(refreshes) == 3
+    flow.release_engine.set()
+    sync_job, sync_thread = flow.start()
+    sync_thread.join(3)
+    assert sync_job.status == "completed"
+    assert len(refreshes) == 6, "external consumers were not refreshed after sync publication"
+    expected = "Video.en.ffsubsync.srt" if output_mode == "keep_all" else "Video.en.srt"
+    assert all("Synced" in files[expected] for _, files in refreshes[3:])
+    assert len(flow.history) == 1
+    assert len(flow.notifications) == 1, "sync publication repeated the upload notification"
+
+
+def test_review_upload_sync_uses_resolved_series_id(upload_flow):
+    flow = upload_flow
+    flow.submit("series", sonarrSeriesId=999)
+    upload_job, upload_thread = flow.start()
+    upload_thread.join(2)
+    assert upload_job.status == "completed"
+    sync_job = flow.queue.jobs_pending_queue[0]
+    assert sync_job.kwargs["sonarr_series_id"] == 10, "unvalidated request ID reached synchronization"
+    assert sync_job.kwargs["callback"].keywords["sonarr_series_id"] == 10
+    assert sync_job.kwargs["sonarr_episode_id"] == 20
+    assert sync_job.kwargs["arr_instance_id"] == 7
+
+
+@pytest.mark.parametrize("media_type", ["movie", "series"])
+@pytest.mark.parametrize("outcome", ["success", "failure", "cancel", "disabled"])
+def test_review_replacement_upload_does_not_list_stale_generated_outputs(upload_flow, monkeypatch, media_type, outcome):
+    from app.config import settings
+
+    flow = upload_flow
+    monkeypatch.setattr(settings.subsync, "output_mode", "keep_all")
+    old_output = flow.video.with_suffix(".en.ffsubsync.srt")
+    old_bytes = b"1\n00:00:01,000 --> 00:00:02,000\nOld generated output\n"
+    old_output.write_bytes(old_bytes)
+    if outcome == "disabled":
+        monkeypatch.setattr(settings.subsync, "use_subsync", False)
+    flow.submit(media_type, content="Replacement upload")
+    upload_job, upload_thread = flow.start()
+    upload_thread.join(2)
+    assert upload_job.status == "completed"
+    assert "Replacement upload" in flow.indexes[-1][1]["Video.en.srt"]
+    assert old_output.name not in flow.indexes[-1][1], "the initial upload index exposed old generated text"
+    assert not old_output.exists()
+    assert any(path.read_bytes() == old_bytes for path in flow.video.parent.rglob("*") if path.is_file()), \
+        "old generated bytes were destroyed instead of quarantined"
+    if outcome == "disabled":
+        assert not flow.queue.jobs_pending_queue
+        return
+    flow.controls.fail = outcome == "failure"
+    sync_job, sync_thread = flow.start()
+    assert flow.engine_started.wait(2)
+    if outcome == "cancel":
+        flow.queue.cancel_running_job(sync_job.job_id)
+    flow.release_engine.set()
+    sync_thread.join(3)
+    assert not sync_thread.is_alive()
+    if outcome == "success":
+        assert "Replacement upload" in old_output.read_text()
+        assert "Old generated output" not in old_output.read_text()
+    else:
+        assert not old_output.exists()
+        assert old_output.name not in flow.indexes[-1][1]
+
+
+@pytest.mark.parametrize("media_type", ["movie", "series"])
+@pytest.mark.parametrize("running", [False, True], ids=["queued", "running"])
+def test_review_deleted_generated_destination_stays_deleted(upload_flow, monkeypatch, media_type, running):
+    from app.config import settings
+    from subtitles.tools import delete
+
+    flow = upload_flow
+    monkeypatch.setattr(settings.subsync, "output_mode", "keep_all")
+    destination = flow.video.with_suffix(".en.ffsubsync.srt")
+    destination.write_text("Old generated output")
+    flow.submit(media_type)
+    upload_job, upload_thread = flow.start()
+    upload_thread.join(2)
+    assert upload_job.status == "completed"
+    if running:
+        sync_job, sync_thread = flow.start()
+        assert flow.engine_started.wait(2)
+    delete.delete_subtitles(media_type=media_type, language="en", forced=False, hi=False,
+                           media_path=str(flow.video), subtitles_path=str(destination),
+                           sonarr_series_id=10, sonarr_episode_id=20, radarr_id=30, arr_instance_id=7)
+    assert not destination.exists()
+    flow.release_engine.set()
+    if not running:
+        sync_job, sync_thread = flow.start()
+    sync_thread.join(3)
+    assert not sync_thread.is_alive()
+    assert not destination.exists(), "background sync recreated an explicitly deleted generated destination"
+    assert destination.name not in flow.indexes[-1][1]
+
+
+@pytest.mark.parametrize("output_mode", ["overwrite", "keep_all"])
+@pytest.mark.parametrize("operation", ["edit", "edit-etag", "promote", "mods", "manual-sync", "google", "lingarr", "openrouter", "gemini", "manual-download", "auto-download", "postprocessing"])
+def test_review_editor_write_cannot_be_lost_at_sync_publication(upload_flow, monkeypatch, output_mode, operation):
+    import importlib
+    import os
+    import sys
+    from threading import current_thread
+    from flask import Flask
+    from app.config import settings
+    from subtitles.tools import subsync_engines
+
+    existing = sys.modules.get("api.subtitles.content")
+    if existing is not None and not getattr(existing, "__file__", None):
+        monkeypatch.delitem(sys.modules, "api.subtitles.content")
+    with monkeypatch.context() as importing:
+        importing.setattr("app.check_update.check_releases", lambda *args, **kwargs: None)
+        importing.setattr("app.announcements.get_announcements_to_file", lambda *args, **kwargs: None)
+        content = importlib.import_module("api.subtitles.content")
+    flow = upload_flow
+    monkeypatch.setattr(settings.subsync, "output_mode", output_mode)
+    source = flow.video.with_suffix(".en.srt")
+    output = flow.video.with_suffix(".en.ffsubsync.srt")
+    promotion = flow.video.with_suffix(".en.alass.srt")
+    user_text = "1\n00:00:01,000 --> 00:00:02,000\nUser selected text\n"
+    metadata = {"mediaPath": str(flow.video), "mediaId": 30, "arrInstanceId": 7}
+    monkeypatch.setattr(content, "resolve_subtitle_path", lambda media_type, media_id, language, **kwargs:
+                        (str(promotion if language == "en:sync-alass" else source), metadata))
+    monkeypatch.setattr(content, "store_subtitles_movie", lambda *args, **kwargs: None)
+    monkeypatch.setattr(content, "event_stream", lambda **kwargs: None)
+    monkeypatch.setattr(content, "history_log_movie", lambda **kwargs: None)
+    monkeypatch.setattr(content, "language_from_alpha2", lambda value: "English")
+    reached_publication, release_publication, writer_started, writer_done = Event(), Event(), Event(), Event()
+    real_replace = os.replace
+    published_destination = output if output_mode == "keep_all" else source
+
+    def replace(temporary, destination):
+        if (Path(destination) == published_destination and Path(temporary).name.startswith(".bazarr-sync-")
+                and current_thread().name != "competing-subtitle-writer"):
+            reached_publication.set()
+            assert release_publication.wait(5), "test did not release sync publication"
+        return real_replace(temporary, destination)
+
+    monkeypatch.setattr(subsync_engines.os, "replace", replace)
+    flow.submit("movie")
+    upload_job, upload_thread = flow.start()
+    upload_thread.join(2)
+    assert upload_job.status == "completed"
+    promotion.write_text(user_text)
+    initial_etag = content.generate_etag(str(source))
+    sync_job, sync_thread = flow.start()
+    assert flow.engine_started.wait(2)
+    flow.release_engine.set()
+    writer_results = []
+    writer_errors = []
+
+    def write():
+        try:
+            writer_started.set()
+            if operation in ("edit", "edit-etag"):
+                app = Flask(__name__)
+                with app.test_request_context(json={"content": user_text},
+                                              headers={"If-Match": initial_etag} if operation == "edit-etag" else {}):
+                    response = content._save_subtitle_content("movie", 30, "en", arr_instance_id=7)
+                    writer_results.append(response.status_code if hasattr(response, "status_code") else response[1])
+            elif operation == "promote":
+                _, status = content.promote_sync_subtitle("movie", 30, "en", "en:sync-alass", arr_instance_id=7)
+                writer_results.append(status)
+            elif operation == "mods":
+                from subtitles.tools import mods
+                monkeypatch.setattr(mods.Subtitle, "get_modified_content", lambda self, **kwargs: user_text.encode())
+                mods.subtitles_apply_mods("en", str(source), [], str(flow.video), arr_instance_id=7)
+                writer_results.append(200)
+            elif operation == "manual-sync":
+                from subtitles.tools import subsyncer
+
+                def external(self, engine, output_path, video_path):
+                    output_path.write_text(user_text)
+                    return {"offset_seconds": 0}
+
+                monkeypatch.setattr(subsyncer.SubSyncer, "_run_external_engine", external)
+                result = subsyncer.SubSyncer().sync(
+                    str(flow.video), str(source), "en", False, False, 60, False, False,
+                    output_mode="overwrite", enabled_engines=["alass"], write_history=False)
+                writer_results.append(200 if result.success else 500)
+            elif operation in ("manual-download", "auto-download"):
+                from subtitles import manual, download, pool
+                from subliminal_patch.subtitle import Subtitle
+                from subzero.language import Language
+
+                subtitle = Subtitle(Language("eng"), original_format=True)
+                subtitle.content = user_text.encode()
+                subtitle.provider_name = "fixture"
+                subtitle.matches = set()
+                video = Mock(original_path=str(flow.video))
+                provider_pool = Mock(providers=["fixture"], discarded_providers=[])
+                monkeypatch.setattr(pool, "_update_pool", lambda *args, **kwargs: False)
+                module = manual if operation == "manual-download" else download
+                monkeypatch.setattr(module, "get_video", lambda *args, **kwargs: video)
+                monkeypatch.setattr(module, "_get_pool", lambda *args, **kwargs: provider_pool)
+                monkeypatch.setattr(module, "get_target_folder", lambda *args, **kwargs: None)
+                monkeypatch.setattr(module, "process_subtitle", lambda **kwargs: "saved")
+                monkeypatch.setattr(module.subliminal, "region", Mock())
+                if operation == "manual-download":
+                    monkeypatch.setattr(manual.subtitle_cache, "get", lambda *args: subtitle)
+                    monkeypatch.setattr(manual, "download_subtitles", lambda *args: None)
+                    result = manual.manual_download_subtitle(
+                        str(flow.video), [], False, False, "cached", "fixture", None, "Video", "movie", True, 1,
+                        arr_instance_id=7)
+                    assert result == "saved"
+                else:
+                    monkeypatch.setattr(download, "_get_language_obj", lambda **kwargs: {Language("eng")})
+                    monkeypatch.setattr(download, "get_profiles_list", lambda **kwargs: {"originalFormat": True})
+                    monkeypatch.setattr(download, "download_best_subtitles", lambda **kwargs: {video: [subtitle]})
+                    monkeypatch.setattr(download, "clear_mismatch_for_video", lambda *args, **kwargs: None)
+                    result = list(download.generate_subtitles(
+                        str(flow.video), [("en", False, False)], [], None, "Video", "movie", 1, arr_instance_id=7))
+                    assert result == ["saved"]
+                writer_results.append(200)
+            elif operation == "postprocessing":
+                from subtitles import post_processing
+
+                def popen(*args, **kwargs):
+                    source.write_text(user_text)
+                    return Mock(communicate=lambda: ("", ""))
+
+                monkeypatch.setattr(post_processing.subprocess, "Popen", popen)
+                post_processing.postprocessing("fixture command", str(flow.video))
+                writer_results.append(200)
+            else:
+                module = importlib.import_module(f"subtitles.tools.translate.services.{operation}_translator")
+                classes = {"google": "GoogleTranslatorService", "lingarr": "LingarrTranslatorService",
+                           "openrouter": "OpenRouterTranslatorService", "gemini": "GeminiTranslatorService"}
+                service = getattr(module, classes[operation])(
+                    source_srt_file=str(promotion), dest_srt_file=str(source), lang_obj=None,
+                    to_lang="eng", from_lang="en", media_type="movie", video_path=str(flow.video),
+                    orig_to_lang="en", forced=False, hi=False, sonarr_series_id=None,
+                    sonarr_episode_id=None, radarr_id=30)
+                monkeypatch.setattr(module, "jobs_queue", Mock())
+                monkeypatch.setattr(module, "history_log_movie", Mock())
+                monkeypatch.setattr(module, "create_process_result", Mock())
+                monkeypatch.setattr(module, "add_translator_info", lambda *args: None)
+                if operation == "google":
+                    monkeypatch.setattr(service, "_translate_text", lambda *args: "User selected text")
+                elif operation == "lingarr":
+                    monkeypatch.setattr(service, "_translate_content", lambda *args, **kwargs:
+                                        [{"position": 0, "line": "User selected text"}])
+                elif operation == "openrouter":
+                    monkeypatch.setattr(service, "_submit_and_poll", lambda *args, **kwargs:
+                                        [{"position": 0, "line": "User selected text"}])
+                else:
+                    monkeypatch.setattr(service, "_get_configured_api_keys", lambda: [])
+                    monkeypatch.setattr(service, "_select_next_api_key", lambda: "fixture")
+                    monkeypatch.setattr(service, "_check_saved_progress", lambda: None)
+                    monkeypatch.setattr(module, "get_description", lambda *args, **kwargs: "")
+                    monkeypatch.setattr(service, "_translate_with_gemini", lambda:
+                                        Path(service.output_file).write_text(user_text))
+                service.translate(job_id=123)
+                writer_results.append(200)
+
+        except BaseException as exc:
+            writer_errors.append(exc)
+        finally:
+            writer_done.set()
+
+    writer = Thread(target=write, name="competing-subtitle-writer")
+    try:
+        assert reached_publication.wait(2)
+        writer.start()
+        assert writer_started.wait(2)
+        writer_done.wait(0.3)
+        release_publication.set()
+        sync_thread.join(3)
+        writer.join(3)
+        assert not writer.is_alive() and not sync_thread.is_alive()
+        assert not writer_errors
+        if operation == "edit-etag" and output_mode == "overwrite":
+            assert writer_results == [412]
+            assert "Synced" in source.read_text()
+        else:
+            assert writer_results == [204 if operation in ("edit", "edit-etag") else 200]
+            assert "User selected text" in source.read_text(), "sync publication overwrote the completed user write"
+        if output_mode == "keep_all":
+            assert not output.exists(), "an output for the superseded source remained available"
+    finally:
+        release_publication.set()
+        if writer.ident:
+            writer.join(3)
+
+
+@pytest.mark.parametrize("failure", ["cancel-before-engine", "setup-error", "settings-error"])
+def test_review_terminal_job_releases_publication_lease(upload_flow, monkeypatch, failure):
+    from subtitles import sync
+
+    flow = upload_flow
+    flow.submit("movie")
+    _, upload_thread = flow.start()
+    upload_thread.join(2)
+    job = flow.queue.jobs_pending_queue[0]
+    publication = job.kwargs["source_version"]
+    if failure == "settings-error":
+        monkeypatch.setattr(sync, "_resolve_subsync_overrides", Mock(side_effect=RuntimeError("controlled settings failure")))
+    elif failure == "setup-error":
+        monkeypatch.setattr(sync, "SubSyncer", Mock(side_effect=RuntimeError("controlled setup failure")))
+    else:
+        original = sync._report_progress
+
+        def report(*args, **kwargs):
+            flow.queue.cancel_running_job(job.job_id)
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(sync, "_report_progress", report)
+    _, thread = flow.start()
+    thread.join(3)
+    assert not thread.is_alive()
+    assert job.status in ("completed", "failed")
+    assert publication.state is None, "terminal Job kwargs retained the media coordinator"
+
+
+def test_review_partial_publication_refreshes_consumers_after_cancellation(upload_flow, monkeypatch):
+    from app.config import settings
+    from app.jobs_queue import JobCancelled
+    from subtitles.tools import subsyncer
+
+    flow = upload_flow
+    monkeypatch.setattr(settings.subsync, "output_mode", "keep_all")
+    monkeypatch.setattr(settings.subsync, "enabled_engines", ["ffsubsync", "alass"])
+    def cancel(self, **kwargs):
+        flow.queue.cancel_running_job(self.job_id)
+        raise JobCancelled()
+
+    monkeypatch.setattr(subsyncer.SubSyncer, "_run_external_engine", cancel)
+    flow.submit("movie")
+    _, thread = flow.start()
+    thread.join(2)
+    flow.release_engine.set()
+    job, thread = flow.start()
+    thread.join(3)
+    assert job.status == "completed" and job.cancelled
+    assert flow.video.with_suffix(".en.ffsubsync.srt").is_file()
+    assert sum("arr_client" in kwargs for _, kwargs in flow.notifications) == 2
+    assert sum("arr_instance_id" in kwargs for _, kwargs in flow.notifications) == 1
+    assert len(flow.history) == 1
+
+
+def test_review_failed_delete_preserves_existing_generated_output(upload_flow, monkeypatch):
+    import os
+    from subtitles.tools import delete
+
+    flow = upload_flow
+    source = flow.video.with_suffix(".en.srt")
+    output = flow.video.with_suffix(".en.ffsubsync.srt")
+    source.write_text("Base")
+    output.write_text("Valid generated output")
+    remove = os.remove
+
+    def reject(path):
+        if Path(path) == source:
+            raise PermissionError("controlled rejected delete")
+        return remove(path)
+
+    monkeypatch.setattr(delete.os, "remove", reject)
+    assert flow.remove("movie") is False
+    assert source.read_text() == "Base"
+    assert output.read_text() == "Valid generated output"
+
+
+@pytest.mark.parametrize("collision", [False, True], ids=["same-mapped-owner", "distinct-owners"])
+def test_review_shared_folder_quarantine_requires_unique_mapped_owner(upload_flow, schema_session, monkeypatch, collision):
+    from app import database as db_module
+    from app.database import TableMovies
+    from app.config import settings
+    from subtitles.tools.subsync_engines import quarantine_sync_outputs, SubtitlePublication, subtitle_source_version
+
+    flow = upload_flow
+    folder = flow.video.parent / "shared"
+    folder.mkdir()
+    other = flow.video.parent / "other" / flow.video.name
+    other.parent.mkdir()
+    other.touch()
+    source = folder / "Video.en.srt"
+    output = folder / "Video.en.ffsubsync.srt"
+    source.write_text("Base")
+    output.write_text("Existing generated bytes")
+    for owner, path in [(7, flow.video), (8, other if collision else flow.video)]:
+        schema_session.add(TableMovies(id=owner, arr_instance_id=owner, radarrId=30,
+                                      title="Movie", path=str(path), tmdbId=str(owner), subtitles="[]"))
+    schema_session.commit()
+    monkeypatch.setattr(db_module, "database", schema_session)
+    monkeypatch.setattr(settings.general, "subfolder", "absolute")
+    monkeypatch.setattr(settings.general, "subfolder_custom", str(folder))
+    quarantine_sync_outputs(str(flow.video), str(source))
+    publication = SubtitlePublication(str(flow.video), str(source), subtitle_source_version(source))
+    try:
+        if collision:
+            assert output.read_text() == "Existing generated bytes"
+            assert not publication.destination_unchanged(output), "ambiguous output remained eligible for overwrite"
+            from subtitles.indexer.utils import add_sync_engine_outputs
+            assert output.name not in add_sync_engine_outputs(str(folder), {}, video_path=str(flow.video))
+        else:
+            assert not output.exists()
+            assert publication.destination_unchanged(output)
+            assert any(p.read_text() == "Existing generated bytes" for p in folder.glob("*.bak"))
+    finally:
+        publication.release()
+
+
+def test_review_create_cannot_overwrite_a_later_upload(upload_flow, monkeypatch):
+    import importlib
+    from threading import current_thread
+    from flask import Flask
+    from app.config import settings
+
+    with monkeypatch.context() as importing:
+        importing.setattr("app.check_update.check_releases", lambda *args, **kwargs: None)
+        importing.setattr("app.announcements.get_announcements_to_file", lambda *args, **kwargs: None)
+        content = importlib.import_module("api.subtitles.content")
+    flow = upload_flow
+    monkeypatch.setattr(settings.subsync, "use_subsync", False)
+    monkeypatch.setattr(content, "database", Mock(execute=Mock(return_value=Mock(
+        first=Mock(return_value=SimpleNamespace(path=str(flow.video), id=30))))))
+    monkeypatch.setattr(content, "get_target_folder", lambda *args: None)
+    monkeypatch.setattr(content, "store_subtitles_movie", lambda *args, **kwargs: None)
+    monkeypatch.setattr(content, "event_stream", lambda **kwargs: None)
+    reached, release = Event(), Event()
+    mkstemp = content.tempfile.mkstemp
+
+    def pause(*args, **kwargs):
+        if current_thread().name == "create-subtitle":
+            reached.set()
+            assert release.wait(5)
+        return mkstemp(*args, **kwargs)
+
+    monkeypatch.setattr(content.tempfile, "mkstemp", pause)
+    results = []
+
+    def create():
+        with Flask(__name__).test_request_context(json={"language": "en", "format": "srt", "content": "Created first"}):
+            results.append(content._create_subtitle("movie", 30, arr_instance_id=7))
+
+    creator = Thread(target=create, name="create-subtitle")
+    creator.start()
+    try:
+        assert reached.wait(2)
+        flow.submit("movie", content="Uploaded later")
+        job, uploader = flow.start()
+        uploader.join(0.3)
+        release.set()
+        creator.join(3)
+        uploader.join(3)
+        assert results[0][1] == 201
+        assert job.status == "completed"
+        assert "Uploaded later" in flow.video.with_suffix(".en.srt").read_text()
+    finally:
+        release.set()
+        creator.join(3)
+
+
+def test_review_combine_waits_for_an_existing_publication(upload_flow, monkeypatch):
+    from subtitles.tools.combine import main
+    from subtitles.tools.combine.rules import SourcePaths
+    from subtitles.tools.subsync_engines import subtitle_write_lock
+
+    flow = upload_flow
+    first = flow.video.with_suffix(".en.srt")
+    second = flow.video.with_suffix(".hu.srt")
+    first.write_text("1\n00:00:01,000 --> 00:00:02,000\nFirst\n")
+    second.write_text("1\n00:00:01,000 --> 00:00:02,000\nSecond\n")
+    monkeypatch.setattr(main, "resolve_source_paths", lambda **kwargs: SourcePaths(str(first), [str(second)]))
+    monkeypatch.setattr(main, "_post_write", lambda *args: None)
+    output = flow.video.with_suffix(".en.combined-hu.srt")
+    results = []
+    finished = Event()
+
+    def combine():
+        results.append(main.try_combine_for_video(str(flow.video), "movie", languages=["en", "hu"], format="srt"))
+        finished.set()
+
+    with subtitle_write_lock(str(flow.video), str(flow.video.parent)):
+        worker = Thread(target=combine)
+        worker.start()
+        blocked = not finished.wait(0.3)
+    worker.join(3)
+    assert results[0].status == "built"
+    assert blocked, "combine published while another writer owned the publication lock"
+    assert output.is_file()
+
+
+@pytest.mark.parametrize("media_type", ["series", "movie"])
+def test_review_external_index_waits_for_publication(upload_flow, monkeypatch, media_type):
+    from subtitles.indexer import movies, series
+    from subtitles.tools.subsync_engines import subtitle_write_lock
+
+    flow = upload_flow
+    module = movies if media_type == "movie" else series
+    db = Mock()
+    db.execute.return_value.first.return_value = SimpleNamespace(arr_instance_id=7, subtitles="[]")
+    db.execute.return_value.all.return_value = []
+    monkeypatch.setattr(module, "database", db)
+    monkeypatch.setattr("app.config.settings.general.use_embedded_subs", False)
+    monkeypatch.setattr(module, "get_language_set", lambda: set())
+    monkeypatch.setattr(module, "event_stream", lambda **kwargs: None)
+    entered = Event()
+    monkeypatch.setattr(module, "search_external_subtitles", lambda *args, **kwargs: (entered.set() or {}))
+    errors = []
+
+    def index():
+        try:
+            flow.real_indexers[media_type](str(flow.video), str(flow.video), arr_instance_id=7)
+        except Exception as exc:
+            errors.append(exc)
+
+    with subtitle_write_lock(str(flow.video), str(flow.video.parent)):
+        worker = Thread(target=index)
+        worker.start()
+        entered_while_locked = entered.wait(0.3)
+    worker.join(3)
+    assert not worker.is_alive() and not errors
+    assert entered.is_set()
+    assert not entered_while_locked, "external scan ran inside another writer's publication transaction"
+
+
+def test_review_duplicate_enqueue_keeps_the_existing_job_lease(upload_flow):
+    from subtitles import sync
+
+    flow = upload_flow
+    flow.submit("movie")
+    _, thread = flow.start()
+    thread.join(2)
+    job = flow.queue.jobs_pending_queue[0]
+    publication = job.kwargs["source_version"]
+    assert sync.sync_subtitles(**job.kwargs) is False
+    assert list(flow.queue.jobs_pending_queue) == [job]
+    assert publication.state is not None, "duplicate rejection invalidated the original queued publication"
+    flow.release_engine.set()
+    _, thread = flow.start()
+    thread.join(3)
+    assert "Synced" in flow.video.with_suffix(".en.srt").read_text()
+    assert publication.state is None
+
+
+def test_review_removed_pending_job_does_not_retain_the_coordinator(upload_flow):
+    import gc
+    import weakref
+
+    flow = upload_flow
+    flow.submit("movie")
+    _, thread = flow.start()
+    thread.join(2)
+    job = flow.queue.jobs_pending_queue[0]
+    state = weakref.ref(job.kwargs["source_version"].state)
+    assert flow.queue.remove_job_from_pending_queue(job.job_id)
+    del job
+    gc.collect()
+    assert state() is None
+
+
+@pytest.mark.parametrize("media_type", ["series", "movie"])
+def test_review_notification_failure_does_not_strand_upload_sync(upload_flow, monkeypatch, media_type):
+    from subtitles import upload
+
+    flow = upload_flow
+    name = "send_notifications" if media_type == "series" else "send_notifications_movie"
+    monkeypatch.setattr(upload, name, Mock(side_effect=RuntimeError("controlled notification failure")))
+    flow.submit(media_type)
+    job, thread = flow.start()
+    thread.join(2)
+    assert job.status == "completed"
+    assert len(flow.queue.jobs_pending_queue) == 1
+    flow.release_engine.set()
+    _, thread = flow.start()
+    thread.join(3)
+    assert "Synced" in flow.video.with_suffix(".en.srt").read_text()
+
+
+@pytest.fixture
+def review_translator(upload_flow, monkeypatch, request):
+    import importlib
+
+    flow = upload_flow
+    name, existing = request.param if isinstance(request.param, tuple) else (request.param, True)
+    module = importlib.import_module(f"subtitles.tools.translate.services.{name}_translator")
+    class_name = {"google": "GoogleTranslatorService", "lingarr": "LingarrTranslatorService",
+                  "openrouter": "OpenRouterTranslatorService", "gemini": "GeminiTranslatorService"}[name]
+    source = flow.video.with_suffix(".hu.srt")
+    destination = flow.video.with_suffix(".en.srt")
+    source.write_text("1\n00:00:01,000 --> 00:00:02,000\nSource\n")
+    if existing:
+        destination.write_text("1\n00:00:01,000 --> 00:00:02,000\nOriginal destination\n")
+    service = getattr(module, class_name)(
+        source_srt_file=str(source), dest_srt_file=str(destination), lang_obj=None,
+        to_lang="eng", from_lang="en", media_type="movie", video_path=str(flow.video),
+        orig_to_lang="en", forced=False, hi=False, sonarr_series_id=None, sonarr_episode_id=None, radarr_id=30)
+    monkeypatch.setattr(module, "jobs_queue", flow.queue)
+    monkeypatch.setattr(module, "history_log_movie", Mock())
+    monkeypatch.setattr(module, "create_process_result", Mock())
+    monkeypatch.setattr(module, "add_translator_info", lambda *args: None)
+    started, release, computed = Event(), Event(), Event()
+
+    def compute(*args, **kwargs):
+        started.set()
+        assert release.wait(5)
+        computed.set()
+        if name == "google":
+            return "Translated text"
+        if name == "gemini":
+            Path(service.output_file).write_text("1\n00:00:01,000 --> 00:00:02,000\nTranslated text\n")
+            return
+        return [{"position": 0, "line": "Translated text"}]
+
+    transport = {"google": "_translate_text", "lingarr": "_translate_content",
+                 "openrouter": "_submit_and_poll", "gemini": "_translate_with_gemini"}[name]
+    monkeypatch.setattr(service, transport, compute)
+    if name == "gemini":
+        monkeypatch.setattr(service, "_get_configured_api_keys", lambda: [])
+        monkeypatch.setattr(service, "_select_next_api_key", lambda: "fixture")
+        monkeypatch.setattr(service, "_check_saved_progress", lambda: None)
+        monkeypatch.setattr(module, "get_description", lambda *args, **kwargs: "")
+    job_id = flow.queue.feed_jobs_pending_queue("Translation", "fixture", "translate", is_progress=True)
+    job = flow.queue.jobs_pending_queue.popleft()
+    job.status = "running"
+    flow.queue.jobs_running_queue.append(job)
+    errors = []
+
+    def run():
+        try:
+            service.translate(job_id=job_id)
+        except Exception as exc:
+            errors.append(exc)
+
+    worker = Thread(target=run)
+    worker.start()
+    assert started.wait(2)
+    yield SimpleNamespace(flow=flow, service=service, destination=destination, release=release,
+                          computed=computed, worker=worker, errors=errors, job_id=job_id)
+    release.set()
+    worker.join(5)
+    assert not worker.is_alive()
+
+
+@pytest.mark.parametrize("review_translator", ["google", "lingarr", "openrouter", "gemini"], indirect=True)
+@pytest.mark.parametrize("change", ["edit", "delete"])
+def test_review_translation_preserves_changes_made_during_remote_work(review_translator, monkeypatch, change):
+    from subtitles.tools import mods
+    from subtitles.tools.subsync_engines import SubtitleDestinationChanged
+
+    run = review_translator
+    if change == "edit":
+        edited = b"1\n00:00:01,000 --> 00:00:02,000\nLater edit\n"
+        monkeypatch.setattr(mods.Subtitle, "get_modified_content", lambda *args, **kwargs: edited)
+        mods.subtitles_apply_mods("en", str(run.destination), [], str(run.flow.video), arr_instance_id=7)
+    else:
+        assert run.flow.remove("movie")
+    run.release.set()
+    run.worker.join(3)
+    assert not run.worker.is_alive()
+    assert any(isinstance(exc, SubtitleDestinationChanged) for exc in run.errors)
+    if change == "edit":
+        assert run.destination.read_bytes() == edited
+    else:
+        assert not run.destination.exists()
+
+
+@pytest.mark.parametrize("review_translator", ["google", "lingarr", "openrouter", "gemini"], indirect=True)
+def test_review_translation_cancellation_while_waiting_to_publish_keeps_old_file(review_translator):
+    from app.jobs_queue import JobCancelled
+    from subtitles.tools.subsync_engines import subtitle_write_lock
+
+    run = review_translator
+    original = run.destination.read_bytes()
+    with subtitle_write_lock(str(run.flow.video), str(run.destination.parent)):
+        run.release.set()
+        assert run.computed.wait(2)
+        assert run.flow.queue.cancel_running_job(run.job_id)
+    run.worker.join(3)
+    assert not run.worker.is_alive()
+    assert any(isinstance(exc, JobCancelled) for exc in run.errors)
+    assert run.destination.read_bytes() == original
+
+
+@pytest.mark.parametrize("review_translator", [(name, False) for name in ["google", "lingarr", "openrouter", "gemini"]], indirect=True)
+def test_review_new_translation_preserves_process_umask(review_translator):
+    run = review_translator
+    control = run.destination.with_name("permission-control.txt")
+    control.write_text("control")
+    run.release.set()
+    run.worker.join(3)
+    assert not run.errors
+    assert run.destination.stat().st_mode & 0o777 == control.stat().st_mode & 0o777
+
+
+@pytest.mark.parametrize("failure", ["write-error", "empty-content"])
+def test_review_failed_upload_save_preserves_prior_subtitle_and_outputs(upload_flow, monkeypatch, failure):
+    import builtins
+    from subtitles import upload
+
+    flow = upload_flow
+    source = flow.video.with_suffix(".en.srt")
+    output = flow.video.with_suffix(".en.ffsubsync.srt")
+    source.write_text("Prior base bytes")
+    output.write_text("Prior generated bytes")
+    if failure == "empty-content":
+        monkeypatch.setattr(upload.Subtitle, "get_modified_content", lambda *args, **kwargs: None)
+    else:
+        original = builtins.open
+
+        def fail(file, mode="r", *args, **kwargs):
+            if "w" in mode and "b" in mode:
+                raise OSError("controlled subtitle write failure")
+            return original(file, mode, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", fail)
+    flow.submit("movie")
+    _, thread = flow.start()
+    thread.join(3)
+    assert source.read_text() == "Prior base bytes"
+    assert output.read_text() == "Prior generated bytes"
+    assert not flow.queue.jobs_pending_queue
+
+
+def test_review_failed_upgrade_keeps_previous_subtitle(upload_flow, monkeypatch):
+    from subtitles import download, pool
+    from subliminal_patch.subtitle import Subtitle
+    from subzero.language import Language
+
+    flow = upload_flow
+    previous = flow.video.with_suffix(".en.ass")
+    output = flow.video.with_suffix(".en.ffsubsync.ass")
+    previous.write_text("Prior base bytes")
+    output.write_text("Prior generated bytes")
+    subtitle = Subtitle(Language("eng"), original_format=True)
+    subtitle.content = b"1\n00:00:01,000 --> 00:00:02,000\nReplacement\n"
+    subtitle.matches = set()
+    video = Mock(original_path=str(flow.video))
+    monkeypatch.setattr(pool, "_update_pool", lambda *args, **kwargs: False)
+    monkeypatch.setattr(download, "get_video", lambda *args, **kwargs: video)
+    monkeypatch.setattr(download, "_get_pool", lambda *args, **kwargs: Mock(providers=["fixture"]))
+    monkeypatch.setattr(download, "_get_language_obj", lambda **kwargs: {Language("eng")})
+    monkeypatch.setattr(download, "get_profiles_list", lambda **kwargs: {"originalFormat": True})
+    monkeypatch.setattr(download, "download_best_subtitles", lambda **kwargs: {video: [subtitle]})
+    monkeypatch.setattr(download, "get_target_folder", lambda *args: None)
+    monkeypatch.setattr(download, "save_subtitles", Mock(side_effect=OSError("controlled failed replacement")))
+    list(download.generate_subtitles(str(flow.video), [("en", False, False)], [], None, "Video", "movie", 1,
+                                     is_upgrade=True, previous_subtitles_to_delete=str(previous), arr_instance_id=7))
+    assert previous.read_text() == "Prior base bytes"
+    assert output.read_text() == "Prior generated bytes"
+
+
+@pytest.fixture
+def review_combine(upload_flow, monkeypatch):
+    from subtitles.tools.combine import main
+    from subtitles.tools.combine.rules import SourcePaths
+
+    flow = upload_flow
+    primary = flow.video.with_suffix(".en.srt")
+    secondary = flow.video.with_suffix(".hu.srt")
+    primary.write_text("1\n00:00:01,000 --> 00:00:02,000\nFirst\n")
+    secondary.write_text("1\n00:00:01,000 --> 00:00:02,000\nSecond\n")
+    monkeypatch.setattr(main, "resolve_source_paths", lambda **kwargs: SourcePaths(str(primary), [str(secondary)]))
+    monkeypatch.setattr(main, "_post_write", lambda *args: None)
+    return SimpleNamespace(flow=flow, module=main, output=flow.video.with_suffix(".en.combined-hu.srt"),
+                           run=lambda format="srt": main.try_combine_for_video(
+                               str(flow.video), "movie", languages=["en", "hu"], format=format))
+
+
+def test_review_combine_cleanup_does_not_follow_sibling_symlinks(review_combine):
+    run = review_combine
+    foreign = run.flow.video.with_suffix(".fr.ass")
+    foreign.write_text("Foreign subtitle bytes")
+    run.output.with_suffix(".ass").symlink_to(foreign)
+    assert run.run().status == "built"
+    assert foreign.read_text() == "Foreign subtitle bytes"
+    assert run.output.with_suffix(".ass").is_symlink()
+
+
+def test_review_combine_format_rebuilds_cannot_delete_each_other(review_combine, monkeypatch):
+    run = review_combine
+    first_cleanup, second_cleanup = Event(), Event()
+    original = run.module._remove_stale_combined_siblings
+    results = []
+
+    def cleanup(path, video):
+        mine, other = (first_cleanup, second_cleanup) if path.endswith(".srt") else (second_cleanup, first_cleanup)
+        mine.set()
+        other.wait(0.3)
+        original(path, video)
+
+    monkeypatch.setattr(run.module, "_remove_stale_combined_siblings", cleanup)
+    workers = [Thread(target=lambda fmt=fmt: results.append(run.run(fmt))) for fmt in ("srt", "ass")]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(3)
+        assert not worker.is_alive()
+    assert all(result.status == "built" for result in results)
+    assert sum(run.output.with_suffix(ext).is_file() for ext in (".srt", ".ass")) == 1
+
+
+def test_review_combine_preserves_edit_during_composition(review_combine, monkeypatch):
+    from subtitles.tools import mods
+
+    run = review_combine
+    run.output.write_text("1\n00:00:01,000 --> 00:00:02,000\nOriginal combined\n")
+    entered, release = Event(), Event()
+    original = run.module.compose
+
+    def compose(**kwargs):
+        result = original(**kwargs)
+        entered.set()
+        assert release.wait(5)
+        return result
+
+    monkeypatch.setattr(run.module, "compose", compose)
+    results = []
+    worker = Thread(target=lambda: results.append(run.run()))
+    worker.start()
+    try:
+        assert entered.wait(2)
+        edited = b"1\n00:00:01,000 --> 00:00:02,000\nEdited combined\n"
+        monkeypatch.setattr(mods.Subtitle, "get_modified_content", lambda *args, **kwargs: edited)
+        mods.subtitles_apply_mods("en", str(run.output), [], str(run.flow.video), arr_instance_id=7)
+        release.set()
+        worker.join(3)
+        assert not worker.is_alive()
+        assert run.output.read_bytes() == edited
+        assert results[0].status != "built"
+    finally:
+        release.set()
+        worker.join(3)
+
+
+def test_review_postprocessing_without_a_queued_job_invalidates_exact_outputs(upload_flow, monkeypatch):
+    from subtitles import post_processing
+
+    flow = upload_flow
+    source = flow.video.with_suffix(".en.srt")
+    output = flow.video.with_suffix(".en.ffsubsync.srt")
+    source.write_text("Before processing")
+    output.write_text("Generated before processing")
+
+    def popen(*args, **kwargs):
+        source.write_text("After processing")
+        return Mock(communicate=lambda: ("", ""))
+
+    monkeypatch.setattr(post_processing.subprocess, "Popen", popen)
+    post_processing.postprocessing("fixture", str(flow.video), subtitle_path=str(source))
+    assert source.read_text() == "After processing"
+    assert not output.exists()
+    assert any(path.read_text() == "Generated before processing" for path in flow.video.parent.glob("*.bak"))
+
+
+def test_review_partial_multiformat_save_records_each_actual_write(upload_flow):
+    from functools import partial
+    from subliminal_patch.core import save_subtitles
+    from subliminal_patch.subtitle import Subtitle
+    from subzero.language import Language
+    from subtitles.tools.subsync_engines import write_subtitle_file, SubtitlePublication, subtitle_source_version
+
+    flow = upload_flow
+    source = flow.video.with_suffix(".en.srt")
+    output = flow.video.with_suffix(".en.ffsubsync.srt")
+    source.write_text("Prior source")
+    output.write_text("Prior generated output")
+    publication = SubtitlePublication(str(flow.video), str(source), subtitle_source_version(source))
+    subtitle = Subtitle(Language("eng"), original_format=True)
+    subtitle.content = b"1\n00:00:01,000 --> 00:00:02,000\nReplacement\n"
+
+    def content(format, **kwargs):
+        if format == "ass":
+            raise ValueError("controlled second format failure")
+        return b"First format succeeded"
+
+    subtitle.get_modified_content = content
+    written_paths = []
+    try:
+        with pytest.raises(ValueError, match="second format"):
+            save_subtitles(str(flow.video), [subtitle], formats=("srt", "ass"),
+                           write_subtitle=partial(write_subtitle_file, str(flow.video), written_paths=written_paths))
+        assert written_paths == [str(source)]
+        assert source.read_text() == "First format succeeded"
+        assert not publication.source_unchanged()
+        assert not output.exists()
+    finally:
+        publication.release()
+
+
+def test_review_index_failure_does_not_suppress_refresh_of_published_output(upload_flow):
+    flow = upload_flow
+    flow.submit("movie")
+    _, thread = flow.start()
+    thread.join(2)
+    job = flow.queue.jobs_pending_queue[0]
+    job.kwargs["callback"] = Mock(side_effect=RuntimeError("controlled final index failure"))
+    flow.release_engine.set()
+    _, thread = flow.start()
+    thread.join(3)
+    assert "Synced" in flow.video.with_suffix(".en.srt").read_text()
+    assert sum("arr_client" in kwargs for _, kwargs in flow.notifications) == 2
+    assert job.kwargs["source_version"].state is None
+
+
+def test_review_deleting_one_engine_destination_preserves_other_engine_publication(upload_flow, monkeypatch):
+    from app.config import settings
+    from subtitles.tools import subsyncer, delete
+
+    flow = upload_flow
+    monkeypatch.setattr(settings.subsync, "enabled_engines", ["ffsubsync", "alass"])
+    monkeypatch.setattr(settings.subsync, "output_mode", "keep_all")
+    monkeypatch.setattr(subsyncer.SubSyncer, "_run_external_engine", lambda self, engine, output_path, video_path:
+                        (output_path.write_text("Other engine output") and {"offset_seconds": 0}))
+    flow.submit("movie")
+    _, thread = flow.start()
+    thread.join(2)
+    deleted = flow.video.with_suffix(".en.ffsubsync.srt")
+    assert delete.delete_subtitles("movie", "en", False, False, str(flow.video), str(deleted),
+                                   radarr_id=30, arr_instance_id=7) is False
+    _, thread = flow.start()
+    thread.join(3)
+    assert not flow.engine_calls
+    assert not deleted.exists()
+    assert flow.video.with_suffix(".en.alass.srt").read_text() == "Other engine output"
+
+
+def test_review_quarantine_moves_only_exact_regular_variants(upload_flow):
+    from subtitles.tools.subsync_engines import quarantine_sync_outputs, SubtitlePublication, subtitle_source_version
+
+    flow = upload_flow
+    source = flow.video.with_suffix(".en.hi.ass")
+    source.write_text("Source")
+    exact = flow.video.with_suffix(".en.hi.ffsubsync.ass")
+    exact.write_text("Owned generated bytes")
+    foreign = flow.video.with_suffix(".hu.srt")
+    foreign.write_text("Foreign bytes")
+    symlink = flow.video.with_suffix(".en.hi.alass.ass")
+    symlink.symlink_to(foreign)
+    untouched = [flow.video.with_suffix(suffix) for suffix in
+                 (".en.ffsubsync.ass", ".en.hi.ffsubsync.srt", ".en.forced.ffsubsync.ass")]
+    for path in untouched:
+        path.write_text("Other variant bytes")
+    quarantine_sync_outputs(str(flow.video), str(source))
+    assert not exact.exists()
+    assert symlink.is_symlink() and foreign.read_text() == "Foreign bytes"
+    assert all(path.read_text() == "Other variant bytes" for path in untouched)
+    assert any(path.read_text() == "Owned generated bytes" for path in flow.video.parent.glob("*.bak"))
+    publication = SubtitlePublication(str(flow.video), str(source), subtitle_source_version(source))
+    try:
+        assert not publication.destination_unchanged(symlink)
+    finally:
+        publication.release()
+
+
+def test_review_failed_quarantine_retains_bytes_and_destination_revision(upload_flow, monkeypatch):
+    from subtitles.tools import subsync_engines
+
+    flow = upload_flow
+    source = flow.video.with_suffix(".en.srt")
+    source.write_text("Source")
+    output = flow.video.with_suffix(".en.ffsubsync.srt")
+    output.write_text("Prior generated bytes")
+    publication = subsync_engines.SubtitlePublication(
+        str(flow.video), str(source), subsync_engines.subtitle_source_version(source))
+    monkeypatch.setattr(subsync_engines.os, "replace", Mock(side_effect=PermissionError("controlled move rejection")))
+    try:
+        with pytest.raises(PermissionError, match="move rejection"):
+            subsync_engines.quarantine_sync_outputs(str(flow.video), str(source))
+        assert output.read_text() == "Prior generated bytes"
+        assert publication.destination_unchanged(output)
+        assert not list(flow.video.parent.glob(".bazarr-sync-obsolete-*.bak"))
+    finally:
+        publication.release()
+
+
+@pytest.fixture
+def rejected_quarantine(upload_flow, monkeypatch):
+    from subtitles.tools import subsync_engines
+
+    flow = upload_flow
+    source = flow.video.with_suffix(".en.srt")
+    source.write_text("Previous subtitle")
+    output = flow.video.with_suffix(".en.ffsubsync.srt")
+    output.write_text("Previous generated output")
+    other = flow.video.with_suffix(".hu.ffsubsync.srt")
+    other.write_text("Other language output")
+    publication = subsync_engines.SubtitlePublication(
+        str(flow.video), str(source), subsync_engines.subtitle_source_version(source))
+    other_revision = publication.state.revision(other)
+    real_replace = subsync_engines.os.replace
+    rejected = []
+
+    def replace(src, dst, *args, **kwargs):
+        if Path(src) == output and Path(dst).name.startswith(".bazarr-sync-obsolete-"):
+            rejected.append(str(src))
+            raise PermissionError("controlled quarantine failure after publication")
+        return real_replace(src, dst, *args, **kwargs)
+
+    monkeypatch.setattr(subsync_engines.os, "replace", replace)
+    yield SimpleNamespace(flow=flow, source=source, output=output, other=other, publication=publication,
+                          other_revision=other_revision, rejected=rejected)
+    publication.release()
+
+
+def _assert_reported_quarantine_failure(probe, caplog):
+    assert probe.rejected == [str(probe.output)]
+    assert not probe.publication.source_unchanged()
+    assert probe.publication.state.revision(probe.source) > probe.publication.source_revision
+    assert probe.output.read_text() == "Previous generated output"
+    assert probe.publication.destination_unchanged(probe.output)
+    assert probe.other.read_text() == "Other language output"
+    assert probe.publication.state.revision(probe.other) == probe.other_revision
+    assert not list(probe.source.parent.glob(".bazarr-sync-obsolete-*.bak"))
+    assert any("cleanup failed" in record.message and "may remain available" in record.message
+               and str(probe.source) in record.message for record in caplog.records)
+
+
+@pytest.mark.parametrize("media_type", ["movie", "series"])
+def test_review_published_upload_is_accounted_when_quarantine_fails(rejected_quarantine, caplog, media_type):
+    probe = rejected_quarantine
+    flow = probe.flow
+    flow.submit(media_type, content="Replacement uploaded text")
+    job, thread = flow.start()
+    thread.join(3)
+    assert not thread.is_alive()
+    assert "Replacement uploaded text" in probe.source.read_text()
+    assert flow.indexes, "durable upload publication was not indexed"
+    assert flow.indexes[0][0] == 7
+    assert flow.indexes[0][1][probe.output.name] == "Previous generated output"
+    assert len(flow.history) == 1
+    assert len(flow.notifications) == 2
+    assert job.status == "completed"
+    assert len(flow.queue.jobs_pending_queue) == 1
+    _assert_reported_quarantine_failure(probe, caplog)
+
+
+@pytest.mark.parametrize("writer", ["manual", "automatic"])
+def test_review_published_provider_subtitle_is_accounted_when_quarantine_fails(
+        rejected_quarantine, monkeypatch, caplog, writer):
+    from subtitles import manual, download, pool
+    from subliminal_patch.subtitle import Subtitle
+    from subzero.language import Language
+
+    probe = rejected_quarantine
+    flow = probe.flow
+    subtitle = Subtitle(Language("eng"), original_format=True)
+    subtitle.content = b"1\n00:00:01,000 --> 00:00:02,000\nReplacement provider text\n"
+    subtitle.provider_name = "fixture"
+    subtitle.matches = set()
+    video = Mock(original_path=str(flow.video))
+    provider_pool = Mock(providers=["fixture"], discarded_providers=[])
+    module = manual if writer == "manual" else download
+    monkeypatch.setattr(pool, "_update_pool", lambda *args, **kwargs: False)
+    monkeypatch.setattr(module, "get_video", lambda *args, **kwargs: video)
+    monkeypatch.setattr(module, "_get_pool", lambda *args, **kwargs: provider_pool)
+    monkeypatch.setattr(module, "get_target_folder", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module.subliminal, "region", Mock())
+    processed = []
+    monkeypatch.setattr(module, "process_subtitle", lambda **kwargs: processed.append(kwargs) or "saved")
+    if writer == "manual":
+        monkeypatch.setattr(manual.subtitle_cache, "get", lambda *args: subtitle)
+        monkeypatch.setattr(manual, "download_subtitles", lambda *args: None)
+        manual.manual_download_subtitle(str(flow.video), [], False, False, "cached", "fixture", None,
+                                        "Video", "movie", True, 1, arr_instance_id=7)
+    else:
+        monkeypatch.setattr(download, "_get_language_obj", lambda **kwargs: {Language("eng")})
+        monkeypatch.setattr(download, "get_profiles_list", lambda **kwargs: {"originalFormat": True})
+        monkeypatch.setattr(download, "download_best_subtitles", lambda **kwargs: {video: [subtitle]})
+        monkeypatch.setattr(download, "clear_mismatch_for_video", lambda *args, **kwargs: None)
+        list(download.generate_subtitles(str(flow.video), [("en", False, False)], [], None,
+                                         "Video", "movie", 1, arr_instance_id=7))
+    assert "Replacement provider text" in probe.source.read_text()
+    assert len(processed) == 1, "durable provider publication was not passed to processing"
+    assert processed[0]["subtitle"].storage_path == str(probe.source)
+    assert processed[0]["path"] == str(flow.video)
+    assert processed[0]["media_type"] == "movie"
+    _assert_reported_quarantine_failure(probe, caplog)
+
+
+@pytest.mark.parametrize("operation", ["delete", "manual-sync"])
+def test_review_completed_mutation_keeps_success_when_quarantine_fails(rejected_quarantine, caplog, operation):
+    from subtitles import sync
+
+    probe = rejected_quarantine
+    flow = probe.flow
+    if operation == "delete":
+        assert flow.remove("movie") is True
+        assert not probe.source.exists()
+        assert flow.indexes
+    else:
+        flow.release_engine.set()
+        assert sync.sync_subtitles(str(flow.video), str(probe.source), "en", False, False, 100,
+                                   radarr_id=30, force_sync=True, track_job_progress=False,
+                                   arr_instance_id=7) is True
+        assert "Synced" in probe.source.read_text()
+        assert flow.sync_history
+    _assert_reported_quarantine_failure(probe, caplog)


### PR DESCRIPTION
Background subtitle sync could overwrite a newer edit or recreate a deleted subtitle after LavX/bazarr#428. This follow-up coordinates subtitle writers and publishes sync results only while their original destination is still current. Ownership checks protect unrelated files, and cleanup errors no longer hide successfully saved subtitles.

Library scans now reuse an ownership index for custom subtitle folders, while mutation checks remain fresh. Successful sync promotions retain confirmation history if index refresh fails. Saved uploads notify media consumers before sync setup or queueing can fail, and refresh them again after successful sync.

Gemini cancellation stops subsequent requests and retries and clears progress. Translator status cards remain visible for zero counts, loading and errors, with a dash for unavailable counts.

The release preparation commit prepares Bazarr+ v2.6.2 (Clockwork): version metadata, 18 in-app release slides, the site entry and archived release notes. This PR targets development; publishing the release is a separate step.

Validation of the combined candidate:

- Independent source review and maintainer verification on the test instance completed. Commit 472e72d82 matches all 1,433 tested ordinary files and modes, with unchanged submodule references.
- Full local CI: 944 frontend tests passed, two skipped; 3,914 backend tests passed, eight skipped on each of Python 3.12, 3.13 and 3.14. Node 24.20.0, type checking, lint, formatting, production build and PostgreSQL checks passed.
- Exact-image checks passed all 517 production files, 49 default-start cases and 192 runtime acceptance cases. Runtime probes used disposable fixtures with networking disabled and no live media/configuration mounts. All 517 deployed files matched the built image.
- Browser checks passed ten translator scenarios, six movie/series upload scenarios and all 18 release-tour slides and destinations. Upload checks cover drops during archive extraction and single-close dismissal. The first tour run reported two HTTP callback errors after its behavior checks; a diagnostic-only repeat passed with zero callback errors. Their cause remains unconfirmed, and both results are retained.
- Full configuration, all 63 provider configurations and installed versions, launch settings, and library/history counts were preserved. The separately deployed translator and existing rollback containers were preserved.
