### PR TITLE
Support multiple Emby and Silo servers for subtitle refresh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,7 @@ jobs:
             tests/bazarr/test_media_server_instances.py \
             tests/bazarr/test_media_server_instance_migration.py \
             tests/bazarr/test_media_server_dispatcher.py \
+            tests/bazarr/test_media_server_resolution.py \
             tests/bazarr/test_media_server_mutation_hooks.py \
             tests/bazarr/test_logging_filters.py \
             tests/bazarr/test_openrouter_provider_routing.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,9 @@ jobs:
             tests/bazarr/test_retired_provider_config_compat.py \
             tests/bazarr/test_settings_profile_deletion.py \
             tests/bazarr/test_jellyfin_apikey_location.py \
+            tests/bazarr/test_emby_api.py \
+            tests/bazarr/test_silo_api.py \
+            tests/bazarr/test_media_server_instances_api.py \
             tests/bazarr/test_provider_hub.py \
             tests/bazarr/test_provider_pool_config_reload.py \
             tests/bazarr/test_rar_extraction_production_config.py \
@@ -277,6 +280,16 @@ jobs:
             tests/bazarr/test_get_video_scenename_fallback.py \
             tests/bazarr/test_jellyfin_client.py \
             tests/bazarr/test_jellyfin_operations.py \
+            tests/bazarr/test_emby_client.py \
+            tests/bazarr/test_silo_client.py \
+            tests/bazarr/test_silo_scans.py \
+            tests/bazarr/test_media_server_paths.py \
+            tests/bazarr/test_media_server_http.py \
+            tests/bazarr/test_media_server_config.py \
+            tests/bazarr/test_media_server_instances.py \
+            tests/bazarr/test_media_server_instance_migration.py \
+            tests/bazarr/test_media_server_dispatcher.py \
+            tests/bazarr/test_media_server_mutation_hooks.py \
             tests/bazarr/test_logging_filters.py \
             tests/bazarr/test_openrouter_provider_routing.py \
             tests/bazarr/test_openrouter_model_migration.py \
@@ -335,6 +348,7 @@ jobs:
             tests/bazarr/test_editor_api.py \
             tests/bazarr/test_arr_atomicity_secrets.py \
             tests/bazarr/test_arr_pg_cutover_migration.py \
+            tests/bazarr/test_media_server_instances_pg.py \
             tests/bazarr/test_editor_instance_scope.py \
             tests/bazarr/test_history_blacklist_scope.py \
             tests/bazarr/test_history_owner_resolution.py \

--- a/bazarr/api/__init__.py
+++ b/bazarr/api/__init__.py
@@ -15,6 +15,8 @@ from .system import api_ns_list_system
 from .webhooks import api_ns_list_webhooks
 from .plex import api_ns_list_plex
 from .jellyfin import api_ns_list_jellyfin
+from .emby import api_ns_list_emby
+from .silo import api_ns_list_silo
 from .translator import api_ns_list_translator
 from .editor import api_ns_list_editor
 from .provider_hub import api_ns_list_provider_hub
@@ -34,6 +36,8 @@ api_ns_list = [
     api_ns_list_webhooks,
     api_ns_list_plex,
     api_ns_list_jellyfin,
+    api_ns_list_emby,
+    api_ns_list_silo,
     api_ns_list_translator,
     api_ns_list_editor,
     api_ns_list_provider_hub,

--- a/bazarr/api/emby/__init__.py
+++ b/bazarr/api/emby/__init__.py
@@ -1,0 +1,9 @@
+# coding=utf-8
+
+from flask_restx import Namespace
+
+api_ns_emby = Namespace('Emby', description='Emby server management')
+
+from .endpoints import *  # noqa: E402, F403
+
+api_ns_list_emby = [api_ns_emby]

--- a/bazarr/api/emby/endpoints.py
+++ b/bazarr/api/emby/endpoints.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+
+from flask import request
+from flask_restx import Resource
+
+from . import api_ns_emby
+from ..utils import authenticate
+from emby.operations import emby_test_connection
+from media_servers.http import MediaServerError, parse_verify_ssl
+
+
+@api_ns_emby.route('emby/test-connection')
+class EmbyTestConnection(Resource):
+    @authenticate
+    @api_ns_emby.response(200, 'Connection result')
+    @api_ns_emby.response(400, 'Invalid connection settings')
+    @api_ns_emby.response(401, 'Not Authenticated')
+    def post(self):
+        """Test the explicitly supplied unsaved connection settings."""
+        body = request.get_json(silent=True) if request.is_json else request.form
+        if not body or not hasattr(body, 'get'):
+            return {'success': False, 'error_code': 'missing_credentials'}, 400
+        if set(body) - {'url', 'apikey', 'verify_ssl'}:
+            return {'success': False, 'error_code': 'invalid_settings'}, 400
+        url, apikey = body.get('url'), body.get('apikey')
+        if not all(isinstance(value, str) and value.strip() for value in (url, apikey)):
+            return {'success': False, 'error_code': 'missing_credentials'}, 400
+        try:
+            verify_ssl = parse_verify_ssl(body.get('verify_ssl', True))
+        except MediaServerError as error:
+            return {'success': False, 'error_code': error.code}, 400
+        return emby_test_connection(url, apikey, verify_ssl), 200

--- a/bazarr/api/episodes/episodes_subtitles.py
+++ b/bazarr/api/episodes/episodes_subtitles.py
@@ -187,7 +187,7 @@ class EpisodesSubtitlesCombine(Resource):
         arr_instance_id = request.args.get('arr_instance_id', type=int)
         row = database.execute(
             scoped(
-                select(TableEpisodes.path, TableEpisodes.sonarrSeriesId)
+                select(TableEpisodes.path, TableEpisodes.sonarrSeriesId, TableEpisodes.arr_instance_id)
                 .where(TableEpisodes.sonarrEpisodeId == episode_id),
                 TableEpisodes.arr_instance_id,
                 arr_instance_id,
@@ -195,7 +195,8 @@ class EpisodesSubtitlesCombine(Resource):
         ).first()
         if not row:
             return {'status': 'not_found'}, 404
-        video_path = path_mappings.path_replace(row.path)
+        arr_instance_id = row.arr_instance_id
+        video_path = path_mappings.path_replace_instance(row.path, arr_instance_id, 'episode')
 
         result = try_combine_for_video(
             video_path=video_path,
@@ -205,6 +206,7 @@ class EpisodesSubtitlesCombine(Resource):
             sonarr_episode_id=episode_id,
             languages=languages,
             format=format_,
+            arr_instance_id=arr_instance_id,
         )
         body = {
             'status': result.status,

--- a/bazarr/api/movies/movies_subtitles.py
+++ b/bazarr/api/movies/movies_subtitles.py
@@ -181,14 +181,15 @@ class MoviesSubtitlesCombine(Resource):
         arr_instance_id = request.args.get('arr_instance_id', type=int)
         row = database.execute(
             scoped(
-                select(TableMovies.path).where(TableMovies.radarrId == radarr_id),
+                select(TableMovies.path, TableMovies.arr_instance_id).where(TableMovies.radarrId == radarr_id),
                 TableMovies.arr_instance_id,
                 arr_instance_id,
             )
         ).first()
         if not row:
             return {'status': 'not_found'}, 404
-        video_path = path_mappings.path_replace_movie(row.path)
+        arr_instance_id = row.arr_instance_id
+        video_path = path_mappings.path_replace_instance(row.path, arr_instance_id, 'movie')
 
         result = try_combine_for_video(
             video_path=video_path,
@@ -198,6 +199,7 @@ class MoviesSubtitlesCombine(Resource):
             sonarr_episode_id=None,
             languages=languages,
             format=format_,
+            arr_instance_id=arr_instance_id,
         )
         body = {
             'status': result.status,

--- a/bazarr/api/series/series.py
+++ b/bazarr/api/series/series.py
@@ -328,6 +328,7 @@ def _list_series_episodes(series_id, arr_instance_id=None):
                 TableEpisodes.sonarrEpisodeId,
                 TableEpisodes.sonarrSeriesId,
                 TableEpisodes.path,
+                TableEpisodes.arr_instance_id,
             ).where(TableEpisodes.sonarrSeriesId == series_id),
             TableEpisodes.arr_instance_id,
             arr_instance_id,
@@ -338,6 +339,7 @@ def _list_series_episodes(series_id, arr_instance_id=None):
             'sonarrEpisodeId': r.sonarrEpisodeId,
             'sonarrSeriesId': r.sonarrSeriesId,
             'path': r.path,
+            'arr_instance_id': r.arr_instance_id,
         }
         for r in rows
     ]
@@ -364,7 +366,8 @@ class SeriesSubtitlesCombine(Resource):
         built, skipped, failed = 0, 0, 0
         details = []
         for ep in episodes:
-            video_path = path_mappings.path_replace(ep['path'])
+            owner = ep['arr_instance_id']
+            video_path = path_mappings.path_replace_instance(ep['path'], owner, 'episode')
             r = try_combine_for_video(
                 video_path=video_path,
                 media_type='series',
@@ -373,6 +376,7 @@ class SeriesSubtitlesCombine(Resource):
                 sonarr_episode_id=ep['sonarrEpisodeId'],
                 languages=languages,
                 format=format_,
+                arr_instance_id=owner,
             )
             details.append({
                 'episodeId': ep['sonarrEpisodeId'],

--- a/bazarr/api/silo/__init__.py
+++ b/bazarr/api/silo/__init__.py
@@ -1,0 +1,9 @@
+# coding=utf-8
+
+from flask_restx import Namespace
+
+api_ns_silo = Namespace('Silo', description='Native Silo server management')
+
+from .endpoints import *  # noqa: E402, F403
+
+api_ns_list_silo = [api_ns_silo]

--- a/bazarr/api/silo/endpoints.py
+++ b/bazarr/api/silo/endpoints.py
@@ -1,0 +1,51 @@
+# coding=utf-8
+
+from flask import request
+from flask_restx import Resource
+
+from . import api_ns_silo
+from ..utils import authenticate
+from media_servers.http import MediaServerError, parse_verify_ssl
+from silo.operations import silo_get_libraries, silo_test_connection
+
+
+def _connection_settings():
+    body = request.get_json(silent=True) if request.is_json else request.form
+    if not body or not hasattr(body, 'get'):
+        raise MediaServerError('missing_credentials')
+    if set(body) - {'url', 'apikey', 'verify_ssl'}:
+        raise MediaServerError('invalid_settings')
+    url, apikey = body.get('url'), body.get('apikey')
+    if not all(isinstance(value, str) and value.strip() for value in (url, apikey)):
+        raise MediaServerError('missing_credentials')
+    return url, apikey, parse_verify_ssl(body.get('verify_ssl', True))
+
+
+@api_ns_silo.route('silo/test-connection')
+class SiloTestConnection(Resource):
+    @authenticate
+    @api_ns_silo.response(200, 'Connection result')
+    @api_ns_silo.response(400, 'Invalid connection settings')
+    @api_ns_silo.response(401, 'Not Authenticated')
+    def post(self):
+        """Test the explicitly supplied unsaved native connection settings."""
+        try:
+            values = _connection_settings()
+        except MediaServerError as error:
+            return {'success': False, 'error_code': error.code}, 400
+        return silo_test_connection(*values), 200
+
+
+@api_ns_silo.route('silo/libraries')
+class SiloLibraries(Resource):
+    @authenticate
+    @api_ns_silo.response(200, 'Library result')
+    @api_ns_silo.response(400, 'Invalid connection settings')
+    @api_ns_silo.response(401, 'Not Authenticated')
+    def post(self):
+        """List supported libraries using explicitly supplied unsaved settings."""
+        try:
+            values = _connection_settings()
+        except MediaServerError as error:
+            return {'data': [], 'error_code': error.code}, 400
+        return silo_get_libraries(*values), 200

--- a/bazarr/api/subtitles/content.py
+++ b/bazarr/api/subtitles/content.py
@@ -6,6 +6,7 @@ import os
 import re
 import tempfile
 from datetime import datetime, timedelta
+from media_servers.events import publication_callback
 
 from flask import make_response, jsonify, request
 from flask_restx import Resource, Namespace
@@ -843,6 +844,7 @@ def _save_subtitle_content(media_type, media_id, language_code, arr_instance_id=
                 return 'Subtitle file has been modified since last read', 412
             with subtitle_mutation(video_path, subtitle_path):
                 _write_bytes_atomically(subtitle_path, encoded)
+                publication_callback(media_type, video_path, 'edit', metadata.get('arrInstanceId'))(subtitle_path)
                 _apply_subtitle_chmod(subtitle_path)
             new_etag = generate_etag(subtitle_path)
     except FileNotFoundError:
@@ -914,6 +916,7 @@ def promote_sync_subtitle(media_type, media_id, target_language, source_language
                 data = source_file.read()
             with subtitle_mutation(video_path, target_path):
                 _write_bytes_atomically(target_path, data)
+                publication_callback(media_type, video_path, 'sync', metadata.get('arrInstanceId'))(target_path)
                 _apply_subtitle_chmod(target_path)
     except FileNotFoundError:
         return 'Subtitle file or directory not found', 404
@@ -1051,7 +1054,7 @@ def _create_subtitle(media_type, media_id, arr_instance_id=None):
     # Look up the media to get the video file path
     if media_type == 'episode':
         query = (
-            select(TableEpisodes.id, TableEpisodes.path)
+            select(TableEpisodes.id, TableEpisodes.path, TableEpisodes.arr_instance_id)
             .where(TableEpisodes.sonarrEpisodeId == media_id)
         )
         if arr_instance_id is not None:
@@ -1059,7 +1062,7 @@ def _create_subtitle(media_type, media_id, arr_instance_id=None):
         row = database.execute(query).first()
     elif media_type == 'movie':
         query = (
-            select(TableMovies.id, TableMovies.path)
+            select(TableMovies.id, TableMovies.path, TableMovies.arr_instance_id)
             .where(TableMovies.radarrId == media_id)
         )
         if arr_instance_id is not None:
@@ -1073,6 +1076,7 @@ def _create_subtitle(media_type, media_id, arr_instance_id=None):
 
     # Apply the owning instance's per-instance path_mappings when configured
     # (#156); falls back to the global mapping when the instance has none.
+    arr_instance_id = row.arr_instance_id
     video_path = path_mappings.path_replace_instance(row.path, arr_instance_id, media_type)
 
     # Build the subtitle filename. `language` was already validated against
@@ -1115,6 +1119,7 @@ def _create_subtitle(media_type, media_id, arr_instance_id=None):
                 return 'Subtitle file already exists', 409
             with subtitle_mutation(video_path, subtitle_path):
                 _write_bytes_atomically(subtitle_path, encoded)
+                publication_callback(media_type, video_path, 'edit', arr_instance_id)(subtitle_path)
                 _apply_subtitle_chmod(subtitle_path)
 
     except FileNotFoundError:

--- a/bazarr/api/subtitles/subtitles.py
+++ b/bazarr/api/subtitles/subtitles.py
@@ -476,6 +476,7 @@ class Subtitles(Resource):
                     video_path=video_path,
                     # Resolve keep-lyrics against the owning instance (#227).
                     arr_instance_id=arr_instance_id,
+                    media_type=media_type,
                 )
                 postprocess_subtitles(
                     subtitles_path, video_path, media_type, metadata, id,

--- a/bazarr/api/system/__init__.py
+++ b/bazarr/api/system/__init__.py
@@ -20,7 +20,10 @@ from .jobs import api_ns_system_jobs
 from .compat_admin import api_ns_compat_admin
 from .arr_instances import api_ns_system_arr_instances
 
+from .media_server_instances import api_ns_system_media_server_instances
+
 api_ns_list_system = [
+    api_ns_system_media_server_instances,
     api_ns_system,
     api_ns_system_account,
     api_ns_system_announcements,

--- a/bazarr/api/system/media_server_instances.py
+++ b/bazarr/api/system/media_server_instances.py
@@ -1,0 +1,88 @@
+# coding=utf-8
+
+from flask import request
+from flask_restx import Namespace, Resource
+
+from app.database import database
+from media_servers import service
+from media_servers.dispatcher import get_refresh_status, retry_pending_refreshes
+from media_servers.http import MediaServerError
+from ..utils import authenticate
+
+api_ns_system_media_server_instances = Namespace('media_server_instances', description='Native media server destinations')
+_ROOT = 'system/media-server-instances'
+
+
+def _body(*, optional=False):
+    if optional and not request.data and not request.form:
+        return {}
+    return request.get_json(silent=True)
+
+
+@api_ns_system_media_server_instances.route(_ROOT)
+class MediaServerInstances(Resource):
+    @authenticate
+    def get(self):
+        return service.list_instances(database, request.args.get('kind'))
+
+    @authenticate
+    def post(self):
+        return service.create_instance(database, _body())
+
+
+@api_ns_system_media_server_instances.route(_ROOT + '/<string:instance_id>')
+class MediaServerInstance(Resource):
+    @authenticate
+    def get(self, instance_id):
+        return service.get_instance(database, instance_id)
+
+    @authenticate
+    def patch(self, instance_id):
+        return service.update_instance(database, instance_id, _body())
+
+    @authenticate
+    def delete(self, instance_id):
+        return service.delete_instance(database, instance_id)
+
+
+@api_ns_system_media_server_instances.route(_ROOT + '/<string:instance_id>/test-connection')
+class MediaServerInstanceTest(Resource):
+    @authenticate
+    def post(self, instance_id):
+        return service.probe_instance(database, instance_id, _body(optional=True))
+
+
+@api_ns_system_media_server_instances.route(_ROOT + '/<string:instance_id>/libraries')
+class MediaServerInstanceLibraries(Resource):
+    @authenticate
+    def post(self, instance_id):
+        return service.probe_instance(database, instance_id, _body(optional=True), libraries=True)
+
+
+@api_ns_system_media_server_instances.route(_ROOT + '/<string:instance_id>/status')
+class MediaServerInstanceStatus(Resource):
+    @authenticate
+    def get(self, instance_id):
+        _body, status = service.get_instance(database, instance_id)
+        if status != 200:
+            return _body, status
+        try:
+            return get_refresh_status(instance_id), 200
+        except MediaServerError:
+            return {'pending': 0, 'state': 'unconfirmed', 'error_code': 'migration_failed'}, 200
+
+
+@api_ns_system_media_server_instances.route(_ROOT + '/<string:instance_id>/retry-pending')
+class MediaServerInstanceRetry(Resource):
+    @authenticate
+    def post(self, instance_id):
+        _body, status = service.get_instance(database, instance_id)
+        if status != 200:
+            return _body, status
+        body = request.get_json(silent=True) if request.data else {}
+        if not isinstance(body, dict) or body:
+            return {'error_code': 'invalid_settings'}, 400
+        try:
+            return {'queued': retry_pending_refreshes(instance_id)}, 200
+        except MediaServerError:
+            return {'queued': 0}, 200

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -129,6 +129,8 @@ validators = [
     Validator('general.use_radarr', must_exist=True, default=False, is_type_of=bool),
     Validator('general.use_plex', must_exist=True, default=False, is_type_of=bool),
     Validator('general.use_jellyfin', must_exist=True, default=False, is_type_of=bool),
+    Validator('general.use_emby', must_exist=True, default=False, is_type_of=bool),
+    Validator('general.use_silo', must_exist=True, default=False, is_type_of=bool),
     # Set True once the first-run onboarding wizard is completed or skipped, so it
     # never auto-triggers again. Defaults False on a fresh install.
     Validator('general.setup_complete', must_exist=True, default=False, is_type_of=bool),
@@ -330,6 +332,18 @@ validators = [
     Validator('plex.migration_timestamp', must_exist=True, default='', is_type_of=(int, float, str)),
     Validator('plex.disable_auto_migration', must_exist=True, default=False, is_type_of=bool),
     Validator('plex.client_identifier', must_exist=True, default='', is_type_of=str),
+
+    # emby section
+    Validator('emby.url', must_exist=True, default='', is_type_of=str),
+    Validator('emby.apikey', must_exist=True, default='', is_type_of=str),
+    Validator('emby.verify_ssl', must_exist=True, default=True, is_type_of=bool),
+    Validator('emby.path_mappings', must_exist=True, default=[], is_type_of=list),
+
+    # silo section
+    Validator('silo.url', must_exist=True, default='', is_type_of=str),
+    Validator('silo.apikey', must_exist=True, default='', is_type_of=str),
+    Validator('silo.verify_ssl', must_exist=True, default=True, is_type_of=bool),
+    Validator('silo.path_mappings', must_exist=True, default=[], is_type_of=list),
 
     # jellyfin section
     Validator('jellyfin.url', must_exist=True, default='', is_type_of=str),
@@ -687,6 +701,7 @@ decrypt_settings_in_place(settings)
 
 
 def write_config():
+    from secret_store.crypto import mark_master_key_persisted
     # On-disk shape compared in plaintext form: encrypt_secret is non-
     # deterministic (per-payload salt + timestamp), so naive ciphertext
     # comparison would always diff and rewrite config.yaml on every save.
@@ -702,24 +717,27 @@ def write_config():
 
     if in_memory_plaintext == on_disk_plaintext and not _force_first_save_migration:
         logging.debug("Nothing changed when comparing to config file. Skipping write to file.")
-        return
+        mark_master_key_persisted(in_memory_plaintext.get("general", {}).get("secrets_encryption_key"))
+        return True
 
     forced_migration = _force_first_save_migration
     if forced_migration:
         logging.info("secret_store: forcing config rewrite to encrypt plaintext credentials on disk")
 
     try:
+        encrypted_payload = encrypt_settings_dict(in_memory_plaintext)
         write(settings_path=config_yaml_file + '.tmp',
-              settings_data=encrypt_settings_dict(in_memory_plaintext),
+              settings_data=encrypted_payload,
               merge=False)
-    except Exception as error:
-        logging.exception(f"Exception raised while trying to save temporary settings file: {error}")  # noqa: G004
+    except Exception:
+        logging.error("Unable to save temporary settings file")
+        return False
     else:
         try:
             move(config_yaml_file + '.tmp', config_yaml_file)
-        except Exception as error:
-            logging.exception(f"Exception raised while trying to overwrite settings file with temporary settings "  # noqa: G004
-                              f"file: {error}")
+        except Exception:
+            logging.error("Unable to replace settings file")
+            return False
         else:
             # Only clear the forced-migration flag once the new
             # encrypted config is durably in place. Clearing it on the
@@ -730,6 +748,8 @@ def write_config():
             # never retry, leaving credentials unencrypted on disk.
             if forced_migration:
                 _force_first_save_migration = False
+            mark_master_key_persisted(encrypted_payload.get("general", {}).get("secrets_encryption_key"))
+            return True
 
 
 # OpenRouter retired these ids, including Bazarr's default and documented recommendation.
@@ -827,10 +847,13 @@ def get_settings():
     # hidden); USER_VISIBLE_SECRETS pass through unchanged because the
     # in-memory settings already hold their decrypted plaintext.
     from secret_store import is_system_secret  # noqa: PLC0415, RUF100
+    from secret_store.registry import IMPORT_ONLY_SECTIONS
     settings_to_return = {}
     for k, v in settings.as_dict().items():
         if isinstance(v, dict):
             k = k.lower()
+            if k in IMPORT_ONLY_SECTIONS:
+                continue
             settings_to_return[k] = dict()
             for subk, subv in v.items():
                 full_path = f"{k}.{subk.lower()}"
@@ -913,7 +936,40 @@ def _active_provider_hub_provider_ids():
         return set()
 
 
+_native_settings_save_lock = threading.RLock()
+
+
 def save_settings(settings_items):
+    from media_servers.http import MediaServerError, parse_verify_ssl
+    from secret_store.registry import IMPORT_ONLY_SECTIONS
+
+    settings_items = list(settings_items)
+    masters = {'settings-general-use_emby', 'settings-general-use_silo'}
+    for index, (key, value) in enumerate(settings_items):
+        parts = key.lower().split('-')
+        if len(parts) > 1 and parts[1] in IMPORT_ONLY_SECTIONS:
+            raise ValidationError('Use media server instances to edit connection settings')
+        if key in masters:
+            if isinstance(value, list) and len(value) == 1:
+                value = value[0]
+            try:
+                settings_items[index] = key, parse_verify_ssl(value)
+            except MediaServerError:
+                raise ValidationError('Invalid native media server master switch') from None
+    with _native_settings_save_lock:
+        if not any(key in masters for key, _value in settings_items):
+            return _save_settings(settings_items)
+        from media_servers.dispatcher import get_native_configuration
+        native = get_native_configuration()
+        with native.lock:
+            try:
+                return _save_settings(settings_items, native)
+            finally:
+                for kind, enabled in native.masters.items():
+                    _settings_mapping(settings, 'general')['use_' + kind] = enabled
+
+
+def _save_settings(settings_items, native_configuration=None):
     configure_debug = False
     configure_captcha = False
     update_schedule = False
@@ -1256,7 +1312,11 @@ def save_settings(settings_items):
         decrypt_settings_in_place(settings)
         raise
     else:
-        write_config()
+        persisted = write_config()
+        if native_configuration is not None:
+            if persisted is not True:
+                raise ValidationError('Unable to persist native media-server settings')
+            native_configuration.publish_masters(settings)
 
         # Set the configured state based on config.yaml file existence
         from .database import database, update, System

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -1318,16 +1318,18 @@ def _save_settings(settings_items, native_configuration=None):
         restore_persisted_settings()
         raise
     else:
-        persisted = write_config()
+        if write_config() is not True:
+            # The request is refused, so none of it may stay applied. Every
+            # submitted value is already on the live settings object by now,
+            # and when a media-server master switch travelled with it the
+            # caller's `finally` restores only those two switches: without this
+            # the process would keep running values that reached no file, tell
+            # the user they were saved, and revert them at the next restart.
+            # Nothing about that is particular to a master switch, so the check
+            # covers every save rather than only those.
+            restore_persisted_settings()
+            raise ValidationError('Unable to save settings to disk')
         if native_configuration is not None:
-            if persisted is not True:
-                # The request is refused, so none of it may stay applied. Every
-                # submitted value is already on the live settings object by now,
-                # and the caller's `finally` restores only the two master
-                # switches: without this the process would keep running values
-                # that reached no file and revert at the next restart.
-                restore_persisted_settings()
-                raise ValidationError('Unable to persist native media-server settings')
             native_configuration.publish_masters(settings)
 
         # Set the configured state based on config.yaml file existence

--- a/bazarr/app/config.py
+++ b/bazarr/app/config.py
@@ -936,6 +936,19 @@ def _active_provider_hub_provider_ids():
         return set()
 
 
+def restore_persisted_settings():
+    """Return the live settings object to what is actually saved on disk.
+
+    Re-decrypt after reload: settings.reload() pulls the on-disk ciphertext back
+    into the live Dynaconf object, so without this second pass downstream code
+    would see `enc:v1:` strings for API keys, auth credentials, provider
+    passwords, and compat tokens until the next process restart.
+    """
+    settings.reload()
+    migrate_legacy_plex_encryption(settings)
+    decrypt_settings_in_place(settings)
+
+
 _native_settings_save_lock = threading.RLock()
 
 
@@ -1302,19 +1315,18 @@ def _save_settings(settings_items, native_configuration=None):
         settings.validators.validate()
         validate_log_regex()
     except ValidationError:
-        # Re-decrypt after reload: settings.reload() pulls the on-disk
-        # ciphertext back into the live Dynaconf object, so without this
-        # second pass downstream code would see `enc:v1:` strings for
-        # API keys, auth credentials, provider passwords, and compat
-        # tokens until the next process restart.
-        settings.reload()
-        migrate_legacy_plex_encryption(settings)
-        decrypt_settings_in_place(settings)
+        restore_persisted_settings()
         raise
     else:
         persisted = write_config()
         if native_configuration is not None:
             if persisted is not True:
+                # The request is refused, so none of it may stay applied. Every
+                # submitted value is already on the live settings object by now,
+                # and the caller's `finally` restores only the two master
+                # switches: without this the process would keep running values
+                # that reached no file and revert at the next restart.
+                restore_persisted_settings()
                 raise ValidationError('Unable to persist native media-server settings')
             native_configuration.publish_masters(settings)
 

--- a/bazarr/app/database.py
+++ b/bazarr/app/database.py
@@ -220,6 +220,32 @@ class TableAnnouncements(Base):
     text = mapped_column(Text)
 
 
+class TableMediaServerInstances(Base):
+    __tablename__ = 'media_server_instances'
+    __table_args__ = (
+        CheckConstraint("kind IN ('emby', 'silo')", name='ck_media_server_kind'),
+        CheckConstraint('enabled IN (0, 1)', name='ck_media_server_enabled'),
+        CheckConstraint('verify_ssl IN (0, 1)', name='ck_media_server_verify_ssl'),
+    )
+
+    id = mapped_column(Text, primary_key=True)
+    kind = mapped_column(Text, nullable=False)
+    name = mapped_column(Text, nullable=False)
+    enabled = mapped_column(Integer, nullable=False, default=0, server_default='0')
+    url = mapped_column(Text, nullable=False)
+    api_key = mapped_column(Text, nullable=False, default='', server_default='')
+    verify_ssl = mapped_column(Integer, nullable=False, default=1, server_default='1')
+    path_mappings = mapped_column(Text, nullable=False, default='[]', server_default='[]')
+    revision = mapped_column(Integer, nullable=False, default=1, server_default='1')
+
+
+class TableMediaServerImports(Base):
+    __tablename__ = 'media_server_imports'
+    __table_args__ = (CheckConstraint("kind IN ('emby', 'silo')", name='ck_media_server_import_kind'),)
+
+    kind = mapped_column(Text, primary_key=True)
+
+
 class TableArrInstances(Base):
     # Multiple Sonarr/Radarr instances (#156). One Bazarr+ install can connect
     # to several named Sonarr/Radarr instances - e.g. split libraries: TV,
@@ -916,6 +942,11 @@ def migrate_db(app):
         database.execute(
             insert(System)
             .values(configured='0', updated='0'))
+
+    # Native destinations retain one-time scalar import markers independently
+    # of destination lifetime. A failed kind remains unavailable to workers.
+    from media_servers.backfill import backfill_instances
+    backfill_instances(database, settings)
 
     # Multiple Sonarr/Radarr instances (#156): represent the existing scalar
     # Sonarr/Radarr config as the default arr_instances rows and stamp existing

--- a/bazarr/emby/__init__.py
+++ b/bazarr/emby/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/bazarr/emby/client.py
+++ b/bazarr/emby/client.py
@@ -1,11 +1,15 @@
 # coding=utf-8
-"""Native Emby movie refresh with exact file-path resolution."""
+"""Native Emby movie and episode refresh with exact file-path resolution."""
 
 from urllib.parse import quote
 from typing import Callable
 
 from media_servers.http import MediaServerError, MediaServerHTTP
 from media_servers.paths import media_paths_equal
+
+# Emby stores both libraries as items refreshed the same way. Only the type it
+# is asked to resolve differs, and an unlisted media type never becomes one.
+_ITEM_TYPES = {"movie": "Movie", "episode": "Episode"}
 
 
 class EmbyClient:
@@ -30,13 +34,17 @@ class EmbyClient:
             raise MediaServerError("invalid_response")
         return {"success": True, "server_name": info["ServerName"], "version": info["Version"]}
 
-    def refresh_movie(self, video_path: str, *, ensure_current: Callable[[], None] | None = None) -> dict:
+    def refresh_item(self, media_type: str, video_path: str, *,
+                     ensure_current: Callable[[], None] | None = None) -> dict:
+        item_type = _ITEM_TYPES.get(media_type) if isinstance(media_type, str) else None
+        if item_type is None:
+            raise MediaServerError("internal_error")
         if not media_paths_equal(video_path, video_path):
             raise MediaServerError("path_invalid")
         if ensure_current:
             ensure_current()
         result = self.http.request_json("GET", "/Items", params={
-            "Path": video_path, "IncludeItemTypes": "Movie", "Recursive": "true",
+            "Path": video_path, "IncludeItemTypes": item_type, "Recursive": "true",
             "Fields": "Path,ProviderIds,MediaStreams,MediaSources",
         })
         if not isinstance(result, dict) or not isinstance(result.get("Items"), list):
@@ -44,13 +52,13 @@ class EmbyClient:
         items = result["Items"]
         total = result.get("TotalRecordCount", len(items))
         if type(total) is not int or total != len(items):
-            # A partial response cannot establish unique movie ownership.
+            # A partial response cannot establish unique item ownership.
             raise MediaServerError("invalid_response")
         matches = []
         for item in items:
             if not isinstance(item, dict):
                 raise MediaServerError("invalid_response")
-            if item.get("Type") != "Movie":
+            if item.get("Type") != item_type:
                 continue
             sources = item.get("MediaSources")
             if sources is None:

--- a/bazarr/emby/client.py
+++ b/bazarr/emby/client.py
@@ -1,0 +1,82 @@
+# coding=utf-8
+"""Native Emby movie refresh with exact file-path resolution."""
+
+from urllib.parse import quote
+from typing import Callable
+
+from media_servers.http import MediaServerError, MediaServerHTTP
+from media_servers.paths import media_paths_equal
+
+
+class EmbyClient:
+    def __init__(self, url: str, apikey: str, verify_ssl: bool = True):
+        if not isinstance(apikey, str) or not apikey.strip() or any(ord(char) < 32 for char in apikey):
+            raise MediaServerError("missing_credentials")
+        self.http = MediaServerHTTP(url, verify_ssl=verify_ssl, headers={"X-Emby-Token": apikey})
+
+    def close(self):
+        self.http.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+    def test_connection(self) -> dict:
+        info = self.http.request_json("GET", "/System/Info")
+        if (not isinstance(info, dict) or not isinstance(info.get("ServerName"), str)
+                or not isinstance(info.get("Version"), str) or not info["Version"]):
+            raise MediaServerError("invalid_response")
+        return {"success": True, "server_name": info["ServerName"], "version": info["Version"]}
+
+    def refresh_movie(self, video_path: str, *, ensure_current: Callable[[], None] | None = None) -> dict:
+        if not media_paths_equal(video_path, video_path):
+            raise MediaServerError("path_invalid")
+        if ensure_current:
+            ensure_current()
+        result = self.http.request_json("GET", "/Items", params={
+            "Path": video_path, "IncludeItemTypes": "Movie", "Recursive": "true",
+            "Fields": "Path,ProviderIds,MediaStreams,MediaSources",
+        })
+        if not isinstance(result, dict) or not isinstance(result.get("Items"), list):
+            raise MediaServerError("invalid_response")
+        items = result["Items"]
+        total = result.get("TotalRecordCount", len(items))
+        if type(total) is not int or total != len(items):
+            # A partial response cannot establish unique movie ownership.
+            raise MediaServerError("invalid_response")
+        matches = []
+        for item in items:
+            if not isinstance(item, dict):
+                raise MediaServerError("invalid_response")
+            if item.get("Type") != "Movie":
+                continue
+            sources = item.get("MediaSources")
+            if sources is None:
+                sources = []
+            if not isinstance(sources, list) or any(not isinstance(source, dict) for source in sources):
+                raise MediaServerError("invalid_response")
+            paths = [item.get("Path"), *(source.get("Path") for source in sources)]
+            if any(media_paths_equal(path, video_path) for path in paths):
+                matches.append(item)
+        if not matches:
+            raise MediaServerError("item_missing")
+        if len(matches) != 1:
+            raise MediaServerError("item_ambiguous")
+        item_id = matches[0].get("Id")
+        if not isinstance(item_id, str) or not item_id or item_id in (".", ".."):
+            raise MediaServerError("invalid_response")
+        try:
+            encoded_id = quote(item_id, safe='')
+        except UnicodeError:
+            raise MediaServerError("invalid_response") from None
+        if ensure_current:
+            ensure_current()
+        self.http.request_empty("POST", f"/Items/{encoded_id}/Refresh", params={
+            "Recursive": "false", "MetadataRefreshMode": "ValidationOnly", "ImageRefreshMode": "ValidationOnly",
+            "ReplaceAllMetadata": "false", "ReplaceAllImages": "false",
+        }, json={"ReplaceThumbnailImages": False}, success_statuses=(200, 204))
+        if ensure_current:
+            ensure_current()
+        return {"status": "requested"}

--- a/bazarr/emby/client.py
+++ b/bazarr/emby/client.py
@@ -6,7 +6,7 @@ from typing import Callable
 
 from media_servers import resolution
 from media_servers.http import MediaServerError, MediaServerHTTP
-from media_servers.paths import media_path_contains, media_paths_equal
+from media_servers.paths import is_media_path, media_path_contains, media_paths_equal
 
 # Emby stores both libraries as items refreshed the same way. Only the type it
 # is asked to resolve differs, and an unlisted media type never becomes one.
@@ -33,6 +33,30 @@ def _accepted_items(result, item_type):
         if item.get("Type") == item_type:
             accepted.append(item)
     return accepted
+
+
+def _item_paths(item):
+    """Every path an item claims: its own, then each media source's."""
+    sources = item.get("MediaSources")
+    if sources is None:
+        sources = []
+    if not isinstance(sources, list) or any(not isinstance(source, dict) for source in sources):
+        raise MediaServerError("invalid_response")
+    return [path for path in (item.get("Path"), *(source.get("Path") for source in sources))
+            if isinstance(path, str) and path]
+
+
+def _holds_path(item, video_path):
+    """Whether an item Emby returned can be the one that holds this file.
+
+    Only the weak title rung asks, and both of its lookups already request
+    ``Path``. A movie answers the file, a series answers the folder its
+    episodes live under, so containment is the test rather than equality. An
+    item Emby returned with no path at all contradicts nothing, and the exact
+    name and the production year still had to match for it to get this far.
+    """
+    paths = _item_paths(item)
+    return not paths or any(media_path_contains(path, video_path) for path in paths)
 
 
 def _encoded_id(item, key="Id"):
@@ -109,13 +133,25 @@ class EmbyClient:
                    and type(item.get("ParentIndexNumber")) is int and item["ParentIndexNumber"] == season]
         return matches[0] if len(matches) == 1 else None
 
-    def _refresh_resolved(self, media_type, parent, metadata, ensure_current):
+    def _refresh_resolved(self, media_type, parent, metadata, ensure_current, *, video_path=None):
+        """Refresh what a rung resolved, or nothing when it did not prove it.
+
+        ``video_path`` is the mapped file the publication is about, and it is
+        passed only by the weak title rung. The identifier rung leaves it out
+        deliberately: a provider id names the item on its own, and outliving a
+        path mapping that is wrong is the whole reason it is asked first, so
+        confirming it against that same mapping would throw the rung away.
+        """
         if parent is None:
+            return None
+        if video_path is not None and not _holds_path(parent, video_path):
             return None
         if media_type == "movie":
             return self._refresh(_encoded_id(parent), ensure_current)
         episode = self._find_episode(parent, metadata.season, metadata.episode, ensure_current)
-        return None if episode is None else self._refresh(_encoded_id(episode), ensure_current)
+        if episode is None or (video_path is not None and not _holds_path(episode, video_path)):
+            return None
+        return self._refresh(_encoded_id(episode), ensure_current)
 
     def refresh_by_provider_id(self, media_type, metadata, *,
                                ensure_current: Callable[[], None] | None = None) -> dict | None:
@@ -131,36 +167,46 @@ class EmbyClient:
         if not metadata.locatable(media_type):
             return None
         for provider, value in metadata.provider_ids(media_type):
+            if "," in value:
+                # The filter is comma-delimited, so a stored id carrying one
+                # would silently become the combined query this avoids.
+                continue
             parent = self._find_parent(media_type, {"AnyProviderIdEquals": f"{provider}.{value}"}, ensure_current)
             result = self._refresh_resolved(media_type, parent, metadata, ensure_current)
             if result is not None:
                 return result
         return None
 
-    def refresh_by_title_year(self, media_type, metadata, *,
+    def refresh_by_title_year(self, media_type, metadata, video_path, *,
                               ensure_current: Callable[[], None] | None = None) -> dict | None:
-        """Resolve the item by an exact title, narrowed by production year.
+        """Resolve the item by an exact title, an exact year and the file it holds.
 
         NameStartsWith is a prefix filter, so it bounds the response rather
         than deciding anything; the name still has to match exactly, case
         insensitively, the way Jellyfin's title fallback matches.
+
+        A title is a weak identifier, so all three have to agree. Titles repeat
+        across remakes, which means a row whose year Bazarr never parsed cannot
+        ask this rung at all: sending the prefix alone and accepting whichever
+        single film came back is how a 1922 film gets refreshed for a 2024 one,
+        with the publication reported as requested and the rungs below it never
+        tried. No year is a reason to climb the next rung, not to guess.
         """
         if media_type not in _PARENT_TYPES:
             raise MediaServerError("internal_error")
-        if not metadata.title or not metadata.locatable(media_type):
+        if not metadata.title or not metadata.year or not metadata.locatable(media_type):
             return None
-        params = {"NameStartsWith": metadata.title}
-        if metadata.year:
-            params["Years"] = str(metadata.year)
-        parent = self._find_parent(media_type, params, ensure_current, name=metadata.title)
-        return self._refresh_resolved(media_type, parent, metadata, ensure_current)
+        parent = self._find_parent(media_type, {"NameStartsWith": metadata.title,
+                                                "Years": str(metadata.year)},
+                                   ensure_current, name=metadata.title)
+        return self._refresh_resolved(media_type, parent, metadata, ensure_current, video_path=video_path)
 
     def refresh_item(self, media_type: str, video_path: str, *,
                      ensure_current: Callable[[], None] | None = None) -> dict:
         item_type = _ITEM_TYPES.get(media_type) if isinstance(media_type, str) else None
         if item_type is None:
             raise MediaServerError("internal_error")
-        if not media_paths_equal(video_path, video_path):
+        if not is_media_path(video_path):
             raise MediaServerError("path_invalid")
         if ensure_current:
             ensure_current()
@@ -168,16 +214,8 @@ class EmbyClient:
             "Path": video_path, "IncludeItemTypes": item_type, "Recursive": "true",
             "Fields": "Path,ProviderIds,MediaStreams,MediaSources",
         }), item_type)
-        matches = []
-        for item in items:
-            sources = item.get("MediaSources")
-            if sources is None:
-                sources = []
-            if not isinstance(sources, list) or any(not isinstance(source, dict) for source in sources):
-                raise MediaServerError("invalid_response")
-            paths = [item.get("Path"), *(source.get("Path") for source in sources)]
-            if any(media_paths_equal(path, video_path) for path in paths):
-                matches.append(item)
+        matches = [item for item in items
+                   if any(media_paths_equal(path, video_path) for path in _item_paths(item))]
         if not matches:
             raise MediaServerError("item_missing")
         if len(matches) != 1:
@@ -185,18 +223,26 @@ class EmbyClient:
         return self._refresh(_encoded_id(matches[0]), ensure_current)
 
     def refresh_library(self, media_type: str, video_path: str, *,
-                        ensure_current: Callable[[], None] | None = None) -> dict | None:
+                        ensure_current: Callable[[], None] | None = None,
+                        coalesce: Callable[[str], bool] | None = None) -> dict | None:
         """Rescan the library holding this file, when the file itself is unknown.
 
         Scoped to the library the path mapping points into, not to every
         library of that type: a library scan is expensive, and Bazarr has no
         setting through which a user sanctioned scanning the rest of the
         server. A path in no library leaves nothing sensible to refresh.
+
+        The scan is recursive, so one of them serves every file in that
+        library. ``coalesce(library)`` answers whether the caller has already
+        asked for this one, and records it when it has not; the library only
+        becomes known here, which is why the decision is taken here rather than
+        by the caller. A library it suppresses was still asked to rescan, so
+        the answer is the same either way.
         """
         collection_type = _COLLECTION_TYPES.get(media_type) if isinstance(media_type, str) else None
         if collection_type is None:
             raise MediaServerError("internal_error")
-        if not media_paths_equal(video_path, video_path):
+        if not is_media_path(video_path):
             raise MediaServerError("path_invalid")
         if ensure_current:
             ensure_current()
@@ -220,5 +266,7 @@ class EmbyClient:
         if not targets:
             return None
         for encoded_id in targets:
+            if coalesce is not None and coalesce(encoded_id):
+                continue
             self._refresh(encoded_id, ensure_current, recursive=True)
         return {"status": "requested"}

--- a/bazarr/emby/client.py
+++ b/bazarr/emby/client.py
@@ -1,18 +1,57 @@
 # coding=utf-8
-"""Native Emby movie and episode refresh with exact file-path resolution."""
+"""Native Emby movie and episode refresh across the shared resolution ladder."""
 
 from urllib.parse import quote
 from typing import Callable
 
+from media_servers import resolution
 from media_servers.http import MediaServerError, MediaServerHTTP
-from media_servers.paths import media_paths_equal
+from media_servers.paths import media_path_contains, media_paths_equal
 
 # Emby stores both libraries as items refreshed the same way. Only the type it
 # is asked to resolve differs, and an unlisted media type never becomes one.
 _ITEM_TYPES = {"movie": "Movie", "episode": "Episode"}
+# An episode carries no identifier and no title of its own, so the identifier
+# and title rungs resolve its series and then descend to the file.
+_PARENT_TYPES = {"movie": "Movie", "episode": "Series"}
+_COLLECTION_TYPES = {"movie": "movies", "episode": "tvshows"}
+
+
+def _accepted_items(result, item_type):
+    """The items of one type from a lookup, or nothing this can vouch for."""
+    if not isinstance(result, dict) or not isinstance(result.get("Items"), list):
+        raise MediaServerError("invalid_response")
+    items = result["Items"]
+    total = result.get("TotalRecordCount", len(items))
+    if type(total) is not int or total != len(items):
+        # A partial response cannot establish unique item ownership.
+        raise MediaServerError("invalid_response")
+    accepted = []
+    for item in items:
+        if not isinstance(item, dict):
+            raise MediaServerError("invalid_response")
+        if item.get("Type") == item_type:
+            accepted.append(item)
+    return accepted
+
+
+def _encoded_id(item, key="Id"):
+    """The item's own opaque id, encoded as exactly one path segment."""
+    item_id = item.get(key) if isinstance(item, dict) else None
+    if not isinstance(item_id, str) or not item_id or item_id in (".", ".."):
+        raise MediaServerError("invalid_response")
+    try:
+        return quote(item_id, safe='')
+    except UnicodeError:
+        raise MediaServerError("invalid_response") from None
 
 
 class EmbyClient:
+    # Emby answers every rung: /Items filters on AnyProviderIdEquals and on
+    # NameStartsWith plus Years, resolves an exact Path, and /Library/VirtualFolders
+    # names the library item to rescan when the file itself is not indexed yet.
+    REFRESH_STEPS = resolution.CHAIN
+
     def __init__(self, url: str, apikey: str, verify_ssl: bool = True):
         if not isinstance(apikey, str) or not apikey.strip() or any(ord(char) < 32 for char in apikey):
             raise MediaServerError("missing_credentials")
@@ -34,6 +73,88 @@ class EmbyClient:
             raise MediaServerError("invalid_response")
         return {"success": True, "server_name": info["ServerName"], "version": info["Version"]}
 
+    def _refresh(self, encoded_id, ensure_current, *, recursive=False) -> dict:
+        if ensure_current:
+            ensure_current()
+        self.http.request_empty("POST", f"/Items/{encoded_id}/Refresh", params={
+            "Recursive": "true" if recursive else "false",
+            "MetadataRefreshMode": "ValidationOnly", "ImageRefreshMode": "ValidationOnly",
+            "ReplaceAllMetadata": "false", "ReplaceAllImages": "false",
+        }, json={"ReplaceThumbnailImages": False}, success_statuses=(200, 204))
+        if ensure_current:
+            ensure_current()
+        return {"status": "requested"}
+
+    def _find_parent(self, media_type, params, ensure_current, *, name=None):
+        """One movie or series, or nothing. A tie is never broken by guessing."""
+        item_type = _PARENT_TYPES[media_type]
+        if ensure_current:
+            ensure_current()
+        items = _accepted_items(self.http.request_json("GET", "/Items", params={
+            "Recursive": "true", "IncludeItemTypes": item_type,
+            "Fields": "Path,ProviderIds", **params}), item_type)
+        if name is not None:
+            items = [item for item in items
+                     if isinstance(item.get("Name"), str) and item["Name"].lower() == name.lower()]
+        return items[0] if len(items) == 1 else None
+
+    def _find_episode(self, series, season, episode, ensure_current):
+        if ensure_current:
+            ensure_current()
+        items = _accepted_items(self.http.request_json(
+            "GET", f"/Shows/{_encoded_id(series)}/Episodes",
+            params={"Season": str(season), "Fields": "Path"}), "Episode")
+        matches = [item for item in items
+                   if type(item.get("IndexNumber")) is int and item["IndexNumber"] == episode
+                   and type(item.get("ParentIndexNumber")) is int and item["ParentIndexNumber"] == season]
+        return matches[0] if len(matches) == 1 else None
+
+    def _refresh_resolved(self, media_type, parent, metadata, ensure_current):
+        if parent is None:
+            return None
+        if media_type == "movie":
+            return self._refresh(_encoded_id(parent), ensure_current)
+        episode = self._find_episode(parent, metadata.season, metadata.episode, ensure_current)
+        return None if episode is None else self._refresh(_encoded_id(episode), ensure_current)
+
+    def refresh_by_provider_id(self, media_type, metadata, *,
+                               ensure_current: Callable[[], None] | None = None) -> dict | None:
+        """Resolve the item by IMDB, then TMDB or TVDB, in Jellyfin's order.
+
+        Identifiers are asked one at a time rather than as the comma-delimited
+        list Emby also accepts, because a combined query answers "one of these
+        matched" and loses which one, and precedence is the whole point of
+        trying IMDB first.
+        """
+        if media_type not in _PARENT_TYPES:
+            raise MediaServerError("internal_error")
+        if not metadata.locatable(media_type):
+            return None
+        for provider, value in metadata.provider_ids(media_type):
+            parent = self._find_parent(media_type, {"AnyProviderIdEquals": f"{provider}.{value}"}, ensure_current)
+            result = self._refresh_resolved(media_type, parent, metadata, ensure_current)
+            if result is not None:
+                return result
+        return None
+
+    def refresh_by_title_year(self, media_type, metadata, *,
+                              ensure_current: Callable[[], None] | None = None) -> dict | None:
+        """Resolve the item by an exact title, narrowed by production year.
+
+        NameStartsWith is a prefix filter, so it bounds the response rather
+        than deciding anything; the name still has to match exactly, case
+        insensitively, the way Jellyfin's title fallback matches.
+        """
+        if media_type not in _PARENT_TYPES:
+            raise MediaServerError("internal_error")
+        if not metadata.title or not metadata.locatable(media_type):
+            return None
+        params = {"NameStartsWith": metadata.title}
+        if metadata.year:
+            params["Years"] = str(metadata.year)
+        parent = self._find_parent(media_type, params, ensure_current, name=metadata.title)
+        return self._refresh_resolved(media_type, parent, metadata, ensure_current)
+
     def refresh_item(self, media_type: str, video_path: str, *,
                      ensure_current: Callable[[], None] | None = None) -> dict:
         item_type = _ITEM_TYPES.get(media_type) if isinstance(media_type, str) else None
@@ -43,23 +164,12 @@ class EmbyClient:
             raise MediaServerError("path_invalid")
         if ensure_current:
             ensure_current()
-        result = self.http.request_json("GET", "/Items", params={
+        items = _accepted_items(self.http.request_json("GET", "/Items", params={
             "Path": video_path, "IncludeItemTypes": item_type, "Recursive": "true",
             "Fields": "Path,ProviderIds,MediaStreams,MediaSources",
-        })
-        if not isinstance(result, dict) or not isinstance(result.get("Items"), list):
-            raise MediaServerError("invalid_response")
-        items = result["Items"]
-        total = result.get("TotalRecordCount", len(items))
-        if type(total) is not int or total != len(items):
-            # A partial response cannot establish unique item ownership.
-            raise MediaServerError("invalid_response")
+        }), item_type)
         matches = []
         for item in items:
-            if not isinstance(item, dict):
-                raise MediaServerError("invalid_response")
-            if item.get("Type") != item_type:
-                continue
             sources = item.get("MediaSources")
             if sources is None:
                 sources = []
@@ -72,19 +182,43 @@ class EmbyClient:
             raise MediaServerError("item_missing")
         if len(matches) != 1:
             raise MediaServerError("item_ambiguous")
-        item_id = matches[0].get("Id")
-        if not isinstance(item_id, str) or not item_id or item_id in (".", ".."):
+        return self._refresh(_encoded_id(matches[0]), ensure_current)
+
+    def refresh_library(self, media_type: str, video_path: str, *,
+                        ensure_current: Callable[[], None] | None = None) -> dict | None:
+        """Rescan the library holding this file, when the file itself is unknown.
+
+        Scoped to the library the path mapping points into, not to every
+        library of that type: a library scan is expensive, and Bazarr has no
+        setting through which a user sanctioned scanning the rest of the
+        server. A path in no library leaves nothing sensible to refresh.
+        """
+        collection_type = _COLLECTION_TYPES.get(media_type) if isinstance(media_type, str) else None
+        if collection_type is None:
+            raise MediaServerError("internal_error")
+        if not media_paths_equal(video_path, video_path):
+            raise MediaServerError("path_invalid")
+        if ensure_current:
+            ensure_current()
+        folders = self.http.request_json("GET", "/Library/VirtualFolders")
+        if not isinstance(folders, list):
             raise MediaServerError("invalid_response")
-        try:
-            encoded_id = quote(item_id, safe='')
-        except UnicodeError:
-            raise MediaServerError("invalid_response") from None
-        if ensure_current:
-            ensure_current()
-        self.http.request_empty("POST", f"/Items/{encoded_id}/Refresh", params={
-            "Recursive": "false", "MetadataRefreshMode": "ValidationOnly", "ImageRefreshMode": "ValidationOnly",
-            "ReplaceAllMetadata": "false", "ReplaceAllImages": "false",
-        }, json={"ReplaceThumbnailImages": False}, success_statuses=(200, 204))
-        if ensure_current:
-            ensure_current()
+        targets = []
+        for folder in folders:
+            if not isinstance(folder, dict):
+                raise MediaServerError("invalid_response")
+            locations = folder.get("Locations")
+            if locations is None:
+                locations = []
+            if not isinstance(locations, list):
+                raise MediaServerError("invalid_response")
+            if (folder.get("CollectionType") or "").lower() != collection_type:
+                continue
+            if not any(media_path_contains(root, video_path) for root in locations):
+                continue
+            targets.append(_encoded_id(folder, "ItemId"))
+        if not targets:
+            return None
+        for encoded_id in targets:
+            self._refresh(encoded_id, ensure_current, recursive=True)
         return {"status": "requested"}

--- a/bazarr/emby/operations.py
+++ b/bazarr/emby/operations.py
@@ -1,0 +1,14 @@
+# coding=utf-8
+
+from .client import EmbyClient
+from media_servers.http import MediaServerError
+
+
+def emby_test_connection(url: str, apikey: str, verify_ssl: bool = True) -> dict:
+    try:
+        with EmbyClient(url, apikey, verify_ssl) as client:
+            return client.test_connection()
+    except MediaServerError as error:
+        return {"success": False, "error_code": error.code}
+    except Exception:
+        return {"success": False, "error_code": "connection_error"}

--- a/bazarr/media_servers/__init__.py
+++ b/bazarr/media_servers/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+"""Native media-server connection primitives."""

--- a/bazarr/media_servers/backfill.py
+++ b/bazarr/media_servers/backfill.py
@@ -1,0 +1,52 @@
+# coding=utf-8
+"""One durable import marker per native kind, atomic with its legacy row."""
+
+import logging
+
+from app.database import TableMediaServerImports
+from .instances import VALID_KINDS
+from .repository import MediaServerInstanceRepository, atomic
+
+
+def _record_import(session, kind):
+    session.add(TableMediaServerImports(kind=kind))
+    session.flush()
+
+
+def _legacy_values(settings, kind):
+    section = getattr(settings, kind)
+    enabled = getattr(settings.general, 'use_' + kind)
+    values = dict(kind=kind, name=kind.capitalize(), enabled=enabled,
+                  url=section.url, api_key=section.apikey, verify_ssl=section.verify_ssl,
+                  path_mappings=[dict(row) for row in section.path_mappings])
+    # Preserve incomplete drafts and historical mapping values. Only malformed
+    # storage types prevent import; current API validation governs future edits.
+    if (type(enabled) is not bool or type(values['verify_ssl']) is not bool
+            or not isinstance(values['url'], str) or not isinstance(values['api_key'], str)
+            or not isinstance(section.path_mappings, list)
+            or any(not isinstance(key, str) or not isinstance(value, str)
+                   for row in values['path_mappings'] for key, value in row.items())):
+        raise ValueError('invalid legacy settings')
+    return values
+
+
+def backfill_instances(session, settings):
+    repo = MediaServerInstanceRepository(session)
+    results = {}
+    for kind in VALID_KINDS:
+        try:
+            with atomic(session, durable=True):
+                if session.get(TableMediaServerImports, kind) is not None:
+                    results[kind] = {'created': False}
+                    continue
+                values = _legacy_values(settings, kind)
+                configured = (values['enabled'] or values['url'] or values['api_key']
+                              or values['path_mappings'] or values['verify_ssl'] is False)
+                row = repo.import_values(values) if configured else None
+                _record_import(session, kind)
+            results[kind] = {'created': row is not None}
+        except Exception:
+            session.rollback()
+            logging.warning('BAZARR native media server import failed for %s; retrying on next startup', kind)
+            results[kind] = {'created': False, 'error_code': 'migration_failed'}
+    return results

--- a/bazarr/media_servers/dispatcher.py
+++ b/bazarr/media_servers/dispatcher.py
@@ -93,20 +93,61 @@ class _ServerState:
     state: str = "idle"
     error_code: str | None = None
     overflow: bool = False
+    # How much scannable work this destination has been handed. A library scan
+    # covers what was published before it, and nothing after it.
+    publications: int = 0
+
+
+def _coalescer(scanned, publications):
+    """One scan of a library per drain, until new work arrives for it.
+
+    A library scan is recursive, so a single one serves every file the library
+    holds. Without this, a bulk mod or a season pack that lands each of its
+    targets on the library rung asks the same library to rescan itself once per
+    video, up to the whole pending queue.
+
+    A publication that arrives after a scan was submitted is not covered by it,
+    so the count of publications the destination has taken is part of the key.
+    That errs towards one scan too many rather than one too few, which is the
+    side to err on: a suppressed scan the file needed would never be asked for
+    again.
+    """
+    def already_requested(library):
+        key = str(library)
+        if scanned.get(key) == publications:
+            return True
+        scanned[key] = publications
+        return False
+    return already_requested
+
+
+def _refusal_code(error):
+    """The refusal code an error carries, whatever generation raised it.
+
+    This module binds ``MediaServerError`` when it is imported and builds its
+    clients lazily, at the first refresh. Nothing makes those two moments share
+    a module generation: test isolation evicts and re-imports these modules,
+    and an identically named class from another generation is a different
+    object, which ``except MediaServerError`` does not catch. Every generation
+    agrees on the code, so that is what is matched, and a refusal keeps its
+    meaning instead of collapsing into internal_error.
+    """
+    code = getattr(error, "code", None)
+    return code if isinstance(code, str) else None
 
 
 def _misses_on(call, codes):
     """Read a refusal this rung declared as "not here", not as a failure.
 
-    Two client methods predate the ladder and answer "no such item" by
+    One client method predates the ladder and answers "no such item" by
     raising. Translating that lives here, at the adapter boundary, so the
     walk itself never has to know one destination's vocabulary.
     """
     def attempt():
         try:
             return call()
-        except MediaServerError as error:
-            if error.code in codes:
+        except Exception as error:
+            if _refusal_code(error) in codes:
                 return None
             raise
     return attempt
@@ -216,8 +257,10 @@ class RefreshDispatcher:
                         target.event = event
                         target.generation += 1
                         target.ready = True
+                        state.publications += 1
                 elif len(state.targets) < self.PENDING_LIMIT:
                     target = state.targets[key] = _Target(event)
+                    state.publications += 1
                 else:
                     state.overflow = True
                     continue
@@ -236,7 +279,7 @@ class RefreshDispatcher:
                                   name=kind + "-subtitle-refresh", daemon=True)
             state.worker.start()
 
-    def _refresh(self, instance_id, revision, snapshot, event):
+    def _refresh(self, instance_id, revision, snapshot, event, coalesce):
         server = snapshot.kind
         from subtitles.tools.subsync_engines import subtitle_write_locks
 
@@ -264,7 +307,7 @@ class RefreshDispatcher:
                                    for root in library["paths"])):
                     raise MediaServerError("library_invalid")
                 guard()
-            resolved = resolution.walk(self._ladder(client, server, event, mapped, guard))
+            resolved = resolution.walk(self._ladder(client, server, event, mapped, guard, coalesce))
             guard()
             if resolved is None:
                 # Every rung this destination has missed, so it holds no such file.
@@ -274,7 +317,7 @@ class RefreshDispatcher:
                 raise MediaServerError("invalid_response")
             return expected
 
-    def _ladder(self, client, server, event, mapped, guard):
+    def _ladder(self, client, server, event, mapped, guard, coalesce):
         """The rungs this destination declared it can climb, in ladder order.
 
         The identifiers come out of the rows Bazarr already wrote, read here
@@ -294,28 +337,32 @@ class RefreshDispatcher:
                 resolution.PROVIDER_ID: (lambda: client.refresh_by_provider_id(
                     event.media_type, metadata, ensure_current=guard), "requested"),
                 resolution.TITLE_YEAR: (lambda: client.refresh_by_title_year(
-                    event.media_type, metadata, ensure_current=guard), "requested"),
+                    event.media_type, metadata, mapped["path"], ensure_current=guard), "requested"),
                 resolution.PATH: (_misses_on(lambda: client.refresh_item(
                     event.media_type, mapped["path"], ensure_current=guard), ("item_missing",)), "requested"),
                 resolution.LIBRARY: (lambda: client.refresh_library(
-                    event.media_type, mapped["path"], ensure_current=guard), "requested"),
+                    event.media_type, mapped["path"], ensure_current=guard,
+                    coalesce=coalesce), "requested"),
             }
         else:
-            # Silo answers every path it cannot place, and every container its
-            # scanner does not read, with one 400. That is a miss: no retry of
-            # the same file scan can change it. A scan that ran and fell short
-            # is a failure and keeps its own code.
+            # Silo's file rung decides its own miss and answers with nothing,
+            # because only Silo can tell the documented 400 for a path it cannot
+            # place from the conflicts, rate limits and refused event-stream
+            # handshakes it folds into the same code. A scan that ran and fell
+            # short, and every refusal, is a failure and keeps its own code.
             available = {
-                resolution.PATH: (_misses_on(lambda: client.refresh_file(
-                    mapped["library_id"], mapped["path"], ensure_current=guard),
-                    ("request_rejected",)), "confirmed"),
+                resolution.PATH: (lambda: client.refresh_file(
+                    mapped["library_id"], mapped["path"], ensure_current=guard), "confirmed"),
                 resolution.LIBRARY: (lambda: client.refresh_library(
-                    mapped["library_id"], ensure_current=guard), "requested"),
+                    mapped["library_id"], ensure_current=guard, coalesce=coalesce), "requested"),
             }
         return [(name, *available[name]) for name in resolution.CHAIN
                 if name in supported and name in available]
 
     def _run(self, server, state):
+        # One drain, one scan per library. The memo dies with this worker, so a
+        # later pass asks again rather than inheriting a stale suppression.
+        scanned = {}
         while True:
             with self.condition:
                 try:
@@ -340,17 +387,19 @@ class RefreshDispatcher:
                     return
                 key, target = target_pair
                 event, generation = target.event, target.generation
+                publications = state.publications
                 target.ready = False
                 target.error_code = None
                 state.state = "pending"
             try:
-                result = self._refresh(server, revision, snapshot, event)
+                result = self._refresh(server, revision, snapshot, event,
+                                       _coalescer(scanned, publications))
                 error_code = None
-            except MediaServerError as error:
+            except Exception as error:
+                # Classified by the code, not the class: see _refusal_code.
+                code = _refusal_code(error)
                 result = "unconfirmed"
-                error_code = error.code if error.code in _ERROR_CODES else "internal_error"
-            except Exception:
-                result, error_code = "unconfirmed", "internal_error"
+                error_code = code if code in _ERROR_CODES else "internal_error"
             with self.condition:
                 if self.servers.get(server) is not state:
                     state.worker = None
@@ -416,6 +465,10 @@ class RefreshDispatcher:
                     target.generation += 1
                     target.error_code = None
                 target.ready = True
+            # Retry is the user asking again. A library scan submitted before
+            # they pressed it is not the answer to it, so a pass still running
+            # must not treat one as already covered.
+            state.publications += 1
             self._start(server, state)
             return len(state.targets)
 

--- a/bazarr/media_servers/dispatcher.py
+++ b/bazarr/media_servers/dispatcher.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass, field, replace
 from threading import Condition, RLock, Thread
 
+from . import resolution
 from .events import SubtitleMutation
 from .http import MediaServerError
 from .paths import _media_path, map_media_path
@@ -93,6 +94,27 @@ class _ServerState:
     overflow: bool = False
 
 
+def _misses_on(call, codes):
+    """Read a refusal this rung declared as "not here", not as a failure.
+
+    Two client methods predate the ladder and answer "no such item" by
+    raising. Translating that lives here, at the adapter boundary, so the
+    walk itself never has to know one destination's vocabulary.
+    """
+    def attempt():
+        try:
+            return call()
+        except MediaServerError as error:
+            if error.code in codes:
+                return None
+            raise
+    return attempt
+
+
+def _metadata(event):
+    return resolution.media_metadata(event.media_type, event.video_path, event.arr_instance_id)
+
+
 def _client(server, snapshot):
     if server == "emby":
         from emby.client import EmbyClient
@@ -104,9 +126,10 @@ def _client(server, snapshot):
 class RefreshDispatcher:
     PENDING_LIMIT = 128
 
-    def __init__(self, configuration, *, client_factory=_client):
+    def __init__(self, configuration, *, client_factory=_client, metadata_factory=_metadata):
         self.configuration = configuration
         self.client_factory = client_factory
+        self.metadata_factory = metadata_factory
         self.condition = Condition(RLock())
         self.servers = {}
 
@@ -147,8 +170,6 @@ class RefreshDispatcher:
             for snapshot in self.configuration.list():
                 server = snapshot.id
                 state = self._server(server)
-                if snapshot.kind == "emby" and event.operation not in {"download", "upload"}:
-                    continue
                 _revision, snapshot, changing = self._connection(server, state)
                 if not snapshot.enabled:
                     continue
@@ -209,9 +230,7 @@ class RefreshDispatcher:
             raise MediaServerError("sidecar_unsupported")
         with self.client_factory(server, snapshot) as client:
             guard()
-            if server == "emby":
-                result = client.refresh_item(event.media_type, mapped["path"], ensure_current=guard)
-            else:
+            if server == "silo":
                 libraries = client.get_libraries()
                 library = next((row for row in libraries if row["id"].lstrip("0") ==
                                 mapped["library_id"].lstrip("0")), None)
@@ -220,12 +239,56 @@ class RefreshDispatcher:
                                    for root in library["paths"])):
                     raise MediaServerError("library_invalid")
                 guard()
-                result = client.refresh_file(mapped["library_id"], mapped["path"], ensure_current=guard)
+            resolved = resolution.walk(self._ladder(client, server, event, mapped, guard))
             guard()
-            expected = "requested" if server == "emby" else "confirmed"
+            if resolved is None:
+                # Every rung this destination has missed, so it holds no such file.
+                raise MediaServerError("item_missing")
+            _rung, result, expected = resolved
             if result != {"status": expected}:
                 raise MediaServerError("invalid_response")
             return expected
+
+    def _ladder(self, client, server, event, mapped, guard):
+        """The rungs this destination declared it can climb, in ladder order.
+
+        The identifiers come out of the rows Bazarr already wrote, read here
+        rather than carried through every publication callback, and the rungs
+        that need them disappear when they cannot be read.
+        """
+        supported = set(getattr(client, "REFRESH_STEPS", ()) or ())
+        metadata = (self.metadata_factory(event)
+                    if supported & {resolution.PROVIDER_ID, resolution.TITLE_YEAR} else None)
+        if metadata is None:
+            supported -= {resolution.PROVIDER_ID, resolution.TITLE_YEAR}
+        if server == "emby":
+            # item_missing is Emby saying it holds no such file, which is a
+            # miss; item_ambiguous and every strict acceptance refusal are not,
+            # and must not be laundered into a refresh of something broader.
+            available = {
+                resolution.PROVIDER_ID: (lambda: client.refresh_by_provider_id(
+                    event.media_type, metadata, ensure_current=guard), "requested"),
+                resolution.TITLE_YEAR: (lambda: client.refresh_by_title_year(
+                    event.media_type, metadata, ensure_current=guard), "requested"),
+                resolution.PATH: (_misses_on(lambda: client.refresh_item(
+                    event.media_type, mapped["path"], ensure_current=guard), ("item_missing",)), "requested"),
+                resolution.LIBRARY: (lambda: client.refresh_library(
+                    event.media_type, mapped["path"], ensure_current=guard), "requested"),
+            }
+        else:
+            # Silo answers every path it cannot place, and every container its
+            # scanner does not read, with one 400. That is a miss: no retry of
+            # the same file scan can change it. A scan that ran and fell short
+            # is a failure and keeps its own code.
+            available = {
+                resolution.PATH: (_misses_on(lambda: client.refresh_file(
+                    mapped["library_id"], mapped["path"], ensure_current=guard),
+                    ("request_rejected",)), "confirmed"),
+                resolution.LIBRARY: (lambda: client.refresh_library(
+                    mapped["library_id"], ensure_current=guard), "requested"),
+            }
+        return [(name, *available[name]) for name in resolution.CHAIN
+                if name in supported and name in available]
 
     def _run(self, server, state):
         while True:

--- a/bazarr/media_servers/dispatcher.py
+++ b/bazarr/media_servers/dispatcher.py
@@ -2,6 +2,7 @@
 """Bounded, independent native refresh workers and saved connection revisions."""
 
 import logging
+import os
 from dataclasses import dataclass, field, replace
 from threading import Condition, RLock, Thread
 
@@ -109,6 +110,30 @@ def _misses_on(call, codes):
                 return None
             raise
     return attempt
+
+
+def _relocated(event):
+    """Where a retained unsupported publication's subtitle sits now, if it moved.
+
+    The warning names a path the user is told to fix, and moving that file
+    publishes nothing. Replaying the recorded path would answer the same
+    refusal forever, so the retained event has to be re-derived against the
+    filesystem instead: the same name beside the video, gone from where it was
+    recorded, is the move the warning asked for. Anything else is not, and
+    keeps the warning.
+    """
+    if event is None:
+        return None
+    try:
+        video, subtitle = _media_path(event.video_path), _media_path(event.subtitle_path)
+    except MediaServerError:
+        return None
+    if subtitle.parent == video.parent:
+        return None
+    moved = video.parent / subtitle.name
+    if os.path.isfile(event.subtitle_path) or not os.path.isfile(str(moved)):
+        return None
+    return replace(event, subtitle_path=str(moved))
 
 
 def _metadata(event):
@@ -336,7 +361,16 @@ class RefreshDispatcher:
                 except MediaServerError:
                     result, error_code = "unconfirmed", "configuration_changed"
                 if not error_code and state.targets[key].generation == generation:
-                    if target.unsupported_event is None:
+                    moved = _relocated(target.unsupported_event)
+                    if moved is not None:
+                        # The subtitle now sits where Silo reads it, so the
+                        # warning has real work again rather than a path the
+                        # user already fixed. Queue that work instead of
+                        # counting it as covered by the scan just finished.
+                        target.event, target.unsupported_event = moved, None
+                        target.generation += 1
+                        target.ready = True
+                    elif target.unsupported_event is None:
                         del state.targets[key]
                     else:
                         # The scan completed eligible work only. Retry the
@@ -373,6 +407,14 @@ class RefreshDispatcher:
             if changing or not snapshot.enabled:
                 return 0
             for target in state.targets.values():
+                # Retry is the button the warning tells the user to press after
+                # moving the subtitle, so this is where the recorded path has to
+                # be re-derived rather than replayed.
+                moved = _relocated(target.unsupported_event)
+                if moved is not None:
+                    target.event, target.unsupported_event = moved, None
+                    target.generation += 1
+                    target.error_code = None
                 target.ready = True
             self._start(server, state)
             return len(state.targets)

--- a/bazarr/media_servers/dispatcher.py
+++ b/bazarr/media_servers/dispatcher.py
@@ -1,0 +1,362 @@
+# coding=utf-8
+"""Bounded, independent native refresh workers and saved connection revisions."""
+
+import logging
+from dataclasses import dataclass, field, replace
+from threading import Condition, RLock, Thread
+
+from .events import SubtitleMutation
+from .http import MediaServerError
+from .paths import _media_path, map_media_path
+
+_SERVERS = ("emby", "silo")
+_OPERATIONS = {"download", "upload", "delete", "sync", "translate", "combine", "edit"}
+_ERROR_CODES = {
+    "configuration_changed", "connection_disabled", "connection_error", "internal_error", "invalid_response",
+    "invalid_url", "invalid_verify_ssl", "missing_credentials", "unauthorized", "forbidden", "not_found",
+    "request_rejected", "redirect_denied", "response_too_large", "timeout", "tls_error", "item_missing",
+    "item_ambiguous", "path_invalid", "mapping_invalid", "mapping_missing", "mapping_ambiguous",
+    "library_missing", "library_invalid", "sidecar_unsupported", "observation_incomplete", "stream_disconnected",
+    "scan_incomplete", "scan_failed", "scan_cancelled", "queue_overflow",
+}
+
+
+class NativeConfiguration:
+    """Publish saved destinations under the request authorization lock."""
+
+    def __init__(self, settings, *, snapshots=(), blocked_kinds=()):
+        self.lock = RLock()
+        self.blocked_kinds = frozenset(blocked_kinds)
+        self.snapshots = {snapshot.id: snapshot for snapshot in snapshots}
+        self.masters = {kind: getattr(settings.general, 'use_' + kind) is True for kind in _SERVERS}
+
+    def publish(self, snapshot):
+        with self.lock:
+            if snapshot.kind in self.blocked_kinds:
+                return
+            previous = self.snapshots.get(snapshot.id)
+            revision = previous.revision + 1 if previous else snapshot.revision
+            self.snapshots[snapshot.id] = replace(snapshot, revision=revision,
+                                                  master_enabled=self.masters[snapshot.kind])
+
+    def delete(self, instance_id):
+        with self.lock:
+            self.snapshots.pop(instance_id, None)
+
+    def publish_masters(self, settings):
+        with self.lock:
+            for kind in _SERVERS:
+                enabled = getattr(settings.general, 'use_' + kind) is True
+                if self.masters[kind] == enabled:
+                    continue
+                self.masters[kind] = enabled
+                for instance_id, snapshot in list(self.snapshots.items()):
+                    if snapshot.kind == kind:
+                        self.snapshots[instance_id] = replace(snapshot, master_enabled=enabled,
+                                                             revision=snapshot.revision + 1)
+
+    def list(self):
+        with self.lock:
+            return tuple(self.snapshots.values())
+
+    def read(self, instance_id):
+        with self.lock:
+            snapshot = self.snapshots.get(instance_id)
+            if snapshot is None:
+                raise MediaServerError('not_found')
+            return snapshot.revision, snapshot, False
+
+    def ensure_current(self, instance_id, revision):
+        with self.lock:
+            snapshot = self.snapshots.get(instance_id)
+            if snapshot is None or snapshot.revision != revision or not snapshot.enabled:
+                raise MediaServerError('configuration_changed')
+
+
+@dataclass
+class _Target:
+    event: SubtitleMutation
+    # One representative is enough to retain the warning without a path backlog.
+    unsupported_event: SubtitleMutation | None = None
+    generation: int = 1
+    ready: bool = True
+    error_code: str | None = None
+
+
+@dataclass
+class _ServerState:
+    revision: int = 0
+    targets: dict = field(default_factory=dict)
+    worker: Thread | None = None
+    state: str = "idle"
+    error_code: str | None = None
+    overflow: bool = False
+
+
+def _client(server, snapshot):
+    if server == "emby":
+        from emby.client import EmbyClient
+        return EmbyClient(snapshot.url, snapshot.apikey, snapshot.verify_ssl)
+    from silo.client import SiloClient
+    return SiloClient(snapshot.url, snapshot.apikey, snapshot.verify_ssl)
+
+
+class RefreshDispatcher:
+    PENDING_LIMIT = 128
+
+    def __init__(self, configuration, *, client_factory=_client):
+        self.configuration = configuration
+        self.client_factory = client_factory
+        self.condition = Condition(RLock())
+        self.servers = {}
+
+    def _connection(self, server, state):
+        revision, snapshot, changing = self.configuration.read(server)
+        if state.revision != revision:
+            state.revision = revision
+            state.state = 'unconfirmed' if state.targets else 'idle'
+            state.error_code = 'configuration_changed' if state.targets else None
+            for target in state.targets.values():
+                target.error_code = 'configuration_changed'
+        return revision, snapshot, changing
+
+    def _server(self, server):
+        revision, _snapshot, _changing = self.configuration.read(server)
+        return self.servers.setdefault(server, _ServerState(revision=revision))
+
+    def _prune_deleted(self):
+        live = {snapshot.id for snapshot in self.configuration.list()}
+        for instance_id in tuple(self.servers):
+            if instance_id not in live:
+                del self.servers[instance_id]
+
+    @property
+    def worker_count(self):
+        with self.condition:
+            return sum(state.worker is not None for state in self.servers.values())
+
+    def notify(self, event):
+        media_type = {"series": "episode", "movies": "movie"}.get(event.media_type, event.media_type)
+        if media_type not in {"movie", "episode"} or event.operation not in _OPERATIONS:
+            return
+        event = SubtitleMutation(media_type, str(_media_path(event.video_path)), event.subtitle_path,
+                                 event.operation, event.arr_instance_id)
+        key = (media_type, _media_path(event.video_path), event.arr_instance_id)
+        with self.condition, self.configuration.lock:
+            self._prune_deleted()
+            for snapshot in self.configuration.list():
+                server = snapshot.id
+                state = self._server(server)
+                if snapshot.kind == "emby" and (media_type != "movie" or event.operation not in {"download", "upload"}):
+                    continue
+                _revision, snapshot, changing = self._connection(server, state)
+                if not snapshot.enabled:
+                    continue
+                try:
+                    map_media_path(event.video_path, snapshot.mappings(), require_library=snapshot.kind == 'silo')
+                except MediaServerError as error:
+                    if error.code == 'mapping_missing':
+                        continue
+                unsupported = False
+                if snapshot.kind == 'silo':
+                    try:
+                        unsupported = _media_path(event.subtitle_path).parent != _media_path(event.video_path).parent
+                    except MediaServerError:
+                        # Keep invalid paths for the worker's normal validation.
+                        pass
+                if key in state.targets:
+                    target = state.targets[key]
+                    if not unsupported:
+                        target.event = event
+                        target.generation += 1
+                        target.ready = True
+                elif len(state.targets) < self.PENDING_LIMIT:
+                    target = state.targets[key] = _Target(event)
+                else:
+                    state.overflow = True
+                    continue
+                if unsupported:
+                    target.unsupported_event = target.unsupported_event or event
+                if changing:
+                    state.state, state.error_code = "unconfirmed", "configuration_changed"
+                else:
+                    self._start(server, state)
+
+    def _start(self, server, state):
+        if state.worker is None and any(target.ready for target in state.targets.values()):
+            state.state, state.error_code = 'pending', None
+            kind = self.configuration.read(server)[1].kind
+            state.worker = Thread(target=self._run, args=(server, state),
+                                  name=kind + "-subtitle-refresh", daemon=True)
+            state.worker.start()
+
+    def _refresh(self, instance_id, revision, snapshot, event):
+        server = snapshot.kind
+        from subtitles.tools.subsync_engines import subtitle_write_locks
+
+        def guard():
+            self.configuration.ensure_current(instance_id, revision)
+        guard()
+        if snapshot.configuration_error:
+            raise MediaServerError(snapshot.configuration_error)
+        # Publication callbacks run before local cleanup releases these locks.
+        # Wait for that cleanup, then release before any native network work.
+        with subtitle_write_locks(event.video_path, event.subtitle_path):
+            pass
+        guard()
+        mapped = map_media_path(event.video_path, snapshot.mappings(), require_library=server == "silo")
+        if server == "silo" and _media_path(event.subtitle_path).parent != _media_path(event.video_path).parent:
+            raise MediaServerError("sidecar_unsupported")
+        with self.client_factory(server, snapshot) as client:
+            guard()
+            if server == "emby":
+                result = client.refresh_movie(mapped["path"], ensure_current=guard)
+            else:
+                libraries = client.get_libraries()
+                library = next((row for row in libraries if row["id"].lstrip("0") ==
+                                mapped["library_id"].lstrip("0")), None)
+                if (library is None or library["type"] != ("movies" if event.media_type == "movie" else "series")
+                        or not any(_media_path(mapped["path"]).is_relative_to(_media_path(root))
+                                   for root in library["paths"])):
+                    raise MediaServerError("library_invalid")
+                guard()
+                result = client.refresh_file(mapped["library_id"], mapped["path"], ensure_current=guard)
+            guard()
+            expected = "requested" if server == "emby" else "confirmed"
+            if result != {"status": expected}:
+                raise MediaServerError("invalid_response")
+            return expected
+
+    def _run(self, server, state):
+        while True:
+            with self.condition:
+                try:
+                    revision, snapshot, changing = self._connection(server, state)
+                except MediaServerError:
+                    state.worker = None
+                    if self.servers.get(server) is state:
+                        del self.servers[server]
+                    self.condition.notify_all()
+                    return
+                target_pair = next(((key, value) for key, value in state.targets.items() if value.ready), None)
+                if target_pair is None or changing or not snapshot.enabled:
+                    if state.targets:
+                        state.state = 'unconfirmed'
+                        state.error_code = next((target.error_code for target in state.targets.values()
+                                                 if target.error_code), 'configuration_changed')
+                    if state.targets and (changing or not snapshot.enabled):
+                        state.state = "unconfirmed"
+                        state.error_code = "configuration_changed" if changing else "connection_disabled"
+                    state.worker = None
+                    self.condition.notify_all()
+                    return
+                key, target = target_pair
+                event, generation = target.event, target.generation
+                target.ready = False
+                target.error_code = None
+                state.state = "pending"
+            try:
+                result = self._refresh(server, revision, snapshot, event)
+                error_code = None
+            except MediaServerError as error:
+                result = "unconfirmed"
+                error_code = error.code if error.code in _ERROR_CODES else "internal_error"
+            except Exception:
+                result, error_code = "unconfirmed", "internal_error"
+            with self.condition:
+                if self.servers.get(server) is not state:
+                    state.worker = None
+                    self.condition.notify_all()
+                    return
+                try:
+                    self.configuration.ensure_current(server, revision)
+                except MediaServerError:
+                    result, error_code = "unconfirmed", "configuration_changed"
+                if not error_code and state.targets[key].generation == generation:
+                    if target.unsupported_event is None:
+                        del state.targets[key]
+                    else:
+                        # The scan completed eligible work only. Retry the
+                        # retained unsupported publication without claiming it
+                        # was covered by this scan.
+                        target.event = target.unsupported_event
+                        result, error_code = 'unconfirmed', 'sidecar_unsupported'
+                        target.error_code = error_code
+                elif error_code:
+                    state.targets[key].error_code = error_code
+                state.state, state.error_code = result, error_code
+                self.condition.notify_all()
+
+    def status(self, server):
+        with self.condition:
+            state = self._server(server)
+            _revision, snapshot, changing = self._connection(server, state)
+            error = state.error_code or snapshot.configuration_error
+            status = "unconfirmed" if snapshot.configuration_error else state.state
+            if any(target.unsupported_event is not None for target in state.targets.values()):
+                error = error or 'sidecar_unsupported'
+                if status in {'idle', 'requested', 'confirmed'}:
+                    status = 'unconfirmed'
+            if state.targets and (changing or not snapshot.enabled):
+                status = "unconfirmed"
+                error = "configuration_changed" if changing else "connection_disabled"
+            return {"pending": len(state.targets), "state": status,
+                    "error_code": "queue_overflow" if state.overflow else error}
+
+    def retry(self, server):
+        with self.condition:
+            state = self._server(server)
+            _revision, snapshot, changing = self._connection(server, state)
+            if changing or not snapshot.enabled:
+                return 0
+            for target in state.targets.values():
+                target.ready = True
+            self._start(server, state)
+            return len(state.targets)
+
+    def wait_idle(self, timeout, *, server=None):
+        with self.condition:
+            states = [self._server(server)] if server else list(self.servers.values())
+            return self.condition.wait_for(lambda: all(state.worker is None for state in states), timeout)
+
+
+_singleton_lock = RLock()
+_configuration = None
+_dispatcher = None
+
+
+def get_native_configuration():
+    global _configuration
+    with _singleton_lock:
+        if _configuration is None:
+            from app.config import settings
+            from app.database import database, TableMediaServerImports
+            from .repository import MediaServerInstanceRepository
+            kinds = [kind for kind in _SERVERS if database.get(TableMediaServerImports, kind) is not None]
+            snapshots = MediaServerInstanceRepository(database).snapshots(settings, kinds=kinds)
+            _configuration = NativeConfiguration(settings, snapshots=snapshots,
+                                                 blocked_kinds=set(_SERVERS) - set(kinds))
+        return _configuration
+
+
+def _get_dispatcher():
+    global _dispatcher
+    with _singleton_lock:
+        if _dispatcher is None:
+            _dispatcher = RefreshDispatcher(get_native_configuration())
+        return _dispatcher
+
+
+def notify_subtitle_mutation(event: SubtitleMutation) -> None:
+    try:
+        _get_dispatcher().notify(event)
+    except Exception:
+        logging.warning("BAZARR native subtitle refresh could not be queued")
+
+
+def get_refresh_status(server: str) -> dict:
+    return _get_dispatcher().status(server)
+
+
+def retry_pending_refreshes(server: str) -> int:
+    return _get_dispatcher().retry(server)

--- a/bazarr/media_servers/dispatcher.py
+++ b/bazarr/media_servers/dispatcher.py
@@ -147,7 +147,7 @@ class RefreshDispatcher:
             for snapshot in self.configuration.list():
                 server = snapshot.id
                 state = self._server(server)
-                if snapshot.kind == "emby" and (media_type != "movie" or event.operation not in {"download", "upload"}):
+                if snapshot.kind == "emby" and event.operation not in {"download", "upload"}:
                     continue
                 _revision, snapshot, changing = self._connection(server, state)
                 if not snapshot.enabled:
@@ -210,7 +210,7 @@ class RefreshDispatcher:
         with self.client_factory(server, snapshot) as client:
             guard()
             if server == "emby":
-                result = client.refresh_movie(mapped["path"], ensure_current=guard)
+                result = client.refresh_item(event.media_type, mapped["path"], ensure_current=guard)
             else:
                 libraries = client.get_libraries()
                 library = next((row for row in libraries if row["id"].lstrip("0") ==

--- a/bazarr/media_servers/events.py
+++ b/bazarr/media_servers/events.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+"""Actual subtitle publications, expressed in Bazarr-visible paths."""
+
+from dataclasses import dataclass
+from contextlib import contextmanager
+import hashlib
+import os
+import stat
+
+
+@dataclass(frozen=True)
+class SubtitleMutation:
+    media_type: str
+    video_path: str
+    subtitle_path: str
+    operation: str
+    arr_instance_id: int | None = None
+
+
+def notify_subtitle_mutation(event: SubtitleMutation) -> None:
+    # Publication must remain successful even if a refresh cannot be queued.
+    from .dispatcher import notify_subtitle_mutation as notify
+    notify(event)
+
+
+def publication_callback(media_type, video_path, operation, arr_instance_id=None):
+    media_type = {'series': 'episode', 'movies': 'movie'}.get(media_type, media_type)
+
+    def published(subtitle_path):
+        notify_subtitle_mutation(SubtitleMutation(media_type, video_path, str(subtitle_path),
+                                                  operation, arr_instance_id))
+    return published
+
+
+def _subtitle_fingerprint(path):
+    try:
+        info = os.stat(path)
+        if not stat.S_ISREG(info.st_mode):
+            return None
+        digest = hashlib.sha256()
+        with open(path, 'rb') as handle:
+            # Bound each read and the total work to the file's initial size.
+            # Include content because scripts can preserve timestamps and size.
+            remaining = info.st_size + 1
+            while remaining:
+                chunk = handle.read(min(remaining, 256 * 1024))
+                if not chunk:
+                    break
+                digest.update(chunk)
+                remaining -= len(chunk)
+        return info.st_ino, info.st_mtime_ns, info.st_size, digest.digest()
+    except OSError:
+        return None
+
+
+@contextmanager
+def observe_subtitle_change(media_type, video_path, subtitle_path, operation, arr_instance_id=None):
+    """Account for a configured postprocessor that may rewrite or remove this file."""
+    before = _subtitle_fingerprint(subtitle_path)
+    try:
+        yield
+    finally:
+        if before != _subtitle_fingerprint(subtitle_path):
+            publication_callback(media_type, video_path, operation, arr_instance_id)(subtitle_path)

--- a/bazarr/media_servers/http.py
+++ b/bazarr/media_servers/http.py
@@ -1,0 +1,110 @@
+# coding=utf-8
+"""Bounded authenticated HTTP without proxy or redirect credential forwarding."""
+
+import json as json_module
+from urllib.parse import urlsplit, urlunsplit
+
+import requests
+from urllib3.exceptions import ReadTimeoutError
+
+
+class MediaServerError(Exception):
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(code)
+
+
+def validate_server_url(url: str) -> str:
+    if not isinstance(url, str) or not url or any(char.isspace() or ord(char) < 32 for char in url):
+        raise MediaServerError("invalid_url")
+    try:
+        parsed = urlsplit(url)
+        if (parsed.scheme not in ("http", "https") or not parsed.hostname
+                or parsed.username is not None or parsed.password is not None
+                or "?" in url or "#" in url or "\\" in url):
+            raise ValueError
+        parsed.port
+    except ValueError:
+        raise MediaServerError("invalid_url") from None
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
+
+
+def parse_verify_ssl(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str) and value.lower() in ("true", "false"):
+        return value.lower() == "true"
+    raise MediaServerError("invalid_verify_ssl")
+
+
+class MediaServerHTTP:
+    RESPONSE_LIMIT = 2 * 1024 * 1024
+
+    def __init__(self, url: str, *, verify_ssl: bool = True, headers=None):
+        self.url = validate_server_url(url)
+        self.verify_ssl = parse_verify_ssl(verify_ssl)
+        self.session = requests.Session()
+        self.session.trust_env = False
+        self.session.headers.update({"Accept": "application/json", **(headers or {})})
+
+    def close(self):
+        self.session.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+    def _request(self, method, path, *, params=None, json=None, success_statuses=(200,)):
+        # API paths are local to this validated base, including any proxy prefix.
+        if not isinstance(path, str) or not path.startswith("/") or path.startswith("//") or "?" in path or "#" in path:
+            raise MediaServerError("invalid_url")
+        try:
+            with self.session.request(method, self.url + path, params=params, json=json,
+                                      timeout=(3, 10), verify=self.verify_ssl,
+                                      allow_redirects=False, stream=True) as response:
+                status = response.status_code
+                if 300 <= status < 400:
+                    raise MediaServerError("redirect_denied")
+                if status not in success_statuses:
+                    code = {401: "unauthorized", 403: "forbidden", 404: "not_found"}.get(status)
+                    raise MediaServerError(code or ("server_error" if status >= 500 else "request_rejected"))
+                length = response.headers.get("Content-Length")
+                if length is not None:
+                    try:
+                        size = int(length)
+                    except ValueError:
+                        raise MediaServerError("invalid_response") from None
+                    if size < 0:
+                        raise MediaServerError("invalid_response")
+                    if size > self.RESPONSE_LIMIT:
+                        raise MediaServerError("response_too_large")
+                body = bytearray()
+                for chunk in response.iter_content(chunk_size=8192):
+                    if len(body) + len(chunk) > self.RESPONSE_LIMIT:
+                        raise MediaServerError("response_too_large")
+                    body.extend(chunk)
+                return bytes(body)
+        except requests.exceptions.SSLError:
+            raise MediaServerError("tls_error") from None
+        except requests.exceptions.Timeout:
+            raise MediaServerError("timeout") from None
+        except requests.exceptions.ConnectionError as error:
+            # Requests wraps urllib3 read timeouts raised during iter_content.
+            code = "timeout" if error.args and isinstance(error.args[0], ReadTimeoutError) else "connection_error"
+            raise MediaServerError(code) from None
+        except requests.exceptions.RequestException:
+            raise MediaServerError("connection_error") from None
+
+    def request_json(self, method, path, *, params=None, json=None, success_statuses=(200,)):
+        body = self._request(method, path, params=params, json=json, success_statuses=success_statuses)
+        try:
+            return json_module.loads(body)
+        except (ValueError, UnicodeError, RecursionError):
+            raise MediaServerError("invalid_response") from None
+
+    def request_empty(self, method, path, *, params=None, json=None, success_statuses=(200, 204)):
+        body = self._request(method, path, params=params, json=json, success_statuses=success_statuses)
+        if body:
+            raise MediaServerError("invalid_response")

--- a/bazarr/media_servers/instances.py
+++ b/bazarr/media_servers/instances.py
@@ -1,0 +1,75 @@
+# coding=utf-8
+"""Immutable destination snapshots and strict request validation."""
+
+import re
+from dataclasses import dataclass
+
+from .http import MediaServerError, validate_server_url
+from .paths import validate_path_mappings
+
+VALID_KINDS = ('emby', 'silo')
+FIELDS = {'name', 'enabled', 'url', 'verify_ssl', 'api_key', 'clear_api_key', 'path_mappings'}
+PROBE_FIELDS = {'url', 'verify_ssl', 'api_key', 'clear_api_key'}
+
+
+@dataclass(frozen=True, repr=False)
+class ConnectionSnapshot:
+    id: str
+    kind: str
+    name: str
+    instance_enabled: bool
+    master_enabled: bool
+    url: str
+    apikey: str
+    verify_ssl: bool
+    path_mappings: tuple
+    revision: int = 1
+    configuration_error: str | None = None
+
+    @property
+    def enabled(self):
+        return self.instance_enabled and self.master_enabled
+
+    def mappings(self):
+        return [dict(row) for row in self.path_mappings]
+
+
+def validate_fields(body, *, create=False, probe=False):
+    allowed = PROBE_FIELDS if probe else FIELDS | ({'kind'} if create else set())
+    if not isinstance(body, dict) or set(body) - allowed:
+        raise MediaServerError('invalid_settings')
+    if create and body.get('kind') not in VALID_KINDS:
+        raise MediaServerError('invalid_kind')
+    for name in ('name', 'url', 'api_key'):
+        if name in body and not isinstance(body[name], str):
+            raise MediaServerError('invalid_settings')
+    for name in ('enabled', 'verify_ssl', 'clear_api_key'):
+        if name in body and type(body[name]) is not bool:
+            raise MediaServerError('invalid_settings')
+    if body.get('api_key') and body.get('clear_api_key'):
+        raise MediaServerError('invalid_settings')
+    if 'name' in body and (not body['name'].strip() or any(ord(c) < 32 for c in body['name'])):
+        raise MediaServerError('invalid_name')
+    if 'url' in body:
+        validate_server_url(body['url'])
+    if 'path_mappings' in body:
+        validate_path_mappings(body['path_mappings'])
+    return body
+
+
+def validate_connection(values, *, probe=False):
+    validate_server_url(values['url'])
+    if not values['name'].strip():
+        raise MediaServerError('invalid_name')
+    mappings = validate_path_mappings(values['path_mappings'])
+    if values['kind'] == 'silo':
+        for row in mappings:
+            value = row.get('library_id')
+            if not isinstance(value, str) or re.fullmatch(r'[0-9]+', value) is None or not value.strip('0'):
+                raise MediaServerError('library_invalid')
+    if values['enabled'] or probe:
+        if not values['api_key'].strip():
+            raise MediaServerError('missing_credentials')
+        if not mappings and not probe:
+            raise MediaServerError('mapping_missing')
+    return values

--- a/bazarr/media_servers/paths.py
+++ b/bazarr/media_servers/paths.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+"""Explicit segment-aware mappings across POSIX and Windows media roots."""
+
+from pathlib import PurePosixPath, PureWindowsPath
+
+from .http import MediaServerError
+
+
+def _media_path(value, code="path_invalid"):
+    if not isinstance(value, str) or not value or any(ord(char) < 32 for char in value):
+        raise MediaServerError(code)
+    windows = bool(PureWindowsPath(value).drive) or "\\" in value
+    path = PureWindowsPath(value) if windows else PurePosixPath(value)
+    if not path.is_absolute() or ".." in path.parts:
+        raise MediaServerError(code)
+    return path
+
+
+def validate_path_mappings(mappings):
+    if not isinstance(mappings, list):
+        raise MediaServerError("mapping_invalid")
+    for row in mappings:
+        if (not isinstance(row, dict) or not {"local_path", "remote_path"}.issubset(row)
+                or set(row) - {"local_path", "remote_path", "library_id"}):
+            raise MediaServerError("mapping_invalid")
+        _media_path(row["local_path"], "mapping_invalid")
+        _media_path(row["remote_path"], "mapping_invalid")
+        library_id = row.get("library_id")
+        if library_id is not None and (not isinstance(library_id, str) or any(ord(char) < 32 for char in library_id)):
+            raise MediaServerError("mapping_invalid")
+    return mappings
+
+
+def media_paths_equal(left, right):
+    try:
+        return _media_path(left) == _media_path(right)
+    except MediaServerError:
+        return False
+
+
+def map_media_path(video_path: str, mappings: list[dict], *, require_library: bool = False) -> dict:
+    path = _media_path(video_path)
+    validate_path_mappings(mappings)
+    matches = []
+    for row in mappings:
+        local = _media_path(row["local_path"])
+        if type(path) is not type(local) or not path.is_relative_to(local):
+            continue
+        matches.append((len(local.parts), row, path.relative_to(local)))
+    if not matches:
+        raise MediaServerError("mapping_missing")
+    specificity = max(match[0] for match in matches)
+    best = [match for match in matches if match[0] == specificity]
+    if len(best) != 1:
+        raise MediaServerError("mapping_ambiguous")
+    _specificity, row, relative = best[0]
+    library_id = row.get("library_id")
+    if require_library and (not library_id or not library_id.strip()):
+        raise MediaServerError("library_missing")
+    remote = _media_path(row["remote_path"])
+    for component in relative.parts:
+        destination_component = type(remote)(component)
+        # A source filename must not reset the drive/root or become different
+        # components when the destination uses another path flavor.
+        if destination_component.anchor or destination_component.parts != (component,):
+            raise MediaServerError("path_invalid")
+    return {"path": str(remote.joinpath(*relative.parts)), "library_id": library_id}

--- a/bazarr/media_servers/paths.py
+++ b/bazarr/media_servers/paths.py
@@ -38,6 +38,20 @@ def media_paths_equal(left, right):
         return False
 
 
+def is_media_path(value) -> bool:
+    """Whether this is a path a media server could hold a file at.
+
+    The same rule :func:`map_media_path` applies, asked as a question rather
+    than answered by comparing a path with itself, which reads like a typo and
+    invites someone to "fix" it into a no-op.
+    """
+    try:
+        _media_path(value)
+    except MediaServerError:
+        return False
+    return True
+
+
 def map_media_path(video_path: str, mappings: list[dict], *, require_library: bool = False) -> dict:
     path = _media_path(video_path)
     validate_path_mappings(mappings)

--- a/bazarr/media_servers/paths.py
+++ b/bazarr/media_servers/paths.py
@@ -65,3 +65,17 @@ def map_media_path(video_path: str, mappings: list[dict], *, require_library: bo
         if destination_component.anchor or destination_component.parts != (component,):
             raise MediaServerError("path_invalid")
     return {"path": str(remote.joinpath(*relative.parts)), "library_id": library_id}
+
+
+def media_path_contains(root: str, path: str) -> bool:
+    """Whether ``path`` sits inside ``root``, within one path flavor.
+
+    Comparing across flavors is not a comparison at all: a Windows library
+    root and a POSIX media path describe different filesystems, so neither
+    can contain the other, and a malformed root simply holds nothing.
+    """
+    try:
+        container, media = _media_path(root), _media_path(path)
+    except MediaServerError:
+        return False
+    return type(container) is type(media) and media.is_relative_to(container)

--- a/bazarr/media_servers/repository.py
+++ b/bazarr/media_servers/repository.py
@@ -1,0 +1,170 @@
+# coding=utf-8
+"""Destination persistence and the encrypted credential boundary."""
+
+import json
+from contextlib import contextmanager
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+
+from app.database import TableMediaServerInstances
+from .http import MediaServerError
+from .instances import ConnectionSnapshot, validate_connection, validate_fields
+
+
+@contextmanager
+def atomic(session, *, durable=False):
+    """Use a real transaction before SAVEPOINT, including AUTOCOMMIT engines.
+
+    SQLite's legacy transaction mode and PostgreSQL AUTOCOMMIT do not start a
+    transaction for SAVEPOINT on our behalf. Inspect the driver transaction,
+    then explicitly own BEGIN/COMMIT only when no transaction exists yet.
+    """
+    connection = session.connection()
+    driver = connection.connection.driver_connection
+    if connection.dialect.name == 'sqlite':
+        active = driver.in_transaction
+    else:
+        active = driver.info.transaction_status != 0
+    own = not active
+    if own:
+        connection.exec_driver_sql('BEGIN')
+    try:
+        with session.begin_nested():
+            yield
+        if own:
+            connection.exec_driver_sql('COMMIT')
+        elif durable:
+            session.commit()
+    except BaseException:
+        if own:
+            connection.exec_driver_sql('ROLLBACK')
+        session.expire_all()
+        raise
+
+
+def _valid_id(value):
+    try:
+        return isinstance(value, str) and str(UUID(value)) == value
+    except (ValueError, AttributeError):
+        return False
+
+
+def _encrypted(value):
+    from secret_store import encrypt_secret, persist_master_key
+    if value:
+        persist_master_key()
+    return encrypt_secret(value)
+
+
+class MediaServerInstanceRepository:
+    def __init__(self, session):
+        self.session = session
+
+    def get(self, instance_id):
+        if not _valid_id(instance_id):
+            return None
+        return self.session.get(TableMediaServerInstances, instance_id, populate_existing=True)
+
+    def list(self, kind=None):
+        statement = select(TableMediaServerInstances).execution_options(populate_existing=True)
+        if kind is not None:
+            statement = statement.where(TableMediaServerInstances.kind == kind)
+        return list(self.session.execute(statement.order_by(TableMediaServerInstances.kind,
+                                                           TableMediaServerInstances.id)).scalars())
+
+    def get_decrypted_api_key(self, instance_id):
+        from secret_store import decrypt_secret
+        row = self.get(instance_id)
+        if row is None:
+            return None
+        try:
+            return decrypt_secret(row.api_key)
+        except ValueError:
+            raise MediaServerError('missing_credentials') from None
+
+    def values(self, row, *, decrypt_key=True):
+        return dict(kind=row.kind, name=row.name, enabled=bool(row.enabled), url=row.url,
+                    verify_ssl=bool(row.verify_ssl), api_key=self.get_decrypted_api_key(row.id) if decrypt_key else '',
+                    path_mappings=json.loads(row.path_mappings))
+
+    def create(self, kind, name, **fields):
+        values = dict(kind=kind, name=name, enabled=False, url='', verify_ssl=True, api_key='', path_mappings=[])
+        values.update(fields)
+        validate_fields(dict(kind=kind, name=name, **fields), create=True)
+        values.pop('clear_api_key', None)
+        validate_connection(values)
+        return self.import_values(values)
+
+    def import_values(self, values):
+        """Legacy structurally valid drafts may be incomplete; keep every value."""
+        encrypted = _encrypted(values['api_key'])
+        with atomic(self.session):
+            row = TableMediaServerInstances(id=str(uuid4()), kind=values['kind'], name=values['name'],
+                                           enabled=int(values['enabled']), url=values['url'],
+                                           verify_ssl=int(values['verify_ssl']), api_key=encrypted,
+                                           path_mappings=json.dumps(values['path_mappings']), revision=1)
+            self.session.add(row)
+            self.session.flush()
+        return row
+
+    def update(self, instance_id, **fields):
+        validate_fields(fields)
+        row = self.get(instance_id)
+        if row is None:
+            return None
+        values = self.values(row, decrypt_key=not (fields.get('api_key') or fields.get('clear_api_key')))
+        if fields.get('clear_api_key'):
+            values['api_key'] = ''
+        values.update({key: value for key, value in fields.items()
+                       if key != 'clear_api_key' and (key != 'api_key' or value)})
+        validate_connection(values)
+        encrypted = _encrypted(values['api_key']) if fields.get('api_key') else row.api_key
+        if fields.get('clear_api_key'):
+            encrypted = ''
+        with atomic(self.session):
+            for key in ('name', 'url', 'enabled', 'verify_ssl'):
+                setattr(row, key, int(values[key]) if key in {'enabled', 'verify_ssl'} else values[key])
+            row.api_key = encrypted
+            row.path_mappings = json.dumps(values['path_mappings'])
+            row.revision += 1
+            self.session.flush()
+        return row
+
+    def delete(self, instance_id):
+        row = self.get(instance_id)
+        if row is None:
+            return False
+        with atomic(self.session):
+            self.session.delete(row)
+            self.session.flush()
+        return True
+
+    def snapshot(self, instance_id, settings):
+        row = self.get(instance_id)
+        if row is None:
+            return None
+        error = None
+        try:
+            key = self.get_decrypted_api_key(row.id)
+        except MediaServerError as exc:
+            key, error = '', exc.code
+        mappings = json.loads(row.path_mappings)
+        try:
+            validate_connection(dict(kind=row.kind, name=row.name, enabled=bool(row.enabled), url=row.url,
+                                     api_key=key, path_mappings=mappings))
+        except MediaServerError as exc:
+            error = error or exc.code
+        return ConnectionSnapshot(row.id, row.kind, row.name, bool(row.enabled),
+                                  getattr(settings.general, 'use_' + row.kind) is True,
+                                  row.url, key, bool(row.verify_ssl),
+                                  tuple(tuple(sorted(item.items())) for item in mappings), row.revision, error)
+
+    def snapshots(self, settings, *, kinds=None):
+        return [self.snapshot(row.id, settings) for row in self.list() if kinds is None or row.kind in kinds]
+
+
+def to_safe_dict(row):
+    return dict(id=row.id, kind=row.kind, name=row.name, enabled=bool(row.enabled), url=row.url,
+                verify_ssl=bool(row.verify_ssl), api_key_set=bool(row.api_key),
+                path_mappings=json.loads(row.path_mappings))

--- a/bazarr/media_servers/repository.py
+++ b/bazarr/media_servers/repository.py
@@ -83,9 +83,23 @@ class MediaServerInstanceRepository:
         except ValueError:
             raise MediaServerError('missing_credentials') from None
 
+    def retained_api_key(self, instance_id):
+        """The saved key as plaintext, or nothing when it can no longer be read.
+
+        A database restored without its master key leaves ciphertext that
+        decrypts to nothing usable. That is a destination holding no
+        credentials, not a request the user is forbidden to make: the enabled
+        checks below still refuse to run it, and turning it off has to stay
+        possible.
+        """
+        try:
+            return self.get_decrypted_api_key(instance_id)
+        except MediaServerError:
+            return ''
+
     def values(self, row, *, decrypt_key=True):
         return dict(kind=row.kind, name=row.name, enabled=bool(row.enabled), url=row.url,
-                    verify_ssl=bool(row.verify_ssl), api_key=self.get_decrypted_api_key(row.id) if decrypt_key else '',
+                    verify_ssl=bool(row.verify_ssl), api_key=self.retained_api_key(row.id) if decrypt_key else '',
                     path_mappings=json.loads(row.path_mappings))
 
     def create(self, kind, name, **fields):
@@ -118,7 +132,16 @@ class MediaServerInstanceRepository:
             values['api_key'] = ''
         values.update({key: value for key, value in fields.items()
                        if key != 'clear_api_key' and (key != 'api_key' or value)})
-        validate_connection(values)
+        try:
+            validate_connection(values)
+        except MediaServerError:
+            # Retained values only have to hold up while the destination is on.
+            # A key that no longer decrypts, or a legacy import that never had a
+            # URL, would otherwise make the destination impossible to switch
+            # off: every field this request actually submits was validated by
+            # validate_fields above, so nothing new gets in this way.
+            if values['enabled']:
+                raise
         encrypted = _encrypted(values['api_key']) if fields.get('api_key') else row.api_key
         if fields.get('clear_api_key'):
             encrypted = ''

--- a/bazarr/media_servers/resolution.py
+++ b/bazarr/media_servers/resolution.py
@@ -1,0 +1,140 @@
+# coding=utf-8
+"""One ordered ladder for turning a publication into a server item.
+
+Jellyfin's inline refresh climbs identifiers first, falls back to a title and
+year, and finally refreshes the whole library. Native destinations climb the
+same ladder, with one rung added: the exact file path, which Jellyfin never had
+and which is the only evidence that proves a single file. Every destination
+publishes the rungs it can actually climb, so a capability that a server does
+not have is absent rather than faked.
+"""
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+PROVIDER_ID = 'provider_id'
+TITLE_YEAR = 'title_year'
+PATH = 'path'
+LIBRARY = 'library'
+
+# Identifiers first because they survive a wrong path mapping, the exact path
+# next because it is the only proof of one file, and the library last because
+# it is the broadest thing we can ask a server to do.
+CHAIN = (PROVIDER_ID, TITLE_YEAR, PATH, LIBRARY)
+
+
+@dataclass(frozen=True)
+class MediaMetadata:
+    """What Bazarr already recorded about the published video."""
+
+    imdb_id: str | None = None
+    tmdb_id: str | None = None
+    tvdb_id: int | None = None
+    title: str | None = None
+    year: int | None = None
+    season: int | None = None
+    episode: int | None = None
+
+    def provider_ids(self, media_type):
+        """Provider pairs in Jellyfin's precedence, as 'prov'/'id' tuples.
+
+        An episode carries no identifier of its own: the ids Bazarr stores
+        belong to the series, so these locate the series and the season and
+        episode numbers pick the file underneath it.
+        """
+        pairs = [('imdb', self.imdb_id),
+                 ('tmdb', self.tmdb_id) if media_type == 'movie' else ('tvdb', self.tvdb_id)]
+        return [(name, str(value)) for name, value in pairs if value not in (None, '')]
+
+    def locatable(self, media_type):
+        """Whether an identifier or title match can reach the published file."""
+        return media_type == 'movie' or (self.season is not None and self.episode is not None)
+
+
+def walk(steps):
+    """The first rung that resolves the item, or None when none of them does.
+
+    ``steps`` are ``(name, call, expected)`` in ladder order, and a rung
+    misses by returning None. Anything a rung raises stops the walk, so a
+    destination's strict acceptance rules keep refusing rather than being
+    laundered into a broader refresh of something else.
+
+    Ordering is all this decides. Which refusal counts as a miss, and what to
+    call a ladder that reached the end, belong to the adapter boundary that
+    knows those servers, so nothing here raises.
+    """
+    for name, call, expected in steps:
+        result = call()
+        if result is not None:
+            return name, result, expected
+    return None
+
+
+@contextmanager
+def _reader():
+    """A read session owned by this call, never left on the worker thread.
+
+    The scoped session is keyed by thread and nothing tears it down for a
+    refresh worker, so a refresh takes its own session and closes it instead
+    of leaving a connection behind for every worker that ever ran.
+    """
+    from app.database import session_factory
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _year(value):
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def media_metadata(media_type, video_path, arr_instance_id):
+    """Read the identifiers Bazarr already stores for this published video.
+
+    Resolved here rather than threaded through every publication callback:
+    each of those callers wrote these rows in the first place, and the ids the
+    subtitles API hands Jellyfin come from exactly this query. ``video_path``
+    is Bazarr-visible, so it is mapped back to the path the arr recorded.
+
+    Returns None whenever the answer would be a guess: no row, a row that no
+    longer joins to its show, more than one owner at that path, or any failure
+    at all reading the database. The caller then climbs a lower rung.
+    """
+    try:
+        from app.database import TableEpisodes, TableMovies, TableShows, select
+        from arr_instances.resolution import scoped
+        from utilities.path_mappings import path_mappings
+
+        movie = media_type == 'movie'
+        stored = path_mappings.path_replace_reverse_instance(
+            video_path, arr_instance_id, 'movie' if movie else 'series')
+        if movie:
+            statement = scoped(
+                select(TableMovies.imdbId, TableMovies.tmdbId, TableMovies.title, TableMovies.year)
+                .where(TableMovies.path == stored),
+                TableMovies.arr_instance_id, arr_instance_id)
+        else:
+            statement = scoped(
+                select(TableEpisodes.season, TableEpisodes.episode, TableShows.imdbId,
+                       TableShows.tvdbId, TableShows.title, TableShows.year)
+                .join(TableShows).where(TableEpisodes.path == stored),
+                TableEpisodes.arr_instance_id, arr_instance_id)
+        with _reader() as session:
+            rows = session.execute(statement.limit(2)).all()
+    except Exception:
+        logging.debug('BAZARR could not read media identifiers for a native refresh', exc_info=True)
+        return None
+    if len(rows) != 1:
+        return None
+    row = rows[0]
+    if movie:
+        return MediaMetadata(imdb_id=row.imdbId, tmdb_id=row.tmdbId,
+                             title=row.title, year=_year(row.year))
+    return MediaMetadata(imdb_id=row.imdbId, tvdb_id=row.tvdbId, title=row.title,
+                         year=_year(row.year), season=row.season, episode=row.episode)

--- a/bazarr/media_servers/resolution.py
+++ b/bazarr/media_servers/resolution.py
@@ -7,6 +7,11 @@ same ladder, with one rung added: the exact file path, which Jellyfin never had
 and which is the only evidence that proves a single file. Every destination
 publishes the rungs it can actually climb, so a capability that a server does
 not have is absent rather than faked.
+
+The added rung also moves the weakest one. Jellyfin had nothing better than a
+title, so it asked for one early; here the exact path sits above it, because
+binding the wrong item is worse than resolving nothing at all: the walk stops
+at the first rung that answers and reports the publication as requested.
 """
 
 import logging
@@ -18,10 +23,12 @@ TITLE_YEAR = 'title_year'
 PATH = 'path'
 LIBRARY = 'library'
 
-# Identifiers first because they survive a wrong path mapping, the exact path
-# next because it is the only proof of one file, and the library last because
-# it is the broadest thing we can ask a server to do.
-CHAIN = (PROVIDER_ID, TITLE_YEAR, PATH, LIBRARY)
+# A provider id first, because it names the item on its own and that is what
+# survives a wrong path mapping. The exact path next, because it is the only
+# proof of one file. A title and a year after it, because two metadata fields
+# are a guess and a guess must not pre-empt proof. The library last, because it
+# is the broadest thing we can ask a server to do.
+CHAIN = (PROVIDER_ID, PATH, TITLE_YEAR, LIBRARY)
 
 
 @dataclass(frozen=True)

--- a/bazarr/media_servers/service.py
+++ b/bazarr/media_servers/service.py
@@ -1,0 +1,93 @@
+# coding=utf-8
+"""Validated instance operations, publishing only durable saved snapshots."""
+
+from .http import MediaServerError
+from .instances import VALID_KINDS, validate_fields
+from .repository import MediaServerInstanceRepository, atomic, to_safe_dict
+
+
+def list_instances(session, kind=None):
+    if kind is not None and kind not in VALID_KINDS:
+        return {'error_code': 'invalid_kind'}, 400
+    return {'data': [to_safe_dict(row) for row in MediaServerInstanceRepository(session).list(kind)]}, 200
+
+
+def get_instance(session, instance_id):
+    row = MediaServerInstanceRepository(session).get(instance_id)
+    return (to_safe_dict(row), 200) if row else ({'error_code': 'not_found'}, 404)
+
+
+def _write(session, operation, instance_id=None, body=None):
+    from app.config import settings
+    from .dispatcher import get_native_configuration
+    repo = MediaServerInstanceRepository(session)
+    try:
+        if operation != 'delete':
+            validate_fields(body, create=operation == 'create')
+        configuration = get_native_configuration()
+        # No staged changes are visible to workers, and failed writes retain
+        # the old revision. Other destination operations resume unchanged.
+        with configuration.lock:
+            with atomic(session, durable=True):
+                if operation == 'create':
+                    if 'name' not in body or 'url' not in body:
+                        raise MediaServerError('invalid_settings')
+                    row = repo.create(**body)
+                    instance_id = row.id
+                elif operation == 'update':
+                    row = repo.update(instance_id, **body)
+                    if row is None:
+                        return {'error_code': 'not_found'}, 404
+                else:
+                    if not repo.delete(instance_id):
+                        return {'error_code': 'not_found'}, 404
+                snapshot = repo.snapshot(instance_id, settings) if operation != 'delete' else None
+                result = to_safe_dict(row) if snapshot else None
+            if snapshot:
+                configuration.publish(snapshot)
+            else:
+                configuration.delete(instance_id)
+        return (None, 204) if operation == 'delete' else (result, 201 if operation == 'create' else 200)
+    except MediaServerError as error:
+        session.rollback()
+        return {'error_code': error.code}, 400
+    except Exception:
+        session.rollback()
+        return {'error_code': 'persistence_failed'}, 500
+
+
+def create_instance(session, body):
+    return _write(session, 'create', body=body)
+
+
+def update_instance(session, instance_id, body):
+    return _write(session, 'update', instance_id, body)
+
+
+def delete_instance(session, instance_id):
+    return _write(session, 'delete', instance_id)
+
+
+def probe_instance(session, instance_id, body, *, libraries=False):
+    from .http import validate_server_url
+    repo = MediaServerInstanceRepository(session)
+    row = repo.get(instance_id)
+    if row is None:
+        return {'error_code': 'not_found'}, 404
+    try:
+        validate_fields(body, probe=True)
+        if libraries and row.kind != 'silo':
+            raise MediaServerError('invalid_kind')
+        key = '' if body.get('clear_api_key') else body.get('api_key') or repo.get_decrypted_api_key(instance_id)
+        url, verify_ssl = body.get('url', row.url), body.get('verify_ssl', bool(row.verify_ssl))
+        validate_server_url(url)
+        if not key or not key.strip():
+            raise MediaServerError('missing_credentials')
+    except MediaServerError as error:
+        return ({'data': [], 'error_code': error.code} if libraries else
+                {'success': False, 'error_code': error.code}), 400
+    if row.kind == 'emby':
+        from emby.operations import emby_test_connection
+        return emby_test_connection(url, key, verify_ssl), 200
+    from silo.operations import silo_get_libraries, silo_test_connection
+    return (silo_get_libraries if libraries else silo_test_connection)(url, key, verify_ssl), 200

--- a/bazarr/secret_store/crypto.py
+++ b/bazarr/secret_store/crypto.py
@@ -41,6 +41,7 @@ import base64
 import hashlib
 import logging
 import secrets as _secrets
+from threading import RLock
 
 from cryptography.fernet import Fernet, InvalidToken
 from itsdangerous import BadPayload, BadSignature, URLSafeSerializer
@@ -54,6 +55,8 @@ SECRET_MARKER_PREFIX = "enc:v1:"
 
 # Generated key length in bytes (token_urlsafe doubles to ~43 chars).
 _MASTER_KEY_BYTES = 32
+_master_key_lock = RLock()
+_unpersisted_master_keys = set()
 
 
 def _generate_master_key() -> str:
@@ -90,13 +93,15 @@ def get_master_key(settings_obj=None) -> str:
     if settings_obj is None:
         from app.config import settings as settings_obj  # noqa: PLC0415, RUF100
 
-    general = settings_obj.general
-    key = getattr(general, "secrets_encryption_key", None)
-    if not key or (isinstance(key, str) and not key.strip()):
-        key = _generate_master_key()
-        general.secrets_encryption_key = key
-        logger.info("Generated new master secrets_encryption_key on first boot")
-    return key
+    with _master_key_lock:
+        general = settings_obj.general
+        key = getattr(general, "secrets_encryption_key", None)
+        if not key or (isinstance(key, str) and not key.strip()):
+            key = _generate_master_key()
+            general.secrets_encryption_key = key
+            _unpersisted_master_keys.add(key)
+            logger.info("Generated new master secrets_encryption_key on first boot")
+        return key
 
 
 def persist_master_key(settings_obj=None) -> None:
@@ -112,19 +117,33 @@ def persist_master_key(settings_obj=None) -> None:
     committing an arr_instances API key (the repository write commits
     immediately under the AUTOCOMMIT engine).
 
-    Only writes config when the key was just generated, so the common path
-    (key already on disk) is a cheap no-op.
+    Keys generated in this process remain pending until a successful settings
+    write confirms them. Keys loaded from disk need no extra write.
     """
     if settings_obj is None:
         from app.config import settings as settings_obj
 
-    general = settings_obj.general
-    before = getattr(general, "secrets_encryption_key", "") or ""
-    get_master_key(settings_obj)
-    after = getattr(general, "secrets_encryption_key", "") or ""
-    if not before and after:
-        from app.config import write_config
-        write_config()
+    with _master_key_lock:
+        general = settings_obj.general
+        before = getattr(general, "secrets_encryption_key", "") or ""
+        key = get_master_key(settings_obj)
+        if key in _unpersisted_master_keys:
+            from app.config import write_config
+            try:
+                if write_config() is not True:
+                    raise ValueError
+            except Exception:
+                general.secrets_encryption_key = before
+                if before != key:
+                    _unpersisted_master_keys.discard(key)
+                raise ValueError("Unable to persist secrets encryption key") from None
+            mark_master_key_persisted(key)
+
+
+def mark_master_key_persisted(key):
+    """A successful settings write confirms only the key in its saved payload."""
+    with _master_key_lock:
+        _unpersisted_master_keys.discard(key)
 
 
 def is_encrypted(value) -> bool:

--- a/bazarr/secret_store/registry.py
+++ b/bazarr/secret_store/registry.py
@@ -31,6 +31,10 @@ The dynaconf API serializer flattens nested settings to that form
 before checking, so this stays simple.
 """
 
+# These legacy sections remain encrypted for one-time database import, but
+# their values are never exposed or edited through the general settings API.
+IMPORT_ONLY_SECTIONS = frozenset({'emby', 'silo'})
+
 USER_VISIBLE_SECRETS = frozenset({
     # Bazarr's own admin login (username + password) and the API key that
     # the SPA uses on every authenticated request. Username is NOT
@@ -54,8 +58,10 @@ USER_VISIBLE_SECRETS = frozenset({
     "plex.token",
     "plex.username",
     "plex.email",
-    # Jellyfin
+    # Media servers
     "jellyfin.apikey",
+    "emby.apikey",
+    "silo.apikey",
     # Network proxy (full login pair).
     "proxy.username",
     "proxy.password",

--- a/bazarr/silo/__init__.py
+++ b/bazarr/silo/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/bazarr/silo/client.py
+++ b/bazarr/silo/client.py
@@ -57,9 +57,10 @@ class SiloClient:
         return result
 
     def refresh_file(self, library_id: str, video_path: str, *, timeout: float = 90.0,
-                     ensure_current: Callable[[], None] | None = None) -> dict:
+                     ensure_current: Callable[[], None] | None = None) -> dict | None:
         return refresh_file(self.http, library_id, video_path, timeout=timeout, ensure_current=ensure_current)
 
     def refresh_library(self, library_id: str, *,
-                        ensure_current: Callable[[], None] | None = None) -> dict:
-        return refresh_library(self.http, library_id, ensure_current=ensure_current)
+                        ensure_current: Callable[[], None] | None = None,
+                        coalesce: Callable[[str], bool] | None = None) -> dict:
+        return refresh_library(self.http, library_id, ensure_current=ensure_current, coalesce=coalesce)

--- a/bazarr/silo/client.py
+++ b/bazarr/silo/client.py
@@ -1,13 +1,21 @@
 # coding=utf-8
 """Native Silo authentication, library selection and observed file scans."""
 
+from media_servers import resolution
 from media_servers.http import MediaServerError, MediaServerHTTP
 from typing import Callable
 
-from .scans import refresh_file
+from .scans import refresh_file, refresh_library
 
 
 class SiloClient:
+    # No identifier rungs, and not for want of asking: Silo's Jellyfin
+    # compatibility layer (10.12.0) answers /Items with no ProviderIds key on
+    # any item, so there is nothing a provider-id or title match could compare
+    # against. Bazarr talks to the native API, which addresses media by path
+    # and library, so the path is the first rung Silo can actually climb.
+    REFRESH_STEPS = (resolution.PATH, resolution.LIBRARY)
+
     def __init__(self, url: str, apikey: str, verify_ssl: bool = True):
         if not isinstance(apikey, str) or not apikey.strip() or any(ord(char) < 32 for char in apikey):
             raise MediaServerError("missing_credentials")
@@ -51,3 +59,7 @@ class SiloClient:
     def refresh_file(self, library_id: str, video_path: str, *, timeout: float = 90.0,
                      ensure_current: Callable[[], None] | None = None) -> dict:
         return refresh_file(self.http, library_id, video_path, timeout=timeout, ensure_current=ensure_current)
+
+    def refresh_library(self, library_id: str, *,
+                        ensure_current: Callable[[], None] | None = None) -> dict:
+        return refresh_library(self.http, library_id, ensure_current=ensure_current)

--- a/bazarr/silo/client.py
+++ b/bazarr/silo/client.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+"""Native Silo authentication, library selection and observed file scans."""
+
+from media_servers.http import MediaServerError, MediaServerHTTP
+from typing import Callable
+
+from .scans import refresh_file
+
+
+class SiloClient:
+    def __init__(self, url: str, apikey: str, verify_ssl: bool = True):
+        if not isinstance(apikey, str) or not apikey.strip() or any(ord(char) < 32 for char in apikey):
+            raise MediaServerError("missing_credentials")
+        self.http = MediaServerHTTP(url, verify_ssl=verify_ssl, headers={"Authorization": f"Bearer {apikey}"})
+
+    def close(self):
+        self.http.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+    def test_connection(self) -> dict:
+        info = self.http.request_json("GET", "/api/v1/health")
+        if (not isinstance(info, dict) or info.get("status") != "ok"
+                or any(not isinstance(info.get(key), str) or not info[key] for key in ("server_id", "server_name"))):
+            raise MediaServerError("invalid_response")
+        # Health is public. Only the admin-only native libraries endpoint proves authentication.
+        self.get_libraries()
+        return {"success": True, "server_id": info["server_id"], "server_name": info["server_name"]}
+
+    def get_libraries(self) -> list[dict]:
+        rows = self.http.request_json("GET", "/api/v1/libraries")
+        if not isinstance(rows, list):
+            raise MediaServerError("invalid_response")
+        result, seen = [], set()
+        for row in rows:
+            if (not isinstance(row, dict) or type(row.get("id")) is not int or row["id"] <= 0
+                    or row["id"] in seen or not isinstance(row.get("name"), str) or not row["name"]
+                    or not isinstance(row.get("type"), str) or not isinstance(row.get("paths"), list)
+                    or any(not isinstance(path, str) or not path for path in row["paths"])
+                    or type(row.get("enabled")) is not bool):
+                raise MediaServerError("invalid_response")
+            seen.add(row["id"])
+            if row["enabled"] and row["type"] in {"movies", "series"}:
+                result.append({"id": str(row["id"]), "name": row["name"], "type": row["type"], "paths": row["paths"]})
+        return result
+
+    def refresh_file(self, library_id: str, video_path: str, *, timeout: float = 90.0,
+                     ensure_current: Callable[[], None] | None = None) -> dict:
+        return refresh_file(self.http, library_id, video_path, timeout=timeout, ensure_current=ensure_current)

--- a/bazarr/silo/operations.py
+++ b/bazarr/silo/operations.py
@@ -1,0 +1,25 @@
+# coding=utf-8
+
+from media_servers.http import MediaServerError
+
+from .client import SiloClient
+
+
+def silo_test_connection(url: str, apikey: str, verify_ssl: bool = True) -> dict:
+    try:
+        with SiloClient(url, apikey, verify_ssl) as client:
+            return client.test_connection()
+    except MediaServerError as error:
+        return {"success": False, "error_code": error.code}
+    except Exception:
+        return {"success": False, "error_code": "connection_error"}
+
+
+def silo_get_libraries(url: str, apikey: str, verify_ssl: bool = True) -> dict:
+    try:
+        with SiloClient(url, apikey, verify_ssl) as client:
+            return {"data": client.get_libraries(), "error_code": None}
+    except MediaServerError as error:
+        return {"data": [], "error_code": error.code}
+    except Exception:
+        return {"data": [], "error_code": "connection_error"}

--- a/bazarr/silo/scans.py
+++ b/bazarr/silo/scans.py
@@ -1,0 +1,429 @@
+# coding=utf-8
+"""Observe a fresh native file scan before acknowledging a subtitle mutation."""
+
+import asyncio
+from datetime import datetime, timezone
+import ipaddress
+import json
+import math
+import os
+from pathlib import Path
+import re
+import socket
+
+import aiohttp
+import dns.asyncresolver
+import dns.exception
+
+from media_servers.http import MediaServerError, MediaServerHTTP
+from media_servers.paths import map_media_path, media_paths_equal
+
+
+_ACTIVE = {"accepted", "running"}
+_TERMINAL = {"completed", "failed", "cancelled"}
+_EVENT_STATUS = {"scan.accepted": "accepted", "scan.started": "running", "scan.progress": "running",
+                 "scan.completed": "completed", "scan.failed": "failed", "scan.cancelled": "cancelled"}
+_CLEAN_COUNTERS = ("skipped", "errors", "missing", "missing_skipped_protected")
+_SNAPSHOT_LIMIT = 500
+_OBSERVED_LIMIT = 2048
+_POST_LIMIT = 3
+_NATIVE_INT_MAX = 2**63 - 1
+_RFC3339 = re.compile(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,9}))?(Z|[+-]\d{2}:\d{2})")
+
+
+def _timestamp(value):
+    if not isinstance(value, str) or len(value) > 35:
+        return None
+    match = _RFC3339.fullmatch(value)
+    if match is None:
+        return None
+    try:
+        stamp = datetime.fromisoformat(match[1] + match[3])
+        elapsed = stamp - datetime(1970, 1, 1, tzinfo=timezone.utc)
+    except (ValueError, OverflowError):
+        return None
+    seconds = elapsed.days * 86400 + elapsed.seconds
+    return seconds * 1_000_000_000 + int((match[2] or "0").ljust(9, "0"))
+
+
+class _NativeResolver(aiohttp.abc.AbstractResolver):
+    """Cancellable DNS plus hosts-file names without a blocking resolver thread."""
+
+    async def resolve(self, host, port=0, family=socket.AF_UNSPEC):
+        addresses = []
+        hosts_path = (Path(os.environ.get("SystemRoot", r"C:\Windows")) / "System32/drivers/etc/hosts"
+                      if os.name == "nt" else Path("/etc/hosts"))
+        try:
+            with hosts_path.open(encoding="utf-8", errors="replace") as hosts:
+                for line in hosts:
+                    fields = line.partition("#")[0].split()
+                    if len(fields) < 2 or host.rstrip(".").lower() not in [name.lower() for name in fields[1:]]:
+                        continue
+                    try:
+                        address = ipaddress.ip_address(fields[0])
+                    except ValueError:
+                        continue
+                    address_family = socket.AF_INET6 if address.version == 6 else socket.AF_INET
+                    if family in {socket.AF_UNSPEC, address_family}:
+                        addresses.append((str(address), address_family))
+        except OSError:
+            pass
+        if not addresses:
+            try:
+                # Preserve configured nameservers, search domains and ndots,
+                # including Docker's embedded resolver. Every DNS socket belongs
+                # to a cancellable async query within the connector's deadline.
+                resolver = dns.asyncresolver.Resolver()
+                answer = await resolver.resolve_name(host, family=family, search=True, lifetime=3)
+                addresses = list(answer.addresses_and_families())
+            except dns.exception.Timeout:
+                raise TimeoutError from None
+            except dns.exception.DNSException:
+                raise OSError("connection_error") from None
+        if not addresses:
+            raise OSError("connection_error")
+        return [{"hostname": host, "host": address, "port": port, "family": address_family,
+                 "proto": 0, "flags": socket.AI_NUMERICHOST} for address, address_family in addresses]
+
+    async def close(self):
+        # dnspython's async query contexts own and close their sockets.
+        pass
+
+
+def _status_error(status):
+    if 300 <= status < 400:
+        return "redirect_denied"
+    return {401: "unauthorized", 403: "forbidden", 404: "not_found"}.get(
+        status, "server_error" if status >= 500 else "request_rejected")
+
+
+async def _reject_redirect(_session, _context, params):
+    # ws_connect has no allow_redirects argument. This hook runs before aiohttp
+    # follows Location, including same-origin redirects that retain the key.
+    params.response.close()
+    raise MediaServerError("redirect_denied")
+
+
+def _decode_json(body):
+    try:
+        return json.loads(body)
+    except (ValueError, UnicodeError, RecursionError):
+        raise MediaServerError("invalid_response") from None
+
+
+async def _receive(ws):
+    message = await ws.receive()
+    if message.type == aiohttp.WSMsgType.TEXT:
+        payload = _decode_json(message.data)
+        if not isinstance(payload, dict):
+            raise MediaServerError("invalid_response")
+        return payload
+    if (message.type == aiohttp.WSMsgType.ERROR and isinstance(message.data, aiohttp.WebSocketError)
+            and message.data.code == aiohttp.WSCloseCode.MESSAGE_TOO_BIG):
+        raise MediaServerError("response_too_large")
+    if message.type in {aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING,
+                        aiohttp.WSMsgType.ERROR}:
+        raise MediaServerError("stream_disconnected")
+    raise MediaServerError("invalid_response")
+
+
+def _validate_run(row):
+    if (not isinstance(row, dict) or not isinstance(row.get("id"), str) or not row["id"]
+            or type(row.get("library_id")) is not int or not 0 < row["library_id"] <= _NATIVE_INT_MAX
+            or not isinstance(row.get("mode"), str) or not isinstance(row.get("status"), str)
+            or row.get("mode") not in {"file", "subtree", "library"}
+            or row.get("status") not in _ACTIVE | _TERMINAL
+            or not isinstance(row.get("trigger"), str)):
+        raise MediaServerError("invalid_response")
+    if row["mode"] == "library":
+        if "path" in row and (not isinstance(row["path"], str)
+                              or row["path"] and not media_paths_equal(row["path"], row["path"])):
+            raise MediaServerError("invalid_response")
+    elif not media_paths_equal(row.get("path"), row.get("path")):
+        raise MediaServerError("invalid_response")
+    result = row.get("result")
+    if result is not None and (not isinstance(result, dict) or any(
+            type(result.get(key)) is not int or not 0 <= result[key] <= _NATIVE_INT_MAX for key in _CLEAN_COUNTERS)):
+        raise MediaServerError("invalid_response")
+
+
+def _same_target(left, right):
+    return (left["library_id"] == right["library_id"] and left["mode"] == right["mode"]
+            and (left["mode"] == "library" or media_paths_equal(left.get("path"), right.get("path"))))
+
+
+class _Observation:
+    def __init__(self, library_id, video_path):
+        self.library_id = library_id
+        self.video_path = video_path
+        self.runs = {}
+        self.sequence = 0
+        self.watermark = None
+        self.retained_text = 0
+        self.changed = asyncio.Event()
+        self.failure = None
+
+    def overlaps(self, row):
+        if row["library_id"] != self.library_id:
+            return False
+        if row["mode"] == "library":
+            return True
+        if row["mode"] == "file":
+            return media_paths_equal(row["path"], self.video_path)
+        try:
+            map_media_path(self.video_path, [{"local_path": row["path"], "remote_path": row["path"]}])
+            return True
+        except MediaServerError as error:
+            if error.code == "mapping_missing":
+                return False
+            raise
+
+    def idle(self):
+        return not any(run["row"]["status"] in _ACTIVE and self.overlaps(run["row"])
+                       for run in self.runs.values())
+
+    def check(self):
+        if self.failure:
+            raise MediaServerError(self.failure)
+
+    async def wait(self):
+        self.check()
+        self.changed.clear()
+        await self.changed.wait()
+        self.check()
+
+    async def wait_idle(self):
+        self.check()
+        while not self.idle():
+            await self.wait()
+
+    def remember(self, row, *, accepted=False, event_time=None):
+        _validate_run(row)
+        # Retain only the target, status and clean-result evidence. Progress text,
+        # arbitrary result extensions and server error messages are unnecessary.
+        result = row.get("result")
+        started, completed = _timestamp(row.get("started_at")), _timestamp(row.get("completed_at"))
+        row = {key: row.get(key) for key in ("id", "library_id", "mode", "path", "status")}
+        if row["mode"] == "library":
+            row["path"] = None
+        row["result"] = ({key: result.get(key) for key in _CLEAN_COUNTERS} if isinstance(result, dict) else None)
+        row.update(started_at=started, completed_at=completed)
+        prior = self.runs.get(row["id"])
+        charge = 4 * (len(row["id"]) + len(row.get("path") or ""))
+        previous_charge = 4 * (len(prior["row"]["id"]) + len(prior["row"].get("path") or "")) if prior else 0
+        retained_text = self.retained_text - previous_charge + charge
+        if retained_text > MediaServerHTTP.RESPONSE_LIMIT or prior is None and len(self.runs) >= _OBSERVED_LIMIT:
+            raise MediaServerError("observation_incomplete")
+        self.sequence += 1
+        if prior:
+            if not _same_target(prior["row"], row):
+                raise MediaServerError("invalid_response")
+            if prior["row"]["status"] in _TERMINAL and row["status"] != prior["row"]["status"]:
+                raise MediaServerError("observation_incomplete")
+            prior["ambiguous"] |= (event_time is None or prior["last_time"] is not None
+                                    and event_time < prior["last_time"]
+                                    or prior["row"]["started_at"] is not None
+                                    and prior["row"]["started_at"] != started)
+            # Keep the original ID object shared with the map key on replacement.
+            row["id"] = prior["row"]["id"]
+            prior["row"] = row
+            prior["last_time"] = event_time
+        else:
+            self.runs[row["id"]] = {"row": row, "first": self.sequence,
+                                    "accepted": self.sequence if accepted else 0, "accepted_time": event_time,
+                                    "last_time": event_time, "ambiguous": event_time is None}
+        self.retained_text = retained_text
+        for stamp in (event_time, started, completed):
+            if stamp is not None:
+                self.watermark = stamp if self.watermark is None else max(self.watermark, stamp)
+        self.changed.set()
+
+    def event(self, payload):
+        if payload.get("type") != "event" or payload.get("channel") != "scans":
+            raise MediaServerError("observation_incomplete")
+        event = payload.get("event")
+        if (not isinstance(event, str) or event not in _EVENT_STATUS
+                or not isinstance(payload.get("event_id"), str) or not payload["event_id"]):
+            raise MediaServerError("invalid_response")
+        row = payload.get("data")
+        _validate_run(row)
+        if row["status"] != _EVENT_STATUS[event]:
+            raise MediaServerError("invalid_response")
+        self.remember(row, accepted=event == "scan.accepted", event_time=_timestamp(payload.get("timestamp")))
+
+
+async def _handshake(ws, state):
+    hello = await _receive(ws)
+    if (hello.get("type") != "hello" or type(hello.get("schema_version")) is not int
+            or hello["schema_version"] != 1 or hello.get("required_action") != "none"
+            or not isinstance(hello.get("connection_id"), str) or not hello["connection_id"]
+            or not isinstance(hello.get("available_channels"), list) or "scans" not in hello["available_channels"]):
+        raise MediaServerError("observation_incomplete")
+    subscribed = await _receive(ws)
+    if (subscribed.get("type") != "subscribed" or not isinstance(subscribed.get("channels"), list)
+            or "scans" not in subscribed["channels"]):
+        raise MediaServerError("observation_incomplete")
+    snapshot = await _receive(ws)
+    if (snapshot.get("type") != "snapshot" or snapshot.get("channel") != "scans"
+            or not isinstance(snapshot.get("data"), list) or len(snapshot["data"]) >= _SNAPSHOT_LIMIT):
+        raise MediaServerError("observation_incomplete")
+    # Native snapshots are timestamped after the active-run query. Envelopes
+    # queued during that query retain their older publication timestamps.
+    state.watermark = _timestamp(snapshot.get("timestamp"))
+    if state.watermark is None:
+        raise MediaServerError("observation_incomplete")
+    for row in snapshot["data"]:
+        _validate_run(row)
+        if row["status"] not in _ACTIVE or row["id"] in state.runs:
+            raise MediaServerError("observation_incomplete")
+        state.remember(row)
+
+
+async def _listen(ws, state):
+    try:
+        while True:
+            state.event(await _receive(ws))
+            # A busy buffered stream must still allow the deadline and HTTP task to run.
+            await asyncio.sleep(0)
+    except MediaServerError as error:
+        state.failure = error.code
+    except (aiohttp.ClientError, OSError):
+        state.failure = "stream_disconnected"
+    except (TypeError, ValueError):
+        state.failure = "invalid_response"
+    finally:
+        state.changed.set()
+
+
+async def _post_scan(session, url, library_id, video_path, verify_ssl):
+    async with session.post(url + "/api/v1/scan", json={"library_id": library_id, "path": video_path},
+                            ssl=verify_ssl, allow_redirects=False) as response:
+        if response.status != 202:
+            raise MediaServerError(_status_error(response.status))
+        if response.content_length is not None and response.content_length > MediaServerHTTP.RESPONSE_LIMIT:
+            raise MediaServerError("response_too_large")
+        body = bytearray()
+        async for chunk in response.content.iter_chunked(8192):
+            if len(body) + len(chunk) > MediaServerHTTP.RESPONSE_LIMIT:
+                raise MediaServerError("response_too_large")
+            body.extend(chunk)
+        result = _decode_json(body)
+        if (not isinstance(result, dict) or result.get("status") != "accepted" or result.get("mode") != "file"
+                or type(result.get("library_id")) is not int or result["library_id"] != library_id):
+            raise MediaServerError("invalid_response")
+
+
+def _clean_completion(row):
+    if row["status"] in {"failed", "cancelled"}:
+        raise MediaServerError("scan_" + row["status"])
+    if row["status"] != "completed":
+        return False
+    result = row.get("result")
+    if (not isinstance(result, dict)
+            or any(type(result.get(key)) is not int or result[key] < 0 for key in _CLEAN_COUNTERS)):
+        raise MediaServerError("invalid_response")
+    if any(result[key] for key in _CLEAN_COUNTERS):
+        raise MediaServerError("scan_incomplete")
+    return True
+
+
+def _causal_completion(run, boundary):
+    row = run["row"]
+    accepted, started = run["accepted_time"], row["started_at"]
+    completed, published = row["completed_at"], run["last_time"]
+    return (not run["ambiguous"] and all(stamp is not None for stamp in (accepted, started, completed, published))
+            and accepted > boundary and boundary < started <= completed <= published and accepted <= published)
+
+
+async def _submit_and_observe(session, http, state, ensure_current=None):
+    for _attempt in range(_POST_LIMIT):
+        await state.wait_idle()
+        if ensure_current:
+            ensure_current()
+        baseline = state.sequence
+        boundary = state.watermark
+        if boundary is None:
+            raise MediaServerError("observation_incomplete")
+        await _post_scan(session, http.url, state.library_id, state.video_path, http.verify_ssl)
+        while True:
+            state.check()
+            fresh = [run for run in state.runs.values() if run["first"] > baseline and state.overlaps(run["row"])]
+            candidates = [run for run in fresh if run["accepted"] > baseline and run["accepted_time"] is not None
+                          and run["accepted_time"] > boundary and run["row"]["mode"] == "file"
+                          and media_paths_equal(run["row"]["path"], state.video_path)]
+            if len(candidates) > 1:
+                raise MediaServerError("observation_incomplete")
+            if candidates and _clean_completion(candidates[0]["row"]):
+                if len(fresh) == 1 and _causal_completion(candidates[0], boundary):
+                    if ensure_current:
+                        ensure_current()
+                    return {"status": "confirmed"}
+                # Concurrent parent/library work can skip this file or publish a stale
+                # directory cache later. Missing/old run times are also ambiguous.
+                # Wait it out, then require another run beyond the updated boundary.
+                break
+            if not candidates and fresh and state.idle():
+                # A reused run or lost accepted event is not causal proof. Its terminal
+                # event only removes a barrier, so submit a bounded trailing scan.
+                break
+            await state.wait()
+    raise MediaServerError("observation_incomplete")
+
+
+async def _refresh(http, library_id, video_path, timeout, ensure_current=None):
+    trace = aiohttp.TraceConfig()
+    trace.on_request_redirect.append(_reject_redirect)
+    network_timeout = aiohttp.ClientTimeout(total=None, connect=3, sock_connect=3, sock_read=10)
+    connector = aiohttp.TCPConnector(resolver=_NativeResolver(), use_dns_cache=False)
+    async with aiohttp.ClientSession(headers={"Authorization": http.session.headers["Authorization"],
+                                             "Accept": "application/json"}, trust_env=False,
+                                     cookie_jar=aiohttp.DummyCookieJar(), timeout=network_timeout,
+                                     trace_configs=[trace], connector=connector) as session:
+        # One event-loop monotonic deadline includes handshake, barriers, requests,
+        # streamed bodies, terminal events and graceful close. Session exit aborts
+        # transports on error or expiry instead of waiting for a close handshake.
+        async with asyncio.timeout(timeout):
+            if ensure_current:
+                ensure_current()
+            ws = await session.ws_connect(http.url + "/api/v1/events/ws", params={"channels": "scans"},
+                                          ssl=http.verify_ssl, max_msg_size=MediaServerHTTP.RESPONSE_LIMIT,
+                                          timeout=aiohttp.ClientWSTimeout(ws_close=0))
+            state = _Observation(library_id, video_path)
+            await _handshake(ws, state)
+            listener = asyncio.create_task(_listen(ws, state))
+            try:
+                result = await _submit_and_observe(session, http, state, ensure_current)
+            finally:
+                listener.cancel()
+                await asyncio.gather(listener, return_exceptions=True)
+            await ws.close()
+            if ensure_current:
+                ensure_current()
+            return result
+
+
+def refresh_file(http, library_id, video_path, *, timeout=90.0, ensure_current=None):
+    if (not isinstance(library_id, str) or not library_id or not library_id.isascii() or not library_id.isdecimal()
+            or len(library_id.lstrip("0")) > 19):
+        raise MediaServerError("library_invalid")
+    native_id = int(library_id.lstrip("0") or "0")
+    if not 0 < native_id <= 2**63 - 1:
+        raise MediaServerError("library_invalid")
+    if not media_paths_equal(video_path, video_path):
+        raise MediaServerError("path_invalid")
+    if type(timeout) not in {int, float} or timeout <= 0 or (type(timeout) is float and not math.isfinite(timeout)):
+        raise MediaServerError("invalid_timeout")
+    if timeout > 2**63 - 1:
+        raise MediaServerError("invalid_timeout")
+    try:
+        return asyncio.run(_refresh(http, native_id, video_path, min(timeout, 90.0), ensure_current))
+    except MediaServerError:
+        raise
+    except TimeoutError:
+        raise MediaServerError("timeout") from None
+    except (aiohttp.ClientSSLError, aiohttp.ClientConnectorCertificateError):
+        raise MediaServerError("tls_error") from None
+    except aiohttp.WSServerHandshakeError as error:
+        raise MediaServerError(_status_error(error.status)) from None
+    except (aiohttp.ClientError, OSError, ValueError):
+        raise MediaServerError("connection_error") from None

--- a/bazarr/silo/scans.py
+++ b/bazarr/silo/scans.py
@@ -402,13 +402,44 @@ async def _refresh(http, library_id, video_path, timeout, ensure_current=None):
             return result
 
 
-def refresh_file(http, library_id, video_path, *, timeout=90.0, ensure_current=None):
+def native_library_id(library_id):
+    """The saved library id as the native integer Silo answers to."""
     if (not isinstance(library_id, str) or not library_id or not library_id.isascii() or not library_id.isdecimal()
             or len(library_id.lstrip("0")) > 19):
         raise MediaServerError("library_invalid")
     native_id = int(library_id.lstrip("0") or "0")
     if not 0 < native_id <= 2**63 - 1:
         raise MediaServerError("library_invalid")
+    return native_id
+
+
+def refresh_library(http, library_id, *, ensure_current=None):
+    """Ask Silo to rescan a whole library, when it cannot scan the file itself.
+
+    Silo's file scan reads a closed set of containers and refuses any path it
+    cannot place in the library, and retrying that request cannot change the
+    answer. The library scan is the broad request Jellyfin falls back to.
+
+    It is submitted rather than observed, unlike the file scan: a full scan
+    outlives any deadline worth holding a worker on, and Silo deduplicates a
+    second one silently while still answering 202, so a completion event is
+    not evidence that this request caused anything.
+    """
+    native_id = native_library_id(library_id)
+    if ensure_current:
+        ensure_current()
+    result = http.request_json("POST", "/api/v1/scan", json={"library_id": native_id},
+                               success_statuses=(202,))
+    if (not isinstance(result, dict) or result.get("status") != "accepted" or result.get("mode") != "library"
+            or type(result.get("library_id")) is not int or result["library_id"] != native_id):
+        raise MediaServerError("invalid_response")
+    if ensure_current:
+        ensure_current()
+    return {"status": "requested"}
+
+
+def refresh_file(http, library_id, video_path, *, timeout=90.0, ensure_current=None):
+    native_id = native_library_id(library_id)
     if not media_paths_equal(video_path, video_path):
         raise MediaServerError("path_invalid")
     if type(timeout) not in {int, float} or timeout <= 0 or (type(timeout) is float and not math.isfinite(timeout)):

--- a/bazarr/silo/scans.py
+++ b/bazarr/silo/scans.py
@@ -16,7 +16,7 @@ import dns.asyncresolver
 import dns.exception
 
 from media_servers.http import MediaServerError, MediaServerHTTP
-from media_servers.paths import map_media_path, media_paths_equal
+from media_servers.paths import is_media_path, map_media_path, media_paths_equal
 
 
 _ACTIVE = {"accepted", "running"}
@@ -97,6 +97,22 @@ def _status_error(status):
         status, "server_error" if status >= 500 else "request_rejected")
 
 
+class _Unscannable(MediaServerError):
+    """Silo's documented 400: this path is not one it can scan, ever.
+
+    Every other refusal Silo can answer with also collapses into
+    ``request_rejected`` through :func:`_status_error` - a 409, a 422, a rate
+    limit, and a refused handshake on the event stream. Those say the request
+    or the connection failed, not that the file is not here, and the caller has
+    to be able to tell the two apart. Carrying the same code keeps the
+    distinction private to this module: nothing outside it ever sees a refusal
+    it does not already know.
+    """
+
+    def __init__(self):
+        super().__init__("request_rejected")
+
+
 async def _reject_redirect(_session, _context, params):
     # ws_connect has no allow_redirects argument. This hook runs before aiohttp
     # follows Location, including same-origin redirects that retain the key.
@@ -137,9 +153,9 @@ def _validate_run(row):
         raise MediaServerError("invalid_response")
     if row["mode"] == "library":
         if "path" in row and (not isinstance(row["path"], str)
-                              or row["path"] and not media_paths_equal(row["path"], row["path"])):
+                              or row["path"] and not is_media_path(row["path"])):
             raise MediaServerError("invalid_response")
-    elif not media_paths_equal(row.get("path"), row.get("path")):
+    elif not is_media_path(row.get("path")):
         raise MediaServerError("invalid_response")
     result = row.get("result")
     if result is not None and (not isinstance(result, dict) or any(
@@ -298,6 +314,8 @@ async def _listen(ws, state):
 async def _post_scan(session, url, library_id, video_path, verify_ssl):
     async with session.post(url + "/api/v1/scan", json={"library_id": library_id, "path": video_path},
                             ssl=verify_ssl, allow_redirects=False) as response:
+        if response.status == 400:
+            raise _Unscannable()
         if response.status != 202:
             raise MediaServerError(_status_error(response.status))
         if response.content_length is not None and response.content_length > MediaServerHTTP.RESPONSE_LIMIT:
@@ -413,7 +431,7 @@ def native_library_id(library_id):
     return native_id
 
 
-def refresh_library(http, library_id, *, ensure_current=None):
+def refresh_library(http, library_id, *, ensure_current=None, coalesce=None):
     """Ask Silo to rescan a whole library, when it cannot scan the file itself.
 
     Silo's file scan reads a closed set of containers and refuses any path it
@@ -424,10 +442,17 @@ def refresh_library(http, library_id, *, ensure_current=None):
     outlives any deadline worth holding a worker on, and Silo deduplicates a
     second one silently while still answering 202, so a completion event is
     not evidence that this request caused anything.
+
+    One scan covers every file in the library. ``coalesce(library)`` answers
+    whether the caller already asked for this one and records it when it has
+    not, so a batch that lands every target on this rung submits one scan
+    rather than one per video.
     """
     native_id = native_library_id(library_id)
     if ensure_current:
         ensure_current()
+    if coalesce is not None and coalesce(native_id):
+        return {"status": "requested"}
     result = http.request_json("POST", "/api/v1/scan", json={"library_id": native_id},
                                success_statuses=(202,))
     if (not isinstance(result, dict) or result.get("status") != "accepted" or result.get("mode") != "library"
@@ -439,8 +464,18 @@ def refresh_library(http, library_id, *, ensure_current=None):
 
 
 def refresh_file(http, library_id, video_path, *, timeout=90.0, ensure_current=None):
+    """The observed scan of one file, or nothing when Silo cannot scan it.
+
+    Nothing means the documented 400 and only that: a path Silo cannot place in
+    the library, or a container its scanner does not read. No retry of the same
+    request changes either answer, so this rung has nothing left to say and the
+    ladder climbs on. Everything else - a refused handshake on the event
+    stream, a conflict, a rate limit, a scan that ran and fell short - keeps its
+    own refusal, because a broken destination must not read as an absent file
+    and quietly escalate every publication to a whole-library scan.
+    """
     native_id = native_library_id(library_id)
-    if not media_paths_equal(video_path, video_path):
+    if not is_media_path(video_path):
         raise MediaServerError("path_invalid")
     if type(timeout) not in {int, float} or timeout <= 0 or (type(timeout) is float and not math.isfinite(timeout)):
         raise MediaServerError("invalid_timeout")
@@ -448,6 +483,8 @@ def refresh_file(http, library_id, video_path, *, timeout=90.0, ensure_current=N
         raise MediaServerError("invalid_timeout")
     try:
         return asyncio.run(_refresh(http, native_id, video_path, min(timeout, 90.0), ensure_current))
+    except _Unscannable:
+        return None
     except MediaServerError:
         raise
     except TimeoutError:

--- a/bazarr/subtitles/download.py
+++ b/bazarr/subtitles/download.py
@@ -5,6 +5,8 @@ import os
 import sys
 import logging
 from functools import partial
+from media_servers.events import publication_callback
+from arr_instances.resolution import scoped
 import subliminal
 import ast
 
@@ -89,7 +91,7 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
             languages_that_landed = []
             for language in language_set:
                 # confirm if language is still missing or if cutoff has been reached
-                if check_if_still_required and language not in check_missing_languages(path, media_type):
+                if check_if_still_required and language not in check_missing_languages(path, media_type, arr_instance_id):
                     # cutoff has been reached
                     logging.debug(f"BAZARR this language ({parse_language_object(language)}) is ignored because cutoff "  # noqa: G004
                                   f"has been reached during this search.")
@@ -161,7 +163,10 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
                                                                  chmod=chmod,
                                                                  formats=subtitle_formats,
                                                                  path_decoder=force_unicode,
-                                                                 write_subtitle=partial(write_subtitle_file, path, written_paths=written_paths)
+                                                                 write_subtitle=partial(
+                                                                     write_subtitle_file, path, written_paths=written_paths,
+                                                                     on_publish=publication_callback(
+                                                                         media_type, path, 'download', arr_instance_id))
                                                                  )
                                 if is_upgrade and previous_subtitles_to_delete and written_paths and (
                                         os.path.normcase(os.path.realpath(previous_subtitles_to_delete)) not in
@@ -169,6 +174,8 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
                                     try:
                                         with subtitle_mutation(path, previous_subtitles_to_delete):
                                             os.remove(previous_subtitles_to_delete)
+                                            publication_callback(media_type, path, 'download', arr_instance_id)(
+                                                previous_subtitles_to_delete)
                                     except OSError:
                                         logging.exception('BAZARR unable to remove superseded subtitle: %s',
                                                           previous_subtitles_to_delete)
@@ -208,7 +215,8 @@ def generate_subtitles(path, languages, audio_language, sceneName, title, media_
                                 processed_subtitle = process_subtitle(subtitle=subtitle, media_type=media_type,
                                                                       audio_language=audio_language,
                                                                       is_upgrade=is_upgrade, is_manual=False,
-                                                                      path=path, max_score=max_score, job_id=job_id)
+                                                                      path=path, max_score=max_score, job_id=job_id,
+                                                                      arr_instance_id=arr_instance_id)
                                 if not processed_subtitle:
                                     logging.debug(f"BAZARR unable to process this subtitles: {subtitle}")  # noqa: G004
                                     continue
@@ -259,22 +267,21 @@ def parse_language_object(language):
         return language
 
 
-def check_missing_languages(path, media_type):
+def check_missing_languages(path, media_type, arr_instance_id=None):
     # confirm if language is still missing or if cutoff has been reached
+    reversed_path = path_mappings.path_replace_reverse_instance(path, arr_instance_id, media_type)
     if media_type == 'series':
-        confirmed_missing_subs = database.execute(
+        confirmed_missing_subs = database.execute(scoped(
             select(TableEpisodes.missing_subtitles)
-            .where(TableEpisodes.path == path_mappings.path_replace_reverse(path)))\
+            .where(TableEpisodes.path == reversed_path), TableEpisodes.arr_instance_id, arr_instance_id))\
             .first()
     else:
-        confirmed_missing_subs = database.execute(
+        confirmed_missing_subs = database.execute(scoped(
             select(TableMovies.missing_subtitles)
-            .where(TableMovies.path == path_mappings.path_replace_reverse_movie(path)))\
+            .where(TableMovies.path == reversed_path), TableMovies.arr_instance_id, arr_instance_id))\
             .first()
 
     if not confirmed_missing_subs:
-        reversed_path = path_mappings.path_replace_reverse(path) if media_type == 'series' else \
-            path_mappings.path_replace_reverse_movie(path)
         logging.debug(f"BAZARR no media with this path have been found in database: {reversed_path}")  # noqa: G004
         return []
 

--- a/bazarr/subtitles/manual.py
+++ b/bazarr/subtitles/manual.py
@@ -5,6 +5,7 @@ import os
 import sys
 import logging
 from functools import partial
+from media_servers.events import publication_callback
 import subliminal
 
 from subzero.language import Language
@@ -18,7 +19,7 @@ from app.config import settings
 from utilities.helper import get_target_folder, force_unicode
 from utilities.path_mappings import path_mappings
 from app.database import (database, get_profiles_list, select, TableEpisodes, TableShows, get_audio_profile_languages,
-                          get_profile_id, TableMovies)
+                          TableMovies)
 from app.jobs_queue import jobs_queue
 from app.notifier import send_notifications, send_notifications_movie
 from sonarr.history import history_log
@@ -207,7 +208,10 @@ def manual_download_subtitle(path, audio_language, hi, forced, subtitle, provide
                                                      chmod=chmod,
                                                      formats=(subtitle.format,),
                                                      path_decoder=force_unicode,
-                                                     write_subtitle=partial(write_subtitle_file, path, written_paths=written_paths))
+                                                     write_subtitle=partial(
+                                                         write_subtitle_file, path, written_paths=written_paths,
+                                                         on_publish=publication_callback(
+                                                             media_type, path, 'download', arr_instance_id)))
                     saved_subtitles = [saved for saved in saved_subtitles if saved.storage_path in written_paths]
 
             except Exception as e:
@@ -222,7 +226,7 @@ def manual_download_subtitle(path, audio_language, hi, forced, subtitle, provide
                         processed_subtitle = process_subtitle(subtitle=saved_subtitle, media_type=media_type,
                                                               audio_language=audio_language, is_upgrade=False,
                                                               is_manual=True, path=path, max_score=max_score,
-                                                              job_id=job_id)
+                                                              job_id=job_id, arr_instance_id=arr_instance_id)
                         if processed_subtitle:
                             return processed_subtitle
                         else:
@@ -252,7 +256,9 @@ def episode_manually_download_specific_subtitle(sonarr_series_id, sonarr_episode
             TableEpisodes.sceneName,
             TableEpisodes.season,
             TableEpisodes.episode,
+            TableEpisodes.arr_instance_id,
             TableEpisodes.title.label('episodeTitle'),
+            TableShows.profileId,
             TableShows.title)
         .select_from(TableEpisodes)
         .join(TableShows)
@@ -267,7 +273,8 @@ def episode_manually_download_specific_subtitle(sonarr_series_id, sonarr_episode
     jobs_queue.update_job_name(job_id=job_id, new_job_name=f"Manually downloading Subtitles for {title} - "
                                                            f"S{episodeInfo.season:02d}E{episodeInfo.episode:02d} - "
                                                            f"{episodeInfo.episodeTitle}")
-    episodePath = path_mappings.path_replace(episodeInfo.path)
+    arr_instance_id = episodeInfo.arr_instance_id
+    episodePath = path_mappings.path_replace_instance(episodeInfo.path, arr_instance_id, 'series')
     sceneName = episodeInfo.sceneName or "None"
 
     audio_language_list = get_audio_profile_languages(episodeInfo.audio_language)
@@ -279,7 +286,7 @@ def episode_manually_download_specific_subtitle(sonarr_series_id, sonarr_episode
     try:
         result = manual_download_subtitle(episodePath, audio_language, hi, forced, subtitle, selected_provider,
                                           sceneName, title, 'series', use_original_format,
-                                          profile_id=get_profile_id(episode_id=sonarr_episode_id), job_id=job_id,
+                                          profile_id=episodeInfo.profileId, job_id=job_id,
                                           arr_instance_id=arr_instance_id)
     except OSError:
         return 'Unable to save subtitles file', 500
@@ -311,6 +318,8 @@ def movie_manually_download_specific_subtitle(radarr_id, hi, forced, use_origina
                TableMovies.year,
                TableMovies.path,
                TableMovies.sceneName,
+               TableMovies.arr_instance_id,
+               TableMovies.profileId,
                TableMovies.audio_language)
         .where(TableMovies.radarrId == radarr_id),
         TableMovies.arr_instance_id, arr_instance_id)) \
@@ -322,7 +331,8 @@ def movie_manually_download_specific_subtitle(radarr_id, hi, forced, use_origina
     title = movieInfo.title
     jobs_queue.update_job_name(job_id=job_id, new_job_name=f"Manually downloading Subtitles for {title} "
                                                            f"({movieInfo.year})")
-    moviePath = path_mappings.path_replace_movie(movieInfo.path)
+    arr_instance_id = movieInfo.arr_instance_id
+    moviePath = path_mappings.path_replace_instance(movieInfo.path, arr_instance_id, 'movie')
     sceneName = movieInfo.sceneName or "None"
 
     audio_language_list = get_audio_profile_languages(movieInfo.audio_language)
@@ -334,7 +344,7 @@ def movie_manually_download_specific_subtitle(radarr_id, hi, forced, use_origina
     try:
         result = manual_download_subtitle(moviePath, audio_language, hi, forced, subtitle, selected_provider,
                                           sceneName, title, 'movie', use_original_format,
-                                          profile_id=get_profile_id(movie_id=radarr_id), job_id=job_id,
+                                          profile_id=movieInfo.profileId, job_id=job_id,
                                           arr_instance_id=arr_instance_id)
     except OSError:
         return 'Unable to save subtitles file', 500

--- a/bazarr/subtitles/mass_download/movies.py
+++ b/bazarr/subtitles/mass_download/movies.py
@@ -14,8 +14,7 @@ from radarr.history import history_log_movie
 from arr_instances.resolution import scoped
 from app.notifier import send_notifications_movie
 from app.get_providers import get_providers
-from app.database import (get_exclusion_clause, get_audio_profile_languages, TableMovies, database, select,
-                          get_profile_id)
+from app.database import get_exclusion_clause, get_audio_profile_languages, TableMovies, database, select
 from app.jobs_queue import jobs_queue
 from app.event_handler import event_stream
 
@@ -46,6 +45,7 @@ def movies_download_subtitles(no, job_id=None, job_sub_function=False, arr_insta
                   TableMovies.tags,
                   TableMovies.monitored,
                   TableMovies.profileId,
+                  TableMovies.arr_instance_id,
                   TableMovies.subtitles)
         .where(reduce(operator.and_, conditions)),
         TableMovies.arr_instance_id, arr_instance_id)
@@ -57,14 +57,15 @@ def movies_download_subtitles(no, job_id=None, job_sub_function=False, arr_insta
         return
     elif movie.subtitles is None:
         # subtitles indexing for this movie is incomplete, we'll do it again
-        store_subtitles_movie(movie.path, path_mappings.path_replace_instance(movie.path, arr_instance_id, 'movie'), arr_instance_id=arr_instance_id)
+        store_subtitles_movie(movie.path, path_mappings.path_replace_instance(movie.path, movie.arr_instance_id, 'movie'), arr_instance_id=movie.arr_instance_id)
         movie = database.execute(stmt).first()
     elif movie.missing_subtitles is None:
         # missing subtitles calculation for this movie is incomplete, we'll do it again
         list_missing_subtitles_movies(no=no, arr_instance_id=arr_instance_id)
         movie = database.execute(stmt).first()
 
-    moviePath = path_mappings.path_replace_movie(movie.path)
+    arr_instance_id = movie.arr_instance_id
+    moviePath = path_mappings.path_replace_instance(movie.path, arr_instance_id, 'movie')
 
     if not os.path.exists(moviePath):
         logging.debug(f"BAZARR movie file not found. Path mapping issue?: {moviePath}")  # noqa: G004
@@ -135,6 +136,8 @@ def movie_download_specific_subtitles(radarr_id, language, hi, forced, job_id=No
                 TableMovies.title,
                 TableMovies.path,
                 TableMovies.sceneName,
+                TableMovies.arr_instance_id,
+                TableMovies.profileId,
                 TableMovies.audio_language)
             .where(TableMovies.radarrId == radarr_id),
             TableMovies.arr_instance_id, arr_instance_id)) \
@@ -143,7 +146,8 @@ def movie_download_specific_subtitles(radarr_id, language, hi, forced, job_id=No
     if not movieInfo:
         return 'Movie not found', 404
 
-    moviePath = path_mappings.path_replace_movie(movieInfo.path)
+    arr_instance_id = movieInfo.arr_instance_id
+    moviePath = path_mappings.path_replace_instance(movieInfo.path, arr_instance_id, 'movie')
 
     if not os.path.exists(moviePath):
         return 'Movie file not found. Path mapping issue?', 500
@@ -170,7 +174,7 @@ def movie_download_specific_subtitles(radarr_id, language, hi, forced, job_id=No
 
     try:
         result = list(generate_subtitles(moviePath, [(language, hi, forced)], audio_language,
-                                         sceneName, title, 'movie', profile_id=get_profile_id(movie_id=radarr_id),
+                                         sceneName, title, 'movie', profile_id=movieInfo.profileId,
                                          job_id=job_id, arr_instance_id=arr_instance_id))
         if isinstance(result, list) and len(result):
             result = result[0]

--- a/bazarr/subtitles/mass_download/series.py
+++ b/bazarr/subtitles/mass_download/series.py
@@ -15,7 +15,7 @@ from sonarr.history import history_log
 from app.notifier import send_notifications
 from app.get_providers import get_providers
 from app.database import (get_exclusion_clause, get_audio_profile_languages, TableShows, TableEpisodes, database,
-                          select, get_profile_id)
+                          select)
 from app.jobs_queue import jobs_queue
 from app.event_handler import event_stream
 from app.config import settings
@@ -136,7 +136,8 @@ def episode_download_subtitles(no, job_id=None, job_sub_function=False, provider
         list_missing_subtitles(epno=no, arr_instance_id=arr_instance_id)
         episode = database.execute(stmt).first()
 
-    episodePath = path_mappings.path_replace_instance(episode.path, episode.arr_instance_id, 'series')
+    arr_instance_id = episode.arr_instance_id
+    episodePath = path_mappings.path_replace_instance(episode.path, arr_instance_id, 'series')
 
     if not os.path.exists(episodePath):
         logging.debug(f"BAZARR episode file not found. Path mapping issue?: {episodePath}")  # noqa: G004
@@ -218,6 +219,7 @@ def episode_download_specific_subtitles(sonarr_series_id, sonarr_episode_id, lan
                    TableEpisodes.season,
                    TableEpisodes.episode,
                    TableEpisodes.title.label("episodeTitle"),
+                   TableShows.profileId,
                    TableShows.title)
             .select_from(TableEpisodes)
             .join(TableShows)
@@ -228,7 +230,8 @@ def episode_download_specific_subtitles(sonarr_series_id, sonarr_episode_id, lan
     if not episodeInfo:
         return 'Episode not found', 404
 
-    episodePath = path_mappings.path_replace_instance(episodeInfo.path, episodeInfo.arr_instance_id, 'series')
+    arr_instance_id = episodeInfo.arr_instance_id
+    episodePath = path_mappings.path_replace_instance(episodeInfo.path, arr_instance_id, 'series')
 
     if not os.path.exists(episodePath):
         return 'Episode file not found. Path mapping issue?', 500
@@ -258,7 +261,7 @@ def episode_download_specific_subtitles(sonarr_series_id, sonarr_episode_id, lan
 
     try:
         result = list(generate_subtitles(episodePath, [(language, hi, forced)], audio_language, sceneName,
-                                         title, 'series', profile_id=get_profile_id(episode_id=sonarr_episode_id),
+                                         title, 'series', profile_id=episodeInfo.profileId,
                                          job_id=job_id, arr_instance_id=arr_instance_id))
         if isinstance(result, list) and len(result):
             result = result[0]

--- a/bazarr/subtitles/mass_operations.py
+++ b/bazarr/subtitles/mass_operations.py
@@ -739,6 +739,7 @@ def _process_subtitle_item(item, action, options, job_id):
             item['video_path'],
             # Resolve keep-lyrics against the per-item owning instance (#227).
             arr_instance_id=item.get('arr_instance_id'),
+            media_type='episode' if item['sonarr_series_id'] else 'movies',
         )
         return True
     return False

--- a/bazarr/subtitles/post_processing.py
+++ b/bazarr/subtitles/post_processing.py
@@ -10,11 +10,15 @@ from utilities.helper import get_target_folder
 from subtitles.tools.subsync_engines import subtitle_write_locks, subtitle_mutation
 
 
-def postprocessing(command, path, subtitle_path=None):
+def postprocessing(command, path, subtitle_path=None, *, lock_paths=None):
     # Configured commands can mutate subtitles in place. This is the one boundary
     # that must hold this media's mutation locks while the external command runs.
-    destination = os.path.join(get_target_folder(path, create=False) or os.path.dirname(path), '.destination')
-    with subtitle_write_locks(path, path, destination, subtitle_path or path) as states:
+    if lock_paths is None:
+        destination = os.path.join(get_target_folder(path, create=False) or os.path.dirname(path), '.destination')
+        lock_paths = (path, destination, subtitle_path or path)
+    # A caller already holding these locks must reuse its resolved directories.
+    # Live destination settings may have changed since that outer acquisition.
+    with subtitle_write_locks(path, *lock_paths) as states:
         watched_paths = {watched for state in states.values() for watched in state.revisions}
         if subtitle_path:
             watched_paths.add(subtitle_path)

--- a/bazarr/subtitles/processing.py
+++ b/bazarr/subtitles/processing.py
@@ -2,16 +2,19 @@
 # fmt: off
 
 import logging
+import os
+from media_servers.events import observe_subtitle_change
 
 from app.config import settings, sync_checker as _defaul_sync_checker
 from utilities.path_mappings import path_mappings
 from utilities.post_processing import pp_replace, set_chmod
 from utilities.autopulse_webhook import call_external_webhook
+from utilities.helper import get_target_folder
 from languages.get_languages import alpha2_from_alpha3, alpha2_from_language, alpha3_from_language, language_from_alpha3
 from app.database import TableShows, TableEpisodes, TableMovies, database, select
 from radarr.notify import notify_radarr
 from sonarr.notify import notify_sonarr
-from arr_instances.resolution import client_for_instance
+from arr_instances.resolution import client_for_instance, scoped
 from plex.operations import plex_set_movie_added_date_now, plex_update_library, plex_set_episode_added_date_now, plex_refresh_item  # noqa: F401
 from jellyfin.operations import jellyfin_refresh_item
 from app.event_handler import event_stream
@@ -21,6 +24,7 @@ from .post_processing import postprocessing
 from .utils import _get_scores
 from .language_profiles import profile_item_language_code
 from .tools.combine.main import try_combine_for_video
+from .tools.subsync_engines import subtitle_write_locks
 
 
 class ProcessSubtitlesResult:
@@ -202,7 +206,7 @@ def _trigger_auto_translation(downloaded_lang, subtitle_path, video_path, media_
         logging.exception('BAZARR error in _trigger_auto_translation')
 
 
-def _trigger_combine(video_path, media_type, radarr_id, series_id, episode_id):
+def _trigger_combine(video_path, media_type, radarr_id, series_id, episode_id, arr_instance_id=None):
     """After a subtitle download/upgrade/translate completes, try to build or
     rebuild the combined subtitle file for the video's profile rule. Best-effort:
     never raises, never blocks the caller."""
@@ -213,6 +217,7 @@ def _trigger_combine(video_path, media_type, radarr_id, series_id, episode_id):
             radarr_id=radarr_id,
             sonarr_series_id=series_id,
             sonarr_episode_id=episode_id,
+            arr_instance_id=arr_instance_id,
         )
     except Exception:
         logging.exception("BAZARR error in _trigger_combine")
@@ -241,7 +246,7 @@ def _postprocessing_config(media_type, arr_instance_id):
 
 
 def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_upgrade=False, is_manual=False,
-                     job_id=None):
+                     job_id=None, arr_instance_id=None):
     downloaded_provider = subtitle.provider_name
     uploader = subtitle.uploader
     release_info = subtitle.release_info
@@ -275,12 +280,13 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
     logging.debug("Sync checker: %s", sync_checker)
 
     if media_type == 'series':
-        episode_metadata = database.execute(
+        episode_metadata = database.execute(scoped(
             select(TableShows.imdbId, TableShows.tvdbId, TableEpisodes.sonarrSeriesId,
                    TableEpisodes.sonarrEpisodeId, TableEpisodes.season, TableEpisodes.episode,
                    TableEpisodes.arr_instance_id)
                 .join(TableShows)\
-                .where(TableEpisodes.path == path_mappings.path_replace_reverse(path)))\
+                .where(TableEpisodes.path == path_mappings.path_replace_reverse_instance(path, arr_instance_id, 'series')),
+                TableEpisodes.arr_instance_id, arr_instance_id))\
             .first()
         if not episode_metadata:
             return
@@ -299,11 +305,12 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
                            sonarr_episode_id=episode_metadata.sonarrEpisodeId,
                            job_id=job_id,
                            arr_instance_id=episode_metadata.arr_instance_id,
-                           owns_job_progress=False)
+                           owns_job_progress=False, publication_operation='download')
     else:
-        movie_metadata = database.execute(
+        movie_metadata = database.execute(scoped(
             select(TableMovies.radarrId, TableMovies.imdbId, TableMovies.tmdbId, TableMovies.arr_instance_id)
-                .where(TableMovies.path == path_mappings.path_replace_reverse_movie(path)))\
+                .where(TableMovies.path == path_mappings.path_replace_reverse_instance(path, arr_instance_id, 'movie')),
+                TableMovies.arr_instance_id, arr_instance_id))\
             .first()
         if not movie_metadata:
             return
@@ -321,7 +328,7 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
                            radarr_id=movie_metadata.radarrId,
                            job_id=job_id,
                            arr_instance_id=movie_metadata.arr_instance_id,
-                           owns_job_progress=False)
+                           owns_job_progress=False, publication_operation='download')
 
     use_postprocessing, postprocessing_cmd, use_pp_threshold, pp_threshold = _postprocessing_config(
         media_type, owner_instance_id)
@@ -333,8 +340,13 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
 
         if not use_pp_threshold or (use_pp_threshold and percent_score < pp_threshold):
             logging.debug(f"BAZARR Using post-processing command: {command}")  # noqa: G004
-            postprocessing(command, path, subtitle_path=downloaded_path)
-            set_chmod(subtitles_path=downloaded_path)
+            destination = os.path.join(get_target_folder(path, create=False) or os.path.dirname(path), '.destination')
+            lock_paths = (path, destination, downloaded_path)
+            # Match the command's complete lock set before observing any bytes.
+            with subtitle_write_locks(path, *lock_paths):
+                with observe_subtitle_change(media_type, path, downloaded_path, 'download', owner_instance_id):
+                    postprocessing(command, path, subtitle_path=downloaded_path, lock_paths=lock_paths)
+                    set_chmod(subtitles_path=downloaded_path)
         else:
             logging.debug(f"BAZARR post-processing skipped because subtitles score isn't below this "  # noqa: G004
                           f"threshold value: {pp_threshold}%")
@@ -416,6 +428,7 @@ def process_subtitle(subtitle, media_type, audio_language, path, max_score, is_u
         radarr_id=movie_metadata.radarrId if media_type != 'series' else None,
         series_id=series_id if media_type == 'series' else None,
         episode_id=episode_id if media_type == 'series' else None,
+        arr_instance_id=owner_instance_id,
     )
 
     return ProcessSubtitlesResult(message=message,

--- a/bazarr/subtitles/sync.py
+++ b/bazarr/subtitles/sync.py
@@ -3,6 +3,7 @@
 
 import logging
 import gc
+from media_servers.events import publication_callback
 
 from app.config import settings
 from app.jobs_queue import jobs_queue, JobCancelled
@@ -261,7 +262,8 @@ def sync_subtitles(video_path,
                    arr_instance_id=None,
                    owns_job_progress=True,
                    source_version=None,
-                   on_success=None):
+                   on_success=None,
+                   publication_operation='sync'):
     try:
         # The audio-sync settings resolve against the owning instance (#227); a None
         # owner / unset override yields the global value, so legacy paths are
@@ -343,6 +345,8 @@ def sync_subtitles(video_path,
                 'enabled_engines': enabled_engines,
                 'progress_callback': update_progress if track_job_progress else None,
                 'arr_instance_id': arr_instance_id,
+                'on_publish': publication_callback('episode' if sonarr_episode_id is not None else 'movie',
+                                                   video_path, publication_operation, arr_instance_id),
             }
             sync_result = None
             if source_version is not None:

--- a/bazarr/subtitles/tools/combine/main.py
+++ b/bazarr/subtitles/tools/combine/main.py
@@ -6,6 +6,7 @@ import re
 import stat
 from dataclasses import dataclass
 from subtitles.tools.subsync_engines import staged_subtitle_write, subtitle_mutation, sync_output_owner_is_unique
+from media_servers.events import publication_callback
 
 from .composer import compose
 from .naming import compose_combined_filename, external_subtitles_dir
@@ -25,7 +26,7 @@ class CombineResult:
 
 def try_combine_for_video(video_path, media_type, sonarr_series_id=None,
                             sonarr_episode_id=None, radarr_id=None,
-                            languages=None, format=None):
+                            languages=None, format=None, arr_instance_id=None):
     """Single entry point: build (or rebuild) a combined subtitle file
     for the given video. Best-effort, never raises.
 
@@ -36,6 +37,7 @@ def try_combine_for_video(video_path, media_type, sonarr_series_id=None,
         rule = _resolve_rule(
             media_type, sonarr_series_id, sonarr_episode_id, radarr_id,
             override_languages=languages, override_format=format,
+            video_path=video_path, arr_instance_id=arr_instance_id,
         )
         if rule is None:
             return CombineResult(status="skipped", reason="no rule")
@@ -101,7 +103,10 @@ def try_combine_for_video(video_path, media_type, sonarr_series_id=None,
                 os.makedirs(out_dir, exist_ok=True)
             with staged_subtitle_write(
                     video_path, out_path, source_paths=(sources.primary, *sources.secondaries),
-                    after_publish=lambda: _remove_stale_combined_siblings(out_path, video_path)) as temporary:
+                    on_publish=publication_callback(media_type, video_path, 'combine', arr_instance_id),
+                    after_publish=lambda: _remove_stale_combined_siblings(
+                        out_path, video_path, publication_callback(media_type, video_path, 'combine', arr_instance_id))
+                    ) as temporary:
                 content = compose(primary_path=sources.primary, secondary_paths=sources.secondaries,
                                   format=rule["format"])
                 with open(temporary, "wb") as fh:
@@ -111,7 +116,7 @@ def try_combine_for_video(video_path, media_type, sonarr_series_id=None,
             return CombineResult(status="failed", error=str(e))
 
         _post_write(out_path, video_path, media_type,
-                     sonarr_episode_id, radarr_id)
+                     sonarr_episode_id, radarr_id, arr_instance_id=arr_instance_id)
 
         logging.info(
             "BAZARR combine built %s for %s", out_path, video_path,
@@ -152,7 +157,7 @@ def _normalize_language_codes(languages):
 _COMBINED_OUTPUT_EXTS = (".srt", ".ass", ".ssa")
 
 
-def _remove_stale_combined_siblings(out_path, video_path):
+def _remove_stale_combined_siblings(out_path, video_path, on_publish=None):
     """Remove combined-output siblings that share this output's stem but use a
     different subtitle extension (e.g. a stale `.ass` left next to a freshly
     written `.srt`). Best-effort: never raises.
@@ -174,6 +179,8 @@ def _remove_stale_combined_siblings(out_path, video_path):
             if stat.S_ISREG(os.lstat(sibling).st_mode):
                 with subtitle_mutation(video_path, sibling):
                     os.remove(sibling)
+                    if on_publish:
+                        on_publish(sibling)
                 logging.info("BAZARR combine removed stale sibling %s", sibling)
         except FileNotFoundError:
             continue
@@ -183,34 +190,53 @@ def _remove_stale_combined_siblings(out_path, video_path):
 
 
 def _resolve_rule(media_type, sonarr_series_id, sonarr_episode_id, radarr_id,
-                   override_languages, override_format):
+                   override_languages, override_format, video_path=None, arr_instance_id=None):
     if override_languages and override_format:
         return {"languages": list(override_languages), "format": override_format}
     profile = _profile_for(
         media_type, sonarr_series_id, sonarr_episode_id, radarr_id,
+        video_path=video_path, arr_instance_id=arr_instance_id,
     )
     return get_combine_rule(profile) if profile else None
 
 
-def _profile_for(media_type, sonarr_series_id, sonarr_episode_id, radarr_id):
-    from app.database import get_profile_id, get_profiles_list
-    # Accept both media-type conventions: the REST endpoints pass 'movies'
-    # (plural), but the auto-combine path forwards process_subtitle's 'movie'
-    # (singular). Treating only the plural as a movie silently skipped every
-    # automatic movie combine.
-    if media_type in ("movies", "movie"):
-        profile_id = get_profile_id(movie_id=radarr_id)
-    else:
-        profile_id = (
-            get_profile_id(episode_id=sonarr_episode_id)
-            or get_profile_id(series_id=sonarr_series_id)
-        )
-    if not profile_id:
+def _profile_for(media_type, sonarr_series_id, sonarr_episode_id, radarr_id,
+                 video_path=None, arr_instance_id=None):
+    from app.database import get_profiles_list
+    metadata = _metadata_for(video_path, media_type, sonarr_episode_id, radarr_id, arr_instance_id)
+    if metadata is None or not metadata.profileId:
         return None
-    return get_profiles_list(profile_id=profile_id)
+    return get_profiles_list(profile_id=metadata.profileId)
 
 
-def _post_write(out_path, video_path, media_type, sonarr_episode_id, radarr_id):
+def _metadata_for(video_path, media_type, sonarr_episode_id, radarr_id, arr_instance_id):
+    from app.database import TableEpisodes, TableShows, TableMovies, database, select
+    from arr_instances.resolution import scoped
+    from utilities.path_mappings import path_mappings
+    from media_servers.paths import media_paths_equal
+    if media_type in ('movies', 'movie'):
+        query = select(TableMovies.path, TableMovies.subtitles, TableMovies.imdbId, TableMovies.tmdbId,
+                       TableMovies.arr_instance_id, TableMovies.profileId).where(TableMovies.radarrId == radarr_id)
+        owner = TableMovies.arr_instance_id
+        kind = 'movie'
+    elif media_type in ('series', 'episode'):
+        query = select(TableEpisodes.path, TableEpisodes.sonarrSeriesId, TableEpisodes.subtitles,
+                       TableEpisodes.season, TableEpisodes.episode, TableShows.imdbId, TableShows.tvdbId,
+                       TableShows.profileId, TableEpisodes.arr_instance_id).join(TableShows).where(
+                           TableEpisodes.sonarrEpisodeId == sonarr_episode_id)
+        owner = TableEpisodes.arr_instance_id
+        kind = 'episode'
+    else:
+        return None
+    # Upstream IDs select candidates only. The actual file and explicit owner
+    # must agree before profile resolution or postprocessing can use a row.
+    rows = database.execute(scoped(query, owner, arr_instance_id)).all()
+    matches = [row for row in rows if media_paths_equal(
+        path_mappings.path_replace_instance(row.path, row.arr_instance_id, kind), video_path)]
+    return matches[0] if len(matches) == 1 else None
+
+
+def _post_write(out_path, video_path, media_type, sonarr_episode_id, radarr_id, arr_instance_id=None):
     """Hook into the same postprocess chain a downloaded subtitle uses.
 
     postprocess_subtitles uses the 'episode'/'movie' media-type convention and
@@ -221,26 +247,12 @@ def _post_write(out_path, video_path, media_type, sonarr_episode_id, radarr_id):
     endpoint does instead of passing None."""
     try:
         from api.subtitles.subtitles import postprocess_subtitles
-        from app.database import (TableEpisodes, TableShows, TableMovies,
-                                  database, select)
         is_movie = media_type in ("movies", "movie")
-        if is_movie:
-            metadata = database.execute(
-                select(TableMovies.path, TableMovies.subtitles,
-                       TableMovies.imdbId, TableMovies.tmdbId)
-                .where(TableMovies.radarrId == radarr_id)
-            ).first()
-            postprocess_subtitles(out_path, video_path, "movie", metadata, radarr_id)
-        else:
-            metadata = database.execute(
-                select(TableEpisodes.path, TableEpisodes.sonarrSeriesId,
-                       TableEpisodes.subtitles, TableEpisodes.season,
-                       TableEpisodes.episode, TableShows.imdbId, TableShows.tvdbId)
-                .join(TableShows)
-                .where(TableEpisodes.sonarrEpisodeId == sonarr_episode_id)
-            ).first()
-            postprocess_subtitles(out_path, video_path, "episode", metadata,
-                                  sonarr_episode_id)
+        metadata = _metadata_for(video_path, media_type, sonarr_episode_id, radarr_id, arr_instance_id)
+        if metadata is not None:
+            postprocess_subtitles(out_path, video_path, "movie" if is_movie else "episode", metadata,
+                                  radarr_id if is_movie else sonarr_episode_id,
+                                  arr_instance_id=metadata.arr_instance_id)
     except Exception:
         logging.exception("BAZARR combine post-write hook failed")
 

--- a/bazarr/subtitles/tools/delete.py
+++ b/bazarr/subtitles/tools/delete.py
@@ -2,6 +2,7 @@
 
 import os
 import logging
+from media_servers.events import publication_callback
 
 from subliminal.subtitle import SUBTITLE_EXTENSIONS
 
@@ -25,7 +26,7 @@ from plex.operations import plex_refresh_item
 from jellyfin.operations import jellyfin_refresh_item
 
 
-def _delete_subtitle_file(media_path, subtitle_path):
+def _delete_subtitle_file(media_path, subtitle_path, on_publish=None):
     with subtitle_write_locks(media_path, subtitle_path):
         state = subtitle_write_lock(media_path, os.path.dirname(subtitle_path))
         try:
@@ -35,6 +36,8 @@ def _delete_subtitle_file(media_path, subtitle_path):
                 state.changed(subtitle_path)
             logging.exception('BAZARR cannot delete subtitles file: %s', subtitle_path)
             return False
+        if on_publish:
+            on_publish(subtitle_path)
         state.changed(subtitle_path)
         quarantine_sync_outputs_after_mutation(media_path, subtitle_path)
         return True
@@ -98,7 +101,8 @@ def delete_subtitles(media_type, language, forced, hi, media_path, subtitles_pat
                                     hearing_impaired=None)
 
     if media_type == 'series':
-        removed = _delete_subtitle_file(media_path, pr(subtitles_path))
+        removed = _delete_subtitle_file(media_path, pr(subtitles_path),
+                                        publication_callback(media_type, media_path, 'delete', arr_instance_id))
         store_subtitles(prr(media_path), media_path, arr_instance_id=arr_instance_id)
         if not removed:
             return False
@@ -127,7 +131,8 @@ def delete_subtitles(media_type, language, forced, hi, media_path, subtitles_pat
 
         return True
     else:
-        removed = _delete_subtitle_file(media_path, pr(subtitles_path))
+        removed = _delete_subtitle_file(media_path, pr(subtitles_path),
+                                        publication_callback(media_type, media_path, 'delete', arr_instance_id))
         store_subtitles_movie(prr(media_path), media_path, arr_instance_id=arr_instance_id)
         if not removed:
             return False

--- a/bazarr/subtitles/tools/mods.py
+++ b/bazarr/subtitles/tools/mods.py
@@ -14,6 +14,7 @@ from languages.custom_lang import CustomLanguage
 from languages.get_languages import alpha3_from_alpha2
 from subtitles.indexer.utils import get_subtitle_destination_path
 from utilities.helper import get_target_folder
+from media_servers.events import publication_callback
 from subtitles.tools.subsync_engines import subtitle_write_locks, subtitle_mutation
 
 
@@ -97,7 +98,7 @@ def apply_subtitle_mods(language, subtitle_path, mods, video_path,
     try:
         subtitles_apply_mods(language=language, subtitle_path=subtitle_path,
                              mods=mods, video_path=video_path,
-                             arr_instance_id=arr_instance_id)
+                             arr_instance_id=arr_instance_id, media_type=media_type)
     except Exception:
         jobs_queue.update_job_name(
             job_id=job_id,
@@ -146,13 +147,13 @@ def apply_subtitle_mods(language, subtitle_path, mods, video_path,
     )
 
 
-def subtitles_apply_mods(language, subtitle_path, mods, video_path, arr_instance_id=None):
+def subtitles_apply_mods(language, subtitle_path, mods, video_path, arr_instance_id=None, media_type=None):
     destination = os.path.join(get_target_folder(video_path, create=False) or os.path.dirname(video_path), '.destination')
     with subtitle_write_locks(video_path, subtitle_path, destination):
-        return _apply_mods_locked(language, subtitle_path, mods, video_path, arr_instance_id)
+        return _apply_mods_locked(language, subtitle_path, mods, video_path, arr_instance_id, media_type)
 
 
-def _apply_mods_locked(language, subtitle_path, mods, video_path, arr_instance_id):
+def _apply_mods_locked(language, subtitle_path, mods, video_path, arr_instance_id, media_type=None):
     # The mod list is user-chosen here, so only the keep-lyrics preference is
     # instance-relevant: resolve it against the media's owning instance (#227).
     # A None owner keeps the legacy global-only behaviour (single-instance).
@@ -204,3 +205,11 @@ def _apply_mods_locked(language, subtitle_path, mods, video_path, arr_instance_i
 
             with open(modded_subtitles_path, 'wb') as f:
                 f.write(content)
+
+            # The mod rewrote the subtitle, and Remove HI can rename it on the
+            # way. Publish the file this leaves behind, here rather than at each
+            # caller, so every route into the mods (the subtitle toolbar, a bulk
+            # action, the job queue) reaches the same destinations.
+            if media_type:
+                publication_callback(media_type, video_path, 'edit',
+                                     arr_instance_id)(modded_subtitles_path)

--- a/bazarr/subtitles/tools/mods.py
+++ b/bazarr/subtitles/tools/mods.py
@@ -15,7 +15,8 @@ from languages.get_languages import alpha3_from_alpha2
 from subtitles.indexer.utils import get_subtitle_destination_path
 from utilities.helper import get_target_folder
 from media_servers.events import publication_callback
-from subtitles.tools.subsync_engines import subtitle_write_locks, subtitle_mutation
+from subtitles.tools.subsync_engines import (_report_subtitle_publication, subtitle_mutation,
+                                            subtitle_write_locks)
 
 
 def has_remove_hi(mods):
@@ -209,7 +210,14 @@ def _apply_mods_locked(language, subtitle_path, mods, video_path, arr_instance_i
             # The mod rewrote the subtitle, and Remove HI can rename it on the
             # way. Publish the file this leaves behind, here rather than at each
             # caller, so every route into the mods (the subtitle toolbar, a bulk
-            # action, the job queue) reaches the same destinations.
+            # action, the job queue) reaches the same destinations. Through the
+            # same guarded reporter every other publication inside a mutation
+            # uses: the file is already written, so nothing raised here may
+            # take the mod down with it.
             if media_type:
-                publication_callback(media_type, video_path, 'edit',
-                                     arr_instance_id)(modded_subtitles_path)
+                _report_subtitle_publication(
+                    publication_callback(media_type, video_path, 'edit', arr_instance_id),
+                    modded_subtitles_path)
+            else:
+                logging.debug('BAZARR mod on %s published nothing: no media type was given',
+                              video_path)

--- a/bazarr/subtitles/tools/subsync_engines.py
+++ b/bazarr/subtitles/tools/subsync_engines.py
@@ -151,7 +151,7 @@ def subtitle_mutation(video_path, *paths, invalidate_outputs=True):
 
 @contextmanager
 def staged_subtitle_write(video_path, destination, before_publish=None, allow_empty=False,
-                          source_paths=(), after_publish=None):
+                          source_paths=(), after_publish=None, on_publish=None):
     """Compute privately, then publish only while source and destination are current."""
     with subtitle_write_locks(video_path, destination, *source_paths) as states:
         def version(path):
@@ -180,6 +180,7 @@ def staged_subtitle_write(video_path, destination, before_publish=None, allow_em
                 if os.path.isfile(destination):
                     shutil.copymode(destination, temporary)
                 os.replace(temporary, destination)
+                _report_subtitle_publication(on_publish, destination)
                 if after_publish:
                     after_publish()
     finally:
@@ -187,9 +188,18 @@ def staged_subtitle_write(video_path, destination, before_publish=None, allow_em
             os.unlink(temporary)
 
 
-def write_subtitle_file(video_path, destination, content, written_paths=None):
+def _report_subtitle_publication(callback, path):
+    if callback:
+        try:
+            callback(str(path))
+        except Exception:
+            logging.warning('BAZARR subtitle publication notification failed')
+
+
+def write_subtitle_file(video_path, destination, content, written_paths=None, on_publish=None):
     """Write one saver output atomically and record that exact successful path."""
     with staged_subtitle_write(video_path, destination,
+                              on_publish=on_publish,
                               after_publish=(lambda: written_paths.append(destination))
                               if written_paths is not None else None) as temporary:
         with open(temporary, 'wb') as handle:
@@ -741,7 +751,7 @@ class SubsyncEngineRunner:
         return output_stat.st_size > 0 and output_stat.st_mtime_ns >= source_stat.st_mtime_ns
 
     def run(self, srt_path, output_mode, enabled_engines, execute_engine, force_sync=False,
-            source_version=None, before_publish=None, publication_lock=None, after_publish=None):
+            source_version=None, before_publish=None, publication_lock=None, after_publish=None, on_publish=None):
         output_mode = normalize_output_mode(output_mode)
         result = self.result = SyncRunResult(source_path=srt_path, output_mode=output_mode)
 
@@ -823,6 +833,7 @@ class SubsyncEngineRunner:
                         os.replace(str(output_path), str(final_engine_output_path))
                         final_output_path = final_engine_output_path
                         generated_path = str(final_engine_output_path)
+                    _report_subtitle_publication(on_publish, final_output_path)
                     if hasattr(state, 'changed'):
                         state.changed(final_output_path)
                     if after_publish:

--- a/bazarr/subtitles/tools/subsyncer.py
+++ b/bazarr/subtitles/tools/subsyncer.py
@@ -527,7 +527,7 @@ class SubSyncer:
     def sync(self, video_path, srt_path, srt_lang, hi, forced,
              max_offset_seconds, no_fix_framerate, gss, reference=None, sonarr_series_id=None, sonarr_episode_id=None,
              radarr_id=None, progress_callback=None, job_id=None, force_sync=False, output_mode=None,
-             enabled_engines=None, write_history=True, arr_instance_id=None, source_version=None):
+             enabled_engines=None, write_history=True, arr_instance_id=None, source_version=None, on_publish=None):
         self.reference = video_path
         self.srtin = srt_path
         self.progress_callback = progress_callback
@@ -609,6 +609,7 @@ class SubSyncer:
                 source_version=publication,
                 before_publish=publish,
                 publication_lock=publication_lock,
+                on_publish=on_publish,
                 after_publish=(lambda: quarantine_sync_outputs_after_mutation(video_path, srt_path))
                 if output_mode == OUTPUT_MODE_OVERWRITE and source_version is None else None,
             )

--- a/bazarr/subtitles/tools/translate/main.py
+++ b/bazarr/subtitles/tools/translate/main.py
@@ -104,6 +104,7 @@ def translate_subtitles_file(video_path, source_srt_file, from_lang, to_lang, fo
                 sonarr_series_id=sonarr_series_id,
                 sonarr_episode_id=sonarr_episode_id,
                 radarr_id=radarr_id,
+                arr_instance_id=arr_instance_id,
             )
         except Exception:
             logging.exception("BAZARR combine-after-translate failed for %s", video_path)

--- a/bazarr/subtitles/tools/translate/services/gemini_translator.py
+++ b/bazarr/subtitles/tools/translate/services/gemini_translator.py
@@ -13,6 +13,7 @@ import logging
 import srt
 import pysubs2
 from subtitles.tools.subsync_engines import staged_subtitle_write
+from media_servers.events import publication_callback
 import requests
 import unicodedata as ud
 from collections import Counter
@@ -110,6 +111,8 @@ class GeminiTranslatorService:
 
             try:
                 with staged_subtitle_write(self.video_path, self.dest_srt_file,
+                                           on_publish=publication_callback(self.media_type, self.video_path,
+                                                                           'translate', self.arr_instance_id),
                                        source_paths=(self.source_srt_file,),
                                            before_publish=lambda: jobs_queue.update_job_progress(job_id=job_id)) as temporary:
                     self.output_file = temporary

--- a/bazarr/subtitles/tools/translate/services/google_translator.py
+++ b/bazarr/subtitles/tools/translate/services/google_translator.py
@@ -3,6 +3,7 @@
 import logging
 import pysubs2
 from subtitles.tools.subsync_engines import staged_subtitle_write
+from media_servers.events import publication_callback
 
 from retry.api import retry
 from app.config import settings  # noqa: F401
@@ -50,6 +51,8 @@ class GoogleTranslatorService:
     def translate(self, job_id):
         try:
             with staged_subtitle_write(self.video_path, self.dest_srt_file,
+                                       on_publish=publication_callback(self.media_type, self.video_path,
+                                                                       'translate', self.arr_instance_id),
                                        source_paths=(self.source_srt_file,),
                                        before_publish=lambda: jobs_queue.update_job_progress(job_id=job_id),
                                        allow_empty=True) as temporary:

--- a/bazarr/subtitles/tools/translate/services/lingarr_translator.py
+++ b/bazarr/subtitles/tools/translate/services/lingarr_translator.py
@@ -3,6 +3,7 @@
 import logging
 import pysubs2
 from subtitles.tools.subsync_engines import staged_subtitle_write
+from media_servers.events import publication_callback
 import requests
 
 from retry.api import retry
@@ -57,6 +58,8 @@ class LingarrTranslatorService:
     def translate(self, job_id=None):
         try:
             with staged_subtitle_write(self.video_path, self.dest_srt_file,
+                                       on_publish=publication_callback(self.media_type, self.video_path,
+                                                                       'translate', self.arr_instance_id),
                                        source_paths=(self.source_srt_file,),
                                        before_publish=lambda: jobs_queue.update_job_progress(job_id=job_id),
                                        allow_empty=True) as temporary:

--- a/bazarr/subtitles/tools/translate/services/openrouter_translator.py
+++ b/bazarr/subtitles/tools/translate/services/openrouter_translator.py
@@ -5,6 +5,7 @@ import time
 import logging
 import pysubs2
 from subtitles.tools.subsync_engines import staged_subtitle_write, SubtitleDestinationChanged
+from media_servers.events import publication_callback
 import requests
 from typing import Optional, List, Dict, Any
 
@@ -173,6 +174,8 @@ class OpenRouterTranslatorService:
         self.partial_error = None
         try:
             with staged_subtitle_write(self.video_path, self.dest_srt_file,
+                                       on_publish=publication_callback(self.media_type, self.video_path,
+                                                                       'translate', self.arr_instance_id),
                                        source_paths=(self.source_srt_file,),
                                        before_publish=lambda: jobs_queue.update_job_progress(job_id=job_id),
                                        allow_empty=True) as temporary:

--- a/bazarr/subtitles/upload.py
+++ b/bazarr/subtitles/upload.py
@@ -5,6 +5,7 @@ import os
 import sys
 import logging
 from functools import partial
+from media_servers.events import publication_callback, observe_subtitle_change
 
 from subzero.language import Language
 from subliminal_patch.core import save_subtitles
@@ -191,7 +192,9 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
                                             chmod=chmod,
                                             formats=sub_format if use_original_format else ("srt",),
                                             path_decoder=force_unicode,
-                                            write_subtitle=partial(write_subtitle_file, path, written_paths=written_paths))
+                                            write_subtitle=partial(
+                                                write_subtitle_file, path, written_paths=written_paths,
+                                                on_publish=publication_callback(media_type, path, 'upload', arr_instance_id)))
             saved_subtitles = [saved for saved in saved_subtitles if saved.storage_path in written_paths]
             source_version = subtitle_source_version(saved_subtitles[0].storage_path) if saved_subtitles else None
             source_publication = (SubtitlePublication(path, saved_subtitles[0].storage_path, source_version)
@@ -242,8 +245,9 @@ def manual_upload_subtitle(path, language, forced, hi, media_type, subtitle, fil
                              sonarrEpisodeId or radarrId,)
         with subtitle_write_locks(path, subtitle_path):
             if subtitle_source_version(subtitle_path) == source_version:
-                postprocessing(command, path, subtitle_path=subtitle_path)
-                set_chmod(subtitles_path=subtitle_path)
+                with observe_subtitle_change(media_type, path, subtitle_path, 'upload', arr_instance_id):
+                    postprocessing(command, path, subtitle_path=subtitle_path)
+                    set_chmod(subtitles_path=subtitle_path)
                 source_version = subtitle_source_version(subtitle_path)
                 source_publication.release()
                 source_publication = SubtitlePublication(path, subtitle_path, source_version)

--- a/frontend/src/apis/hooks/index.ts
+++ b/frontend/src/apis/hooks/index.ts
@@ -12,3 +12,4 @@ export * from "./status";
 export * from "./subtitles";
 export * from "./system";
 export * from "./translator";
+export * from "./mediaServers";

--- a/frontend/src/apis/hooks/mediaServers.test.tsx
+++ b/frontend/src/apis/hooks/mediaServers.test.tsx
@@ -1,0 +1,292 @@
+/* eslint-disable camelcase */
+
+import { PropsWithChildren } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import type { MediaServerKind } from "@/apis/raw/mediaServers";
+import { act, renderHook, waitFor } from "@/tests";
+import server from "@/tests/mocks/node";
+import {
+  useMediaServerStatus,
+  useMediaServerTest,
+  useSaveMediaServerInstance,
+  useSiloLibraries,
+} from "./mediaServers";
+
+function queryWrapper() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        networkMode: "offlineFirst",
+        staleTime: 60000,
+        placeholderData: (previous: unknown) => previous,
+      },
+      mutations: { networkMode: "offlineFirst" },
+    },
+  });
+  return {
+    client,
+    wrapper: ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+  };
+}
+
+it("does not show another server's previous status while its own status is loading", async () => {
+  let finish: (() => void) | undefined;
+  server.use(
+    http.get("/api/system/media-server-instances/a/status", () =>
+      HttpResponse.json({ pending: 0, state: "confirmed", error_code: null }),
+    ),
+    http.get("/api/system/media-server-instances/b/status", async () => {
+      await new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+      return HttpResponse.json({
+        pending: 1,
+        state: "unconfirmed",
+        error_code: "timeout",
+      });
+    }),
+  );
+  const { wrapper, client } = queryWrapper();
+  const { result, rerender, unmount } = renderHook(
+    ({ kind }: { kind: MediaServerKind }) =>
+      useMediaServerStatus(kind, kind === "emby" ? "a" : "b"),
+    { wrapper, initialProps: { kind: "emby" } },
+  );
+  try {
+    await waitFor(() => expect(result.current.data?.state).toBe("confirmed"));
+    rerender({ kind: "silo" });
+    await waitFor(() => expect(result.current.data).toBeUndefined());
+    await waitFor(() => expect(finish).toBeDefined());
+    finish?.();
+    await waitFor(() => expect(result.current.data?.state).toBe("unconfirmed"));
+  } finally {
+    finish?.();
+    unmount();
+    client.clear();
+  }
+});
+
+it("discards late read-only results after credentials change without caching the API key", async () => {
+  let finish: (() => void) | undefined;
+  server.use(
+    http.post("/api/silo/test-connection", async () => {
+      await new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+      return HttpResponse.json({
+        success: true,
+        server_name: "Old connection",
+      });
+    }),
+  );
+  const { wrapper, client } = queryWrapper();
+  const { result, rerender, unmount } = renderHook(
+    ({ apikey }) =>
+      useMediaServerTest("silo", {
+        url: "https://silo.example",
+        api_key: apikey,
+        verify_ssl: true,
+      }),
+    { wrapper, initialProps: { apikey: "sentinel-hook-secret" } },
+  );
+  try {
+    let pending: Promise<unknown>;
+    act(() => {
+      pending = result.current.mutateAsync();
+    });
+    await waitFor(() => expect(finish).toBeDefined());
+    rerender({ apikey: "new-key" });
+    await act(async () => {
+      finish?.();
+      await pending;
+    });
+    await waitFor(() => expect(result.current.isIdle).toBe(true));
+    await waitFor(() => expect(result.current.data).toBeUndefined());
+    expect(
+      JSON.stringify(
+        client
+          .getMutationCache()
+          .getAll()
+          .map((mutation) => mutation.state),
+      ),
+    ).not.toContain("sentinel-hook-secret");
+  } finally {
+    finish?.();
+    unmount();
+    client.clear();
+  }
+});
+
+it("clears loaded Silo library choices after the URL, key or TLS setting changes", async () => {
+  server.use(
+    http.post("/api/silo/libraries", () =>
+      HttpResponse.json({
+        data: [{ id: "0007", name: "TV", type: "series", paths: ["/tv"] }],
+        error_code: null,
+      }),
+    ),
+  );
+  const { wrapper, client } = queryWrapper();
+  const initialProps = {
+    url: "https://silo.example",
+    api_key: "key",
+    verify_ssl: true,
+  };
+  const { result, rerender, unmount } = renderHook(
+    (input) => useSiloLibraries(input),
+    { wrapper, initialProps },
+  );
+  try {
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+    await waitFor(() => expect(result.current.data?.[0].id).toBe("0007"));
+    rerender({ ...initialProps, verify_ssl: false });
+    await waitFor(() => expect(result.current.data).toBeUndefined());
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+    rerender({ ...initialProps, api_key: "changed" });
+    await waitFor(() => expect(result.current.data).toBeUndefined());
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+    rerender({ ...initialProps, url: "https://other.example" });
+    await waitFor(() => expect(result.current.data).toBeUndefined());
+  } finally {
+    unmount();
+    client.clear();
+  }
+});
+
+it("isolates saved probes for two UUIDs and retains no secret mutation variables or errors", async () => {
+  const requests: unknown[] = [];
+  server.use(
+    http.post(
+      "/api/system/media-server-instances/:id/test-connection",
+      async ({ request, params }) => {
+        requests.push([params.id, await request.json()]);
+        return HttpResponse.json({}, { status: 502 });
+      },
+    ),
+  );
+  const { wrapper, client } = queryWrapper();
+  const { result, rerender, unmount } = renderHook(
+    ({ id }) =>
+      useMediaServerTest(
+        "emby",
+        {
+          url: "https://edited.example",
+          verify_ssl: false,
+          api_key: "sentinel-secret",
+        },
+        id,
+      ),
+    { wrapper, initialProps: { id: "a" } },
+  );
+  try {
+    await act(async () => {
+      await result.current.mutateAsync().catch(() => undefined);
+    });
+    rerender({ id: "b" });
+    await waitFor(() => expect(result.current.isIdle).toBe(true));
+    expect(requests).toEqual([
+      [
+        "a",
+        {
+          url: "https://edited.example",
+          verify_ssl: false,
+          api_key: "sentinel-secret",
+        },
+      ],
+    ]);
+    for (const mutation of client.getMutationCache().getAll()) {
+      expect(mutation.state.variables).toBeUndefined();
+      expect(mutation.state.error).not.toHaveProperty("config");
+    }
+    expect(JSON.stringify(client.getQueryCache().getAll())).not.toContain(
+      "sentinel-secret",
+    );
+    expect(
+      JSON.stringify(
+        client
+          .getMutationCache()
+          .getAll()
+          .map((m) => m.state),
+      ),
+    ).not.toContain("sentinel-secret");
+  } finally {
+    unmount();
+    client.clear();
+  }
+});
+
+it("saves a credential from its closure and keeps only safe DTO state on success or failure", async () => {
+  const writes: unknown[] = [];
+  let failed = false;
+  const row = {
+    id: "2af88684-d7d2-4534-82bb-a6d839cc5c10",
+    kind: "emby",
+    name: "Room",
+    enabled: false,
+    url: "https://emby.example",
+    verify_ssl: true,
+    api_key_set: true,
+    path_mappings: [],
+  };
+  server.use(
+    http.patch(
+      `/api/system/media-server-instances/${row.id}`,
+      async ({ request }) => {
+        writes.push(await request.json());
+        return failed
+          ? HttpResponse.json({}, { status: 502 })
+          : HttpResponse.json({ ...row, api_key: "sentinel-save-secret" });
+      },
+    ),
+  );
+  const { wrapper, client } = queryWrapper();
+  const { result, unmount } = renderHook(
+    () =>
+      useSaveMediaServerInstance(
+        "emby",
+        { api_key: "sentinel-save-secret" },
+        row.id,
+      ),
+    { wrapper },
+  );
+  try {
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+    await waitFor(() => expect(result.current.data).toEqual(row));
+    failed = true;
+    await act(async () => {
+      await result.current.mutateAsync().catch(() => undefined);
+    });
+    expect(writes).toEqual([
+      { api_key: "sentinel-save-secret" },
+      { api_key: "sentinel-save-secret" },
+    ]);
+    const mutations = client.getMutationCache().getAll();
+    expect(mutations.every((m) => m.state.variables === undefined)).toBe(true);
+    expect(JSON.stringify(mutations.map((m) => m.state))).not.toContain(
+      "sentinel-save-secret",
+    );
+    expect(
+      JSON.stringify(
+        client
+          .getQueryCache()
+          .getAll()
+          .map((q) => q.queryKey),
+      ),
+    ).not.toContain("sentinel-save-secret");
+  } finally {
+    unmount();
+    client.clear();
+  }
+});

--- a/frontend/src/apis/hooks/mediaServers.ts
+++ b/frontend/src/apis/hooks/mediaServers.ts
@@ -1,0 +1,148 @@
+/* eslint-disable camelcase */
+
+import { useEffect } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import api from "@/apis/raw";
+import type {
+  ConnectionOverrides,
+  MediaServerKind,
+  MediaServerUpdate,
+} from "@/apis/raw/mediaServers";
+
+const instancesKey = (kind: MediaServerKind) => [
+  "media-servers",
+  kind,
+  "instances",
+];
+const itemKey = (kind: MediaServerKind, id: string) => [
+  "media-servers",
+  kind,
+  id,
+];
+const statusKey = (kind: MediaServerKind, id: string) => [
+  ...itemKey(kind, id),
+  "status",
+];
+
+export function useMediaServerInstances(kind: MediaServerKind) {
+  return useQuery({
+    queryKey: instancesKey(kind),
+    queryFn: () => api.mediaServers.list(kind),
+    placeholderData: undefined,
+  });
+}
+
+export function useSaveMediaServerInstance(
+  kind: MediaServerKind,
+  input: MediaServerUpdate,
+  id?: string,
+) {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      id
+        ? api.mediaServers.update(id, input)
+        : api.mediaServers.create({
+            ...input,
+            kind,
+            name: input.name ?? "",
+            url: input.url ?? "",
+          }),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: instancesKey(kind) });
+      if (id) void client.invalidateQueries({ queryKey: itemKey(kind, id) });
+    },
+  });
+}
+
+export function useDeleteMediaServerInstance(
+  kind: MediaServerKind,
+  id: string,
+) {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.mediaServers.remove(id),
+    onSuccess: async () => {
+      await client.cancelQueries({ queryKey: itemKey(kind, id) });
+      client.removeQueries({ queryKey: itemKey(kind, id) });
+      void client.invalidateQueries({ queryKey: instancesKey(kind) });
+    },
+  });
+}
+
+export function useMediaServerTest(
+  kind: MediaServerKind,
+  input: ConnectionOverrides = {},
+  id?: string,
+) {
+  const mutation = useMutation({
+    mutationFn: () =>
+      id
+        ? api.mediaServers.testExisting(id, input)
+        : api.mediaServers.testConnection(kind, {
+            url: input.url ?? "",
+            apikey: input.api_key ?? "",
+            verify_ssl: input.verify_ssl ?? true,
+          }),
+  });
+  const { reset } = mutation;
+  useEffect(
+    () => reset(),
+    [
+      kind,
+      id,
+      input.url,
+      input.api_key,
+      input.clear_api_key,
+      input.verify_ssl,
+      reset,
+    ],
+  );
+  return mutation;
+}
+
+export function useSiloLibraries(input: ConnectionOverrides, id?: string) {
+  const mutation = useMutation({
+    mutationFn: () =>
+      id
+        ? api.mediaServers.librariesExisting(id, input)
+        : api.mediaServers.libraries({
+            url: input.url ?? "",
+            apikey: input.api_key ?? "",
+            verify_ssl: input.verify_ssl ?? true,
+          }),
+  });
+  const { reset } = mutation;
+  useEffect(
+    () => reset(),
+    [
+      id,
+      input.url,
+      input.api_key,
+      input.clear_api_key,
+      input.verify_ssl,
+      reset,
+    ],
+  );
+  return mutation;
+}
+
+export function useMediaServerStatus(kind: MediaServerKind, id: string) {
+  return useQuery({
+    queryKey: statusKey(kind, id),
+    queryFn: () => api.mediaServers.status(id),
+    retry: false,
+    placeholderData: undefined,
+    staleTime: 0,
+    refetchInterval: 10000,
+  });
+}
+
+export function useRetryPendingMediaServer(kind: MediaServerKind, id: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.mediaServers.retryPending(id),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: statusKey(kind, id) }),
+  });
+}

--- a/frontend/src/apis/raw/index.ts
+++ b/frontend/src/apis/raw/index.ts
@@ -5,6 +5,7 @@ import episodes from "./episodes";
 import files from "./files";
 import history from "./history";
 import jellyfin from "./jellyfin";
+import mediaServers from "./mediaServers";
 import movies from "./movies";
 import plex from "./plex";
 import providerHub from "./providerHub";
@@ -20,6 +21,7 @@ const api = {
   files,
   jellyfin,
   movies,
+  mediaServers,
   series,
   providers,
   history,

--- a/frontend/src/apis/raw/mediaServers.test.ts
+++ b/frontend/src/apis/raw/mediaServers.test.ts
@@ -1,0 +1,201 @@
+/* eslint-disable camelcase */
+
+import { http, HttpResponse } from "msw";
+import server from "@/tests/mocks/node";
+import api from "./index";
+
+const id = "2af88684-d7d2-4534-82bb-a6d839cc5c10";
+const item = `/api/system/media-server-instances/${id}`;
+
+const input = {
+  url: "https://silo.example/prefix",
+  apikey: "0007",
+  verify_ssl: false,
+};
+
+it.each(["emby", "silo"] as const)(
+  "sends the current %s connection as JSON without credentials in the URL",
+  async (kind) => {
+    let received: unknown;
+    let requestUrl = "";
+    server.use(
+      http.post(`/api/${kind}/test-connection`, async ({ request }) => {
+        received = await request.json();
+        requestUrl = request.url;
+        return HttpResponse.json({
+          success: true,
+          server_name: "Media server",
+        });
+      }),
+    );
+    expect(await api.mediaServers.testConnection(kind, input)).toEqual({
+      success: true,
+      server_name: "Media server",
+    });
+    expect(received).toEqual({
+      url: "https://silo.example/prefix",
+      apikey: "0007",
+      verify_ssl: false,
+    });
+    expect(new URL(requestUrl).search).toBe("");
+  },
+);
+
+it("preserves Silo native library types, paths and string IDs", async () => {
+  server.use(
+    http.post("/api/silo/libraries", () =>
+      HttpResponse.json({
+        data: [
+          { id: "0007", name: "TV", type: "series", paths: ["/media/tv"] },
+          {
+            id: "0010",
+            name: "Films",
+            type: "movies",
+            paths: ["/media/films"],
+          },
+        ],
+        error_code: null,
+      }),
+    ),
+  );
+  expect(await api.mediaServers.libraries(input)).toEqual([
+    { id: "0007", name: "TV", type: "series", paths: ["/media/tv"] },
+    { id: "0010", name: "Films", type: "movies", paths: ["/media/films"] },
+  ]);
+});
+
+it("distinguishes an empty library response from a failed probe", async () => {
+  server.use(
+    http.post("/api/silo/libraries", () =>
+      HttpResponse.json({ data: [], error_code: null }),
+    ),
+  );
+  expect(await api.mediaServers.libraries(input)).toEqual([]);
+  server.use(
+    http.post("/api/silo/libraries", () =>
+      HttpResponse.json({ data: [], error_code: "connection_error" }),
+    ),
+  );
+  await expect(api.mediaServers.libraries(input)).rejects.toThrow();
+});
+
+it("does not treat missing or malformed status endpoints as idle success", async () => {
+  server.use(
+    http.get(`${item}/status`, () => HttpResponse.json({}, { status: 404 })),
+  );
+  await expect(api.mediaServers.status(id)).rejects.toThrow();
+  server.use(
+    http.get(`${item}/status`, () => HttpResponse.json({ success: true })),
+  );
+  await expect(api.mediaServers.status(id)).rejects.toThrow();
+});
+
+it.each(["emby", "silo"] as const)(
+  "reads %s refresh state and queues a retry without connection fields",
+  async () => {
+    let body: unknown;
+    server.use(
+      http.get(`${item}/status`, () =>
+        HttpResponse.json({
+          pending: 2,
+          state: "unconfirmed",
+          error_code: "timeout",
+        }),
+      ),
+      http.post(`${item}/retry-pending`, async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ queued: 2 });
+      }),
+    );
+    expect(await api.mediaServers.status(id)).toEqual({
+      pending: 2,
+      state: "unconfirmed",
+      error_code: "timeout",
+    });
+    expect(await api.mediaServers.retryPending(id)).toEqual({ queued: 2 });
+    expect(body).toEqual({});
+  },
+);
+
+it.each([
+  { id: 7, name: "TV", type: "series", paths: ["/tv"] },
+  { id: "7", name: "Audio", type: "music", paths: ["/audio"] },
+  { id: "7", name: "TV", type: "series", paths: null },
+])(
+  "rejects invalid native library choices without coercing IDs or types",
+  async (library) => {
+    server.use(
+      http.post("/api/silo/libraries", () =>
+        HttpResponse.json({ data: [library], error_code: null }),
+      ),
+    );
+    await expect(api.mediaServers.libraries(input)).rejects.toThrow(
+      "Could not load Silo libraries",
+    );
+  },
+);
+
+it("rejects malformed retry acceptance instead of claiming work was queued", async () => {
+  server.use(
+    http.post(`${item}/retry-pending`, () =>
+      HttpResponse.json({ success: true }),
+    ),
+  );
+  await expect(api.mediaServers.retryPending(id)).rejects.toThrow(
+    "Could not queue pending refreshes",
+  );
+});
+
+it("uses item probes with saved-key overrides and omits credential fields from DTOs", async () => {
+  const row = {
+    id,
+    kind: "silo",
+    name: "TV",
+    enabled: false,
+    url: input.url,
+    verify_ssl: true,
+    api_key_set: true,
+    path_mappings: [],
+  };
+  const received: unknown[] = [];
+  server.use(
+    http.get("/api/system/media-server-instances", ({ request }) => {
+      expect(new URL(request.url).searchParams.get("kind")).toBe("silo");
+      return HttpResponse.json({ data: [row] });
+    }),
+    http.post(`${item}/test-connection`, async ({ request }) => {
+      received.push(await request.json());
+      return HttpResponse.json({ success: true });
+    }),
+    http.patch(item, async ({ request }) => {
+      received.push(await request.json());
+      return HttpResponse.json(row);
+    }),
+  );
+  expect(await api.mediaServers.list("silo")).toEqual([row]);
+  expect(
+    await api.mediaServers.testExisting(id, {
+      url: "https://changed.example",
+      verify_ssl: false,
+    }),
+  ).toEqual({ success: true });
+  expect(await api.mediaServers.update(id, { api_key: "0007" })).toEqual(row);
+  expect(received).toEqual([
+    { url: "https://changed.example", verify_ssl: false },
+    { api_key: "0007" },
+  ]);
+});
+
+it("discards credential-bearing transport errors", async () => {
+  server.use(
+    http.post(`${item}/test-connection`, () =>
+      HttpResponse.json({}, { status: 502 }),
+    ),
+  );
+  const error = await api.mediaServers
+    .testExisting(id, { api_key: "sentinel-private-key" })
+    .catch((error) => error);
+  expect(error).toBeInstanceOf(Error);
+  expect(error).not.toHaveProperty("config");
+  expect(JSON.stringify(error)).not.toContain("sentinel-private-key");
+});

--- a/frontend/src/apis/raw/mediaServers.ts
+++ b/frontend/src/apis/raw/mediaServers.ts
@@ -1,0 +1,269 @@
+/* eslint-disable camelcase */
+
+import BaseApi from "./base";
+
+export type MediaServerKind = "emby" | "silo";
+export type PathMapping = {
+  local_path: string;
+  remote_path: string;
+  library_id?: string;
+};
+export type MediaServerInstance = {
+  id: string;
+  kind: MediaServerKind;
+  name: string;
+  enabled: boolean;
+  url: string;
+  verify_ssl: boolean;
+  api_key_set: boolean;
+  path_mappings: PathMapping[];
+};
+export type MediaServerUpdate = Partial<
+  Pick<
+    MediaServerInstance,
+    "name" | "enabled" | "url" | "verify_ssl" | "path_mappings"
+  >
+> & { api_key?: string; clear_api_key?: boolean };
+export type MediaServerCreate = MediaServerUpdate & {
+  kind: MediaServerKind;
+  name: string;
+  url: string;
+};
+export type ConnectionInput = {
+  url: string;
+  apikey: string;
+  verify_ssl: boolean;
+};
+export type ConnectionOverrides = {
+  url?: string;
+  api_key?: string;
+  clear_api_key?: boolean;
+  verify_ssl?: boolean;
+};
+export type SiloLibrary = {
+  id: string;
+  name: string;
+  type: "movies" | "series";
+  paths: string[];
+};
+export type RefreshStatus = {
+  pending: number;
+  state: "idle" | "pending" | "requested" | "confirmed" | "unconfirmed";
+  error_code: string | null;
+};
+export type ConnectionTestResult = {
+  success: boolean;
+  server_name?: string;
+  server_id?: string;
+  version?: string;
+  error_code?: string;
+};
+
+const instancesPath = "/system/media-server-instances";
+const itemPath = (id: string) => `${instancesPath}/${encodeURIComponent(id)}`;
+
+// Transport errors can retain request bodies, including write-only credentials.
+// Never expose them to query/mutation state or callers.
+async function safeRequest<T>(request: () => Promise<T>, message: string) {
+  try {
+    return await request();
+  } catch {
+    throw new Error(message);
+  }
+}
+
+function safeInstance(row: MediaServerInstance): MediaServerInstance {
+  if (
+    !row ||
+    typeof row.id !== "string" ||
+    !["emby", "silo"].includes(row.kind) ||
+    typeof row.name !== "string" ||
+    typeof row.enabled !== "boolean" ||
+    typeof row.url !== "string" ||
+    typeof row.verify_ssl !== "boolean" ||
+    typeof row.api_key_set !== "boolean" ||
+    !Array.isArray(row.path_mappings) ||
+    row.path_mappings.some(
+      (mapping) =>
+        !mapping ||
+        typeof mapping.local_path !== "string" ||
+        typeof mapping.remote_path !== "string" ||
+        !(
+          mapping.library_id === undefined ||
+          typeof mapping.library_id === "string"
+        ),
+    )
+  ) {
+    throw new Error("Invalid instance response");
+  }
+  return {
+    id: row.id,
+    kind: row.kind,
+    name: row.name,
+    enabled: row.enabled,
+    url: row.url,
+    verify_ssl: row.verify_ssl,
+    api_key_set: row.api_key_set,
+    path_mappings: row.path_mappings.map((mapping) => ({
+      local_path: mapping.local_path,
+      remote_path: mapping.remote_path,
+      ...(mapping.library_id === undefined
+        ? {}
+        : { library_id: mapping.library_id }),
+    })),
+  };
+}
+
+class MediaServersApi extends BaseApi {
+  constructor() {
+    super("");
+  }
+
+  list(kind: MediaServerKind) {
+    return safeRequest(async () => {
+      const response = await this.get<{ data: MediaServerInstance[] }>(
+        instancesPath,
+        { kind },
+      );
+      return response.data.map(safeInstance);
+    }, "Could not load media server instances");
+  }
+
+  getOne(id: string) {
+    return safeRequest(
+      async () =>
+        safeInstance(await this.get<MediaServerInstance>(itemPath(id))),
+      "Could not load media server instance",
+    );
+  }
+
+  create(input: MediaServerCreate) {
+    return safeRequest(
+      async () =>
+        safeInstance(
+          (await this.postRaw<MediaServerInstance>(instancesPath, input)).data,
+        ),
+      "Could not save media server instance",
+    );
+  }
+
+  update(id: string, input: MediaServerUpdate) {
+    return safeRequest(
+      async () =>
+        safeInstance(
+          (await this.patchRaw<MediaServerInstance>(itemPath(id), input)).data,
+        ),
+      "Could not save media server instance",
+    );
+  }
+
+  remove(id: string) {
+    return safeRequest(async () => {
+      await this.delete(itemPath(id));
+    }, "Could not delete media server instance");
+  }
+
+  private probe(path: string, input: ConnectionInput | ConnectionOverrides) {
+    return safeRequest(async (): Promise<ConnectionTestResult> => {
+      const { data } = await this.postRaw<ConnectionTestResult>(path, input);
+      if (!data || typeof data.success !== "boolean") throw new Error();
+      // Failure detail is intentionally generic, including in mutation state.
+      return data.success
+        ? {
+            success: true,
+            ...(typeof data.server_name === "string"
+              ? { server_name: data.server_name }
+              : {}),
+            ...(typeof data.version === "string"
+              ? { version: data.version }
+              : {}),
+          }
+        : { success: false };
+    }, "Connection test failed");
+  }
+
+  testConnection(kind: MediaServerKind, input: ConnectionInput) {
+    return this.probe(`/${kind}/test-connection`, input);
+  }
+
+  testExisting(id: string, input: ConnectionOverrides = {}) {
+    return this.probe(`${itemPath(id)}/test-connection`, input);
+  }
+
+  private loadLibraries(
+    path: string,
+    input: ConnectionInput | ConnectionOverrides,
+  ) {
+    return safeRequest(async () => {
+      const response = await this.postRaw<{
+        data: SiloLibrary[];
+        error_code: string | null;
+      }>(path, input);
+      const { data, error_code: errorCode } = response.data;
+      if (
+        errorCode ||
+        !Array.isArray(data) ||
+        data.some(
+          (library) =>
+            !library ||
+            typeof library.id !== "string" ||
+            !library.id ||
+            typeof library.name !== "string" ||
+            !["movies", "series"].includes(library.type) ||
+            !Array.isArray(library.paths) ||
+            library.paths.some((path) => typeof path !== "string"),
+        )
+      )
+        throw new Error();
+      return data.map((library) => ({
+        id: library.id,
+        name: library.name,
+        type: library.type,
+        paths: library.paths,
+      }));
+    }, "Could not load Silo libraries");
+  }
+
+  libraries(input: ConnectionInput) {
+    return this.loadLibraries("/silo/libraries", input);
+  }
+
+  librariesExisting(id: string, input: ConnectionOverrides = {}) {
+    return this.loadLibraries(`${itemPath(id)}/libraries`, input);
+  }
+
+  status(id: string): Promise<RefreshStatus> {
+    return safeRequest(async () => {
+      const data = await this.get<RefreshStatus>(`${itemPath(id)}/status`);
+      if (
+        !data ||
+        !Number.isInteger(data.pending) ||
+        data.pending < 0 ||
+        !["idle", "pending", "requested", "confirmed", "unconfirmed"].includes(
+          data.state,
+        ) ||
+        !(data.error_code === null || typeof data.error_code === "string")
+      )
+        throw new Error();
+      return {
+        pending: data.pending,
+        state: data.state,
+        error_code: data.error_code,
+      };
+    }, "Refresh status unavailable");
+  }
+
+  retryPending(id: string) {
+    return safeRequest(async () => {
+      const { data } = await this.postRaw<{ queued: number }>(
+        `${itemPath(id)}/retry-pending`,
+        {},
+      );
+      if (!data || !Number.isInteger(data.queued) || data.queued < 0)
+        throw new Error();
+      return { queued: data.queued };
+    }, "Could not queue pending refreshes");
+  }
+}
+
+export default new MediaServersApi();

--- a/frontend/src/pages/Settings/Connections/index.test.tsx
+++ b/frontend/src/pages/Settings/Connections/index.test.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable camelcase */
+
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
@@ -6,6 +8,25 @@ import server from "@/tests/mocks/node";
 import SettingsConnectionsView from "./index";
 
 describe("Connections page", () => {
+  beforeEach(() =>
+    server.use(
+      http.get("/api/system/media-server-instances", () =>
+        HttpResponse.json({ data: [] }),
+      ),
+    ),
+  );
+  afterEach(() => window.history.replaceState(null, "", "/"));
+
+  it.each(["emby", "silo"])("opens %s directly from its hash", async (kind) => {
+    window.history.replaceState(null, "", `/#${kind}`);
+    customRender(<SettingsConnectionsView />);
+    expect(
+      await screen.findByRole("tab", { name: new RegExp(kind, "i") }),
+    ).toHaveAttribute("aria-selected", "true");
+    expect(
+      screen.getByText(`Use ${kind === "emby" ? "Emby" : "Silo"}`),
+    ).toBeInTheDocument();
+  });
   it("renders a tab for each service", async () => {
     customRender(<SettingsConnectionsView />);
     await waitFor(() => {
@@ -44,4 +65,13 @@ describe("Connections page", () => {
       expect(screen.getByText("Use Plex Media Server")).toBeInTheDocument();
     });
   });
+});
+
+it("switches to Jellyfin and preserves its configuration section", async () => {
+  customRender(<SettingsConnectionsView />);
+  await userEvent.click(await screen.findByRole("tab", { name: "Jellyfin" }));
+  expect(
+    await screen.findByText("Use Jellyfin Media Server"),
+  ).toBeInTheDocument();
+  expect(screen.getByRole("switch", { name: "Enabled" })).toBeInTheDocument();
 });

--- a/frontend/src/pages/Settings/Connections/index.tsx
+++ b/frontend/src/pages/Settings/Connections/index.tsx
@@ -29,6 +29,7 @@ import {
 import type { ArrInstance, ArrKind } from "@/apis/raw/arrInstances";
 import { Layout, Section } from "@/pages/Settings/components";
 import JellyfinSection from "@/pages/Settings/Jellyfin/JellyfinSection";
+import MediaServerSection from "@/pages/Settings/MediaServers/MediaServerSection";
 import PlexSection from "@/pages/Settings/Plex/PlexSection";
 import RadarrSection from "@/pages/Settings/Radarr/RadarrSection";
 import SonarrSection from "@/pages/Settings/Sonarr/SonarrSection";
@@ -241,6 +242,15 @@ const SettingsConnectionsView: FunctionComponent = () => {
           >
             Jellyfin
           </Tabs.Tab>
+          <Tabs.Tab value="emby" leftSection={<FontAwesomeIcon icon={faTv} />}>
+            Emby
+          </Tabs.Tab>
+          <Tabs.Tab
+            value="silo"
+            leftSection={<FontAwesomeIcon icon={faServer} />}
+          >
+            Silo
+          </Tabs.Tab>
         </Tabs.List>
 
         <Tabs.Panel value="sonarr">
@@ -273,6 +283,12 @@ const SettingsConnectionsView: FunctionComponent = () => {
 
         <Tabs.Panel value="jellyfin">
           <JellyfinSection />
+        </Tabs.Panel>
+        <Tabs.Panel value="emby">
+          <MediaServerSection kind="emby" />
+        </Tabs.Panel>
+        <Tabs.Panel value="silo">
+          <MediaServerSection kind="silo" />
         </Tabs.Panel>
       </Tabs>
 

--- a/frontend/src/pages/Settings/Connections/tabs.test.ts
+++ b/frontend/src/pages/Settings/Connections/tabs.test.ts
@@ -7,8 +7,15 @@ import {
 } from "./tabs";
 
 describe("connection tabs", () => {
-  it("lists the four services in order", () => {
-    expect(CONNECTION_TABS).toEqual(["sonarr", "radarr", "plex", "jellyfin"]);
+  it("lists all services in order", () => {
+    expect(CONNECTION_TABS).toEqual([
+      "sonarr",
+      "radarr",
+      "plex",
+      "jellyfin",
+      "emby",
+      "silo",
+    ]);
   });
 
   it("recognises valid tab keys", () => {
@@ -19,6 +26,8 @@ describe("connection tabs", () => {
   it("parses a leading-hash fragment to its tab", () => {
     expect(parseTabFromHash("#plex")).toBe("plex");
     expect(parseTabFromHash("#jellyfin")).toBe("jellyfin");
+    expect(parseTabFromHash("#emby")).toBe("emby");
+    expect(parseTabFromHash("#silo")).toBe("silo");
   });
 
   it("parses a bare fragment without a hash", () => {

--- a/frontend/src/pages/Settings/Connections/tabs.ts
+++ b/frontend/src/pages/Settings/Connections/tabs.ts
@@ -7,6 +7,8 @@ export const CONNECTION_TABS = [
   "radarr",
   "plex",
   "jellyfin",
+  "emby",
+  "silo",
 ] as const;
 
 export type ConnectionTab = (typeof CONNECTION_TABS)[number];

--- a/frontend/src/pages/Settings/MediaServers/MediaServerInstanceCard.tsx
+++ b/frontend/src/pages/Settings/MediaServers/MediaServerInstanceCard.tsx
@@ -109,6 +109,9 @@ export default function MediaServerInstanceCard({
             </Button>
           </Group>
         </Group>
+        <Text size="sm" c="dimmed">
+          Test checks access, not refresh permission.
+        </Text>
         {update.isError && (
           <Alert color="red">
             Could not update this instance. Check its API key and path mappings
@@ -117,9 +120,9 @@ export default function MediaServerInstanceCard({
         )}
         {test.isSuccess && test.data.success && (
           <Alert color="green">
-            Read-only connection succeeded
-            {test.data.server_name ? `: ${test.data.server_name}` : ""}. This
-            does not confirm refresh permission or subtitle discovery.
+            {test.data.server_name
+              ? `Connected to ${test.data.server_name}.`
+              : "Connection succeeded."}
           </Alert>
         )}
         {(test.isError || (test.isSuccess && !test.data.success)) && (

--- a/frontend/src/pages/Settings/MediaServers/MediaServerInstanceCard.tsx
+++ b/frontend/src/pages/Settings/MediaServers/MediaServerInstanceCard.tsx
@@ -1,0 +1,139 @@
+import { useEffect } from "react";
+import {
+  Alert,
+  Badge,
+  Button,
+  Code,
+  Group,
+  Stack,
+  Switch,
+  Text,
+} from "@mantine/core";
+import {
+  useMediaServerTest,
+  useSaveMediaServerInstance,
+} from "@/apis/hooks/mediaServers";
+import type { MediaServerInstance } from "@/apis/raw/mediaServers";
+import MediaServerRefreshStatus from "./MediaServerRefreshStatus";
+import styles from "@/pages/Settings/Connections/Connections.module.scss";
+
+interface Props {
+  instance: MediaServerInstance;
+  masterEnabled: boolean;
+  masterChanged: boolean;
+  onEdit: (instance: MediaServerInstance) => void;
+  onDelete: (instance: MediaServerInstance) => void;
+}
+
+export default function MediaServerInstanceCard({
+  instance,
+  masterEnabled,
+  masterChanged,
+  onEdit,
+  onDelete,
+}: Props) {
+  const update = useSaveMediaServerInstance(
+    instance.kind,
+    { enabled: !instance.enabled },
+    instance.id,
+  );
+  const test = useMediaServerTest(instance.kind, {}, instance.id);
+  const { reset } = test;
+  useEffect(() => reset(), [instance, reset]);
+  return (
+    <section
+      aria-label={instance.name}
+      className={styles.card}
+      data-disabled={!instance.enabled || undefined}
+    >
+      <Stack gap="md">
+        <Group justify="space-between" align="flex-start">
+          <Stack gap={6} className={styles.dimmable}>
+            <Group gap="xs">
+              <Text fw={600} size="sm">
+                {instance.name}
+              </Text>
+              {!instance.enabled && (
+                <Badge size="xs" color="gray">
+                  Disabled
+                </Badge>
+              )}
+            </Group>
+            <Code>{instance.url}</Code>
+            <Text size="xs" c={instance.api_key_set ? "dimmed" : "orange"}>
+              {instance.api_key_set ? "Key stored" : "No API key"}
+            </Text>
+          </Stack>
+          <Group gap="xs">
+            <Switch
+              size="sm"
+              checked={instance.enabled}
+              disabled={update.isPending}
+              aria-label={
+                instance.enabled ? "Disable instance" : "Enable instance"
+              }
+              onChange={() => {
+                test.reset();
+                update.mutate();
+              }}
+            />
+            <Button
+              type="button"
+              size="xs"
+              variant="light"
+              loading={test.isPending}
+              disabled={!instance.api_key_set || !instance.url}
+              onClick={() => test.mutate()}
+            >
+              Test
+            </Button>
+            <Button
+              type="button"
+              size="xs"
+              variant="default"
+              onClick={() => {
+                test.reset();
+                onEdit(instance);
+              }}
+            >
+              Edit
+            </Button>
+            <Button
+              type="button"
+              size="xs"
+              variant="subtle"
+              color="red"
+              onClick={() => onDelete(instance)}
+            >
+              Delete
+            </Button>
+          </Group>
+        </Group>
+        {update.isError && (
+          <Alert color="red">
+            Could not update this instance. Check its API key and path mappings
+            before enabling it.
+          </Alert>
+        )}
+        {test.isSuccess && test.data.success && (
+          <Alert color="green">
+            Read-only connection succeeded
+            {test.data.server_name ? `: ${test.data.server_name}` : ""}. This
+            does not confirm refresh permission or subtitle discovery.
+          </Alert>
+        )}
+        {(test.isError || (test.isSuccess && !test.data.success)) && (
+          <Alert color="red">
+            Connection test failed. Check the saved connection and server
+            access.
+          </Alert>
+        )}
+        <MediaServerRefreshStatus
+          instance={instance}
+          enabled={masterEnabled && instance.enabled}
+          hasChanges={masterChanged}
+        />
+      </Stack>
+    </section>
+  );
+}

--- a/frontend/src/pages/Settings/MediaServers/MediaServerInstanceFormModal.tsx
+++ b/frontend/src/pages/Settings/MediaServers/MediaServerInstanceFormModal.tsx
@@ -158,17 +158,16 @@ export default function MediaServerInstanceFormModal({
           />
           {kind === "silo" && (
             <Text size="sm" c="dimmed">
-              Refreshes support IP addresses and names resolved through DNS or
-              the hosts file. Names relying only on local discovery, such as
-              mDNS, are unsupported for refreshes and can still pass the
-              read-only Test.
+              Refreshes need an IP address or a name resolved by DNS or the
+              hosts file. mDNS and other local-discovery names pass the Test but
+              fail refreshes.
             </Text>
           )}
           {instance && (
             <>
               <Text size="sm">
                 {instance.api_key_set
-                  ? "An API key is stored. Keep it, replace it or explicitly clear it."
+                  ? "An API key is stored. Keep it, replace it or clear it."
                   : "No API key is stored."}
               </Text>
               <SegmentedControl
@@ -221,6 +220,9 @@ export default function MediaServerInstanceFormModal({
               Test
             </Button>
           </Group>
+          <Text size="sm" c="dimmed">
+            Test checks access, not refresh permission.
+          </Text>
           {!configured && (
             <Text size="sm" c="dimmed">
               Enter a Server URL and API Key to test this connection.
@@ -228,12 +230,13 @@ export default function MediaServerInstanceFormModal({
           )}
           {test.isSuccess && test.data.success && (
             <Alert color="green">
-              Read-only connection succeeded
-              {test.data.server_name ? `: ${test.data.server_name}` : ""}
+              {test.data.server_name
+                ? `Connected to ${test.data.server_name}`
+                : "Connection succeeded"}
               {kind === "emby" && test.data.version
                 ? ` (v${test.data.version})`
                 : ""}
-              . This does not confirm refresh permission or subtitle discovery.
+              .
             </Alert>
           )}
           {(test.isError || (test.isSuccess && !test.data.success)) && (

--- a/frontend/src/pages/Settings/MediaServers/MediaServerInstanceFormModal.tsx
+++ b/frontend/src/pages/Settings/MediaServers/MediaServerInstanceFormModal.tsx
@@ -1,0 +1,315 @@
+/* eslint-disable camelcase */
+
+import { FormEvent, useState } from "react";
+import {
+  Alert,
+  Button,
+  Divider,
+  Group,
+  Modal,
+  PasswordInput,
+  SegmentedControl,
+  Stack,
+  Switch,
+  Text,
+  TextInput,
+} from "@mantine/core";
+import { useForm } from "@mantine/form";
+import {
+  useMediaServerTest,
+  useSaveMediaServerInstance,
+  useSiloLibraries,
+} from "@/apis/hooks/mediaServers";
+import type {
+  ConnectionOverrides,
+  MediaServerInstance,
+  MediaServerKind,
+  PathMapping,
+} from "@/apis/raw/mediaServers";
+import PathMappings from "./PathMappings";
+
+type KeyMode = "keep" | "replace" | "clear";
+interface Props {
+  kind: MediaServerKind;
+  instance: MediaServerInstance | null;
+  onClose: () => void;
+}
+
+// Mount one editor per opening so its state and mutation observers cannot be
+// reused by a different instance or a later opening of the same instance.
+export default function MediaServerInstanceFormModal({
+  kind,
+  instance,
+  onClose,
+}: Props) {
+  const name = kind === "emby" ? "Emby" : "Silo";
+  const [keyMode, setKeyMode] = useState<KeyMode>(
+    instance ? "keep" : "replace",
+  );
+  const form = useForm({
+    initialValues: {
+      name: instance?.name ?? "",
+      enabled: instance?.enabled ?? false,
+      url: instance?.url ?? "",
+      apiKey: "",
+      verifySsl: instance?.verify_ssl ?? true,
+      mappings: instance?.path_mappings ?? ([] as PathMapping[]),
+    },
+    validate: {
+      name: (value) => (value.trim() ? null : "Name is required"),
+      url: (value) => {
+        try {
+          const parsed = new URL(value);
+          return ["http:", "https:"].includes(parsed.protocol) &&
+            !parsed.username &&
+            !parsed.password &&
+            !parsed.search &&
+            !parsed.hash
+            ? null
+            : "Enter a full HTTP or HTTPS URL without credentials, query or fragment";
+        } catch {
+          return "Enter a full HTTP or HTTPS URL";
+        }
+      },
+      apiKey: (value, values) =>
+        values.enabled &&
+        !(keyMode === "keep"
+          ? instance?.api_key_set
+          : keyMode === "replace" && value.trim())
+          ? "An enabled instance needs an API key"
+          : null,
+      mappings: (value, values) =>
+        values.enabled && value.length === 0
+          ? "An enabled instance needs at least one path mapping"
+          : null,
+    },
+  });
+  const credentials: ConnectionOverrides =
+    keyMode === "clear"
+      ? { clear_api_key: true }
+      : keyMode === "replace"
+        ? { api_key: form.values.apiKey }
+        : {};
+  const connection = {
+    url: form.values.url,
+    verify_ssl: form.values.verifySsl,
+    ...credentials,
+  };
+  const configured = Boolean(
+    form.values.url.trim() &&
+    (keyMode === "keep"
+      ? instance?.api_key_set
+      : keyMode === "replace" && form.values.apiKey.trim()),
+  );
+  const test = useMediaServerTest(kind, connection, instance?.id);
+  const libraries = useSiloLibraries(connection, instance?.id);
+  const save = useSaveMediaServerInstance(
+    kind,
+    {
+      ...connection,
+      name: form.values.name,
+      enabled: form.values.enabled,
+      path_mappings: form.values.mappings,
+    },
+    instance?.id,
+  );
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!save.isPending && !form.validate().hasErrors)
+      save.mutate(undefined, { onSuccess: onClose });
+  };
+  return (
+    <Modal
+      opened
+      onClose={onClose}
+      title={`${instance ? "Edit" : "Add"} ${name} instance`}
+      centered
+      size="lg"
+    >
+      <form
+        onSubmit={submit}
+        onKeyDown={(event) => {
+          if ((event.ctrlKey || event.metaKey) && event.key === "s") {
+            event.preventDefault();
+            event.stopPropagation();
+            event.currentTarget.requestSubmit();
+          }
+        }}
+      >
+        <Stack gap="md">
+          <TextInput label="Name" {...form.getInputProps("name")} />
+          <Switch
+            label="Instance enabled"
+            {...form.getInputProps("enabled", { type: "checkbox" })}
+          />
+          <Text size="sm" c="dimmed">
+            The saved {name} master switch must also be enabled for refreshes.
+          </Text>
+          <TextInput
+            label="Server URL"
+            placeholder={
+              kind === "emby"
+                ? "http://192.168.1.100:8096"
+                : "https://silo.example"
+            }
+            description={`Full URL of your ${name} server, including any path prefix. Keep credentials in the API Key field.`}
+            {...form.getInputProps("url")}
+          />
+          {kind === "silo" && (
+            <Text size="sm" c="dimmed">
+              Refreshes support IP addresses and names resolved through DNS or
+              the hosts file. Names relying only on local discovery, such as
+              mDNS, are unsupported for refreshes and can still pass the
+              read-only Test.
+            </Text>
+          )}
+          {instance && (
+            <>
+              <Text size="sm">
+                {instance.api_key_set
+                  ? "An API key is stored. Keep it, replace it or explicitly clear it."
+                  : "No API key is stored."}
+              </Text>
+              <SegmentedControl
+                aria-label="API key action"
+                value={keyMode}
+                onChange={(value) => {
+                  setKeyMode(value as KeyMode);
+                  form.setFieldValue("apiKey", "");
+                }}
+                data={[
+                  { value: "keep", label: "Keep" },
+                  { value: "replace", label: "Replace" },
+                  { value: "clear", label: "Clear" },
+                ]}
+              />
+            </>
+          )}
+          {keyMode === "replace" && (
+            <PasswordInput
+              label="API Key"
+              autoComplete="new-password"
+              {...form.getInputProps("apiKey")}
+            />
+          )}
+          {keyMode !== "replace" && form.errors.apiKey && (
+            <Text size="sm" c="red">
+              {form.errors.apiKey}
+            </Text>
+          )}
+          {keyMode === "clear" && (
+            <Alert color="yellow">
+              The saved API key will be removed when you save. Disable this
+              instance to save without a key.
+            </Alert>
+          )}
+          <Switch
+            label="Verify SSL certificate"
+            {...form.getInputProps("verifySsl", { type: "checkbox" })}
+          />
+          <Text size="xs" c="dimmed">
+            Certificate verification applies to HTTPS connections.
+          </Text>
+          <Group>
+            <Button
+              type="button"
+              disabled={!configured}
+              loading={test.isPending}
+              onClick={() => test.mutate()}
+            >
+              Test
+            </Button>
+          </Group>
+          {!configured && (
+            <Text size="sm" c="dimmed">
+              Enter a Server URL and API Key to test this connection.
+            </Text>
+          )}
+          {test.isSuccess && test.data.success && (
+            <Alert color="green">
+              Read-only connection succeeded
+              {test.data.server_name ? `: ${test.data.server_name}` : ""}
+              {kind === "emby" && test.data.version
+                ? ` (v${test.data.version})`
+                : ""}
+              . This does not confirm refresh permission or subtitle discovery.
+            </Alert>
+          )}
+          {(test.isError || (test.isSuccess && !test.data.success)) && (
+            <Alert color="red">
+              Connection test failed. Check the Server URL, API Key, certificate
+              and server access.
+            </Alert>
+          )}
+          <Text size="sm" c="dimmed">
+            Test{kind === "silo" ? " and Load libraries use" : " uses"} the
+            current fields, including unsaved changes.
+          </Text>
+          <Divider label="Path mappings" />
+          {kind === "silo" && (
+            <>
+              <Group>
+                <Button
+                  type="button"
+                  variant="light"
+                  disabled={!configured}
+                  loading={libraries.isPending}
+                  onClick={() => libraries.mutate()}
+                >
+                  Load libraries
+                </Button>
+              </Group>
+              {libraries.isPending && (
+                <Text size="sm">Loading Silo libraries...</Text>
+              )}
+              {libraries.isError && (
+                <Alert color="red">
+                  Could not load Silo libraries. Check the connection and
+                  library access. Saved mappings are preserved.
+                </Alert>
+              )}
+              {libraries.isSuccess && libraries.data.length === 0 && (
+                <Alert color="gray">
+                  No supported libraries found. Enable a movie or series library
+                  in Silo and check the API key's access.
+                </Alert>
+              )}
+              {libraries.isIdle && (
+                <Text size="sm" c="dimmed">
+                  Load libraries to add mappings or choose an available Silo
+                  library.
+                </Text>
+              )}
+            </>
+          )}
+          <PathMappings
+            kind={kind}
+            value={form.values.mappings}
+            onChange={(value) => form.setFieldValue("mappings", value)}
+            libraries={libraries.data}
+          />
+          {form.errors.mappings && (
+            <Text size="sm" c="red">
+              {form.errors.mappings}
+            </Text>
+          )}
+          {save.isError && (
+            <Alert color="red">
+              Could not save this instance. Check the name, full URL, API key
+              and path mappings, then try again.
+            </Alert>
+          )}
+          <Group justify="flex-end">
+            <Button type="button" variant="default" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" loading={save.isPending}>
+              Save instance
+            </Button>
+          </Group>
+        </Stack>
+      </form>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Settings/MediaServers/MediaServerRefreshStatus.tsx
+++ b/frontend/src/pages/Settings/MediaServers/MediaServerRefreshStatus.tsx
@@ -1,0 +1,134 @@
+import {
+  Alert,
+  Button,
+  Group,
+  Stack,
+  Text as MantineText,
+} from "@mantine/core";
+import {
+  useMediaServerStatus,
+  useRetryPendingMediaServer,
+} from "@/apis/hooks/mediaServers";
+import type {
+  MediaServerInstance,
+  RefreshStatus,
+} from "@/apis/raw/mediaServers";
+
+const statusMessages: Record<RefreshStatus["state"], string> = {
+  idle: "No pending refreshes.",
+  pending:
+    "Refresh pending. Check the saved connection and retry when the server is available.",
+  requested: "Refresh requested. The server has accepted the request.",
+  confirmed: "Refresh confirmed by the server.",
+  unconfirmed:
+    "Refresh unconfirmed. The request may have reached the server, but completion could not be confirmed.",
+};
+
+function getStatusErrorMessage(errorCode: RefreshStatus["error_code"]) {
+  switch (errorCode) {
+    case "queue_overflow":
+      return "Refresh queue capacity exceeded. Some refresh targets were not queued. Retry pending only retries retained targets and cannot recover dropped targets.";
+    case "sidecar_unsupported":
+      return "Refresh unsupported for this subtitle location. Silo requires subtitles beside the video file. Retrying an unchanged subtitle location will not resolve this.";
+    default:
+      return null;
+  }
+}
+
+export default function MediaServerRefreshStatus({
+  instance,
+  enabled,
+  hasChanges,
+}: {
+  instance: MediaServerInstance;
+  enabled: boolean;
+  hasChanges: boolean;
+}) {
+  const { kind, id } = instance;
+  const status = useMediaServerStatus(kind, id);
+  const retry = useRetryPendingMediaServer(kind, id);
+  const currentStatus = !status.isError ? status.data : undefined;
+  const statusErrorMessage =
+    currentStatus && getStatusErrorMessage(currentStatus.error_code);
+  const warning =
+    currentStatus &&
+    (currentStatus.pending > 0 ||
+      currentStatus.state === "unconfirmed" ||
+      currentStatus.error_code !== null);
+  return (
+    <Stack gap="xs">
+      {status.isPending ? (
+        <MantineText size="sm">Loading refresh status...</MantineText>
+      ) : !currentStatus ? (
+        <Alert color="yellow">
+          Refresh status unavailable. No refresh outcome can be confirmed. Check
+          that the Bazarr API is available.
+        </Alert>
+      ) : (
+        <Alert color={warning ? "yellow" : "gray"}>
+          {statusErrorMessage ??
+            statusMessages[
+              currentStatus.state === "idle" && currentStatus.pending > 0
+                ? "pending"
+                : currentStatus.state
+            ]}{" "}
+          {currentStatus.pending} pending.
+          {currentStatus.error_code !== null &&
+            !statusErrorMessage &&
+            " Check the saved connection, server access and path mappings."}
+          {currentStatus.state !== "idle" &&
+            " Subtitle discovery is not confirmed."}
+        </Alert>
+      )}
+      {kind === "silo" && (
+        <MantineText size="sm" c="dimmed">
+          When Silo runs across machines, synchronize the
+          application/event-publisher and database clocks so refresh completion
+          can be confirmed.
+        </MantineText>
+      )}
+      <MantineText size="sm" c="dimmed">
+        Retry pending uses the saved connection settings.
+      </MantineText>
+      {!enabled && (
+        <MantineText size="sm" c="dimmed">
+          Enable this instance and save the master switch to retry pending
+          refreshes.
+        </MantineText>
+      )}
+      {hasChanges && (
+        <MantineText size="sm" c="dimmed">
+          Save your changes before retrying pending refreshes.
+        </MantineText>
+      )}
+      <Group>
+        <Button
+          type="button"
+          variant="light"
+          loading={retry.isPending}
+          disabled={
+            !enabled ||
+            hasChanges ||
+            !currentStatus ||
+            currentStatus.pending === 0
+          }
+          onClick={() => retry.mutate()}
+        >
+          Retry pending
+        </Button>
+      </Group>
+      {retry.isSuccess && (
+        <Alert color="gray">
+          Queued {retry.data.queued} pending refreshes. Queue acceptance does
+          not confirm subtitle discovery.
+        </Alert>
+      )}
+      {retry.isError && (
+        <Alert color="red">
+          Could not queue pending refreshes. Check the saved connection and try
+          again.
+        </Alert>
+      )}
+    </Stack>
+  );
+}

--- a/frontend/src/pages/Settings/MediaServers/MediaServerRefreshStatus.tsx
+++ b/frontend/src/pages/Settings/MediaServers/MediaServerRefreshStatus.tsx
@@ -16,20 +16,22 @@ import type {
 
 const statusMessages: Record<RefreshStatus["state"], string> = {
   idle: "No pending refreshes.",
-  pending:
-    "Refresh pending. Check the saved connection and retry when the server is available.",
-  requested: "Refresh requested. The server has accepted the request.",
-  confirmed: "Refresh confirmed by the server.",
-  unconfirmed:
-    "Refresh unconfirmed. The request may have reached the server, but completion could not be confirmed.",
+  pending: "Refresh pending.",
+  requested: "Refresh sent.",
+  confirmed: "Refresh confirmed.",
+  unconfirmed: "Refresh unconfirmed.",
 };
+
+function refreshCount(count: number) {
+  return `${count} refresh${count === 1 ? "" : "es"}`;
+}
 
 function getStatusErrorMessage(errorCode: RefreshStatus["error_code"]) {
   switch (errorCode) {
     case "queue_overflow":
-      return "Refresh queue capacity exceeded. Some refresh targets were not queued. Retry pending only retries retained targets and cannot recover dropped targets.";
+      return "The refresh queue overflowed. Retry pending covers the refreshes it kept, but dropped ones need a new refresh.";
     case "sidecar_unsupported":
-      return "Refresh unsupported for this subtitle location. Silo requires subtitles beside the video file. Retrying an unchanged subtitle location will not resolve this.";
+      return "Silo only refreshes subtitles stored beside the video file. Move the subtitle there, then retry.";
     default:
       return null;
   }
@@ -61,8 +63,7 @@ export default function MediaServerRefreshStatus({
         <MantineText size="sm">Loading refresh status...</MantineText>
       ) : !currentStatus ? (
         <Alert color="yellow">
-          Refresh status unavailable. No refresh outcome can be confirmed. Check
-          that the Bazarr API is available.
+          Refresh status unavailable. Check that the Bazarr API is reachable.
         </Alert>
       ) : (
         <Alert color={warning ? "yellow" : "gray"}>
@@ -71,15 +72,18 @@ export default function MediaServerRefreshStatus({
               currentStatus.state === "idle" && currentStatus.pending > 0
                 ? "pending"
                 : currentStatus.state
-            ]}{" "}
-          {currentStatus.pending} pending.
+            ]}
+          {currentStatus.pending > 0 &&
+            ` ${refreshCount(currentStatus.pending)} queued.`}
           {currentStatus.error_code !== null &&
             !statusErrorMessage &&
             " Check the saved connection, server access and path mappings."}
-          {currentStatus.state !== "idle" &&
-            " Subtitle discovery is not confirmed."}
         </Alert>
       )}
+      <MantineText size="sm" c="dimmed">
+        Confirmation means the server finished a scan, not that it found the
+        subtitle.
+      </MantineText>
       {kind === "silo" && (
         <MantineText size="sm" c="dimmed">
           When Silo runs across machines, synchronize the
@@ -118,10 +122,7 @@ export default function MediaServerRefreshStatus({
         </Button>
       </Group>
       {retry.isSuccess && (
-        <Alert color="gray">
-          Queued {retry.data.queued} pending refreshes. Queue acceptance does
-          not confirm subtitle discovery.
-        </Alert>
+        <Alert color="gray">Queued {refreshCount(retry.data.queued)}.</Alert>
       )}
       {retry.isError && (
         <Alert color="red">

--- a/frontend/src/pages/Settings/MediaServers/MediaServerSection.test.tsx
+++ b/frontend/src/pages/Settings/MediaServers/MediaServerSection.test.tsx
@@ -101,10 +101,11 @@ it.each(["emby", "silo"] as const)(
     );
     await userEvent.click(form.getByRole("button", { name: "Test" }));
     expect(
-      await form.findByText(/Read-only connection succeeded/),
-    ).toHaveTextContent(
-      /does not confirm refresh permission or subtitle discovery/,
-    );
+      await form.findByText("Connected to Living room."),
+    ).not.toHaveTextContent(/refresh permission|subtitle/i);
+    expect(
+      form.getAllByText("Test checks access, not refresh permission."),
+    ).toHaveLength(1);
     expect(form.queryByText(/vundefined/)).not.toBeInTheDocument();
     expect(testBody).toEqual({
       url: `https://${kind}.example/prefix`,
@@ -168,10 +169,10 @@ it.each(["emby", "silo"] as const)(
       await screen.findByRole("region", { name: "Living room" }),
     );
     const second = within(screen.getByRole("region", { name: "Bedroom" }));
-    expect(await first.findByText(/2 pending/)).toBeInTheDocument();
+    expect(await first.findByText(/2 refreshes queued/)).toBeInTheDocument();
     expect(await second.findByText(/No pending refreshes/)).toBeInTheDocument();
     await userEvent.click(first.getByRole("button", { name: "Retry pending" }));
-    await first.findByText(/Queued 2 pending refreshes/);
+    await first.findByText("Queued 2 refreshes.");
     await userEvent.click(
       first.getByRole("switch", { name: "Disable instance" }),
     );
@@ -305,15 +306,15 @@ it("warns about unconfirmed refreshes, retries pending work and refreshes status
     }),
   );
   expect(await screen.findByText(/Refresh unconfirmed/)).toBeInTheDocument();
-  expect(screen.getByText(/2 pending/)).toBeInTheDocument();
+  expect(screen.getByText(/2 refreshes queued/)).toBeInTheDocument();
   await userEvent.click(screen.getByRole("button", { name: "Retry pending" }));
+  expect(await screen.findByText("Queued 2 refreshes.")).toBeInTheDocument();
+  expect(await screen.findByText(/Refresh sent/)).toBeInTheDocument();
   expect(
-    await screen.findByText(/Queued 2 pending refreshes/),
-  ).toBeInTheDocument();
-  expect(await screen.findByText(/Refresh requested/)).toBeInTheDocument();
-  expect(
-    screen.getByText(/Subtitle discovery is not confirmed/),
-  ).toBeInTheDocument();
+    screen.getAllByText(
+      "Confirmation means the server finished a scan, not that it found the subtitle.",
+    ),
+  ).toHaveLength(1);
 });
 
 it("disables retry when master changes are staged and shows retry failures safely", async () => {
@@ -350,9 +351,25 @@ it("does not claim there is no pending work when an idle status includes queued 
       HttpResponse.json({ pending: 2, state: "idle", error_code: null }),
     ),
   );
-  expect(await screen.findByText(/2 pending/)).toBeInTheDocument();
+  expect(await screen.findByText(/2 refreshes queued/)).toBeInTheDocument();
   expect(screen.queryByText(/No pending refreshes/)).not.toBeInTheDocument();
   expect(screen.getByRole("button", { name: "Retry pending" })).toBeEnabled();
+});
+
+it("counts a single queued refresh in the singular", async () => {
+  setup("emby");
+  server.use(
+    http.get(`${item}/status`, () =>
+      HttpResponse.json({ pending: 1, state: "pending", error_code: null }),
+    ),
+    http.post(`${item}/retry-pending`, () => HttpResponse.json({ queued: 1 })),
+  );
+  expect(await screen.findByText(/1 refresh queued\./)).toBeInTheDocument();
+  expect(screen.queryByText(/1 refreshes/)).not.toBeInTheDocument();
+  const retry = screen.getByRole("button", { name: "Retry pending" });
+  await waitFor(() => expect(retry).toBeEnabled());
+  await userEvent.click(retry);
+  expect(await screen.findByText("Queued 1 refresh.")).toBeInTheDocument();
 });
 
 it.each(["confirmed", "requested", "idle"] as const)(
@@ -364,14 +381,13 @@ it.each(["confirmed", "requested", "idle"] as const)(
         HttpResponse.json({ pending: 0, state, error_code: "queue_overflow" }),
       ),
     );
-    const warning = await screen.findByText(/0 pending/);
-    expect(warning).toHaveTextContent(/queue.*capacity|queue overflow/i);
-    expect(warning).toHaveTextContent(/not queued/i);
+    const warning = await screen.findByText(/refresh queue overflowed/i);
     expect(warning).toHaveTextContent(
-      /Retry pending.*cannot recover.*dropped/i,
+      /Retry pending covers the refreshes it kept/i,
     );
+    expect(warning).toHaveTextContent(/dropped ones need a new refresh/i);
     expect(warning).not.toHaveTextContent(
-      /Refresh confirmed|Refresh requested|No pending refreshes/i,
+      /Refresh confirmed|Refresh sent|No pending refreshes|0 refresh/i,
     );
     expect(
       screen.getByRole("button", { name: "Retry pending" }),
@@ -395,16 +411,16 @@ it("retries retained overflow targets and keeps the dropped-target warning after
       return HttpResponse.json({ queued: 2 });
     }),
   );
-  expect(await screen.findByText(/2 pending/)).toHaveTextContent(/not queued/i);
+  expect(await screen.findByText(/2 refreshes queued/)).toHaveTextContent(
+    /refresh queue overflowed/i,
+  );
   const retry = screen.getByRole("button", { name: "Retry pending" });
   expect(retry).toBeEnabled();
   await userEvent.click(retry);
-  expect(
-    await screen.findByText(/Queued 2 pending refreshes/),
-  ).toBeInTheDocument();
-  const warning = await screen.findByText(/0 pending/);
-  expect(warning).toHaveTextContent(/Retry pending.*cannot recover.*dropped/i);
-  expect(warning).not.toHaveTextContent(/Refresh confirmed/i);
+  expect(await screen.findByText("Queued 2 refreshes.")).toBeInTheDocument();
+  const warning = await screen.findByText(/refresh queue overflowed/i);
+  expect(warning).toHaveTextContent(/dropped ones need a new refresh/i);
+  expect(warning).not.toHaveTextContent(/Refresh confirmed|0 refresh/i);
   expect(retry).toBeDisabled();
 });
 
@@ -420,14 +436,11 @@ it("explains that an unsupported Silo subtitle location needs to change before r
       }),
     ),
   );
-  const warning = await screen.findByText(/1 pending/);
-  expect(warning).toHaveTextContent(/unsupported.*subtitle location/i);
-  expect(warning).toHaveTextContent(/subtitles.*beside the video/i);
-  expect(warning).toHaveTextContent(
-    /Retrying.*unchanged.*location.*will not resolve/i,
-  );
+  const warning = await screen.findByText(/1 refresh queued/);
+  expect(warning).toHaveTextContent(/subtitles stored beside the video file/i);
+  expect(warning).toHaveTextContent(/Move the subtitle there, then retry/i);
   expect(warning).not.toHaveTextContent(
-    /may have reached the server|Check the saved connection|private|movie\.srt/i,
+    /Refresh unconfirmed|Check the saved connection|private|movie\.srt/i,
   );
   expect(screen.getByRole("button", { name: "Retry pending" })).toBeEnabled();
 });
@@ -443,7 +456,7 @@ it("keeps unknown status errors generic without exposing the raw error", async (
       }),
     ),
   );
-  const warning = await screen.findByText(/1 pending/);
+  const warning = await screen.findByText(/1 refresh queued/);
   expect(warning).toHaveTextContent(/Refresh unconfirmed/i);
   expect(warning).toHaveTextContent(
     /Check the saved connection, server access and path mappings/i,
@@ -504,7 +517,7 @@ it.each(["emby", "silo"] as const)(
       modal.getByRole("switch", { name: "Verify SSL certificate" }),
     );
     await userEvent.click(modal.getByRole("button", { name: "Test" }));
-    await modal.findByText(/Read-only connection succeeded/);
+    await modal.findByText("Connection succeeded.");
     expect(probe).toEqual({
       url: `https://${kind}.example/prefix`,
       apikey: "0007",
@@ -671,7 +684,7 @@ it("tests a saved card by UUID using the current server-side connection", async 
     }),
   );
   await userEvent.click(await screen.findByRole("button", { name: "Test" }));
-  await screen.findByText(/Read-only connection succeeded/);
+  await screen.findByText("Connected to Living room.");
   expect(body).toEqual({});
 });
 

--- a/frontend/src/pages/Settings/MediaServers/MediaServerSection.test.tsx
+++ b/frontend/src/pages/Settings/MediaServers/MediaServerSection.test.tsx
@@ -1,0 +1,692 @@
+/* eslint-disable camelcase */
+
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import queryClient from "@/apis/queries";
+import type {
+  MediaServerInstance,
+  MediaServerKind,
+} from "@/apis/raw/mediaServers";
+import SettingsConnectionsView from "@/pages/Settings/Connections";
+import { act, customRender, screen, waitFor, within } from "@/tests";
+import server from "@/tests/mocks/node";
+
+const id = "2af88684-d7d2-4534-82bb-a6d839cc5c10";
+const secondId = "66e883df-68c7-4d66-8217-8fc206c5a563";
+const item = `/api/system/media-server-instances/${id}`;
+function instance(
+  kind: MediaServerKind,
+  overrides: Partial<MediaServerInstance> = {},
+): MediaServerInstance {
+  return {
+    id,
+    kind,
+    name: "Living room",
+    enabled: true,
+    url: `https://${kind}.example`,
+    verify_ssl: true,
+    api_key_set: true,
+    path_mappings: [
+      {
+        local_path: "/movies",
+        remote_path: "/media/movies",
+        ...(kind === "silo" ? { library_id: "0007" } : {}),
+      },
+    ],
+    ...overrides,
+  };
+}
+function setup(kind: MediaServerKind, enabled = true, rows = [instance(kind)]) {
+  window.history.replaceState(null, "", `/#${kind}`);
+  server.use(
+    http.get("/api/system/settings", () =>
+      HttpResponse.json({
+        general: { theme: "auto", [`use_${kind}`]: enabled },
+      }),
+    ),
+    http.get("/api/system/media-server-instances", () =>
+      HttpResponse.json({ data: rows }),
+    ),
+    http.get("/api/system/media-server-instances/:id/status", () =>
+      HttpResponse.json({ pending: 0, state: "idle", error_code: null }),
+    ),
+  );
+  customRender(<SettingsConnectionsView />);
+}
+async function edit() {
+  await userEvent.click(await screen.findByRole("button", { name: "Edit" }));
+  return screen.findByRole("dialog");
+}
+afterEach(() => window.history.replaceState(null, "", "/"));
+
+it.each(["emby", "silo"] as const)(
+  "edits %s with saved credentials and keeps dirty global settings through instance save",
+  async (kind) => {
+    const writes: unknown[] = [];
+    let testBody: unknown;
+    let settingsReads = 0;
+    setup(kind, false);
+    server.use(
+      http.get("/api/system/settings", () => {
+        settingsReads++;
+        return HttpResponse.json({
+          general: { theme: "auto", [`use_${kind}`]: false },
+        });
+      }),
+      http.patch(item, async ({ request }) => {
+        const body = await request.json();
+        writes.push(body);
+        return HttpResponse.json({ ...instance(kind), ...(body as object) });
+      }),
+      http.post(`${item}/test-connection`, async ({ request }) => {
+        testBody = await request.json();
+        return HttpResponse.json({ success: true, server_name: "Living room" });
+      }),
+      http.post("/api/system/settings", () => {
+        writes.push("global-save");
+        return HttpResponse.json({});
+      }),
+    );
+    await screen.findByRole("button", { name: "Edit" });
+    await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+    await userEvent.click(screen.getByRole("switch", { name: "Enabled" }));
+    const form = within(await edit());
+    await userEvent.clear(form.getByLabelText("Server URL"));
+    await userEvent.type(
+      form.getByLabelText("Server URL"),
+      `https://${kind}.example/prefix`,
+    );
+    await userEvent.click(
+      form.getByRole("switch", { name: "Verify SSL certificate" }),
+    );
+    await userEvent.click(form.getByRole("button", { name: "Test" }));
+    expect(
+      await form.findByText(/Read-only connection succeeded/),
+    ).toHaveTextContent(
+      /does not confirm refresh permission or subtitle discovery/,
+    );
+    expect(form.queryByText(/vundefined/)).not.toBeInTheDocument();
+    expect(testBody).toEqual({
+      url: `https://${kind}.example/prefix`,
+      verify_ssl: false,
+    });
+    const beforeSave = settingsReads;
+    await userEvent.click(form.getByRole("button", { name: "Save instance" }));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({
+      url: `https://${kind}.example/prefix`,
+      verify_ssl: false,
+    });
+    expect(writes[0]).not.toHaveProperty("api_key");
+    expect(settingsReads).toBe(beforeSave);
+    expect(screen.getByRole("switch", { name: "Enabled" })).toBeChecked();
+    expect(
+      screen.getByRole("button", { name: /Save 1 pending change/ }),
+    ).toBeInTheDocument();
+  },
+);
+
+it.each(["emby", "silo"] as const)(
+  "shows two %s cards and scopes toggle, edit, delete, status and retry to their UUIDs",
+  async (kind) => {
+    const rows = [
+      instance(kind),
+      instance(kind, { id: secondId, name: "Bedroom" }),
+    ];
+    const writes: unknown[] = [];
+    let retried = false;
+    setup(kind, true, rows);
+    server.use(
+      http.patch(item, async ({ request }) => {
+        const body = (await request.json()) as Partial<MediaServerInstance>;
+        writes.push([id, body]);
+        Object.assign(rows[0], body);
+        return HttpResponse.json(rows[0]);
+      }),
+      http.get(`${item}/status`, () =>
+        HttpResponse.json({
+          pending: retried ? 0 : 2,
+          state: retried ? "requested" : "unconfirmed",
+          error_code: null,
+        }),
+      ),
+      http.post(`${item}/retry-pending`, () => {
+        writes.push([id, "retry"]);
+        retried = true;
+        return HttpResponse.json({ queued: 2 });
+      }),
+      http.delete(item, () => {
+        writes.push([id, "delete"]);
+        rows.shift();
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+    const first = within(
+      await screen.findByRole("region", { name: "Living room" }),
+    );
+    const second = within(screen.getByRole("region", { name: "Bedroom" }));
+    expect(await first.findByText(/2 pending/)).toBeInTheDocument();
+    expect(await second.findByText(/No pending refreshes/)).toBeInTheDocument();
+    await userEvent.click(first.getByRole("button", { name: "Retry pending" }));
+    await first.findByText(/Queued 2 pending refreshes/);
+    await userEvent.click(
+      first.getByRole("switch", { name: "Disable instance" }),
+    );
+    await waitFor(() =>
+      expect(
+        first.getByRole("switch", { name: "Enable instance" }),
+      ).not.toBeChecked(),
+    );
+    expect(
+      second.getByRole("switch", { name: "Disable instance" }),
+    ).toBeChecked();
+    await userEvent.click(first.getByRole("button", { name: "Edit" }));
+    const modal = within(await screen.findByRole("dialog"));
+    await userEvent.clear(modal.getByLabelText("Name"));
+    await userEvent.type(modal.getByLabelText("Name"), "Renamed");
+    await userEvent.click(modal.getByRole("button", { name: "Save instance" }));
+    const renamed = within(
+      await screen.findByRole("region", { name: "Renamed" }),
+    );
+    await userEvent.click(renamed.getByRole("button", { name: "Delete" }));
+    await userEvent.click(
+      within(await screen.findByRole("dialog")).getByRole("button", {
+        name: "Cancel",
+      }),
+    );
+    expect(writes).toHaveLength(3);
+    await userEvent.click(renamed.getByRole("button", { name: "Delete" }));
+    await userEvent.click(
+      within(await screen.findByRole("dialog")).getByRole("button", {
+        name: "Delete instance",
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("region", { name: "Renamed" }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.getByRole("region", { name: "Bedroom" })).toBeInTheDocument();
+    expect(writes).toHaveLength(4);
+    expect(
+      queryClient.getQueryData(["media-servers", kind, id, "status"]),
+    ).toBeUndefined();
+  },
+);
+
+it("shows safe Test failures, resets on edits and disables probes when clearing a saved key", async () => {
+  setup("emby");
+  server.use(
+    http.post(`${item}/test-connection`, () =>
+      HttpResponse.json({ success: false, error_code: "authentication" }),
+    ),
+  );
+  const form = within(await edit());
+  await userEvent.click(form.getByRole("button", { name: "Test" }));
+  await form.findByText(/Connection test failed/);
+  await userEvent.type(form.getByLabelText("Server URL"), "/changed");
+  expect(form.queryByText(/Connection test failed/)).not.toBeInTheDocument();
+  await userEvent.click(form.getByRole("radio", { name: "Clear" }));
+  expect(form.getByRole("button", { name: "Test" })).toBeDisabled();
+});
+
+it("shows HTTP Test failures without displaying raw errors", async () => {
+  setup("silo");
+  server.use(
+    http.post(`${item}/test-connection`, () =>
+      HttpResponse.json({}, { status: 502 }),
+    ),
+  );
+  const form = within(await edit());
+  await userEvent.click(form.getByRole("button", { name: "Test" }));
+  await form.findByText(/Connection test failed/);
+});
+
+it("loads saved-key Silo libraries with current fields and distinguishes empty from failure", async () => {
+  let body: unknown;
+  setup("silo");
+  server.use(
+    http.post(`${item}/libraries`, async ({ request }) => {
+      body = await request.json();
+      return HttpResponse.json({ data: [], error_code: null });
+    }),
+  );
+  const form = within(await edit());
+  await userEvent.click(form.getByRole("radio", { name: "Replace" }));
+  await userEvent.type(form.getByLabelText("API Key"), "0007");
+  await userEvent.click(form.getByRole("button", { name: "Load libraries" }));
+  await form.findByText(/No supported libraries found/);
+  expect(body).toEqual({
+    url: "https://silo.example",
+    api_key: "0007",
+    verify_ssl: true,
+  });
+  server.use(
+    http.post(`${item}/libraries`, () =>
+      HttpResponse.json({ data: [], error_code: "connection_error" }),
+    ),
+  );
+  await userEvent.click(form.getByRole("button", { name: "Load libraries" }));
+  await form.findByText(/Could not load Silo libraries/);
+  expect(
+    form.queryByText(/No supported libraries found/),
+  ).not.toBeInTheDocument();
+});
+
+it("treats missing status as unavailable and keeps retry disabled", async () => {
+  setup("silo");
+  server.use(
+    http.get(`${item}/status`, () => HttpResponse.json({}, { status: 404 })),
+  );
+  expect(
+    await screen.findByText(/Refresh status unavailable/),
+  ).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Retry pending" })).toBeDisabled();
+  expect(screen.queryByText(/No pending refreshes/)).not.toBeInTheDocument();
+});
+
+it("warns about unconfirmed refreshes, retries pending work and refreshes status", async () => {
+  setup("silo");
+  let retried = false;
+  server.use(
+    http.get(`${item}/status`, () =>
+      HttpResponse.json({
+        pending: retried ? 0 : 2,
+        state: retried ? "requested" : "unconfirmed",
+        error_code: retried ? null : "timeout",
+      }),
+    ),
+    http.post(`${item}/retry-pending`, () => {
+      retried = true;
+      return HttpResponse.json({ queued: 2 });
+    }),
+  );
+  expect(await screen.findByText(/Refresh unconfirmed/)).toBeInTheDocument();
+  expect(screen.getByText(/2 pending/)).toBeInTheDocument();
+  await userEvent.click(screen.getByRole("button", { name: "Retry pending" }));
+  expect(
+    await screen.findByText(/Queued 2 pending refreshes/),
+  ).toBeInTheDocument();
+  expect(await screen.findByText(/Refresh requested/)).toBeInTheDocument();
+  expect(
+    screen.getByText(/Subtitle discovery is not confirmed/),
+  ).toBeInTheDocument();
+});
+
+it("disables retry when master changes are staged and shows retry failures safely", async () => {
+  setup("emby");
+  server.use(
+    http.get(`${item}/status`, () =>
+      HttpResponse.json({
+        pending: 1,
+        state: "pending",
+        error_code: "connection_error",
+      }),
+    ),
+    http.post(`${item}/retry-pending`, () =>
+      HttpResponse.json({}, { status: 502 }),
+    ),
+  );
+  const retry = await screen.findByRole("button", { name: "Retry pending" });
+  await waitFor(() => expect(retry).toBeEnabled());
+  await userEvent.click(retry);
+  expect(
+    await screen.findByText(/Could not queue pending refreshes/),
+  ).toBeInTheDocument();
+  await userEvent.click(screen.getByRole("switch", { name: "Enabled" }));
+  expect(retry).toBeDisabled();
+  expect(
+    screen.getByText(/Save your changes before retrying/),
+  ).toBeInTheDocument();
+});
+
+it("does not claim there is no pending work when an idle status includes queued changes", async () => {
+  setup("emby");
+  server.use(
+    http.get(`${item}/status`, () =>
+      HttpResponse.json({ pending: 2, state: "idle", error_code: null }),
+    ),
+  );
+  expect(await screen.findByText(/2 pending/)).toBeInTheDocument();
+  expect(screen.queryByText(/No pending refreshes/)).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Retry pending" })).toBeEnabled();
+});
+
+it.each(["confirmed", "requested", "idle"] as const)(
+  "keeps overflow actionable when the status is %s with no retained work",
+  async (state) => {
+    setup("silo");
+    server.use(
+      http.get(`${item}/status`, () =>
+        HttpResponse.json({ pending: 0, state, error_code: "queue_overflow" }),
+      ),
+    );
+    const warning = await screen.findByText(/0 pending/);
+    expect(warning).toHaveTextContent(/queue.*capacity|queue overflow/i);
+    expect(warning).toHaveTextContent(/not queued/i);
+    expect(warning).toHaveTextContent(
+      /Retry pending.*cannot recover.*dropped/i,
+    );
+    expect(warning).not.toHaveTextContent(
+      /Refresh confirmed|Refresh requested|No pending refreshes/i,
+    );
+    expect(
+      screen.getByRole("button", { name: "Retry pending" }),
+    ).toBeDisabled();
+  },
+);
+
+it("retries retained overflow targets and keeps the dropped-target warning after they drain", async () => {
+  setup("silo");
+  let retried = false;
+  server.use(
+    http.get(`${item}/status`, () =>
+      HttpResponse.json({
+        pending: retried ? 0 : 2,
+        state: retried ? "confirmed" : "unconfirmed",
+        error_code: "queue_overflow",
+      }),
+    ),
+    http.post(`${item}/retry-pending`, () => {
+      retried = true;
+      return HttpResponse.json({ queued: 2 });
+    }),
+  );
+  expect(await screen.findByText(/2 pending/)).toHaveTextContent(/not queued/i);
+  const retry = screen.getByRole("button", { name: "Retry pending" });
+  expect(retry).toBeEnabled();
+  await userEvent.click(retry);
+  expect(
+    await screen.findByText(/Queued 2 pending refreshes/),
+  ).toBeInTheDocument();
+  const warning = await screen.findByText(/0 pending/);
+  expect(warning).toHaveTextContent(/Retry pending.*cannot recover.*dropped/i);
+  expect(warning).not.toHaveTextContent(/Refresh confirmed/i);
+  expect(retry).toBeDisabled();
+});
+
+it("explains that an unsupported Silo subtitle location needs to change before retrying", async () => {
+  setup("silo");
+  server.use(
+    http.get(`${item}/status`, () =>
+      HttpResponse.json({
+        pending: 1,
+        state: "unconfirmed",
+        error_code: "sidecar_unsupported",
+        message: "Unsupported subtitle: /private/subtitles/movie.srt",
+      }),
+    ),
+  );
+  const warning = await screen.findByText(/1 pending/);
+  expect(warning).toHaveTextContent(/unsupported.*subtitle location/i);
+  expect(warning).toHaveTextContent(/subtitles.*beside the video/i);
+  expect(warning).toHaveTextContent(
+    /Retrying.*unchanged.*location.*will not resolve/i,
+  );
+  expect(warning).not.toHaveTextContent(
+    /may have reached the server|Check the saved connection|private|movie\.srt/i,
+  );
+  expect(screen.getByRole("button", { name: "Retry pending" })).toBeEnabled();
+});
+
+it("keeps unknown status errors generic without exposing the raw error", async () => {
+  setup("emby");
+  server.use(
+    http.get(`${item}/status`, () =>
+      HttpResponse.json({
+        pending: 1,
+        state: "unconfirmed",
+        error_code: "unknown_error: /private/subtitles/movie.srt",
+      }),
+    ),
+  );
+  const warning = await screen.findByText(/1 pending/);
+  expect(warning).toHaveTextContent(/Refresh unconfirmed/i);
+  expect(warning).toHaveTextContent(
+    /Check the saved connection, server access and path mappings/i,
+  );
+  expect(warning).not.toHaveTextContent(/unknown_error|private|movie\.srt/i);
+});
+
+it.each(["emby", "silo"] as const)(
+  "adds a disabled %s instance with an unsaved string key, and Cancel performs no write",
+  async (kind) => {
+    const writes: unknown[] = [];
+    let probe: unknown;
+    setup(kind, false, []);
+    server.use(
+      http.post(`/api/${kind}/test-connection`, async ({ request }) => {
+        probe = await request.json();
+        return HttpResponse.json({ success: true });
+      }),
+      http.post("/api/system/media-server-instances", async ({ request }) => {
+        const body = (await request.json()) as LooseObject;
+        writes.push(body);
+        return HttpResponse.json(
+          instance(kind, { ...body, api_key_set: true }),
+        );
+      }),
+      http.post("/api/system/settings", () => {
+        writes.push("global-save");
+        return HttpResponse.json({});
+      }),
+    );
+    await screen.findByText(
+      `No ${kind === "emby" ? "Emby" : "Silo"} instances yet`,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Add instance" }));
+    let modal = within(await screen.findByRole("dialog"));
+    expect(
+      modal.getByRole("switch", { name: "Instance enabled" }),
+    ).not.toBeChecked();
+    expect(
+      modal.getByRole("switch", { name: "Verify SSL certificate" }),
+    ).toBeChecked();
+    expect(modal.getByRole("button", { name: "Test" })).toBeDisabled();
+    await userEvent.type(modal.getByLabelText("Name"), "Cancelled");
+    await userEvent.type(modal.getByLabelText("API Key"), "cancelled-key");
+    await userEvent.click(modal.getByRole("button", { name: "Cancel" }));
+    expect(writes).toEqual([]);
+    await userEvent.click(screen.getByRole("button", { name: "Add instance" }));
+    modal = within(await screen.findByRole("dialog"));
+    expect(modal.getByLabelText("Name")).toHaveValue("");
+    expect(modal.getByLabelText("API Key")).toHaveValue("");
+    await userEvent.type(modal.getByLabelText("Name"), "New room");
+    await userEvent.type(
+      modal.getByLabelText("Server URL"),
+      `https://${kind}.example/prefix`,
+    );
+    await userEvent.type(modal.getByLabelText("API Key"), "0007");
+    await userEvent.click(
+      modal.getByRole("switch", { name: "Verify SSL certificate" }),
+    );
+    await userEvent.click(modal.getByRole("button", { name: "Test" }));
+    await modal.findByText(/Read-only connection succeeded/);
+    expect(probe).toEqual({
+      url: `https://${kind}.example/prefix`,
+      apikey: "0007",
+      verify_ssl: false,
+    });
+    await userEvent.click(modal.getByRole("button", { name: "Save instance" }));
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+    );
+    expect(writes).toEqual([
+      {
+        kind,
+        name: "New room",
+        url: `https://${kind}.example/prefix`,
+        api_key: "0007",
+        enabled: false,
+        verify_ssl: false,
+        path_mappings: [],
+      },
+    ]);
+  },
+);
+
+it("keeps a failed save open, saves explicit clear, and handles Enter and Ctrl+S within the instance form", async () => {
+  setup("emby", false);
+  const writes: LooseObject[] = [];
+  let fail = true;
+  let globalWrites = 0;
+  server.use(
+    http.patch(item, async ({ request }) => {
+      const body = (await request.json()) as LooseObject;
+      writes.push(body);
+      return fail
+        ? HttpResponse.json({}, { status: 502 })
+        : HttpResponse.json(instance("emby", { ...body, api_key_set: false }));
+    }),
+    http.post("/api/system/settings", () => {
+      globalWrites++;
+      return HttpResponse.json({});
+    }),
+  );
+  await screen.findByRole("button", { name: "Edit" });
+  await waitFor(() => expect(queryClient.isFetching()).toBe(0));
+  await userEvent.click(screen.getByRole("switch", { name: "Enabled" }));
+  const modal = within(await edit());
+  await userEvent.click(modal.getByRole("radio", { name: "Clear" }));
+  await userEvent.click(
+    modal.getByRole("switch", { name: "Instance enabled" }),
+  );
+  await userEvent.type(modal.getByLabelText("Name"), "{Enter}");
+  await modal.findByText(/Could not save this instance/);
+  expect(screen.getByRole("dialog")).toBeInTheDocument();
+  expect(writes[0]).toMatchObject({ clear_api_key: true, enabled: false });
+  expect(writes[0]).not.toHaveProperty("api_key");
+  expect(globalWrites).toBe(0);
+  fail = false;
+  await userEvent.click(modal.getByLabelText("Name"));
+  await userEvent.keyboard("{Control>}s{/Control}");
+  await waitFor(() =>
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+  );
+  expect(writes).toHaveLength(2);
+  expect(globalWrites).toBe(0);
+  expect(
+    screen.getByRole("button", { name: /Save 1 pending change/ }),
+  ).toBeInTheDocument();
+});
+
+it.each([
+  ["test-connection", "Bedroom"],
+  ["libraries", "Bedroom"],
+  ["save", "Bedroom"],
+  ["test-connection", "Living room"],
+  ["libraries", "Living room"],
+  ["save", "Living room"],
+] as const)(
+  "a late %s response cannot change or close the %s editor",
+  async (operation, target) => {
+    const rows = [
+      instance("silo"),
+      instance("silo", { id: secondId, name: "Bedroom" }),
+    ];
+    setup("silo", true, rows);
+    let finish: (() => void) | undefined;
+    const handler = async () => {
+      await new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+      return HttpResponse.json(
+        operation === "test-connection"
+          ? { success: true, server_name: "Stale response" }
+          : operation === "libraries"
+            ? {
+                data: [
+                  {
+                    id: "0007",
+                    name: "Stale library",
+                    type: "series",
+                    paths: ["/tv"],
+                  },
+                ],
+                error_code: null,
+              }
+            : rows[0],
+      );
+    };
+    server.use(
+      operation === "save"
+        ? http.patch(item, handler)
+        : http.post(`${item}/${operation}`, handler),
+    );
+    await userEvent.click(
+      within(
+        await screen.findByRole("region", { name: "Living room" }),
+      ).getByRole("button", { name: "Edit" }),
+    );
+    const first = within(await screen.findByRole("dialog"));
+    await userEvent.click(
+      first.getByRole("button", {
+        name:
+          operation === "test-connection"
+            ? "Test"
+            : operation === "libraries"
+              ? "Load libraries"
+              : "Save instance",
+      }),
+    );
+    await waitFor(() => expect(finish).toBeDefined());
+    await userEvent.click(first.getByRole("button", { name: "Cancel" }));
+    await userEvent.click(
+      within(screen.getByRole("region", { name: target })).getByRole("button", {
+        name: "Edit",
+      }),
+    );
+    await act(async () => finish?.());
+    await waitFor(() => expect(queryClient.isMutating()).toBe(0));
+    const second = within(await screen.findByRole("dialog"));
+    expect(second.getByLabelText("Name")).toHaveValue(target);
+    expect(
+      second.queryByText(/Stale response|Stale library/),
+    ).not.toBeInTheDocument();
+    await userEvent.click(second.getByRole("button", { name: "Cancel" }));
+    await userEvent.click(
+      within(screen.getByRole("region", { name: "Living room" })).getByRole(
+        "button",
+        { name: "Edit" },
+      ),
+    );
+    const reopened = within(await screen.findByRole("dialog"));
+    expect(reopened.getByLabelText("Name")).toHaveValue("Living room");
+    expect(
+      reopened.queryByText(/Stale response|Stale library/),
+    ).not.toBeInTheDocument();
+  },
+);
+
+it("tests a saved card by UUID using the current server-side connection", async () => {
+  let body: unknown;
+  setup("emby");
+  server.use(
+    http.post(`${item}/test-connection`, async ({ request }) => {
+      body = await request.json();
+      return HttpResponse.json({ success: true, server_name: "Living room" });
+    }),
+  );
+  await userEvent.click(await screen.findByRole("button", { name: "Test" }));
+  await screen.findByText(/Read-only connection succeeded/);
+  expect(body).toEqual({});
+});
+
+it("shows an instance loading failure and retries the list without a settings write", async () => {
+  setup("emby");
+  let fail = true;
+  server.use(
+    http.get("/api/system/media-server-instances", () =>
+      fail
+        ? HttpResponse.json({}, { status: 502 })
+        : HttpResponse.json({ data: [] }),
+    ),
+  );
+  await screen.findByText("Could not load Emby instances");
+  fail = false;
+  await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+  await screen.findByText("No Emby instances yet");
+});

--- a/frontend/src/pages/Settings/MediaServers/MediaServerSection.test.tsx
+++ b/frontend/src/pages/Settings/MediaServers/MediaServerSection.test.tsx
@@ -703,3 +703,18 @@ it("shows an instance loading failure and retries the list without a settings wr
   await userEvent.click(screen.getByRole("button", { name: "Retry" }));
   await screen.findByText("No Emby instances yet");
 });
+
+it.each([
+  ["emby", "Notify Emby about movie and episode subtitle changes."],
+  [
+    "silo",
+    "Notify Silo about movie and episode subtitle changes. Subtitle sidecars must be beside the video file.",
+  ],
+] as const)(
+  "says every subtitle change reaches %s, not only new ones",
+  async (kind, copy) => {
+    setup(kind);
+    expect(await screen.findByText(copy)).toBeInTheDocument();
+    expect(screen.queryByText(/subtitle additions/i)).not.toBeInTheDocument();
+  },
+);

--- a/frontend/src/pages/Settings/MediaServers/MediaServerSection.tsx
+++ b/frontend/src/pages/Settings/MediaServers/MediaServerSection.tsx
@@ -86,7 +86,7 @@ export default function MediaServerSection({
         <Check label="Enabled" settingKey={enabledKey} />
         <Text size="sm" c="dimmed">
           {kind === "emby"
-            ? "Notify Emby about movie and episode subtitle additions."
+            ? "Notify Emby about movie and episode subtitle changes."
             : "Notify Silo about movie and episode subtitle changes. Subtitle sidecars must be beside the video file."}
         </Text>
       </Section>

--- a/frontend/src/pages/Settings/MediaServers/MediaServerSection.tsx
+++ b/frontend/src/pages/Settings/MediaServers/MediaServerSection.tsx
@@ -1,0 +1,164 @@
+import { useState } from "react";
+import {
+  Alert,
+  Button,
+  Group,
+  Modal,
+  Skeleton,
+  Stack,
+  Text,
+} from "@mantine/core";
+import {
+  useDeleteMediaServerInstance,
+  useMediaServerInstances,
+} from "@/apis/hooks/mediaServers";
+import type {
+  MediaServerInstance,
+  MediaServerKind,
+} from "@/apis/raw/mediaServers";
+import { Check, Section } from "@/pages/Settings/components";
+import { useStagedValues } from "@/pages/Settings/utilities/FormValues";
+import { useSettingValue } from "@/pages/Settings/utilities/hooks";
+import MediaServerInstanceCard from "./MediaServerInstanceCard";
+import MediaServerInstanceFormModal from "./MediaServerInstanceFormModal";
+import styles from "@/pages/Settings/Connections/Connections.module.scss";
+
+function DeleteInstanceModal({
+  instance,
+  onClose,
+}: {
+  instance: MediaServerInstance;
+  onClose: () => void;
+}) {
+  const remove = useDeleteMediaServerInstance(instance.kind, instance.id);
+  return (
+    <Modal opened onClose={onClose} title="Delete instance" centered>
+      <Stack gap="md">
+        <Text size="sm">
+          Delete {instance.name}? Its connection settings and pending refreshes
+          will be removed. This cannot be undone.
+        </Text>
+        {remove.isError && (
+          <Alert color="red">
+            Could not delete this instance. Check that the Bazarr API is
+            available and try again.
+          </Alert>
+        )}
+        <Group justify="flex-end">
+          <Button type="button" variant="default" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            color="red"
+            loading={remove.isPending}
+            onClick={() => remove.mutate(undefined, { onSuccess: onClose })}
+          >
+            Delete instance
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}
+
+export default function MediaServerSection({
+  kind,
+}: {
+  kind: MediaServerKind;
+}) {
+  const name = kind === "emby" ? "Emby" : "Silo";
+  const enabledKey = `settings-general-use_${kind}`;
+  const savedEnabled =
+    useSettingValue<boolean>(enabledKey, { original: true }) ?? false;
+  const staged = useStagedValues();
+  const masterChanged = Object.hasOwn(staged, enabledKey);
+  const query = useMediaServerInstances(kind);
+  const [editor, setEditor] = useState<{
+    instance: MediaServerInstance | null;
+  } | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<MediaServerInstance | null>(
+    null,
+  );
+  return (
+    <>
+      <Section header={`Use ${name}`}>
+        <Check label="Enabled" settingKey={enabledKey} />
+        <Text size="sm" c="dimmed">
+          {kind === "emby"
+            ? "Notify Emby about movie subtitle additions."
+            : "Notify Silo about movie and episode subtitle changes. Subtitle sidecars must be beside the video file."}
+        </Text>
+      </Section>
+      <Section header={`${name} instances`}>
+        <Group justify="space-between">
+          <Text size="sm" c="dimmed">
+            Manage each {name} connection and its refreshes independently.
+          </Text>
+          <Button
+            type="button"
+            size="xs"
+            variant="light"
+            onClick={() => setEditor({ instance: null })}
+          >
+            Add instance
+          </Button>
+        </Group>
+        {query.isLoading ? (
+          <Skeleton height={96} radius="lg" aria-label="Loading instances" />
+        ) : query.isError ? (
+          <Alert color="red" title={`Could not load ${name} instances`}>
+            <Group justify="space-between">
+              <Text size="sm">
+                Check that the Bazarr API is reachable, then try again.
+              </Text>
+              <Button
+                type="button"
+                size="xs"
+                variant="light"
+                onClick={() => void query.refetch()}
+              >
+                Retry
+              </Button>
+            </Group>
+          </Alert>
+        ) : query.data?.length === 0 ? (
+          <div className={styles.empty}>
+            <Text fw={600}>No {name} instances yet</Text>
+            <Text size="sm" c="dimmed">
+              Add a connection to choose which local videos notify this server.
+            </Text>
+          </div>
+        ) : (
+          <Stack gap="sm">
+            {query.data?.map((instance) => (
+              <MediaServerInstanceCard
+                key={instance.id}
+                instance={instance}
+                masterEnabled={savedEnabled}
+                masterChanged={masterChanged}
+                onEdit={(instance) => setEditor({ instance })}
+                onDelete={setDeleteTarget}
+              />
+            ))}
+          </Stack>
+        )}
+      </Section>
+      {editor && (
+        <MediaServerInstanceFormModal
+          key={editor.instance?.id ?? "new"}
+          kind={kind}
+          instance={editor.instance}
+          onClose={() => setEditor(null)}
+        />
+      )}
+      {deleteTarget && (
+        <DeleteInstanceModal
+          key={deleteTarget.id}
+          instance={deleteTarget}
+          onClose={() => setDeleteTarget(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/Settings/MediaServers/MediaServerSection.tsx
+++ b/frontend/src/pages/Settings/MediaServers/MediaServerSection.tsx
@@ -86,7 +86,7 @@ export default function MediaServerSection({
         <Check label="Enabled" settingKey={enabledKey} />
         <Text size="sm" c="dimmed">
           {kind === "emby"
-            ? "Notify Emby about movie subtitle additions."
+            ? "Notify Emby about movie and episode subtitle additions."
             : "Notify Silo about movie and episode subtitle changes. Subtitle sidecars must be beside the video file."}
         </Text>
       </Section>

--- a/frontend/src/pages/Settings/MediaServers/PathMappings.test.tsx
+++ b/frontend/src/pages/Settings/MediaServers/PathMappings.test.tsx
@@ -1,0 +1,187 @@
+/* eslint-disable camelcase */
+
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import SettingsConnectionsView from "@/pages/Settings/Connections";
+import { customRender, screen, waitFor } from "@/tests";
+import server from "@/tests/mocks/node";
+
+const id = "2af88684-d7d2-4534-82bb-a6d839cc5c10";
+const item = `/api/system/media-server-instances/${id}`;
+
+afterEach(() => window.history.replaceState(null, "", "/"));
+
+it.each(["emby", "silo"] as const)(
+  "adds, edits, removes and submits controlled %s mappings as JSON with string IDs",
+  async (kind) => {
+    window.history.replaceState(null, "", `/#${kind}`);
+    const saved: LooseObject[] = [];
+    server.use(
+      http.get("/api/system/settings", () =>
+        HttpResponse.json({
+          general: { theme: "auto", [`use_${kind}`]: true },
+        }),
+      ),
+      http.get("/api/system/media-server-instances", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id,
+              kind,
+              name: "Living room",
+              enabled: false,
+              api_key_set: true,
+              url: `https://${kind}.example`,
+              verify_ssl: true,
+              path_mappings: [],
+            },
+          ],
+        }),
+      ),
+      http.get(`${item}/status`, () =>
+        HttpResponse.json({ pending: 0, state: "idle", error_code: null }),
+      ),
+      http.post(`${item}/libraries`, () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "0010",
+              name: "Movies",
+              type: "movies",
+              paths: ["/media/movies"],
+            },
+            { id: "0007", name: "TV", type: "series", paths: ["/media/tv"] },
+          ],
+          error_code: null,
+        }),
+      ),
+      http.patch(item, async ({ request }) => {
+        const body = (await request.json()) as LooseObject;
+        saved.push(body);
+        return HttpResponse.json({
+          id,
+          kind,
+          name: "Living room",
+          enabled: false,
+          api_key_set: true,
+          ...body,
+        });
+      }),
+    );
+    customRender(<SettingsConnectionsView />);
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("button", { name: "Edit" }));
+    if (kind === "silo") {
+      await user.click(
+        await screen.findByRole("button", { name: "Load libraries" }),
+      );
+    }
+    const add = await screen.findByRole("button", { name: "Add mapping" });
+    await waitFor(() => expect(add).toBeEnabled());
+    await user.click(add);
+    const local = screen.getByLabelText("Local path 1");
+    await user.type(local, "/wrong");
+    await user.clear(local);
+    await user.type(local, "/tv");
+    await user.type(screen.getByLabelText("Server path 1"), "/media/tv");
+    if (kind === "silo") {
+      await user.click(
+        screen.getByRole("combobox", { name: "Silo library 1" }),
+      );
+      await user.click(await screen.findByText("TV (series)"));
+      const library = screen.getByRole("combobox", { name: "Silo library 1" });
+      await user.clear(library);
+      await user.type(library, "unknown-library");
+      await user.tab();
+    }
+    await user.click(add);
+    await user.click(screen.getByRole("button", { name: "Remove mapping 2" }));
+    expect(screen.getByLabelText("Local path 1")).toHaveValue("/tv");
+    await user.click(
+      await screen.findByRole("button", { name: /Save instance/ }),
+    );
+    await waitFor(() => expect(saved).toHaveLength(1));
+    const expected =
+      kind === "silo"
+        ? [{ local_path: "/tv", remote_path: "/media/tv", library_id: "0007" }]
+        : [{ local_path: "/tv", remote_path: "/media/tv" }];
+    expect(saved[0].path_mappings).toEqual(expected);
+    expect(JSON.stringify(saved[0].path_mappings)).not.toContain(
+      "[object Object]",
+    );
+  },
+);
+
+it("preserves saved Silo mappings while libraries are unavailable and permits removal", async () => {
+  window.history.replaceState(null, "", "/#silo");
+  const saved: LooseObject[] = [];
+  server.use(
+    http.get("/api/system/settings", () =>
+      HttpResponse.json({
+        general: { theme: "auto", use_silo: true },
+      }),
+    ),
+    http.get("/api/system/media-server-instances", () =>
+      HttpResponse.json({
+        data: [
+          {
+            id,
+            kind: "silo",
+            name: "Living room",
+            enabled: false,
+            api_key_set: true,
+            url: "https://silo.example",
+            verify_ssl: true,
+            path_mappings: [
+              {
+                local_path: "/tv",
+                remote_path: "/media/tv",
+                library_id: "0007",
+              },
+            ],
+          },
+        ],
+      }),
+    ),
+    http.get(`${item}/status`, () =>
+      HttpResponse.json({ pending: 0, state: "idle", error_code: null }),
+    ),
+    http.post(`${item}/libraries`, () =>
+      HttpResponse.json({ data: [], error_code: "connection_error" }),
+    ),
+    http.patch(item, async ({ request }) => {
+      const body = (await request.json()) as LooseObject;
+      saved.push(body);
+      return HttpResponse.json({
+        id,
+        kind: "silo",
+        name: "Living room",
+        enabled: false,
+        api_key_set: true,
+        ...body,
+      });
+    }),
+  );
+  customRender(<SettingsConnectionsView />);
+  await userEvent.click(await screen.findByRole("button", { name: "Edit" }));
+  expect(await screen.findByLabelText("Local path 1")).toHaveValue("/tv");
+  expect(screen.getByLabelText("Server path 1")).toHaveValue("/media/tv");
+  expect(screen.getByLabelText("Local path 1")).toBeDisabled();
+  expect(screen.getByRole("combobox", { name: "Silo library 1" })).toHaveValue(
+    "Unavailable library (0007)",
+  );
+  expect(screen.getByRole("button", { name: "Add mapping" })).toBeDisabled();
+  await userEvent.click(screen.getByRole("button", { name: "Load libraries" }));
+  expect(
+    await screen.findByText(/Could not load Silo libraries/),
+  ).toBeInTheDocument();
+  expect(screen.getByLabelText("Local path 1")).toHaveValue("/tv");
+  await userEvent.click(
+    screen.getByRole("button", { name: "Remove mapping 1" }),
+  );
+  await userEvent.click(
+    await screen.findByRole("button", { name: /Save instance/ }),
+  );
+  await waitFor(() => expect(saved).toHaveLength(1));
+  expect(saved[0].path_mappings).toEqual([]);
+});

--- a/frontend/src/pages/Settings/MediaServers/PathMappings.tsx
+++ b/frontend/src/pages/Settings/MediaServers/PathMappings.tsx
@@ -1,0 +1,153 @@
+/* eslint-disable camelcase */
+
+import { Button, Group, Select, Stack, Text, TextInput } from "@mantine/core";
+import type {
+  MediaServerKind,
+  PathMapping,
+  SiloLibrary,
+} from "@/apis/raw/mediaServers";
+
+interface Props {
+  kind: MediaServerKind;
+  libraries?: SiloLibrary[];
+  value: PathMapping[];
+  onChange: (value: PathMapping[]) => void;
+}
+
+export default function PathMappings({
+  kind,
+  libraries = [],
+  value: mappings,
+  onChange: update,
+}: Props) {
+  const isSilo = kind === "silo";
+  const options = libraries.map((library) => ({
+    value: library.id,
+    label: `${library.name} (${library.type})`,
+  }));
+  const change = (index: number, patch: Partial<PathMapping>) => {
+    update(
+      mappings.map((mapping, i) =>
+        i === index ? { ...mapping, ...patch } : mapping,
+      ),
+    );
+  };
+
+  return (
+    <Stack gap="md">
+      <Text size="sm" c="dimmed">
+        Local path is the folder as Bazarr sees it. Server path is the same
+        folder as {isSilo ? "Silo" : "Emby"} sees it. Add a mapping for each
+        media folder, even when both paths are the same. Mappings select which
+        local videos notify this instance. A path matching several instances
+        refreshes each one.
+        {isSilo && " Select the Silo library that contains that server folder."}
+      </Text>
+      {mappings.map((mapping, index) => {
+        const library = libraries.find(
+          (item) => item.id === mapping.library_id,
+        );
+        const unavailable = isSilo && !library;
+        const selectOptions =
+          unavailable && mapping.library_id
+            ? [
+                ...options,
+                {
+                  value: mapping.library_id,
+                  label: `Unavailable library (${mapping.library_id})`,
+                  disabled: true,
+                },
+              ]
+            : options;
+        return (
+          <Stack key={index} gap="xs">
+            <Group align="flex-start" grow>
+              <TextInput
+                label={`Local path ${index + 1}`}
+                value={mapping.local_path}
+                placeholder="/tv"
+                disabled={unavailable}
+                onChange={(event) =>
+                  change(index, { local_path: event.currentTarget.value })
+                }
+              />
+              <TextInput
+                label={`Server path ${index + 1}`}
+                value={mapping.remote_path}
+                placeholder="/media/tv"
+                disabled={unavailable}
+                onChange={(event) =>
+                  change(index, { remote_path: event.currentTarget.value })
+                }
+              />
+            </Group>
+            {isSilo && (
+              <>
+                <Select
+                  label={`Silo library ${index + 1}`}
+                  data={selectOptions}
+                  value={mapping.library_id ?? null}
+                  searchable
+                  allowDeselect={false}
+                  disabled={libraries.length === 0}
+                  onChange={(id) => {
+                    if (
+                      id !== null &&
+                      libraries.some((item) => item.id === id)
+                    ) {
+                      change(index, { library_id: id });
+                    }
+                  }}
+                />
+                {unavailable && (
+                  <Text size="xs" c="dimmed">
+                    Load libraries and select an available library before
+                    editing this mapping. The saved mapping is preserved until
+                    you edit or remove it.
+                  </Text>
+                )}
+                {library && (
+                  <Text size="xs" c="dimmed">
+                    Library folders:{" "}
+                    {library.paths.join(", ") || "None reported"}
+                  </Text>
+                )}
+              </>
+            )}
+            <Group justify="flex-end">
+              <Button
+                type="button"
+                variant="subtle"
+                color="red"
+                size="xs"
+                aria-label={`Remove mapping ${index + 1}`}
+                onClick={() => update(mappings.filter((_, i) => i !== index))}
+              >
+                Remove mapping
+              </Button>
+            </Group>
+          </Stack>
+        );
+      })}
+      <Group>
+        <Button
+          type="button"
+          variant="light"
+          disabled={isSilo && libraries.length === 0}
+          onClick={() =>
+            update([
+              ...mappings,
+              {
+                local_path: "",
+                remote_path: "",
+                ...(isSilo ? { library_id: libraries[0].id } : {}),
+              },
+            ])
+          }
+        >
+          Add mapping
+        </Button>
+      </Group>
+    </Stack>
+  );
+}

--- a/frontend/src/pages/Settings/components/Layout.test.tsx
+++ b/frontend/src/pages/Settings/components/Layout.test.tsx
@@ -1,11 +1,15 @@
+import { createMemoryRouter, Link, RouterProvider } from "react-router";
 import { Text } from "@mantine/core";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { useFormActions } from "@/pages/Settings/utilities/FormValues";
-import { customRender, screen, waitFor } from "@/tests";
+import { AllProviders } from "@/providers";
+import { customRender, rawRender, screen, waitFor } from "@/tests";
 import server from "@/tests/mocks/node";
+import { Password } from "./forms";
 import Layout from "./Layout";
+import LayoutModal from "./LayoutModal";
 
 // An input that only stages its value when it is left, the way the AI Model
 // field commits an OpenRouter routing shortcut.
@@ -165,4 +169,137 @@ describe("Settings layout", () => {
       "typed-then-enter",
     );
   });
+});
+
+it("submits a secret while the active development logger records only field names", async () => {
+  vi.stubEnv("MODE", "development");
+  const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  const submitted: LooseObject[] = [];
+  server.use(
+    http.post("/api/system/settings", async ({ request }) => {
+      submitted.push(Object.fromEntries((await request.formData()).entries()));
+      return HttpResponse.json({});
+    }),
+  );
+  try {
+    customRender(
+      <Layout name="Logging test">
+        <CommitOnBlurInput />
+      </Layout>,
+    );
+    await userEvent.type(
+      screen.getByLabelText("Commits on blur"),
+      "sentinel-layout-secret{Enter}",
+    );
+    await waitFor(() => expect(submitted).toHaveLength(1));
+    expect(submitted[0]["settings-general-instance_name"]).toBe(
+      "sentinel-layout-secret",
+    );
+    expect(log).toHaveBeenCalledWith("[info] submitting settings", [
+      "settings-general-instance_name",
+    ]);
+    expect(
+      JSON.stringify([log.mock.calls, warn.mock.calls, error.mock.calls]),
+    ).not.toContain("sentinel-layout-secret");
+  } finally {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  }
+});
+
+it("keeps modal submission values out of the active development logger", async () => {
+  vi.stubEnv("MODE", "development");
+  const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  const submitted: LooseObject[] = [];
+  const close = vi.fn();
+  server.use(
+    http.post("/api/system/settings", async ({ request }) => {
+      submitted.push(Object.fromEntries((await request.formData()).entries()));
+      return HttpResponse.json({});
+    }),
+  );
+  try {
+    customRender(
+      <LayoutModal callbackModal={close}>
+        <Password label="API Key" settingKey="settings-silo-apikey" />
+      </LayoutModal>,
+    );
+    await userEvent.type(
+      screen.getByLabelText("API Key"),
+      "sentinel-modal-secret",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(submitted).toHaveLength(1));
+    expect(submitted[0]["settings-silo-apikey"]).toBe("sentinel-modal-secret");
+    expect(log).toHaveBeenCalledWith("[info] submitting settings", [
+      "settings-silo-apikey",
+    ]);
+    expect(
+      JSON.stringify([log.mock.calls, warn.mock.calls, error.mock.calls]),
+    ).not.toContain("sentinel-modal-secret");
+    await waitFor(() => expect(close).toHaveBeenCalledWith(true));
+  } finally {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  }
+});
+
+it("keeps Save and Leave values out of the active development logger", async () => {
+  vi.stubEnv("MODE", "development");
+  const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  const submitted: LooseObject[] = [];
+  server.use(
+    http.post("/api/system/settings", async ({ request }) => {
+      submitted.push(Object.fromEntries((await request.formData()).entries()));
+      return HttpResponse.json({});
+    }),
+  );
+  const router = createMemoryRouter([
+    {
+      path: "/",
+      element: (
+        <Layout name="Logging test">
+          <Password label="API Key" settingKey="settings-emby-apikey" />
+          <Link to="/away">Leave settings</Link>
+        </Layout>
+      ),
+    },
+    { path: "/away", element: <p>Destination</p> },
+  ]);
+  try {
+    rawRender(
+      <AllProviders>
+        <RouterProvider router={router} />
+      </AllProviders>,
+    );
+    await userEvent.type(
+      screen.getByLabelText("API Key"),
+      "sentinel-leave-secret",
+    );
+    await userEvent.click(screen.getByRole("link", { name: "Leave settings" }));
+    await userEvent.click(
+      await screen.findByRole("button", {
+        name: "Save all changes and leave this page",
+      }),
+    );
+    await waitFor(() => expect(submitted).toHaveLength(1));
+    expect(await screen.findByText("Destination")).toBeInTheDocument();
+    expect(submitted[0]["settings-emby-apikey"]).toBe("sentinel-leave-secret");
+    expect(log).toHaveBeenCalledWith("[info] save & leave", [
+      "settings-emby-apikey",
+    ]);
+    expect(
+      JSON.stringify([log.mock.calls, warn.mock.calls, error.mock.calls]),
+    ).not.toContain("sentinel-leave-secret");
+  } finally {
+    router.dispose();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  }
 });

--- a/frontend/src/pages/Settings/components/Layout.tsx
+++ b/frontend/src/pages/Settings/components/Layout.tsx
@@ -68,7 +68,7 @@ const Layout: FunctionComponent<Props> = (props) => {
       if (Object.keys(settings).length > 0) {
         const settingsToSubmit = { ...settings };
         runHooks(hooks, settingsToSubmit);
-        LOG("info", "submitting settings", settingsToSubmit);
+        LOG("info", "submitting settings", Object.keys(settingsToSubmit));
         mutate(settingsToSubmit);
       }
     },
@@ -80,7 +80,7 @@ const Layout: FunctionComponent<Props> = (props) => {
     if (Object.keys(settings).length > 0) {
       const settingsToSubmit = { ...settings };
       runHooks(hooks, settingsToSubmit);
-      LOG("info", "save & leave", settingsToSubmit);
+      LOG("info", "save & leave", Object.keys(settingsToSubmit));
       await mutateAsync(settingsToSubmit);
     }
   }, [form.values, mutateAsync]);

--- a/frontend/src/pages/Settings/components/LayoutModal.tsx
+++ b/frontend/src/pages/Settings/components/LayoutModal.tsx
@@ -49,7 +49,7 @@ const LayoutModal: FunctionComponent<Props> = (props) => {
       if (Object.keys(settings).length > 0) {
         const settingsToSubmit = { ...settings };
         runHooks(hooks, settingsToSubmit);
-        LOG("info", "submitting settings", settingsToSubmit);
+        LOG("info", "submitting settings", Object.keys(settingsToSubmit));
         mutate(settingsToSubmit);
         // wait for settings to be validated before callback
         // let the user see the spinning indicator on the Save button before the modal closes

--- a/frontend/src/pages/Settings/utilities/FormValues.test.tsx
+++ b/frontend/src/pages/Settings/utilities/FormValues.test.tsx
@@ -1,0 +1,87 @@
+import { useForm } from "@mantine/form";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { customRender, screen } from "@/tests";
+import {
+  FormContext,
+  FormValues,
+  runHooks,
+  useFormActions,
+} from "./FormValues";
+
+function StageSecrets() {
+  const { update, setValue } = useFormActions();
+  return (
+    <button
+      onClick={() => {
+        update({ "settings-silo-apikey": "sentinel-stage-secret" });
+        setValue(
+          "sentinel-stage-secret",
+          "settings-emby-apikey",
+          (value: string) => `${value}-hooked`,
+        );
+      }}
+    >
+      Stage secrets
+    </button>
+  );
+}
+
+function Harness({ saved }: { saved: LooseObject[] }) {
+  const form = useForm<FormValues>({
+    initialValues: { settings: {}, hooks: {} },
+  });
+  return (
+    <FormContext.Provider value={form}>
+      <StageSecrets />
+      <button
+        onClick={() => {
+          const values = { ...form.values.settings };
+          runHooks(form.values.hooks, values);
+          saved.push(values);
+        }}
+      >
+        Run hooks
+      </button>
+    </FormContext.Provider>
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+it("logs staged field names with the real development logger, never values before or after hooks", async () => {
+  vi.stubEnv("MODE", "development");
+  const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+  const saved: LooseObject[] = [];
+  customRender(<Harness saved={saved} />);
+  await userEvent.click(screen.getByRole("button", { name: "Stage secrets" }));
+  await userEvent.click(screen.getByRole("button", { name: "Run hooks" }));
+  expect(log).toHaveBeenCalledWith(
+    "[info] Updating value of settings-emby-apikey",
+  );
+  expect(log).toHaveBeenCalledWith("[info] Updating values", [
+    "settings-silo-apikey",
+  ]);
+  expect(log).toHaveBeenCalledWith(
+    "[info] Running submit hook for",
+    "settings-emby-apikey",
+  );
+  expect(log).toHaveBeenCalledWith(
+    "[info] Finish submit hook",
+    "settings-emby-apikey",
+  );
+  expect(
+    JSON.stringify([log.mock.calls, warn.mock.calls, error.mock.calls]),
+  ).not.toContain("sentinel-stage-secret");
+  expect(saved).toEqual([
+    {
+      "settings-silo-apikey": "sentinel-stage-secret",
+      "settings-emby-apikey": "sentinel-stage-secret-hooked",
+    },
+  ]);
+});

--- a/frontend/src/pages/Settings/utilities/FormValues.ts
+++ b/frontend/src/pages/Settings/utilities/FormValues.ts
@@ -28,7 +28,7 @@ export function useFormActions() {
   formRef.current = form;
 
   const update = useCallback((object: LooseObject) => {
-    LOG("info", `Updating values`, object);
+    LOG("info", `Updating values`, Object.keys(object));
     formRef.current.setValues((values) => {
       const changes = { ...values.settings, ...object };
       return { ...values, settings: changes };
@@ -36,7 +36,7 @@ export function useFormActions() {
   }, []);
 
   const setValue = useCallback((v: unknown, key: string, hook?: HookType) => {
-    LOG("info", `Updating value of ${key}`, v);
+    LOG("info", `Updating value of ${key}`);
     formRef.current.setValues((values) => {
       const changes = { ...values.settings, [key]: v };
       const hooks = { ...values.hooks };
@@ -76,11 +76,11 @@ export function runHooks(
 ) {
   for (const key in settings) {
     if (key in hooks) {
-      LOG("info", "Running submit hook for", key, settings[key]);
+      LOG("info", "Running submit hook for", key);
       const value = settings[key];
       const fn = hooks[key];
       settings[key] = fn(value);
-      LOG("info", "Finish submit hook", key, settings[key]);
+      LOG("info", "Finish submit hook", key);
     }
   }
 }

--- a/frontend/src/types/settings.d.ts
+++ b/frontend/src/types/settings.d.ts
@@ -78,6 +78,8 @@ declare namespace Settings {
     upgrade_manual: boolean;
     use_embedded_subs: boolean;
     use_jellyfin?: boolean;
+    use_emby?: boolean;
+    use_silo?: boolean;
     use_plex?: boolean;
     use_postprocessing: boolean;
     use_postprocessing_threshold: boolean;

--- a/migrations/versions/c2e7a4d9f810_media_server_instances.py
+++ b/migrations/versions/c2e7a4d9f810_media_server_instances.py
@@ -1,0 +1,42 @@
+"""Independent native media server destinations.
+
+Revision ID: c2e7a4d9f810
+Revises: b8d2c5f1a604
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'c2e7a4d9f810'
+down_revision = 'b8d2c5f1a604'
+branch_labels = None
+depends_on = None
+
+
+def create_media_server_tables(bind):
+    metadata = sa.MetaData()
+    sa.Table('media_server_instances', metadata,
+             sa.Column('id', sa.Text, primary_key=True),
+             sa.Column('kind', sa.Text, nullable=False),
+             sa.Column('name', sa.Text, nullable=False),
+             sa.Column('enabled', sa.Integer, nullable=False, server_default='0'),
+             sa.Column('url', sa.Text, nullable=False),
+             sa.Column('api_key', sa.Text, nullable=False, server_default=''),
+             sa.Column('verify_ssl', sa.Integer, nullable=False, server_default='1'),
+             sa.Column('path_mappings', sa.Text, nullable=False, server_default='[]'),
+             sa.Column('revision', sa.Integer, nullable=False, server_default='1'),
+             sa.CheckConstraint("kind IN ('emby', 'silo')", name='ck_media_server_kind'),
+             sa.CheckConstraint('enabled IN (0, 1)', name='ck_media_server_enabled'),
+             sa.CheckConstraint('verify_ssl IN (0, 1)', name='ck_media_server_verify_ssl'))
+    sa.Table('media_server_imports', metadata,
+             sa.Column('kind', sa.Text, primary_key=True),
+             sa.CheckConstraint("kind IN ('emby', 'silo')", name='ck_media_server_import_kind'))
+    metadata.create_all(bind)
+
+
+def upgrade():
+    create_media_server_tables(op.get_bind())
+
+
+def downgrade():
+    pass

--- a/tests/bazarr/test_anti_captcha_config.py
+++ b/tests/bazarr/test_anti_captcha_config.py
@@ -69,7 +69,8 @@ def test_save_settings_reconfigures_captcha_on_captchaai_key(monkeypatch):
     from app import config
 
     called = []
-    monkeypatch.setattr(config, "write_config", lambda: None)
+    # A write that reached disk. Anything else is refused.
+    monkeypatch.setattr(config, "write_config", lambda: True)
     monkeypatch.setattr(config, "validate_log_regex", lambda: None)
     monkeypatch.setattr(config.settings.validators, "validate", lambda: None)
     monkeypatch.setattr(config, "configure_captcha_func", lambda: called.append(True))

--- a/tests/bazarr/test_arr_atomicity_secrets.py
+++ b/tests/bazarr/test_arr_atomicity_secrets.py
@@ -129,7 +129,7 @@ def test_persist_master_key_generates_and_writes_when_empty(monkeypatch):
 
     monkeypatch.setattr(cfg.settings.general, "secrets_encryption_key", "", raising=False)
     calls = []
-    monkeypatch.setattr(cfg, "write_config", lambda: calls.append(True))
+    monkeypatch.setattr(cfg, "write_config", lambda: (calls.append(True) or True))
 
     persist_master_key()
 
@@ -143,7 +143,7 @@ def test_persist_master_key_noop_when_already_persisted(monkeypatch):
 
     monkeypatch.setattr(cfg.settings.general, "secrets_encryption_key", "already-here", raising=False)
     calls = []
-    monkeypatch.setattr(cfg, "write_config", lambda: calls.append(True))
+    monkeypatch.setattr(cfg, "write_config", lambda: (calls.append(True) or True))
 
     persist_master_key()
 
@@ -197,3 +197,72 @@ def test_test_connection_for_instance_handles_undecryptable_key(schema_session):
     assert status == 200
     assert body["ok"] is False
     assert body["error"] == "decrypt_failed"  # clean structured error, not a 500
+
+
+@pytest.mark.parametrize('result', [False, None, 'raise'])
+def test_failed_master_key_persistence_restores_blank_and_retries(monkeypatch, result):
+    from app import config
+    from secret_store import persist_master_key
+    monkeypatch.setattr(config.settings.general, 'secrets_encryption_key', '')
+    def fail():
+        if result == 'raise':
+            raise OSError('synthetic private detail')
+        return result
+    monkeypatch.setattr(config, 'write_config', fail)
+    with pytest.raises(ValueError, match='Unable to persist secrets encryption key'):
+        persist_master_key()
+    assert config.settings.general.secrets_encryption_key == ''
+    monkeypatch.setattr(config, 'write_config', lambda: True)
+    persist_master_key()
+    assert config.settings.general.secrets_encryption_key
+
+
+def test_concurrent_first_master_key_waits_for_durability(monkeypatch):
+    from threading import Event, Thread
+    from app import config
+    from secret_store import persist_master_key
+    monkeypatch.setattr(config.settings.general, 'secrets_encryption_key', '')
+    reached, release, second_done = Event(), Event(), Event()
+    writes, errors = [], []
+    def write():
+        writes.append(config.settings.general.secrets_encryption_key)
+        reached.set()
+        assert release.wait(3)
+        return True
+    monkeypatch.setattr(config, 'write_config', write)
+    def persist(done=None):
+        try:
+            persist_master_key()
+        except Exception as error:
+            errors.append(type(error).__name__)
+        if done:
+            done.set()
+    first = Thread(target=persist)
+    second = Thread(target=persist, args=(second_done,))
+    first.start()
+    try:
+        assert reached.wait(3)
+        second.start()
+        assert not second_done.wait(.05)
+    finally:
+        release.set()
+        first.join(3)
+        second.join(3)
+    assert not errors and second_done.is_set()
+    assert len(writes) == 1
+
+
+def test_generated_before_persist_is_not_mistaken_for_durable(monkeypatch):
+    from app import config
+    from secret_store import get_master_key, persist_master_key
+    monkeypatch.setattr(config.settings.general, 'secrets_encryption_key', '')
+    generated = get_master_key()
+    monkeypatch.setattr(config, 'write_config', lambda: False)
+    with pytest.raises(ValueError, match='Unable to persist secrets encryption key'):
+        persist_master_key()
+    assert config.settings.general.secrets_encryption_key == generated
+    writes = []
+    monkeypatch.setattr(config, 'write_config', lambda: (writes.append(True) or True))
+    persist_master_key()
+    persist_master_key()
+    assert writes == [True]

--- a/tests/bazarr/test_combine_api_episodes.py
+++ b/tests/bazarr/test_combine_api_episodes.py
@@ -126,7 +126,7 @@ def _make_result(status, path="", alignment="", reason="", error=""):
 
 
 def _make_db_row(path="/series/Show/S01E01.mkv", sonarr_series_id=7):
-    return type("Row", (), {"path": path, "sonarrSeriesId": sonarr_series_id})()
+    return type("Row", (), {"path": path, "sonarrSeriesId": sonarr_series_id, "arr_instance_id": 7})()
 
 
 # ---------------------------------------------------------------------------
@@ -154,7 +154,7 @@ class TestEpisodesSubtitlesCombinePost:
              patch.object(episodes_subtitles_module, 'request', self._make_request({})):
 
             mock_db.execute.return_value = mock_db_result
-            mock_pm.path_replace.return_value = '/mapped/series/Show/S01E01.mkv'
+            mock_pm.path_replace_instance.return_value = '/mapped/series/Show/S01E01.mkv'
             mock_combine.return_value = _make_result(
                 status='built',
                 path='/series/Show/S01E01.en.combined-hu.srt',
@@ -190,7 +190,7 @@ class TestEpisodesSubtitlesCombinePost:
              patch.object(episodes_subtitles_module, 'request', self._make_request(payload)):
 
             mock_db.execute.return_value = mock_db_result
-            mock_pm.path_replace.return_value = '/mapped/series/Show/S01E01.mkv'
+            mock_pm.path_replace_instance.return_value = '/mapped/series/Show/S01E01.mkv'
             mock_combine.return_value = _make_result(
                 status='built',
                 path='/x.srt',
@@ -221,7 +221,7 @@ class TestEpisodesSubtitlesCombinePost:
              patch.object(episodes_subtitles_module, 'request', self._make_request({})):
 
             mock_db.execute.return_value = mock_db_result
-            mock_pm.path_replace.return_value = '/mapped/series/Show/S01E01.mkv'
+            mock_pm.path_replace_instance.return_value = '/mapped/series/Show/S01E01.mkv'
             mock_combine.return_value = _make_result(
                 status='skipped',
                 reason='no rule',
@@ -246,7 +246,7 @@ class TestEpisodesSubtitlesCombinePost:
              patch.object(episodes_subtitles_module, 'request', self._make_request({})):
 
             mock_db.execute.return_value = mock_db_result
-            mock_pm.path_replace.return_value = '/mapped/series/Show/S01E01.mkv'
+            mock_pm.path_replace_instance.return_value = '/mapped/series/Show/S01E01.mkv'
             mock_combine.return_value = _make_result(
                 status='failed',
                 error='malformed SRT',

--- a/tests/bazarr/test_combine_api_movies.py
+++ b/tests/bazarr/test_combine_api_movies.py
@@ -127,7 +127,7 @@ def _make_result(status, path="", alignment="", reason="", error=""):
 
 
 def _make_db_row(path="/movies/Movie.mkv"):
-    return type("Row", (), {"path": path})()
+    return type("Row", (), {"path": path, "arr_instance_id": 7})()
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +155,7 @@ class TestMoviesSubtitlesCombinePost:
              patch.object(movies_subtitles_module, 'request', self._make_request({})):
 
             mock_db.execute.return_value = mock_db_result
-            mock_pm.path_replace_movie.return_value = '/mapped/movies/Movie.mkv'
+            mock_pm.path_replace_instance.return_value = '/mapped/movies/Movie.mkv'
             mock_combine.return_value = _make_result(
                 status='built',
                 path='/movies/Movie.en.combined-hu.srt',
@@ -187,7 +187,7 @@ class TestMoviesSubtitlesCombinePost:
              patch.object(movies_subtitles_module, 'request', self._make_request(payload)):
 
             mock_db.execute.return_value = mock_db_result
-            mock_pm.path_replace_movie.return_value = '/mapped/movies/Movie.mkv'
+            mock_pm.path_replace_instance.return_value = '/mapped/movies/Movie.mkv'
             mock_combine.return_value = _make_result(
                 status='built',
                 path='/x.srt',
@@ -214,7 +214,7 @@ class TestMoviesSubtitlesCombinePost:
              patch.object(movies_subtitles_module, 'request', self._make_request({})):
 
             mock_db.execute.return_value = mock_db_result
-            mock_pm.path_replace_movie.return_value = '/mapped/movies/Movie.mkv'
+            mock_pm.path_replace_instance.return_value = '/mapped/movies/Movie.mkv'
             mock_combine.return_value = _make_result(
                 status='skipped',
                 reason='missing source(s)',
@@ -239,7 +239,7 @@ class TestMoviesSubtitlesCombinePost:
              patch.object(movies_subtitles_module, 'request', self._make_request({})):
 
             mock_db.execute.return_value = mock_db_result
-            mock_pm.path_replace_movie.return_value = '/mapped/movies/Movie.mkv'
+            mock_pm.path_replace_instance.return_value = '/mapped/movies/Movie.mkv'
             mock_combine.return_value = _make_result(
                 status='failed',
                 error='bad SRT',

--- a/tests/bazarr/test_combine_api_series.py
+++ b/tests/bazarr/test_combine_api_series.py
@@ -145,11 +145,11 @@ _module_isolation.restore(_SYS_BEFORE)
 @patch.object(series_module, 'try_combine_for_video')
 @patch.object(series_module, 'path_mappings')
 def test_series_batch_combine(mock_paths, mock_combine, mock_list):
-    mock_paths.path_replace.side_effect = lambda p: p
+    mock_paths.path_replace_instance.side_effect = lambda p, owner, kind: p
     mock_list.return_value = [
-        {'sonarrEpisodeId': 1, 'path': '/tv/Show/S01E01.mkv', 'sonarrSeriesId': 5},
-        {'sonarrEpisodeId': 2, 'path': '/tv/Show/S01E02.mkv', 'sonarrSeriesId': 5},
-        {'sonarrEpisodeId': 3, 'path': '/tv/Show/S01E03.mkv', 'sonarrSeriesId': 5},
+        {'sonarrEpisodeId': 1, 'path': '/tv/Show/S01E01.mkv', 'sonarrSeriesId': 5, 'arr_instance_id': 7},
+        {'sonarrEpisodeId': 2, 'path': '/tv/Show/S01E02.mkv', 'sonarrSeriesId': 5, 'arr_instance_id': 7},
+        {'sonarrEpisodeId': 3, 'path': '/tv/Show/S01E03.mkv', 'sonarrSeriesId': 5, 'arr_instance_id': 7},
     ]
     mock_combine.side_effect = [
         type('R', (), {'status': 'built', 'path': '/x1.srt',

--- a/tests/bazarr/test_combine_hook.py
+++ b/tests/bazarr/test_combine_hook.py
@@ -21,6 +21,7 @@ class TestTriggerCombine:
             radarr_id=42,
             sonarr_series_id=None,
             sonarr_episode_id=None,
+            arr_instance_id=None,
         )
 
     @patch("subtitles.processing.try_combine_for_video")
@@ -38,6 +39,7 @@ class TestTriggerCombine:
             radarr_id=None,
             sonarr_series_id=5,
             sonarr_episode_id=99,
+            arr_instance_id=None,
         )
 
     @patch("subtitles.processing.try_combine_for_video")

--- a/tests/bazarr/test_combine_main.py
+++ b/tests/bazarr/test_combine_main.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import pytest
 from unittest.mock import patch
+from types import SimpleNamespace
 
 from subtitles.tools.combine.main import (
     CombineResult,
@@ -164,57 +165,57 @@ class TestTryCombine:
 
 
 class TestPostWrite:
-    @patch("app.database.database")
+    @patch("subtitles.tools.combine.main._metadata_for")
     @patch("api.subtitles.subtitles.postprocess_subtitles")
     def test_maps_series_to_episode(self, mock_pp, mock_db):
-        meta = object()
-        mock_db.execute.return_value.first.return_value = meta
+        meta = SimpleNamespace(arr_instance_id=7)
+        mock_db.return_value = meta
         _post_write("/out.srt", "/video.mkv", "series",
                     sonarr_episode_id=99, radarr_id=None)
-        mock_pp.assert_called_once_with("/out.srt", "/video.mkv", "episode", meta, 99)
+        mock_pp.assert_called_once_with("/out.srt", "/video.mkv", "episode", meta, 99, arr_instance_id=7)
 
-    @patch("app.database.database")
+    @patch("subtitles.tools.combine.main._metadata_for")
     @patch("api.subtitles.subtitles.postprocess_subtitles")
     def test_maps_movies_to_movie(self, mock_pp, mock_db):
-        meta = object()
-        mock_db.execute.return_value.first.return_value = meta
+        meta = SimpleNamespace(arr_instance_id=7)
+        mock_db.return_value = meta
         _post_write("/out.srt", "/video.mkv", "movies",
                     sonarr_episode_id=None, radarr_id=42)
-        mock_pp.assert_called_once_with("/out.srt", "/video.mkv", "movie", meta, 42)
+        mock_pp.assert_called_once_with("/out.srt", "/video.mkv", "movie", meta, 42, arr_instance_id=7)
 
-    @patch("app.database.database")
+    @patch("subtitles.tools.combine.main._metadata_for")
     @patch("api.subtitles.subtitles.postprocess_subtitles")
     def test_maps_singular_movie_to_movie(self, mock_pp, mock_db):
         # The auto-combine path forwards process_subtitle's singular 'movie'.
-        meta = object()
-        mock_db.execute.return_value.first.return_value = meta
+        meta = SimpleNamespace(arr_instance_id=7)
+        mock_db.return_value = meta
         _post_write("/out.srt", "/video.mkv", "movie",
                     sonarr_episode_id=None, radarr_id=42)
-        mock_pp.assert_called_once_with("/out.srt", "/video.mkv", "movie", meta, 42)
+        mock_pp.assert_called_once_with("/out.srt", "/video.mkv", "movie", meta, 42, arr_instance_id=7)
 
 
 class TestProfileFor:
     @patch("app.database.get_profiles_list")
-    @patch("app.database.get_profile_id")
+    @patch("subtitles.tools.combine.main._metadata_for")
     def test_singular_movie_resolves_via_radarr_id(self, mock_pid, mock_list):
         # Regression: the auto-combine path passes 'movie' (singular); it must
         # resolve the movie profile by radarr id, not fall through to the
         # episode/series branch (which has no ids and returns no rule).
-        mock_pid.return_value = 7
+        mock_pid.return_value = SimpleNamespace(profileId=7)
         mock_list.return_value = {"profileId": 7}
         result = _profile_for("movie", sonarr_series_id=None,
                               sonarr_episode_id=None, radarr_id=42)
-        mock_pid.assert_called_once_with(movie_id=42)
+        mock_pid.assert_called_once_with(None, "movie", None, 42, None)
         assert result == {"profileId": 7}
 
     @patch("app.database.get_profiles_list")
-    @patch("app.database.get_profile_id")
+    @patch("subtitles.tools.combine.main._metadata_for")
     def test_plural_movies_resolves_via_radarr_id(self, mock_pid, mock_list):
-        mock_pid.return_value = 7
+        mock_pid.return_value = SimpleNamespace(profileId=7)
         mock_list.return_value = {"profileId": 7}
         _profile_for("movies", sonarr_series_id=None,
                      sonarr_episode_id=None, radarr_id=42)
-        mock_pid.assert_called_once_with(movie_id=42)
+        mock_pid.assert_called_once_with(None, "movies", None, 42, None)
 
 
 class TestCustomLanguageRoundTrip:

--- a/tests/bazarr/test_config_save.py
+++ b/tests/bazarr/test_config_save.py
@@ -14,7 +14,8 @@ def test_save_settings_creates_missing_provider_section_for_hub_config(monkeypat
     provider_id = "testhubdynamic"
     executed = []
 
-    monkeypatch.setattr(config, "write_config", lambda: None)
+    # A write that reached disk. Anything else is refused.
+    monkeypatch.setattr(config, "write_config", lambda: True)
     monkeypatch.setattr(config, "validate_log_regex", lambda: None)
     monkeypatch.setattr(config.settings.validators, "validate", lambda: None)
     monkeypatch.setitem(
@@ -52,7 +53,8 @@ def test_save_settings_resets_compat_pool_for_dynamic_provider_hub_config(monkey
     def record_compat_pool_reset():
         reset_calls.append(config.settings[provider_id]["flaresolverr_url"])
 
-    monkeypatch.setattr(config, "write_config", lambda: None)
+    # A write that reached disk. Anything else is refused.
+    monkeypatch.setattr(config, "write_config", lambda: True)
     monkeypatch.setattr(config, "validate_log_regex", lambda: None)
     monkeypatch.setattr(config.settings.validators, "validate", lambda: None)
     monkeypatch.setitem(
@@ -98,7 +100,8 @@ def test_save_settings_invalidates_the_compat_cache_for_a_score_modifier(monkeyp
     executed = []
     invalidations = []
 
-    monkeypatch.setattr(config, "write_config", lambda: None)
+    # A write that reached disk. Anything else is refused.
+    monkeypatch.setattr(config, "write_config", lambda: True)
     monkeypatch.setattr(config, "validate_log_regex", lambda: None)
     monkeypatch.setattr(config.settings.validators, "validate", lambda: None)
     monkeypatch.setitem(
@@ -134,7 +137,8 @@ def test_save_settings_leaves_the_compat_cache_alone_for_an_unrelated_setting(mo
 
     invalidations = []
 
-    monkeypatch.setattr(config, "write_config", lambda: None)
+    # A write that reached disk. Anything else is refused.
+    monkeypatch.setattr(config, "write_config", lambda: True)
     monkeypatch.setattr(config, "validate_log_regex", lambda: None)
     monkeypatch.setattr(config.settings.validators, "validate", lambda: None)
     monkeypatch.setitem(

--- a/tests/bazarr/test_emby_api.py
+++ b/tests/bazarr/test_emby_api.py
@@ -1,0 +1,50 @@
+import pytest
+from flask import Flask
+
+from test_media_server_http import http_fixture as http_fixture
+
+
+@pytest.fixture
+def api_client(monkeypatch):
+    from api import api_bp
+    from app.config import settings
+    monkeypatch.setitem(settings.auth, "apikey", "synthetic-bazarr-key")
+    app = Flask(__name__)
+    app.register_blueprint(api_bp)
+    return app.test_client()
+
+
+@pytest.mark.parametrize("encoding", ["json", "data"])
+def test_current_unsaved_body_values_reach_server(api_client, http_fixture, encoding):
+    base, records = http_fixture([(200, {"ServerName": "Unsaved", "Version": "4.9.5.0"}, {})])
+    body = {"url": base + "/unsaved", "apikey": "synthetic-unsaved-key", "verify_ssl": "false"}
+    response = api_client.post("/api/emby/test-connection?url=http://wrong&apikey=wrong&verify_ssl=wrong",
+                               headers={"X-API-KEY": "synthetic-bazarr-key"}, **{encoding: body})
+    assert response.status_code == 200
+    assert response.json["success"] is True
+    assert records[0]["path"] == "/unsaved/System/Info"
+    assert records[0]["headers"]["X-Emby-Token"] == "synthetic-unsaved-key"
+
+
+def test_bazarr_authentication_required(api_client):
+    response = api_client.post("/api/emby/test-connection", json={"url": "http://server", "apikey": "synthetic-key"})
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize('server', ['emby', 'silo'])
+def test_ambiguous_singleton_status_and_retry_routes_are_retired(api_client, server):
+    headers = {'X-API-KEY': 'synthetic-bazarr-key'}
+    assert api_client.get(f'/api/{server}/status', headers=headers).status_code == 404
+    assert api_client.post(f'/api/{server}/retry-pending', headers=headers).status_code == 404
+
+
+@pytest.mark.parametrize("body", [{}, {"url": "http://server"}, {"url": "", "apikey": "synthetic-key"},
+                                 {"url": "http://server", "apikey": ""}, {"url": "http://server", "apikey": 7},
+                                 {"url": "http://server", "apikey": "synthetic-key", "verify_ssl": "maybe"},
+                                 {"url": "http://server", "apikey": "synthetic-key", "verify_ssl": 0}])
+def test_invalid_body_never_uses_query_or_saved_key(api_client, body):
+    response = api_client.post("/api/emby/test-connection?url=http://server&apikey=synthetic-key",
+                               headers={"X-API-KEY": "synthetic-bazarr-key"}, json=body)
+    assert response.status_code == 400
+    assert response.json["success"] is False
+    assert response.json["error_code"] in {"missing_credentials", "invalid_verify_ssl"}

--- a/tests/bazarr/test_emby_client.py
+++ b/tests/bazarr/test_emby_client.py
@@ -197,3 +197,253 @@ def test_reinterpreted_mapping_cannot_refresh_a_different_item(http_fixture, pat
         mapped = map_media_path(path, rows)
         client.refresh_item(media_type, mapped["path"])
     assert records == []
+
+
+# --------------------------------------------------- identifier and title rungs
+
+PARENT_TYPES = {"movie": "Movie", "episode": "Series"}
+SERIES = {"Id": "35", "Type": "Series", "Name": "Firefly", "Path": "/media/Firefly"}
+EPISODES = {"Items": [
+    {"Id": "37", "Type": "Episode", "Name": "Serenity", "IndexNumber": 1, "ParentIndexNumber": 1},
+    {"Id": "38", "Type": "Episode", "Name": "The Train Job", "IndexNumber": 2, "ParentIndexNumber": 1},
+], "TotalRecordCount": 2}
+
+
+def metadata(**overrides):
+    from media_servers.resolution import MediaMetadata
+    values = dict(imdb_id="tt0303461", tmdb_id="19", tvdb_id=78874, title="Firefly",
+                  year=2002, season=1, episode=2)
+    return MediaMetadata(**{**values, **overrides})
+
+
+def query(record):
+    return parse_qs(urlsplit(record["path"]).query)
+
+
+def test_declared_rungs_are_the_whole_jellyfin_ladder():
+    from emby.client import EmbyClient
+    from media_servers import resolution
+    assert EmbyClient.REFRESH_STEPS == resolution.CHAIN
+
+
+@pytest.mark.parametrize(("media_type", "provider"), [("movie", "tmdb.19"), ("episode", "tvdb.78874")])
+def test_provider_lookup_tries_imdb_first_then_the_type_specific_id(http_fixture, media_type, provider):
+    from emby.client import EmbyClient
+    found = {"Id": "opaque", "Type": PARENT_TYPES[media_type], "Name": "Firefly"}
+    replies = [(200, {"Items": [], "TotalRecordCount": 0}, {}),
+               (200, {"Items": [found], "TotalRecordCount": 1}, {})]
+    if media_type == "episode":
+        replies.append((200, EPISODES, {}))
+    replies.append((204, b"", {}))
+    base, records = http_fixture(replies)
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_by_provider_id(media_type, metadata()) == {"status": "requested"}
+    assert query(records[0])["AnyProviderIdEquals"] == ["imdb.tt0303461"]
+    assert query(records[0])["IncludeItemTypes"] == [PARENT_TYPES[media_type]]
+    assert query(records[0])["Recursive"] == ["true"]
+    assert "ProviderIds" in query(records[0])["Fields"][0].split(",")
+    assert query(records[1])["AnyProviderIdEquals"] == [provider]
+    assert urlsplit(records[-1]["path"]).path == (
+        "/Items/38/Refresh" if media_type == "episode" else "/Items/opaque/Refresh")
+    assert parse_qs(urlsplit(records[-1]["path"]).query)["Recursive"] == ["false"]
+
+
+def test_provider_lookup_stops_at_the_first_identifier_that_resolves(http_fixture):
+    from emby.client import EmbyClient
+    base, records = http_fixture([
+        (200, {"Items": [{"Id": "1", "Type": "Movie", "Name": "Metropolis"}], "TotalRecordCount": 1}, {}),
+        (204, b"", {})])
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_by_provider_id("movie", metadata()) == {"status": "requested"}
+    assert len(records) == 2
+    assert query(records[0])["AnyProviderIdEquals"] == ["imdb.tt0303461"]
+
+
+@pytest.mark.parametrize("media_type", MEDIA_TYPES)
+def test_provider_lookup_without_usable_identifiers_never_reaches_the_server(http_fixture, media_type):
+    from emby.client import EmbyClient
+    base, records = http_fixture([])
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_by_provider_id(media_type, metadata(imdb_id=None, tmdb_id=None, tvdb_id=None)) is None
+        # An episode with no numbers cannot be reached even through its series.
+        assert client.refresh_by_provider_id("episode", metadata(season=None, episode=None)) is None
+    assert records == []
+
+
+@pytest.mark.parametrize("media_type", MEDIA_TYPES)
+@pytest.mark.parametrize(("items", "reason"), [
+    ([], "no-match"),
+    ([{"Id": "1", "Name": "Firefly"}, {"Id": "2", "Name": "Firefly"}], "ambiguous"),
+], ids=["no-match", "ambiguous"])
+def test_a_non_unique_identifier_match_misses_instead_of_guessing(http_fixture, items, reason, media_type):
+    from emby.client import EmbyClient
+    items = [{**item, "Type": PARENT_TYPES[media_type]} for item in items]
+    replies = [(200, {"Items": items, "TotalRecordCount": len(items)}, {})] * 2
+    base, records = http_fixture(replies)
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_by_provider_id(media_type, metadata()) is None
+    assert len(records) == 2
+
+
+@pytest.mark.parametrize("media_type", MEDIA_TYPES)
+def test_title_lookup_narrows_by_name_and_year_then_matches_the_name_exactly(http_fixture, media_type):
+    from emby.client import EmbyClient
+    items = [{"Id": "wrong", "Type": PARENT_TYPES[media_type], "Name": "Firefly Lane"},
+             {"Id": "right", "Type": PARENT_TYPES[media_type], "Name": "FIREFLY"}]
+    replies = [(200, {"Items": items, "TotalRecordCount": 2}, {})]
+    if media_type == "episode":
+        replies.append((200, EPISODES, {}))
+    replies.append((204, b"", {}))
+    base, records = http_fixture(replies)
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_by_title_year(media_type, metadata()) == {"status": "requested"}
+    assert query(records[0])["NameStartsWith"] == ["Firefly"]
+    assert query(records[0])["Years"] == ["2002"]
+    assert query(records[0])["IncludeItemTypes"] == [PARENT_TYPES[media_type]]
+    assert urlsplit(records[-1]["path"]).path == (
+        "/Items/38/Refresh" if media_type == "episode" else "/Items/right/Refresh")
+
+
+def test_title_lookup_omits_an_unknown_year_and_misses_without_a_title(http_fixture):
+    from emby.client import EmbyClient
+    base, records = http_fixture([
+        (200, {"Items": [{"Id": "1", "Type": "Movie", "Name": "Firefly"}], "TotalRecordCount": 1}, {}),
+        (204, b"", {})])
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_by_title_year("movie", metadata(title=None)) is None
+        assert client.refresh_by_title_year("movie", metadata(year=None)) == {"status": "requested"}
+    assert "Years" not in query(records[0])
+    assert len(records) == 2
+
+
+def test_a_series_without_the_published_episode_misses(http_fixture):
+    from emby.client import EmbyClient
+    base, records = http_fixture([
+        (200, {"Items": [SERIES], "TotalRecordCount": 1}, {}),
+        (200, {"Items": [], "TotalRecordCount": 0}, {})])
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_by_title_year("episode", metadata(episode=9)) is None
+    assert urlsplit(records[1]["path"]).path == "/Shows/35/Episodes"
+    assert query(records[1])["Season"] == ["1"]
+
+
+def test_an_episode_of_another_season_is_never_refreshed(http_fixture):
+    from emby.client import EmbyClient
+    other = {"Items": [{"Id": "99", "Type": "Episode", "IndexNumber": 2, "ParentIndexNumber": 4}],
+             "TotalRecordCount": 1}
+    base, records = http_fixture([(200, {"Items": [SERIES], "TotalRecordCount": 1}, {}), (200, other, {})])
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_by_title_year("episode", metadata()) is None
+    assert len(records) == 2
+
+
+@pytest.mark.parametrize("media_type", MEDIA_TYPES)
+def test_identifier_rungs_reject_a_partial_or_malformed_response(http_fixture, media_type):
+    from emby.client import EmbyClient
+    from media_servers.http import MediaServerError
+    items = [{"Id": "1", "Type": PARENT_TYPES[media_type], "Name": "Firefly"}]
+    base, records = http_fixture([(200, {"Items": items, "TotalRecordCount": 4}, {})])
+    with EmbyClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match="invalid_response"):
+        client.refresh_by_provider_id(media_type, metadata())
+    assert len(records) == 1
+
+
+@pytest.mark.parametrize("media_type", MEDIA_TYPES)
+@pytest.mark.parametrize("phase", ["lookup", "post"])
+def test_identifier_rungs_honour_the_revision_guard(monkeypatch, media_type, phase):
+    from emby.client import EmbyClient
+    from media_servers.http import MediaServerError
+    requests = []
+    valid = phase != "lookup"
+
+    def guard():
+        if not valid:
+            raise MediaServerError("configuration_changed")
+
+    with EmbyClient("http://emby.example", "synthetic-key") as client:
+        def lookup(_method, path, **_kwargs):
+            nonlocal valid
+            requests.append(path)
+            if phase == "post":
+                valid = False
+            if path.startswith("/Shows/"):
+                return EPISODES
+            return {"Items": [{"Id": "35", "Type": PARENT_TYPES[media_type], "Name": "Firefly"}],
+                    "TotalRecordCount": 1}
+
+        monkeypatch.setattr(client.http, "request_json", lookup)
+        monkeypatch.setattr(client.http, "request_empty", lambda *args, **kwargs: requests.append("post"))
+        with pytest.raises(MediaServerError, match="configuration_changed"):
+            client.refresh_by_provider_id(media_type, metadata(), ensure_current=guard)
+    assert requests == [] if phase == "lookup" else requests[0] == "/Items"
+
+
+# ------------------------------------------------------------- library rung
+
+FOLDERS = [
+    {"Name": "Movies A1", "ItemId": "3", "CollectionType": "movies", "Locations": ["/media/movies"]},
+    {"Name": "Movies A2", "ItemId": "5", "CollectionType": "movies", "Locations": ["/other"]},
+    {"Name": "TV A", "ItemId": "19", "CollectionType": "tvshows", "Locations": ["/media/series"]},
+    {"Name": "Music", "ItemId": "21", "CollectionType": "music", "Locations": ["/media"]},
+]
+
+
+@pytest.mark.parametrize(("media_type", "path", "item_id"), [
+    ("movie", "/media/movies/A.mkv", "3"),
+    ("episode", "/media/series/Firefly/S01E02.mkv", "19"),
+])
+def test_library_rung_refreshes_only_the_library_that_holds_the_file(http_fixture, media_type, path, item_id):
+    from emby.client import EmbyClient
+    base, records = http_fixture([(200, FOLDERS, {}), (204, b"", {})])
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_library(media_type, path) == {"status": "requested"}
+    assert urlsplit(records[0]["path"]).path == "/Library/VirtualFolders"
+    assert urlsplit(records[1]["path"]).path == f"/Items/{item_id}/Refresh"
+    refresh = query(records[1])
+    assert refresh["Recursive"] == ["true"]
+    assert refresh["MetadataRefreshMode"] == ["ValidationOnly"]
+    assert refresh["ReplaceAllMetadata"] == ["false"]
+
+
+@pytest.mark.parametrize(("media_type", "path"), [
+    ("movie", "/nowhere/A.mkv"),
+    ("movie", "/media/series/Firefly/S01E02.mkv"),
+    ("episode", "/media/movies/A.mkv"),
+])
+def test_library_rung_misses_when_no_library_of_that_type_holds_the_file(http_fixture, media_type, path):
+    from emby.client import EmbyClient
+    base, records = http_fixture([(200, FOLDERS, {})])
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_library(media_type, path) is None
+    assert len(records) == 1
+
+
+@pytest.mark.parametrize("folders", [
+    {"Items": FOLDERS}, [None], [{**FOLDERS[0], "ItemId": 3}], [{**FOLDERS[0], "Locations": "/media/movies"}],
+], ids=["not-a-list", "not-a-folder", "non-string-id", "locations-shape"])
+def test_library_rung_rejects_a_malformed_folder_listing(http_fixture, folders):
+    from emby.client import EmbyClient
+    from media_servers.http import MediaServerError
+    base, records = http_fixture([(200, folders, {})])
+    with EmbyClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match="invalid_response"):
+        client.refresh_library("movie", "/media/movies/A.mkv")
+    assert len(records) == 1
+
+
+@pytest.mark.parametrize("media_type", ["", "series", None])
+def test_library_rung_rejects_an_unknown_media_type_before_any_request(http_fixture, media_type):
+    from emby.client import EmbyClient
+    from media_servers.http import MediaServerError
+    base, records = http_fixture([])
+    with EmbyClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match="internal_error"):
+        client.refresh_library(media_type, "/media/movies/A.mkv")
+    assert records == []
+
+
+def test_a_windows_library_root_never_swallows_a_posix_path(http_fixture):
+    from emby.client import EmbyClient
+    folders = [{"Name": "Movies", "ItemId": "3", "CollectionType": "movies", "Locations": ["D:\\Library"]}]
+    base, records = http_fixture([(200, folders, {})])
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_library("movie", "/media/movies/A.mkv") is None
+    assert len(records) == 1

--- a/tests/bazarr/test_emby_client.py
+++ b/tests/bazarr/test_emby_client.py
@@ -5,9 +5,15 @@ import pytest
 
 from test_media_server_http import http_fixture as http_fixture
 
+# Emby names the two libraries Bazarr publishes into. Both resolve by exact
+# file path and refresh identically; only the queried type differs.
+ITEM_TYPES = {"movie": "Movie", "episode": "Episode"}
+MEDIA_TYPES = list(ITEM_TYPES)
 
+
+@pytest.mark.parametrize('media_type', MEDIA_TYPES)
 @pytest.mark.parametrize('phase', ['lookup', 'post', 'completion'])
-def test_revision_guard_prevents_later_authenticated_requests(monkeypatch, phase):
+def test_revision_guard_prevents_later_authenticated_requests(monkeypatch, phase, media_type):
     from emby.client import EmbyClient
     from media_servers.http import MediaServerError
     requests = []
@@ -23,7 +29,7 @@ def test_revision_guard_prevents_later_authenticated_requests(monkeypatch, phase
             requests.append('lookup')
             if phase == 'post':
                 valid = False
-            return {'Items': [{'Id': '1', 'Type': 'Movie', 'Path': '/media/A.mkv'}]}
+            return {'Items': [{'Id': '1', 'Type': ITEM_TYPES[media_type], 'Path': '/media/A.mkv'}]}
 
         def post(*args, **kwargs):
             nonlocal valid
@@ -33,7 +39,7 @@ def test_revision_guard_prevents_later_authenticated_requests(monkeypatch, phase
         monkeypatch.setattr(client.http, 'request_json', lookup)
         monkeypatch.setattr(client.http, 'request_empty', post)
         with pytest.raises(MediaServerError, match='configuration_changed'):
-            client.refresh_movie('/media/A.mkv', ensure_current=guard)
+            client.refresh_item(media_type, '/media/A.mkv', ensure_current=guard)
     assert requests == {'lookup': [], 'post': ['lookup'], 'completion': ['lookup', 'post']}[phase]
 
 
@@ -59,20 +65,22 @@ def test_bad_system_info_is_not_connection_success(http_fixture, body):
     assert emby_test_connection(base, "synthetic-key") == {"success": False, "error_code": "invalid_response"}
 
 
+@pytest.mark.parametrize("media_type", MEDIA_TYPES)
 @pytest.mark.parametrize("status", [200, 204])
-def test_refresh_resolves_exact_path_and_encodes_opaque_item_id(http_fixture, status):
+def test_refresh_resolves_exact_path_and_encodes_opaque_item_id(http_fixture, status, media_type):
     from emby.client import EmbyClient
     base, records = http_fixture([
-        (200, {"Items": [{"Id": "edition/a?x=#", "Type": "Movie", "Path": "/media/A.mkv"}], "TotalRecordCount": 1}, {}),
+        (200, {"Items": [{"Id": "edition/a?x=#", "Type": ITEM_TYPES[media_type], "Path": "/media/A.mkv"}],
+               "TotalRecordCount": 1}, {}),
         (status, b"", {}),
     ])
     with EmbyClient(base + "/emby", "synthetic-key") as client:
-        assert client.refresh_movie("/media/A.mkv") == {"status": "requested"}
+        assert client.refresh_item(media_type, "/media/A.mkv") == {"status": "requested"}
     lookup = urlsplit(records[0]["path"])
     assert lookup.path == "/emby/Items"
     query = parse_qs(lookup.query)
     assert query["Path"] == ["/media/A.mkv"]
-    assert query["IncludeItemTypes"] == ["Movie"]
+    assert query["IncludeItemTypes"] == [ITEM_TYPES[media_type]]
     assert query["Recursive"] == ["true"]
     assert "MediaSources" in query["Fields"][0].split(",")
     refresh = urlsplit(records[1]["path"])
@@ -86,77 +94,106 @@ def test_refresh_resolves_exact_path_and_encodes_opaque_item_id(http_fixture, st
     assert records[1]["headers"]["X-Emby-Token"] == "synthetic-key"
 
 
-def test_media_source_exact_path_can_identify_movie(http_fixture):
+@pytest.mark.parametrize("media_type", MEDIA_TYPES)
+def test_media_source_exact_path_can_identify_item(http_fixture, media_type):
     from emby.client import EmbyClient
     base, records = http_fixture([
-        (200, {"Items": [{"Id": "opaque", "Type": "Movie", "Path": "/media/other.mkv",
+        (200, {"Items": [{"Id": "opaque", "Type": ITEM_TYPES[media_type], "Path": "/media/other.mkv",
                           "MediaSources": [{"Path": "/media/A.mkv"}]}], "TotalRecordCount": 1}, {}),
         (204, b"", {}),
     ])
     with EmbyClient(base, "synthetic-key") as client:
-        assert client.refresh_movie("/media/A.mkv")["status"] == "requested"
+        assert client.refresh_item(media_type, "/media/A.mkv")["status"] == "requested"
     assert len(records) == 2
 
 
+@pytest.mark.parametrize("media_type", MEDIA_TYPES)
 @pytest.mark.parametrize(("items", "code"), [
     ([], "item_missing"),
-    ([{"Id": "1", "Type": "Movie", "Path": "/media/other.mkv", "ProviderIds": {"Tmdb": "1"}}], "item_missing"),
-    ([{"Id": "1", "Type": "Episode", "Path": "/media/A.mkv"}], "item_missing"),
-    ([{"Id": "1", "Type": "Movie", "Path": "/media/A.mkv"},
-      {"Id": "2", "Type": "Movie", "Path": "/media/A.mkv"}], "item_ambiguous"),
-    ([{"Id": 1, "Type": "Movie", "Path": "/media/A.mkv"}], "invalid_response"),
+    ([{"Id": "1", "Path": "/media/other.mkv", "ProviderIds": {"Tmdb": "1"}}], "item_missing"),
+    ([{"Id": "1", "Path": "/media/A.mkv"}, {"Id": "2", "Path": "/media/A.mkv"}], "item_ambiguous"),
+    ([{"Id": 1, "Path": "/media/A.mkv"}], "invalid_response"),
 ])
-def test_non_unique_movie_never_triggers_refresh(http_fixture, items, code):
+def test_non_unique_item_never_triggers_refresh(http_fixture, items, code, media_type):
     from emby.client import EmbyClient
     from media_servers.http import MediaServerError
+    items = [{**item, "Type": ITEM_TYPES[media_type]} for item in items]
     base, records = http_fixture([(200, {"Items": items, "TotalRecordCount": len(items)}, {})])
     with EmbyClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match=code):
-        client.refresh_movie("/media/A.mkv")
+        client.refresh_item(media_type, "/media/A.mkv")
     assert len(records) == 1
 
 
+@pytest.mark.parametrize("media_type", MEDIA_TYPES)
+def test_other_library_type_at_the_same_path_is_never_refreshed(http_fixture, media_type):
+    from emby.client import EmbyClient
+    from media_servers.http import MediaServerError
+    other = ITEM_TYPES["episode" if media_type == "movie" else "movie"]
+    base, records = http_fixture([
+        (200, {"Items": [{"Id": "1", "Type": other, "Path": "/media/A.mkv"}], "TotalRecordCount": 1}, {})])
+    with EmbyClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match="item_missing"):
+        client.refresh_item(media_type, "/media/A.mkv")
+    assert len(records) == 1
+
+
+@pytest.mark.parametrize("media_type", ["", "series", "movies", "Movie", "episodes", None])
+def test_unknown_media_type_never_reaches_the_server(http_fixture, media_type):
+    from emby.client import EmbyClient
+    from media_servers.http import MediaServerError
+    base, records = http_fixture([])
+    with EmbyClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match="internal_error"):
+        client.refresh_item(media_type, "/media/A.mkv")
+    assert records == []
+
+
+@pytest.mark.parametrize("media_type", MEDIA_TYPES)
 @pytest.mark.parametrize(("status", "body", "code"), [(202, b"", "request_rejected"), (200, b"{}", "invalid_response"),
                                                        (403, b"", "forbidden")])
-def test_refresh_acceptance_is_strict_and_has_no_broader_fallback(http_fixture, status, body, code):
+def test_refresh_acceptance_is_strict_and_has_no_broader_fallback(http_fixture, status, body, code, media_type):
     from emby.client import EmbyClient
     from media_servers.http import MediaServerError
     base, records = http_fixture([
-        (200, {"Items": [{"Id": "1", "Type": "Movie", "Path": "/media/A.mkv"}], "TotalRecordCount": 1}, {}),
+        (200, {"Items": [{"Id": "1", "Type": ITEM_TYPES[media_type], "Path": "/media/A.mkv"}],
+               "TotalRecordCount": 1}, {}),
         (status, body, {}),
     ])
     with EmbyClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match=code):
-        client.refresh_movie("/media/A.mkv")
+        client.refresh_item(media_type, "/media/A.mkv")
     assert len(records) == 2
 
 
+@pytest.mark.parametrize("media_type", MEDIA_TYPES)
 @pytest.mark.parametrize("result", [
     {"Items": {}},
-    {"Items": [{"Id": "1", "Type": "Movie", "Path": "/media/A.mkv"}], "TotalRecordCount": 2},
-    {"Items": [{"Id": "1", "Type": "Movie", "Path": "/media/A.mkv", "MediaSources": {}}]},
-    {"Items": [{"Id": "\ud800", "Type": "Movie", "Path": "/media/A.mkv"}]},
+    {"Items": [{"Id": "1", "Path": "/media/A.mkv"}], "TotalRecordCount": 2},
+    {"Items": [{"Id": "1", "Path": "/media/A.mkv", "MediaSources": {}}]},
+    {"Items": [{"Id": "\ud800", "Path": "/media/A.mkv"}]},
 ], ids=["items-shape", "partial-result", "sources-shape", "invalid-id-encoding"])
-def test_malformed_lookup_cannot_refresh_or_leak_raw_errors(http_fixture, result):
+def test_malformed_lookup_cannot_refresh_or_leak_raw_errors(http_fixture, result, media_type):
     from emby.client import EmbyClient
     from media_servers.http import MediaServerError
+    if isinstance(result["Items"], list):
+        result = {**result, "Items": [{**item, "Type": ITEM_TYPES[media_type]} for item in result["Items"]]}
     base, records = http_fixture([(200, result, {})])
     with EmbyClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match="invalid_response"):
-        client.refresh_movie("/media/A.mkv")
+        client.refresh_item(media_type, "/media/A.mkv")
     assert len(records) == 1
 
 
+@pytest.mark.parametrize("media_type", MEDIA_TYPES)
 @pytest.mark.parametrize("path", ["/movies/D:/A.mkv", "/movies/C:/A.mkv", "/movies/D:A.mkv", "/movies/C:A.mkv"],
                          ids=["same-drive", "other-drive", "same-drive-filename", "other-drive-filename"])
-def test_reinterpreted_mapping_cannot_refresh_a_different_movie(http_fixture, path):
+def test_reinterpreted_mapping_cannot_refresh_a_different_item(http_fixture, path, media_type):
     from emby.client import EmbyClient
     from media_servers.http import MediaServerError
     from media_servers.paths import map_media_path
     base, records = http_fixture([
-        (200, {"Items": [{"Id": "wrong-file", "Type": "Movie", "Path": "D:\\Library\\A.mkv"}],
+        (200, {"Items": [{"Id": "wrong-file", "Type": ITEM_TYPES[media_type], "Path": "D:\\Library\\A.mkv"}],
                "TotalRecordCount": 1}, {}),
         (204, b"", {}),
     ])
     rows = [{"local_path": "/movies", "remote_path": "D:\\Library"}]
     with EmbyClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match="path_invalid"):
         mapped = map_media_path(path, rows)
-        client.refresh_movie(mapped["path"])
+        client.refresh_item(media_type, mapped["path"])
     assert records == []

--- a/tests/bazarr/test_emby_client.py
+++ b/tests/bazarr/test_emby_client.py
@@ -207,6 +207,20 @@ EPISODES = {"Items": [
     {"Id": "37", "Type": "Episode", "Name": "Serenity", "IndexNumber": 1, "ParentIndexNumber": 1},
     {"Id": "38", "Type": "Episode", "Name": "The Train Job", "IndexNumber": 2, "ParentIndexNumber": 1},
 ], "TotalRecordCount": 2}
+# The mapped file each title-rung publication is about. The weak rung binds
+# nothing that contradicts it.
+TITLE_PATHS = {"movie": "/media/Firefly.mkv", "episode": "/media/Firefly/Season 1/S01E02.mkv"}
+# A 2024 remake Bazarr published a subtitle beside. Emby holds the 1922 film.
+NOSFERATU_2024 = "/media/movies/Nosferatu (2024)/Nosferatu (2024) Bluray-1080p.mkv"
+
+
+def _title_replies(media_type, items):
+    """Everything a title lookup that resolved would consume, so a rung that
+    binds the wrong item fails on the assertion rather than on a short fixture."""
+    replies = [(200, {"Items": items, "TotalRecordCount": len(items)}, {})]
+    if media_type == "episode":
+        replies.append((200, EPISODES, {}))
+    return replies + [(204, b"", {})]
 
 
 def metadata(**overrides):
@@ -246,6 +260,17 @@ def test_provider_lookup_tries_imdb_first_then_the_type_specific_id(http_fixture
     assert urlsplit(records[-1]["path"]).path == (
         "/Items/38/Refresh" if media_type == "episode" else "/Items/opaque/Refresh")
     assert parse_qs(urlsplit(records[-1]["path"]).query)["Recursive"] == ["false"]
+
+
+def test_a_stored_identifier_carrying_the_filter_delimiter_is_never_sent(http_fixture):
+    """AnyProviderIdEquals is comma-delimited. A comma in a stored id would turn
+    the deliberate one-at-a-time query into the combined one it avoids, which
+    answers "one of these matched" and loses which."""
+    from emby.client import EmbyClient
+    base, records = http_fixture([(200, {"Items": [], "TotalRecordCount": 0}, {})] * 2)
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_by_provider_id("movie", metadata(imdb_id="tt0303461,tt0017136")) is None
+    assert [query(record)["AnyProviderIdEquals"] for record in records] == [["tmdb.19"]]
 
 
 def test_provider_lookup_stops_at_the_first_identifier_that_resolves(http_fixture):
@@ -296,7 +321,8 @@ def test_title_lookup_narrows_by_name_and_year_then_matches_the_name_exactly(htt
     replies.append((204, b"", {}))
     base, records = http_fixture(replies)
     with EmbyClient(base, "synthetic-key") as client:
-        assert client.refresh_by_title_year(media_type, metadata()) == {"status": "requested"}
+        assert client.refresh_by_title_year(
+            media_type, metadata(), TITLE_PATHS[media_type]) == {"status": "requested"}
     assert query(records[0])["NameStartsWith"] == ["Firefly"]
     assert query(records[0])["Years"] == ["2002"]
     assert query(records[0])["IncludeItemTypes"] == [PARENT_TYPES[media_type]]
@@ -304,16 +330,78 @@ def test_title_lookup_narrows_by_name_and_year_then_matches_the_name_exactly(htt
         "/Items/38/Refresh" if media_type == "episode" else "/Items/right/Refresh")
 
 
-def test_title_lookup_omits_an_unknown_year_and_misses_without_a_title(http_fixture):
+@pytest.mark.parametrize("media_type", MEDIA_TYPES)
+@pytest.mark.parametrize("missing", ["title", "year"])
+def test_the_title_rung_never_runs_without_both_a_title_and_a_year(http_fixture, missing, media_type):
+    """A title on its own is not an identifier, so it is not asked as one.
+
+    Titles collide constantly through remakes, and a row whose year Bazarr
+    never parsed would otherwise send a bare prefix and accept whatever single
+    film came back.
+    """
     from emby.client import EmbyClient
-    base, records = http_fixture([
-        (200, {"Items": [{"Id": "1", "Type": "Movie", "Name": "Firefly"}], "TotalRecordCount": 1}, {}),
-        (204, b"", {})])
+    items = [{"Id": "1", "Type": PARENT_TYPES[media_type], "Name": "Firefly", "Path": "/media/Firefly"}]
+    base, records = http_fixture(_title_replies(media_type, items))
     with EmbyClient(base, "synthetic-key") as client:
-        assert client.refresh_by_title_year("movie", metadata(title=None)) is None
-        assert client.refresh_by_title_year("movie", metadata(year=None)) == {"status": "requested"}
-    assert "Years" not in query(records[0])
+        assert client.refresh_by_title_year(
+            media_type, metadata(**{missing: None}), TITLE_PATHS[media_type]) is None
+    assert records == [], "no year is a reason to climb the next rung, not to guess"
+
+
+def test_the_title_rung_never_binds_a_film_that_only_shares_a_prefix(http_fixture):
+    """NameStartsWith bounds the response; it never decides anything."""
+    from emby.client import EmbyClient
+    items = [{"Id": "33", "Type": "Movie", "Name": "Nosferatu the Vampyre",
+              "Path": "/media/movies/Nosferatu the Vampyre (1979)/Nosferatu the Vampyre.mkv"}]
+    base, records = http_fixture([(200, {"Items": items, "TotalRecordCount": 1}, {})])
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_by_title_year(
+            "movie", metadata(title="Nosferatu", year=2024), NOSFERATU_2024) is None
+    assert len(records) == 1, "a prefix match is not a title match"
+
+
+@pytest.mark.parametrize("media_type", MEDIA_TYPES)
+def test_the_title_rung_never_binds_an_item_that_holds_another_file(http_fixture, media_type):
+    """The same exact title in the same year, at a path this file is not under.
+
+    Emby answers Path on both lookups already. A title and a year are a weak
+    identifier, so the path it comes back with has to agree before anything is
+    refreshed; the alternative is refreshing a different film and reporting the
+    publication as requested.
+    """
+    from emby.client import EmbyClient
+    elsewhere = {"movie": "/media/movies/Nosferatu (1922)/Nosferatu (1922) Bluray-1080p.mkv",
+                 "episode": "/media/series/Nosferatu (1922)"}
+    items = [{"Id": "33", "Type": PARENT_TYPES[media_type], "Name": "Nosferatu",
+              "Path": elsewhere[media_type]}]
+    base, records = http_fixture(_title_replies(media_type, items))
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_by_title_year(
+            media_type, metadata(title="Nosferatu", year=2024), NOSFERATU_2024) is None
+    assert len(records) == 1, "nothing may be refreshed, and the episodes of a wrong series never listed"
+
+
+def test_the_title_rung_never_binds_an_episode_of_another_series_folder(http_fixture):
+    """The series matched the title; the episode Emby returned is elsewhere."""
+    from emby.client import EmbyClient
+    episodes = {"Items": [{"Id": "38", "Type": "Episode", "IndexNumber": 2, "ParentIndexNumber": 1,
+                           "Path": "/media/series/Firefly/Specials/S01E02.mkv"}], "TotalRecordCount": 1}
+    base, records = http_fixture([(200, {"Items": [SERIES], "TotalRecordCount": 1}, {}),
+                                  (200, episodes, {}), (204, b"", {})])
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_by_title_year("episode", metadata(), "/media/Firefly/Season 1/S01E02.mkv") is None
     assert len(records) == 2
+
+
+def test_an_identifier_still_binds_an_item_the_path_mapping_cannot_reach(http_fixture):
+    """A provider id is proof of identity, and outliving a wrong mapping is why it is asked first."""
+    from emby.client import EmbyClient
+    items = [{"Id": "33", "Type": "Movie", "Name": "Nosferatu",
+              "Path": "/somewhere/else/entirely/Nosferatu (2024).mkv"}]
+    base, records = http_fixture([(200, {"Items": items, "TotalRecordCount": 1}, {}), (204, b"", {})])
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_by_provider_id("movie", metadata()) == {"status": "requested"}
+    assert urlsplit(records[-1]["path"]).path == "/Items/33/Refresh"
 
 
 def test_a_series_without_the_published_episode_misses(http_fixture):
@@ -322,7 +410,8 @@ def test_a_series_without_the_published_episode_misses(http_fixture):
         (200, {"Items": [SERIES], "TotalRecordCount": 1}, {}),
         (200, {"Items": [], "TotalRecordCount": 0}, {})])
     with EmbyClient(base, "synthetic-key") as client:
-        assert client.refresh_by_title_year("episode", metadata(episode=9)) is None
+        assert client.refresh_by_title_year("episode", metadata(episode=9),
+                                            TITLE_PATHS["episode"]) is None
     assert urlsplit(records[1]["path"]).path == "/Shows/35/Episodes"
     assert query(records[1])["Season"] == ["1"]
 
@@ -333,7 +422,7 @@ def test_an_episode_of_another_season_is_never_refreshed(http_fixture):
              "TotalRecordCount": 1}
     base, records = http_fixture([(200, {"Items": [SERIES], "TotalRecordCount": 1}, {}), (200, other, {})])
     with EmbyClient(base, "synthetic-key") as client:
-        assert client.refresh_by_title_year("episode", metadata()) is None
+        assert client.refresh_by_title_year("episode", metadata(), TITLE_PATHS["episode"]) is None
     assert len(records) == 2
 
 
@@ -375,7 +464,10 @@ def test_identifier_rungs_honour_the_revision_guard(monkeypatch, media_type, pha
         monkeypatch.setattr(client.http, "request_empty", lambda *args, **kwargs: requests.append("post"))
         with pytest.raises(MediaServerError, match="configuration_changed"):
             client.refresh_by_provider_id(media_type, metadata(), ensure_current=guard)
-    assert requests == [] if phase == "lookup" else requests[0] == "/Items"
+    if phase == "lookup":
+        assert requests == []
+    else:
+        assert requests[0] == "/Items"
 
 
 # ------------------------------------------------------------- library rung
@@ -386,6 +478,30 @@ FOLDERS = [
     {"Name": "TV A", "ItemId": "19", "CollectionType": "tvshows", "Locations": ["/media/series"]},
     {"Name": "Music", "ItemId": "21", "CollectionType": "music", "Locations": ["/media"]},
 ]
+
+
+def test_one_recursive_library_scan_serves_every_file_in_it(http_fixture):
+    """A recursive rescan of a library covers every file in that library, so a
+    bulk mod or a season pack against a slightly wrong mapping must not issue
+    one per video. A second library is still its own scan."""
+    from emby.client import EmbyClient
+    # Exactly what the coalesced sequence consumes: look, scan, look, look, scan.
+    base, records = http_fixture([(200, FOLDERS, {}), (204, b"", {}),
+                                  (200, FOLDERS, {}), (200, FOLDERS, {}), (204, b"", {})])
+    scanned = {}
+
+    def coalesce(library):
+        seen = library in scanned
+        scanned[library] = True
+        return seen
+
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_library("movie", "/media/movies/A.mkv", coalesce=coalesce) == {"status": "requested"}
+        assert client.refresh_library("movie", "/media/movies/B.mkv", coalesce=coalesce) == {"status": "requested"}
+        assert client.refresh_library("episode", "/media/series/F/S01E01.mkv",
+                                      coalesce=coalesce) == {"status": "requested"}
+    posts = [record for record in records if record["method"] == "POST"]
+    assert [urlsplit(post["path"]).path for post in posts] == ["/Items/3/Refresh", "/Items/19/Refresh"]
 
 
 @pytest.mark.parametrize(("media_type", "path", "item_id"), [

--- a/tests/bazarr/test_emby_client.py
+++ b/tests/bazarr/test_emby_client.py
@@ -1,0 +1,162 @@
+import json
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from test_media_server_http import http_fixture as http_fixture
+
+
+@pytest.mark.parametrize('phase', ['lookup', 'post', 'completion'])
+def test_revision_guard_prevents_later_authenticated_requests(monkeypatch, phase):
+    from emby.client import EmbyClient
+    from media_servers.http import MediaServerError
+    requests = []
+    valid = phase != 'lookup'
+
+    def guard():
+        if not valid:
+            raise MediaServerError('configuration_changed')
+
+    with EmbyClient('http://emby.example', 'synthetic-key') as client:
+        def lookup(*args, **kwargs):
+            nonlocal valid
+            requests.append('lookup')
+            if phase == 'post':
+                valid = False
+            return {'Items': [{'Id': '1', 'Type': 'Movie', 'Path': '/media/A.mkv'}]}
+
+        def post(*args, **kwargs):
+            nonlocal valid
+            requests.append('post')
+            valid = False
+
+        monkeypatch.setattr(client.http, 'request_json', lookup)
+        monkeypatch.setattr(client.http, 'request_empty', post)
+        with pytest.raises(MediaServerError, match='configuration_changed'):
+            client.refresh_movie('/media/A.mkv', ensure_current=guard)
+    assert requests == {'lookup': [], 'post': ['lookup'], 'completion': ['lookup', 'post']}[phase]
+
+
+def test_authenticated_connection_uses_system_info(http_fixture):
+    from emby.operations import emby_test_connection
+    base, records = http_fixture([(200, {"ServerName": "Fixture", "Version": "4.9.5.0"}, {})])
+    assert emby_test_connection(base + "/emby", "synthetic-key") == {
+        "success": True, "server_name": "Fixture", "version": "4.9.5.0"}
+    assert records[0]["path"] == "/emby/System/Info"
+    assert records[0]["headers"]["X-Emby-Token"] == "synthetic-key"
+
+
+def test_invalid_key_returns_only_a_sanitized_code(http_fixture):
+    from emby.operations import emby_test_connection
+    base, _records = http_fixture([(401, b"synthetic-sensitive-response", {})])
+    assert emby_test_connection(base, "synthetic-invalid-key") == {"success": False, "error_code": "unauthorized"}
+
+
+@pytest.mark.parametrize("body", [[], {}, {"ServerName": 1, "Version": "4"}, {"ServerName": "Fixture"}])
+def test_bad_system_info_is_not_connection_success(http_fixture, body):
+    from emby.operations import emby_test_connection
+    base, _records = http_fixture([(200, body, {})])
+    assert emby_test_connection(base, "synthetic-key") == {"success": False, "error_code": "invalid_response"}
+
+
+@pytest.mark.parametrize("status", [200, 204])
+def test_refresh_resolves_exact_path_and_encodes_opaque_item_id(http_fixture, status):
+    from emby.client import EmbyClient
+    base, records = http_fixture([
+        (200, {"Items": [{"Id": "edition/a?x=#", "Type": "Movie", "Path": "/media/A.mkv"}], "TotalRecordCount": 1}, {}),
+        (status, b"", {}),
+    ])
+    with EmbyClient(base + "/emby", "synthetic-key") as client:
+        assert client.refresh_movie("/media/A.mkv") == {"status": "requested"}
+    lookup = urlsplit(records[0]["path"])
+    assert lookup.path == "/emby/Items"
+    query = parse_qs(lookup.query)
+    assert query["Path"] == ["/media/A.mkv"]
+    assert query["IncludeItemTypes"] == ["Movie"]
+    assert query["Recursive"] == ["true"]
+    assert "MediaSources" in query["Fields"][0].split(",")
+    refresh = urlsplit(records[1]["path"])
+    assert records[1]["method"] == "POST"
+    assert refresh.path == "/emby/Items/edition%2Fa%3Fx%3D%23/Refresh"
+    assert parse_qs(refresh.query) == {
+        "Recursive": ["false"], "MetadataRefreshMode": ["ValidationOnly"],
+        "ImageRefreshMode": ["ValidationOnly"], "ReplaceAllMetadata": ["false"], "ReplaceAllImages": ["false"],
+    }
+    assert json.loads(records[1]["body"]) == {"ReplaceThumbnailImages": False}
+    assert records[1]["headers"]["X-Emby-Token"] == "synthetic-key"
+
+
+def test_media_source_exact_path_can_identify_movie(http_fixture):
+    from emby.client import EmbyClient
+    base, records = http_fixture([
+        (200, {"Items": [{"Id": "opaque", "Type": "Movie", "Path": "/media/other.mkv",
+                          "MediaSources": [{"Path": "/media/A.mkv"}]}], "TotalRecordCount": 1}, {}),
+        (204, b"", {}),
+    ])
+    with EmbyClient(base, "synthetic-key") as client:
+        assert client.refresh_movie("/media/A.mkv")["status"] == "requested"
+    assert len(records) == 2
+
+
+@pytest.mark.parametrize(("items", "code"), [
+    ([], "item_missing"),
+    ([{"Id": "1", "Type": "Movie", "Path": "/media/other.mkv", "ProviderIds": {"Tmdb": "1"}}], "item_missing"),
+    ([{"Id": "1", "Type": "Episode", "Path": "/media/A.mkv"}], "item_missing"),
+    ([{"Id": "1", "Type": "Movie", "Path": "/media/A.mkv"},
+      {"Id": "2", "Type": "Movie", "Path": "/media/A.mkv"}], "item_ambiguous"),
+    ([{"Id": 1, "Type": "Movie", "Path": "/media/A.mkv"}], "invalid_response"),
+])
+def test_non_unique_movie_never_triggers_refresh(http_fixture, items, code):
+    from emby.client import EmbyClient
+    from media_servers.http import MediaServerError
+    base, records = http_fixture([(200, {"Items": items, "TotalRecordCount": len(items)}, {})])
+    with EmbyClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match=code):
+        client.refresh_movie("/media/A.mkv")
+    assert len(records) == 1
+
+
+@pytest.mark.parametrize(("status", "body", "code"), [(202, b"", "request_rejected"), (200, b"{}", "invalid_response"),
+                                                       (403, b"", "forbidden")])
+def test_refresh_acceptance_is_strict_and_has_no_broader_fallback(http_fixture, status, body, code):
+    from emby.client import EmbyClient
+    from media_servers.http import MediaServerError
+    base, records = http_fixture([
+        (200, {"Items": [{"Id": "1", "Type": "Movie", "Path": "/media/A.mkv"}], "TotalRecordCount": 1}, {}),
+        (status, body, {}),
+    ])
+    with EmbyClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match=code):
+        client.refresh_movie("/media/A.mkv")
+    assert len(records) == 2
+
+
+@pytest.mark.parametrize("result", [
+    {"Items": {}},
+    {"Items": [{"Id": "1", "Type": "Movie", "Path": "/media/A.mkv"}], "TotalRecordCount": 2},
+    {"Items": [{"Id": "1", "Type": "Movie", "Path": "/media/A.mkv", "MediaSources": {}}]},
+    {"Items": [{"Id": "\ud800", "Type": "Movie", "Path": "/media/A.mkv"}]},
+], ids=["items-shape", "partial-result", "sources-shape", "invalid-id-encoding"])
+def test_malformed_lookup_cannot_refresh_or_leak_raw_errors(http_fixture, result):
+    from emby.client import EmbyClient
+    from media_servers.http import MediaServerError
+    base, records = http_fixture([(200, result, {})])
+    with EmbyClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match="invalid_response"):
+        client.refresh_movie("/media/A.mkv")
+    assert len(records) == 1
+
+
+@pytest.mark.parametrize("path", ["/movies/D:/A.mkv", "/movies/C:/A.mkv", "/movies/D:A.mkv", "/movies/C:A.mkv"],
+                         ids=["same-drive", "other-drive", "same-drive-filename", "other-drive-filename"])
+def test_reinterpreted_mapping_cannot_refresh_a_different_movie(http_fixture, path):
+    from emby.client import EmbyClient
+    from media_servers.http import MediaServerError
+    from media_servers.paths import map_media_path
+    base, records = http_fixture([
+        (200, {"Items": [{"Id": "wrong-file", "Type": "Movie", "Path": "D:\\Library\\A.mkv"}],
+               "TotalRecordCount": 1}, {}),
+        (204, b"", {}),
+    ])
+    rows = [{"local_path": "/movies", "remote_path": "D:\\Library"}]
+    with EmbyClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match="path_invalid"):
+        mapped = map_media_path(path, rows)
+        client.refresh_movie(mapped["path"])
+    assert records == []

--- a/tests/bazarr/test_mass_operations.py
+++ b/tests/bazarr/test_mass_operations.py
@@ -90,7 +90,19 @@ class TestProcessSubtitleItem:
         result = _process_subtitle_item(item, 'remove_HI', {}, 'test_job')
         assert result is True
         mock_mods.assert_called_once_with('en', '/subs/test.en.srt', ['remove_HI'],
-                                          '/video/test.mkv', arr_instance_id=None)
+                                          '/video/test.mkv', arr_instance_id=None,
+                                          media_type='episode')
+
+    @patch('subtitles.mass_operations.subtitles_apply_mods')
+    def test_mod_action_on_a_movie_carries_the_movie_media_type(self, mock_mods):
+        # The media type reaches the mods so the rewritten subtitle can be
+        # published to the native destinations; a movie item has no series id.
+        from subtitles.mass_operations import _process_subtitle_item
+        item = self._make_item(sonarr_series_id=None, sonarr_episode_id=None, radarr_id=30)
+        assert _process_subtitle_item(item, 'remove_HI', {}, 'test_job') is True
+        mock_mods.assert_called_once_with('en', '/subs/test.en.srt', ['remove_HI'],
+                                          '/video/test.mkv', arr_instance_id=None,
+                                          media_type='movies')
 
     @patch('subtitles.mass_operations.subtitles_apply_mods')
     def test_mod_action_ocr_fixes(self, mock_mods):
@@ -99,7 +111,8 @@ class TestProcessSubtitleItem:
         result = _process_subtitle_item(item, 'OCR_fixes', {}, 'test_job')
         assert result is True
         mock_mods.assert_called_once_with('en', '/subs/test.en.srt', ['OCR_fixes'],
-                                          '/video/test.mkv', arr_instance_id=None)
+                                          '/video/test.mkv', arr_instance_id=None,
+                                          media_type='episode')
 
     @patch('subtitles.mass_operations.subtitles_apply_mods')
     def test_mod_action_threads_owning_instance(self, mock_mods):
@@ -111,7 +124,8 @@ class TestProcessSubtitleItem:
         result = _process_subtitle_item(item, 'remove_HI', {}, 'test_job')
         assert result is True
         mock_mods.assert_called_once_with('en', '/subs/test.en.srt', ['remove_HI'],
-                                          '/video/test.mkv', arr_instance_id=7)
+                                          '/video/test.mkv', arr_instance_id=7,
+                                          media_type='episode')
 
     @patch('subtitles.tools.translate.main.translate_subtitles_file', return_value=True)
     def test_translate_action(self, mock_translate):

--- a/tests/bazarr/test_media_server_config.py
+++ b/tests/bazarr/test_media_server_config.py
@@ -13,10 +13,12 @@ def saved_config(tmp_path, monkeypatch):
     from sqlalchemy import update
     from app.database import System
     snapshot = config.settings.as_dict()
-    settings = Dynaconf(core_loaders=["YAML"], validators=config.validators)
+    path = tmp_path / "config.yaml"
+    # Bound to its own file, exactly as the live object is: a settings object
+    # with nowhere to reload from cannot show what a failed save falls back to.
+    settings = Dynaconf(settings_file=str(path), core_loaders=["YAML"], validators=config.validators)
     settings.update(snapshot)
     settings.validators.validate()
-    path = tmp_path / "config.yaml"
     monkeypatch.setattr(config, "settings", settings)
     from media_servers import dispatcher
     monkeypatch.setattr(dispatcher, "_configuration", dispatcher.NativeConfiguration(settings))
@@ -156,3 +158,55 @@ def test_successful_ordinary_save_marks_generated_master_key_durable(saved_confi
     assert config.write_config() is True and path.exists()
     monkeypatch.setattr(config, 'write_config', lambda: pytest.fail('ordinary save already persisted this key'))
     persist_master_key()
+
+
+@pytest.mark.parametrize('failure', ['write', 'move'])
+def test_a_save_that_never_reached_disk_leaves_nothing_applied(saved_config, monkeypatch, failure):
+    """A master switch travels with whatever else the settings page submitted.
+
+    Refusing the request while the co-saved values stay on the live settings
+    object leaves the process running a configuration that is not on disk, and
+    reverting silently at the next restart.
+    """
+    from media_servers.dispatcher import get_native_configuration
+    from test_media_server_dispatcher import IDS, native_settings, native_snapshots
+    config, path = saved_config
+    native = get_native_configuration()
+    for snapshot in native_snapshots(native_settings()):
+        native.publish(snapshot)
+    config.save_settings([('settings-general-use_silo', ['true']),
+                          ('settings-general-page_size', ['25'])])
+    before_disk = path.read_bytes()
+    before = native.read(IDS['silo'])
+
+    def fail(*args, **kwargs):
+        raise OSError('synthetic-sensitive-remote-text')
+
+    monkeypatch.setattr(config, failure, fail)
+    with pytest.raises(ValidationError):
+        config.save_settings([('settings-general-use_silo', ['false']),
+                              ('settings-general-page_size', ['250'])])
+
+    assert path.read_bytes() == before_disk
+    assert config.settings.general.page_size == 25
+    assert config.settings.general.use_silo is True
+    assert native.read(IDS['silo']) == before
+    native.ensure_current(IDS['silo'], before[0])
+
+
+def test_a_failed_save_keeps_credentials_readable(saved_config, monkeypatch):
+    """settings.reload() pulls the on-disk ciphertext back in, so the rollback
+    has to decrypt again or every secret stays an ``enc:v1:`` string until the
+    process restarts."""
+    config, _path = saved_config
+    config.settings.auth.apikey = 'synthetic-rollback-key'
+    config.save_settings([('settings-general-use_emby', ['false'])])
+
+    def fail(*args, **kwargs):
+        raise OSError('synthetic-sensitive-remote-text')
+
+    monkeypatch.setattr(config, 'write', fail)
+    with pytest.raises(ValidationError):
+        config.save_settings([('settings-general-use_emby', ['true']),
+                              ('settings-general-page_size', ['250'])])
+    assert config.settings.auth.apikey == 'synthetic-rollback-key'

--- a/tests/bazarr/test_media_server_config.py
+++ b/tests/bazarr/test_media_server_config.py
@@ -197,10 +197,17 @@ def test_a_save_that_never_reached_disk_leaves_nothing_applied(saved_config, mon
 def test_a_failed_save_keeps_credentials_readable(saved_config, monkeypatch):
     """settings.reload() pulls the on-disk ciphertext back in, so the rollback
     has to decrypt again or every secret stays an ``enc:v1:`` string until the
-    process restarts."""
+    process restarts.
+
+    The co-submitted page size is what makes the key assertion mean anything:
+    without a rollback nothing touches the apikey either, so the plaintext set
+    below survives trivially and the test cannot tell "reloaded and decrypted
+    again" from "never reloaded".
+    """
     config, _path = saved_config
     config.settings.auth.apikey = 'synthetic-rollback-key'
-    config.save_settings([('settings-general-use_emby', ['false'])])
+    config.save_settings([('settings-general-use_emby', ['false']),
+                          ('settings-general-page_size', ['25'])])
 
     def fail(*args, **kwargs):
         raise OSError('synthetic-sensitive-remote-text')
@@ -209,4 +216,28 @@ def test_a_failed_save_keeps_credentials_readable(saved_config, monkeypatch):
     with pytest.raises(ValidationError):
         config.save_settings([('settings-general-use_emby', ['true']),
                               ('settings-general-page_size', ['250'])])
+    assert config.settings.general.page_size == 25, 'the rollback did not reload'
     assert config.settings.auth.apikey == 'synthetic-rollback-key'
+
+
+@pytest.mark.parametrize('failure', ['write', 'move'])
+def test_an_ordinary_save_that_never_reached_disk_is_refused(saved_config, monkeypatch, failure):
+    """Every save, not only the ones carrying a media-server master switch.
+
+    A settings request applies each submitted value to the live object before
+    config.yaml is written. A write that fails and is ignored answers success
+    to the frontend and leaves the process running a configuration that is on
+    no disk and reverts silently at the next restart.
+    """
+    config, path = saved_config
+    config.save_settings([('settings-general-page_size', ['25'])])
+    before_disk = path.read_bytes()
+
+    def fail(*args, **kwargs):
+        raise OSError('synthetic-sensitive-remote-text')
+
+    monkeypatch.setattr(config, failure, fail)
+    with pytest.raises(ValidationError):
+        config.save_settings([('settings-general-page_size', ['250'])])
+    assert path.read_bytes() == before_disk
+    assert config.settings.general.page_size == 25

--- a/tests/bazarr/test_media_server_config.py
+++ b/tests/bazarr/test_media_server_config.py
@@ -1,0 +1,158 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from dynaconf import Dynaconf
+from dynaconf.validator import ValidationError
+
+
+@pytest.fixture
+def saved_config(tmp_path, monkeypatch):
+    from app import config
+    from sqlalchemy import update
+    from app.database import System
+    snapshot = config.settings.as_dict()
+    settings = Dynaconf(core_loaders=["YAML"], validators=config.validators)
+    settings.update(snapshot)
+    settings.validators.validate()
+    path = tmp_path / "config.yaml"
+    monkeypatch.setattr(config, "settings", settings)
+    from media_servers import dispatcher
+    monkeypatch.setattr(dispatcher, "_configuration", dispatcher.NativeConfiguration(settings))
+    monkeypatch.setattr(config, "config_yaml_file", str(path))
+    monkeypatch.setattr(config, "_active_provider_hub_provider_ids", lambda: set())
+    monkeypatch.setitem(sys.modules, "app.database", SimpleNamespace(
+        database=SimpleNamespace(execute=lambda statement: None), update=update, System=System))
+    return config, path
+
+
+@pytest.mark.parametrize("server", ["emby", "silo"])
+def test_retired_numeric_key_remains_encrypted_after_unrelated_save(saved_config, server):
+    from secret_store.migration import decrypt_settings_in_place
+    config, path = saved_config
+    config.settings[server].apikey = '000123'
+    rows = [{"local_path": "/movies", "remote_path": "/media", "library_id": "0007"}]
+    config.settings[server].path_mappings = rows
+    config.settings[server].verify_ssl = False
+    config.save_settings([("settings-general-page_size", ["50"])])
+    on_disk = yaml.safe_load(path.read_text())
+    assert on_disk[server]["apikey"].startswith("enc:v1:")
+    assert "000123" not in path.read_text()
+    rebooted = Dynaconf(settings_file=str(path), core_loaders=["YAML"])
+    decrypt_settings_in_place(rebooted)
+    assert rebooted[server].apikey == "000123"
+    assert rebooted[server].path_mappings == rows
+    assert rebooted[server].verify_ssl is False
+    assert rebooted.general.page_size == 50
+    assert server not in config.get_settings()
+
+
+@pytest.mark.parametrize("value", ["not-json", "{}", '[{"local_path":"/movies"}]',
+                                  '[{"local_path":"/movies","remote_path":"/media","library_id":7}]'])
+@pytest.mark.parametrize("server", ["emby", "silo"])
+def test_invalid_mapping_batch_is_rejected_before_any_setting_changes(saved_config, value, server):
+    config, path = saved_config
+    config.write_config()
+    before_bytes = path.read_bytes()
+    before_page_size = config.settings.general.page_size
+    with pytest.raises(ValidationError):
+        config.save_settings([("settings-general-page_size", ["123"]), (f"settings-{server}-path_mappings", [value])])
+    assert path.read_bytes() == before_bytes
+    assert config.settings.general.page_size == before_page_size
+
+
+@pytest.mark.parametrize("server", ["emby", "silo"])
+def test_native_defaults_are_disabled_and_safe(server):
+    from app import config
+    settings = Dynaconf(core_loaders=["YAML"], validators=[v for v in config.validators
+                        if any(name.startswith(f"{server}.") or name == f"general.use_{server}" for name in v.names)])
+    settings.validators.validate()
+    assert settings.general[f"use_{server}"] is False
+    assert settings[server].url == ""
+    assert settings[server].apikey == ""
+    assert settings[server].verify_ssl is True
+    assert settings[server].path_mappings == []
+
+
+def test_master_switch_changes_only_affected_kind(saved_config):
+    from media_servers.dispatcher import get_native_configuration
+    from test_media_server_dispatcher import IDS, native_settings, native_snapshots
+    config, _path = saved_config
+    native = get_native_configuration()
+    config.settings.general.use_emby = True
+    config.settings.general.use_silo = True
+    native.publish_masters(native_settings())
+    for snapshot in native_snapshots(native_settings()):
+        native.publish(snapshot)
+    emby_before = native.read(IDS['emby'])
+    silo_before = native.read(IDS['silo'])
+    config.save_settings([('settings-general-use_silo', ['false'])])
+    assert native.read(IDS['emby']) == emby_before
+    assert native.read(IDS['silo'])[0] != silo_before[0]
+    assert native.read(IDS['silo'])[1].enabled is False
+
+
+@pytest.mark.parametrize('failure', ['validation', 'write', 'move'])
+def test_failed_master_save_keeps_last_usable_revision(saved_config, monkeypatch, failure):
+    from media_servers.dispatcher import get_native_configuration
+    from test_media_server_dispatcher import IDS, native_settings, native_snapshots
+    config, path = saved_config
+    native = get_native_configuration()
+    for snapshot in native_snapshots(native_settings()):
+        native.publish(snapshot)
+    config.save_settings([('settings-general-use_silo', ['true'])])
+    before = native.read(IDS['silo'])
+    before_disk = path.read_bytes()
+    def fail(*args, **kwargs):
+        raise OSError('synthetic-sensitive-remote-text')
+    if failure != 'validation':
+        monkeypatch.setattr(config, failure, fail)
+    value = 'invalid' if failure == 'validation' else 'false'
+    with pytest.raises(ValidationError):
+        config.save_settings([('settings-general-use_silo', [value])])
+    assert native.read(IDS['silo']) == before
+    native.ensure_current(IDS['silo'], before[0])
+    assert config.settings.general.use_silo is True
+    assert path.read_bytes() == before_disk
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_import_only_scalar_secrets_hidden_and_edits_rejected(saved_config, kind):
+    config, _path = saved_config
+    config.settings[kind].apikey = 'synthetic-private-import-key'
+    assert kind not in config.get_settings()
+    before = config.settings.general.page_size
+    with pytest.raises(ValidationError):
+        config.save_settings([('settings-general-page_size', ['999']), (f'settings-{kind}-url', ['http://other'])])
+    assert config.settings.general.page_size == before
+
+
+def test_failed_startup_write_keeps_generated_key_pending_until_persisted(saved_config, monkeypatch):
+    from secret_store import persist_master_key
+    config, path = saved_config
+    config.settings.general.secrets_encryption_key = ''
+    original_write = config.write
+    def fail(*args, **kwargs):
+        raise OSError('synthetic failure')
+    monkeypatch.setattr(config, 'write', fail)
+    assert config.write_config() is False
+    generated = config.settings.general.secrets_encryption_key
+    assert generated
+    with pytest.raises(ValueError, match='Unable to persist secrets encryption key'):
+        persist_master_key()
+    assert not path.exists()
+    monkeypatch.setattr(config, 'write', original_write)
+    persist_master_key()
+    assert yaml.safe_load(path.read_text())['general']['secrets_encryption_key'] == generated
+    monkeypatch.setattr(config, 'write_config', lambda: pytest.fail('durable key was persisted again'))
+    persist_master_key()
+
+
+def test_successful_ordinary_save_marks_generated_master_key_durable(saved_config, monkeypatch):
+    from secret_store import persist_master_key
+    config, path = saved_config
+    config.settings.general.secrets_encryption_key = ''
+    assert config.write_config() is True and path.exists()
+    monkeypatch.setattr(config, 'write_config', lambda: pytest.fail('ordinary save already persisted this key'))
+    persist_master_key()

--- a/tests/bazarr/test_media_server_dispatcher.py
+++ b/tests/bazarr/test_media_server_dispatcher.py
@@ -446,6 +446,76 @@ def test_unsupported_warning_capacity_counts_distinct_video_and_arr_owner_target
     assert dispatcher.status(IDS['silo'])['error_code'] == 'queue_overflow'
 
 
+@pytest.mark.parametrize('drain', ['retry', 'covering_scan'])
+def test_a_moved_subtitle_lets_the_retained_unsupported_warning_drain(dispatch, tmp_path, drain):
+    """The warning tells the user to move the subtitle beside the video and retry.
+
+    That move publishes nothing of its own, so the retained event is the only
+    record of the target. Replaying the path it was recorded with re-raises
+    sidecar_unsupported however many times the user retries, and the covering
+    scan of a later eligible publication does not release it either: the
+    destination can never return to idle short of deleting the instance or
+    restarting Bazarr.
+    """
+    dispatcher = dispatch.dispatcher
+    settings = native_settings()
+    settings.general.use_emby = False
+    settings.silo.path_mappings[0]['local_path'] = str(tmp_path)
+    apply_settings(dispatch.config, settings)
+    dispatch.release.set()
+    video = tmp_path / 'Video.mkv'
+    video.touch()
+    custom = tmp_path / 'subtitles'
+    custom.mkdir()
+    stray = custom / 'Video.hu.srt'
+    stray.write_text('Stored in the configured custom subtitle folder')
+    warning = {'pending': 1, 'state': 'unconfirmed', 'error_code': 'sidecar_unsupported'}
+
+    dispatcher.notify(movie_event(video_path=str(video), subtitle_path=str(stray)))
+    assert dispatcher.wait_idle(10)
+    assert dispatch.calls['silo'] == []
+    assert dispatcher.status(IDS['silo']) == warning
+
+    stray.rename(video.parent / stray.name)
+
+    if drain == 'retry':
+        assert dispatcher.retry(IDS['silo']) == 1
+    else:
+        dispatcher.notify(movie_event(video_path=str(video),
+                                      subtitle_path=str(video.with_suffix('.en.srt'))))
+    assert dispatcher.wait_idle(10)
+    assert [path for path, _snapshot in dispatch.calls['silo']] == ['/media/Video.mkv'] * (
+        1 if drain == 'retry' else 2)
+    assert dispatcher.status(IDS['silo']) == {'pending': 0, 'state': 'confirmed', 'error_code': None}
+
+
+def test_a_retained_unsupported_warning_survives_a_subtitle_that_never_moved(dispatch, tmp_path):
+    """Only an actual move releases it. A file still sitting where Silo cannot
+    read it keeps the warning, however many times the user retries."""
+    dispatcher = dispatch.dispatcher
+    settings = native_settings()
+    settings.general.use_emby = False
+    settings.silo.path_mappings[0]['local_path'] = str(tmp_path)
+    apply_settings(dispatch.config, settings)
+    dispatch.release.set()
+    video = tmp_path / 'Video.mkv'
+    video.touch()
+    custom = tmp_path / 'subtitles'
+    custom.mkdir()
+    stray = custom / 'Video.hu.srt'
+    stray.write_text('Stored in the configured custom subtitle folder')
+    warning = {'pending': 1, 'state': 'unconfirmed', 'error_code': 'sidecar_unsupported'}
+
+    dispatcher.notify(movie_event(video_path=str(video), subtitle_path=str(stray)))
+    assert dispatcher.wait_idle(10)
+    assert dispatcher.status(IDS['silo']) == warning
+    for _attempt in range(2):
+        assert dispatcher.retry(IDS['silo']) == 1
+        assert dispatcher.wait_idle(10)
+        assert dispatch.calls['silo'] == []
+        assert dispatcher.status(IDS['silo']) == warning
+
+
 def test_read_only_status_and_invalid_selection_never_start_worker(dispatch):
     from media_servers.http import MediaServerError
     assert dispatch.dispatcher.status(IDS["silo"]) == {"pending": 0, "state": "idle", "error_code": None}

--- a/tests/bazarr/test_media_server_dispatcher.py
+++ b/tests/bazarr/test_media_server_dispatcher.py
@@ -40,6 +40,9 @@ def dispatch():
     from media_servers.dispatcher import NativeConfiguration, RefreshDispatcher
     configuration = NativeConfiguration(native_settings(), snapshots=native_snapshots(native_settings()))
     calls = {"emby": [], "silo": []}
+    # Emby resolves the item itself, so the media type it was asked for is the
+    # only evidence that an episode publication actually reached the client.
+    emby_items = []
     started, release = Event(), Event()
     failures = set()
     failed_paths = set()
@@ -59,7 +62,8 @@ def dispatch():
         def get_libraries(self):
             return libraries
 
-        def refresh_movie(self, path, *, ensure_current):
+        def refresh_item(self, media_type, path, *, ensure_current):
+            emby_items.append((media_type, path))
             return self.refresh_file(None, path, ensure_current=ensure_current)
 
         def refresh_file(self, library_id, path, *, ensure_current):
@@ -75,7 +79,8 @@ def dispatch():
 
     dispatcher = RefreshDispatcher(configuration, client_factory=Client)
     yield SimpleNamespace(dispatcher=dispatcher, config=configuration, calls=calls, started=started,
-                          release=release, failures=failures, libraries=libraries, failed_paths=failed_paths)
+                          release=release, failures=failures, libraries=libraries, failed_paths=failed_paths,
+                          emby_items=emby_items)
     release.set()
     assert dispatcher.wait_idle(3)
 
@@ -89,9 +94,10 @@ def movie_event(**overrides):
 def test_second_write_requires_followup_and_servers_are_independent(dispatch, media_type):
     dispatch.libraries[0]['type'] = 'movies' if media_type == 'movie' else 'series'
     dispatch.dispatcher.notify(movie_event(media_type=media_type))
-    assert dispatch.started.wait(3)
+    # The first worker in the process pays the one-time subsync engine import.
+    assert dispatch.started.wait(10)
     assert dispatch.dispatcher.wait_idle(3, server=IDS["emby"])
-    assert len(dispatch.calls["emby"]) == (1 if media_type == 'movie' else 0)
+    assert dispatch.emby_items == [(media_type, "/media/A.mkv")]
     dispatch.dispatcher.notify(movie_event(media_type=media_type))
     dispatch.release.set()
     assert dispatch.dispatcher.wait_idle(3)
@@ -159,12 +165,26 @@ def test_disabled_connection_retains_pending_without_new_requests(dispatch):
     assert len(dispatch.calls["silo"]) == 1
 
 
-@pytest.mark.parametrize("event", [movie_event(operation="delete"), movie_event(media_type="episode")])
-def test_emby_only_consumes_movie_download_and_upload(dispatch, event):
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+@pytest.mark.parametrize('operation', ['delete', 'sync', 'translate', 'combine', 'edit'])
+def test_emby_only_consumes_download_and_upload(dispatch, operation, media_type):
+    dispatch.libraries[0]['type'] = 'movies' if media_type == 'movie' else 'series'
     dispatch.release.set()
-    dispatch.dispatcher.notify(event)
+    dispatch.dispatcher.notify(movie_event(media_type=media_type, operation=operation))
     assert dispatch.dispatcher.wait_idle(3)
     assert dispatch.calls["emby"] == []
+    assert dispatch.emby_items == []
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+@pytest.mark.parametrize('operation', ['download', 'upload'])
+def test_emby_accepts_each_supported_publication_for_movies_and_episodes(dispatch, operation, media_type):
+    dispatch.libraries[0]['type'] = 'movies' if media_type == 'movie' else 'series'
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event(media_type=media_type, operation=operation))
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.emby_items == [(media_type, '/media/A.mkv')]
+    assert dispatch.dispatcher.status(IDS['emby']) == {'pending': 0, 'state': 'requested', 'error_code': None}
 
 
 @pytest.mark.parametrize(("event", "code"), [

--- a/tests/bazarr/test_media_server_dispatcher.py
+++ b/tests/bazarr/test_media_server_dispatcher.py
@@ -59,7 +59,16 @@ def dispatch():
     failures = set()
     failed_paths = set()
     missing_paths = set()
+    # Non-empty means the clients raise from another module generation.
+    generation = []
+    # Every refusal Silo folds into request_rejected that is not the documented
+    # 400: a refused event-stream handshake, a conflict, a rate limit.
+    rejected_paths = set()
     libraries = [{"id": "7", "type": "movies", "paths": ["/media"]}]
+
+    def server_error(code):
+        from media_servers.http import MediaServerError
+        return (generation[0] if generation else MediaServerError)(code)
 
     class Client:
         def __init__(self, server, snapshot):
@@ -83,33 +92,45 @@ def dispatch():
             return {"status": "requested"} if name in resolves else None
 
         def refresh_by_provider_id(self, media_type, media_metadata, *, ensure_current):
-            identifier_calls.append((self.server, resolution.PROVIDER_ID, media_type, media_metadata))
+            identifier_calls.append((self.server, resolution.PROVIDER_ID, media_type, media_metadata, None))
             return self._rung(resolution.PROVIDER_ID, ensure_current)
 
-        def refresh_by_title_year(self, media_type, media_metadata, *, ensure_current):
-            identifier_calls.append((self.server, resolution.TITLE_YEAR, media_type, media_metadata))
+        def refresh_by_title_year(self, media_type, media_metadata, video_path, *, ensure_current):
+            identifier_calls.append((self.server, resolution.TITLE_YEAR, media_type, media_metadata, video_path))
             return self._rung(resolution.TITLE_YEAR, ensure_current)
 
-        def refresh_library(self, *args, ensure_current):
-            library_calls.append((self.server, args))
-            return self._rung(resolution.LIBRARY, ensure_current)
+        def refresh_library(self, *args, ensure_current, coalesce=None):
+            # The real clients decide the library themselves and skip a scan
+            # this pass already asked for, answering the same either way.
+            rungs.append((self.server, resolution.LIBRARY))
+            ensure_current()
+            if resolution.LIBRARY not in resolves:
+                return None
+            library = args[-1] if self.server == "silo" else "emby-library"
+            if coalesce is None or not coalesce(library):
+                library_calls.append((self.server, args))
+            return {"status": "requested"}
 
         def refresh_item(self, media_type, path, *, ensure_current):
             emby_items.append((media_type, path))
             return self.refresh_file(None, path, ensure_current=ensure_current)
 
         def refresh_file(self, library_id, path, *, ensure_current):
-            from media_servers.http import MediaServerError
             rungs.append((self.server, resolution.PATH))
             calls[self.server].append((path, self.snapshot))
             if self.server == "silo" and len(calls["silo"]) == 1:
                 started.set()
                 assert release.wait(3)
             ensure_current()
+            if path in rejected_paths:
+                raise server_error("request_rejected")
             if path in missing_paths:
-                raise MediaServerError("item_missing" if self.server == "emby" else "request_rejected")
+                if self.server == "emby":
+                    raise server_error("item_missing")
+                # Silo's file rung answers a path it cannot place with nothing.
+                return None
             if self.server in failures or path in failed_paths:
-                raise MediaServerError("scan_incomplete")
+                raise server_error("scan_incomplete")
             return {"status": "confirmed" if self.server == "silo" else "requested"}
 
     dispatcher = RefreshDispatcher(configuration, client_factory=Client,
@@ -118,7 +139,8 @@ def dispatch():
                           release=release, failures=failures, libraries=libraries, failed_paths=failed_paths,
                           emby_items=emby_items, rungs=rungs, resolves=resolves, library_calls=library_calls,
                           identifier_calls=identifier_calls, missing_paths=missing_paths,
-                          metadata=metadata, metadata_box=metadata_box)
+                          rejected_paths=rejected_paths, metadata=metadata, metadata_box=metadata_box,
+                          generation=generation)
     release.set()
     assert dispatcher.wait_idle(3)
 
@@ -244,18 +266,22 @@ def test_emby_climbs_the_ladder_and_stops_at_the_first_rung_that_resolves(dispat
 def test_emby_identifier_rungs_receive_the_stored_media_identifiers(dispatch, media_type):
     from media_servers import resolution
     dispatch.libraries[0]['type'] = 'movies' if media_type == 'movie' else 'series'
+    # The exact path outranks the title, so the weak rung is only reached once
+    # the file itself missed.
+    dispatch.missing_paths.add('/media/A.mkv')
     dispatch.release.set()
     dispatch.dispatcher.notify(movie_event(media_type=media_type))
     assert dispatch.dispatcher.wait_idle(3)
     assert dispatch.identifier_calls == [
-        ('emby', resolution.PROVIDER_ID, media_type, dispatch.metadata),
-        ('emby', resolution.TITLE_YEAR, media_type, dispatch.metadata),
+        ('emby', resolution.PROVIDER_ID, media_type, dispatch.metadata, None),
+        ('emby', resolution.TITLE_YEAR, media_type, dispatch.metadata, '/media/A.mkv'),
     ]
 
 
 def test_identifiers_are_never_read_for_a_destination_that_cannot_use_them(dispatch):
     reads = []
     dispatch.dispatcher.metadata_factory = lambda event: reads.append(event) or dispatch.metadata
+    dispatch.missing_paths.add('/media/A.mkv')
     dispatch.release.set()
     dispatch.dispatcher.notify(movie_event())
     assert dispatch.dispatcher.wait_idle(3)
@@ -291,6 +317,86 @@ def test_a_file_scan_silo_refuses_falls_back_to_scanning_the_whole_library(dispa
     assert dispatch.dispatcher.wait_idle(3)
     assert ('silo', ('7',)) in dispatch.library_calls
     assert dispatch.dispatcher.status(IDS['silo']) == {'pending': 0, 'state': 'requested', 'error_code': None}
+
+
+def other_generation():
+    """A second execution of media_servers.http, which is what test isolation
+    leaves behind: the same class by name, a different object by identity."""
+    import importlib.util
+    from media_servers.http import MediaServerError as live
+    spec = importlib.util.find_spec('media_servers.http')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.MediaServerError is not live
+    return module.MediaServerError
+
+
+@pytest.mark.parametrize(('lever', 'expected'), [
+    ('missing_paths', {'pending': 0, 'state': 'requested', 'error_code': None}),
+    ('failures', {'pending': 1, 'state': 'unconfirmed', 'error_code': 'scan_incomplete'}),
+])
+def test_a_refusal_from_another_module_generation_keeps_its_meaning(dispatch, lever, expected):
+    """The dispatcher binds MediaServerError when it is imported and builds its
+    clients lazily, at the first refresh, so nothing makes the two share a
+    module generation. ``except MediaServerError`` catches a class, not a
+    vocabulary: once they split, an honest miss stops falling through to the
+    next rung and every refusal is reported as internal_error."""
+    dispatch.generation.append(other_generation())
+    if lever == 'missing_paths':
+        dispatch.missing_paths.add('/media/A.mkv')
+    else:
+        dispatch.failures.add('emby')
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.dispatcher.status(IDS['emby']) == expected
+
+
+def test_a_refused_scan_request_never_escalates_to_the_whole_library(dispatch):
+    """Silo folds a refused event-stream handshake, a 409 and a 429 into the
+    same request_rejected as its documented 400. Reading all of them as "this
+    path is not here" turns a broken destination into a stream of library scans
+    reported as success, with no signal to the user at all."""
+    dispatch.rejected_paths.add('/media/A.mkv')
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.library_calls == [], 'a refused request is not a path Silo could not place'
+    assert dispatch.dispatcher.status(IDS['silo']) == {
+        'pending': 1, 'state': 'unconfirmed', 'error_code': 'request_rejected'}
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_one_library_scan_covers_every_target_the_pass_already_held(dispatch, kind):
+    """A bulk mod or a season pack against a mapping that is slightly wrong
+    lands every one of its targets on the library rung, and the scan there is
+    recursive over the whole library. One per video is a hundred-odd identical
+    rescans of the same library."""
+    dispatcher = dispatch.dispatcher
+    dispatch.release.set()
+    with dispatcher.condition:
+        for number in range(8):
+            dispatch.missing_paths.add(f'/media/{number}.mkv')
+            dispatcher.notify(movie_event(video_path=f'/movies/{number}.mkv'))
+    assert dispatcher.wait_idle(10)
+    assert len(dispatch.calls[kind]) == 8, 'every file is still asked for on its own'
+    assert [call for call in dispatch.library_calls if call[0] == kind] == [
+        (kind, ('movie', '/media/0.mkv') if kind == 'emby' else ('7',))]
+    assert dispatcher.status(IDS[kind]) == {'pending': 0, 'state': 'requested', 'error_code': None}
+
+
+def test_a_publication_that_arrived_after_a_scan_is_not_counted_as_covered(dispatch):
+    """A recursive scan covers the files that were there when it was submitted.
+    A subtitle written after that gets its own, or it waits for a scan nobody
+    is going to ask for."""
+    dispatcher = dispatch.dispatcher
+    dispatch.missing_paths.update({'/media/A.mkv', '/media/B.mkv'})
+    dispatcher.notify(movie_event())
+    assert dispatch.started.wait(3)
+    dispatcher.notify(movie_event(video_path='/movies/B.mkv'))
+    dispatch.release.set()
+    assert dispatcher.wait_idle(10)
+    assert [call for call in dispatch.library_calls if call[0] == 'silo'] == [('silo', ('7',))] * 2
 
 
 def test_a_scan_that_ran_and_fell_short_is_a_failure_not_a_missing_file(dispatch):
@@ -641,9 +747,9 @@ def test_a_rung_that_answers_with_the_wrong_status_is_not_a_refresh(dispatch):
     dispatch.release.set()
     original = dispatch.dispatcher._ladder
 
-    def confused(client, server, event, mapped, guard):
+    def confused(client, server, event, mapped, guard, coalesce):
         return [(name, lambda: {'status': 'whatever'}, expected)
-                for name, _call, expected in original(client, server, event, mapped, guard)]
+                for name, _call, expected in original(client, server, event, mapped, guard, coalesce)]
 
     dispatch.dispatcher._ladder = confused
     dispatch.dispatcher.notify(movie_event())

--- a/tests/bazarr/test_media_server_dispatcher.py
+++ b/tests/bazarr/test_media_server_dispatcher.py
@@ -37,21 +37,36 @@ def apply_settings(configuration, settings):
 
 @pytest.fixture
 def dispatch():
+    from media_servers import resolution
     from media_servers.dispatcher import NativeConfiguration, RefreshDispatcher
+    from media_servers.resolution import MediaMetadata
     configuration = NativeConfiguration(native_settings(), snapshots=native_snapshots(native_settings()))
     calls = {"emby": [], "silo": []}
     # Emby resolves the item itself, so the media type it was asked for is the
     # only evidence that an episode publication actually reached the client.
     emby_items = []
+    # Every rung the dispatcher climbed, in order, per destination.
+    rungs = []
+    library_calls = []
+    identifier_calls = []
+    # Identifier rungs miss by default, which is what a server that has not
+    # matched the item does; the library rung resolves, as a real one would.
+    resolves = {resolution.LIBRARY}
+    metadata = MediaMetadata(imdb_id="tt0017136", tmdb_id="19", tvdb_id=78874,
+                             title="Metropolis", year=1927, season=1, episode=2)
+    metadata_box = [metadata]
     started, release = Event(), Event()
     failures = set()
     failed_paths = set()
+    missing_paths = set()
     libraries = [{"id": "7", "type": "movies", "paths": ["/media"]}]
 
     class Client:
         def __init__(self, server, snapshot):
             self.server = server
             self.snapshot = snapshot
+            self.REFRESH_STEPS = (resolution.CHAIN if server == "emby"
+                                  else (resolution.PATH, resolution.LIBRARY))
 
         def __enter__(self):
             return self
@@ -62,25 +77,48 @@ def dispatch():
         def get_libraries(self):
             return libraries
 
+        def _rung(self, name, ensure_current):
+            rungs.append((self.server, name))
+            ensure_current()
+            return {"status": "requested"} if name in resolves else None
+
+        def refresh_by_provider_id(self, media_type, media_metadata, *, ensure_current):
+            identifier_calls.append((self.server, resolution.PROVIDER_ID, media_type, media_metadata))
+            return self._rung(resolution.PROVIDER_ID, ensure_current)
+
+        def refresh_by_title_year(self, media_type, media_metadata, *, ensure_current):
+            identifier_calls.append((self.server, resolution.TITLE_YEAR, media_type, media_metadata))
+            return self._rung(resolution.TITLE_YEAR, ensure_current)
+
+        def refresh_library(self, *args, ensure_current):
+            library_calls.append((self.server, args))
+            return self._rung(resolution.LIBRARY, ensure_current)
+
         def refresh_item(self, media_type, path, *, ensure_current):
             emby_items.append((media_type, path))
             return self.refresh_file(None, path, ensure_current=ensure_current)
 
         def refresh_file(self, library_id, path, *, ensure_current):
             from media_servers.http import MediaServerError
+            rungs.append((self.server, resolution.PATH))
             calls[self.server].append((path, self.snapshot))
             if self.server == "silo" and len(calls["silo"]) == 1:
                 started.set()
                 assert release.wait(3)
             ensure_current()
+            if path in missing_paths:
+                raise MediaServerError("item_missing" if self.server == "emby" else "request_rejected")
             if self.server in failures or path in failed_paths:
                 raise MediaServerError("scan_incomplete")
             return {"status": "confirmed" if self.server == "silo" else "requested"}
 
-    dispatcher = RefreshDispatcher(configuration, client_factory=Client)
+    dispatcher = RefreshDispatcher(configuration, client_factory=Client,
+                                   metadata_factory=lambda event: metadata_box[0])
     yield SimpleNamespace(dispatcher=dispatcher, config=configuration, calls=calls, started=started,
                           release=release, failures=failures, libraries=libraries, failed_paths=failed_paths,
-                          emby_items=emby_items)
+                          emby_items=emby_items, rungs=rungs, resolves=resolves, library_calls=library_calls,
+                          identifier_calls=identifier_calls, missing_paths=missing_paths,
+                          metadata=metadata, metadata_box=metadata_box)
     release.set()
     assert dispatcher.wait_idle(3)
 
@@ -166,25 +204,115 @@ def test_disabled_connection_retains_pending_without_new_requests(dispatch):
 
 
 @pytest.mark.parametrize('media_type', ['movie', 'episode'])
-@pytest.mark.parametrize('operation', ['delete', 'sync', 'translate', 'combine', 'edit'])
-def test_emby_only_consumes_download_and_upload(dispatch, operation, media_type):
-    dispatch.libraries[0]['type'] = 'movies' if media_type == 'movie' else 'series'
-    dispatch.release.set()
-    dispatch.dispatcher.notify(movie_event(media_type=media_type, operation=operation))
-    assert dispatch.dispatcher.wait_idle(3)
-    assert dispatch.calls["emby"] == []
-    assert dispatch.emby_items == []
-
-
-@pytest.mark.parametrize('media_type', ['movie', 'episode'])
-@pytest.mark.parametrize('operation', ['download', 'upload'])
-def test_emby_accepts_each_supported_publication_for_movies_and_episodes(dispatch, operation, media_type):
+@pytest.mark.parametrize('operation', ['download', 'upload', 'delete', 'sync', 'translate', 'combine', 'edit'])
+def test_emby_consumes_every_publication_silo_does(dispatch, operation, media_type):
     dispatch.libraries[0]['type'] = 'movies' if media_type == 'movie' else 'series'
     dispatch.release.set()
     dispatch.dispatcher.notify(movie_event(media_type=media_type, operation=operation))
     assert dispatch.dispatcher.wait_idle(3)
     assert dispatch.emby_items == [(media_type, '/media/A.mkv')]
     assert dispatch.dispatcher.status(IDS['emby']) == {'pending': 0, 'state': 'requested', 'error_code': None}
+
+
+def test_no_publication_reaches_one_destination_and_not_the_other():
+    from media_servers.dispatcher import _OPERATIONS
+    assert _OPERATIONS == {'download', 'upload', 'delete', 'sync', 'translate', 'combine', 'edit'}
+
+
+# ------------------------------------------------------------ resolution ladder
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+@pytest.mark.parametrize('resolving', ['provider_id', 'title_year', 'path', 'library'])
+def test_emby_climbs_the_ladder_and_stops_at_the_first_rung_that_resolves(dispatch, resolving, media_type):
+    from media_servers import resolution
+    order = list(resolution.CHAIN)
+    dispatch.libraries[0]['type'] = 'movies' if media_type == 'movie' else 'series'
+    dispatch.resolves.clear()
+    dispatch.resolves.add(resolving)
+    if resolving != resolution.PATH:
+        dispatch.missing_paths.add('/media/A.mkv')
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event(media_type=media_type))
+    assert dispatch.dispatcher.wait_idle(3)
+    climbed = [name for server, name in dispatch.rungs if server == 'emby']
+    assert climbed == order[:order.index(resolving) + 1], 'a resolved rung must never reach a later one'
+    assert dispatch.dispatcher.status(IDS['emby']) == {'pending': 0, 'state': 'requested', 'error_code': None}
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+def test_emby_identifier_rungs_receive_the_stored_media_identifiers(dispatch, media_type):
+    from media_servers import resolution
+    dispatch.libraries[0]['type'] = 'movies' if media_type == 'movie' else 'series'
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event(media_type=media_type))
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.identifier_calls == [
+        ('emby', resolution.PROVIDER_ID, media_type, dispatch.metadata),
+        ('emby', resolution.TITLE_YEAR, media_type, dispatch.metadata),
+    ]
+
+
+def test_identifiers_are_never_read_for_a_destination_that_cannot_use_them(dispatch):
+    reads = []
+    dispatch.dispatcher.metadata_factory = lambda event: reads.append(event) or dispatch.metadata
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.dispatcher.wait_idle(3)
+    assert len(dispatch.calls['silo']) == 1
+    assert [call[0] for call in dispatch.identifier_calls] == ['emby', 'emby']
+    assert len(reads) == 1, 'Silo declares no identifier rungs, so it must not read the database'
+
+
+def test_unreadable_identifiers_skip_straight_to_the_path(dispatch):
+    from media_servers import resolution
+    dispatch.metadata_box[0] = None
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.identifier_calls == []
+    assert [name for server, name in dispatch.rungs if server == 'emby'] == [resolution.PATH]
+    assert dispatch.emby_items == [('movie', '/media/A.mkv')]
+
+
+def test_a_path_emby_has_not_indexed_falls_back_to_the_library_holding_it(dispatch):
+    dispatch.missing_paths.add('/media/A.mkv')
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.dispatcher.wait_idle(3)
+    assert ('emby', ('movie', '/media/A.mkv')) in dispatch.library_calls
+    assert dispatch.dispatcher.status(IDS['emby']) == {'pending': 0, 'state': 'requested', 'error_code': None}
+
+
+def test_a_file_scan_silo_refuses_falls_back_to_scanning_the_whole_library(dispatch):
+    dispatch.missing_paths.add('/media/A.mkv')
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.dispatcher.wait_idle(3)
+    assert ('silo', ('7',)) in dispatch.library_calls
+    assert dispatch.dispatcher.status(IDS['silo']) == {'pending': 0, 'state': 'requested', 'error_code': None}
+
+
+def test_a_scan_that_ran_and_fell_short_is_a_failure_not_a_missing_file(dispatch):
+    dispatch.failures.add('silo')
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.library_calls == [], 'a scan that ran is not a path Silo could not find'
+    assert dispatch.dispatcher.status(IDS['silo']) == {
+        'pending': 1, 'state': 'unconfirmed', 'error_code': 'scan_incomplete'}
+    assert dispatch.dispatcher.status(IDS['emby'])['state'] == 'requested'
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_a_ladder_that_resolves_nothing_reports_the_item_as_missing(dispatch, kind):
+    dispatch.resolves.clear()
+    dispatch.missing_paths.add('/media/A.mkv')
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.dispatcher.status(IDS[kind]) == {
+        'pending': 1, 'state': 'unconfirmed', 'error_code': 'item_missing'}
 
 
 @pytest.mark.parametrize(("event", "code"), [
@@ -436,3 +564,20 @@ def test_incomplete_connection_still_excludes_disjoint_publications(kind):
     dispatcher.notify(movie_event())
     assert dispatcher.wait_idle(3)
     assert dispatcher.status(snapshot.id) == {'pending': 1, 'state': 'unconfirmed', 'error_code': 'invalid_url'}
+
+
+def test_a_rung_that_answers_with_the_wrong_status_is_not_a_refresh(dispatch):
+    dispatch.resolves.add('provider_id')
+    dispatch.release.set()
+    original = dispatch.dispatcher._ladder
+
+    def confused(client, server, event, mapped, guard):
+        return [(name, lambda: {'status': 'whatever'}, expected)
+                for name, _call, expected in original(client, server, event, mapped, guard)]
+
+    dispatch.dispatcher._ladder = confused
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.dispatcher.wait_idle(3)
+    for kind in ('emby', 'silo'):
+        assert dispatch.dispatcher.status(IDS[kind]) == {
+            'pending': 1, 'state': 'unconfirmed', 'error_code': 'invalid_response'}

--- a/tests/bazarr/test_media_server_dispatcher.py
+++ b/tests/bazarr/test_media_server_dispatcher.py
@@ -1,0 +1,418 @@
+from dataclasses import replace
+from threading import Event, Thread
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+
+def native_settings():
+    return SimpleNamespace(
+        general=SimpleNamespace(use_emby=True, use_silo=True),
+        **{server: SimpleNamespace(url=f"http://{server}.example", apikey="synthetic-key", verify_ssl=True,
+                                  path_mappings=[{"local_path": "/movies", "remote_path": "/media",
+                                                  "library_id": "7"}]) for server in ("emby", "silo")})
+
+
+IDS = {'emby': '01f0e1bc-68fe-4013-84b1-d4becad3e8fb', 'silo': '72d8b1db-9fe4-4d62-9678-f472b322ed78'}
+
+
+def native_snapshots(settings):
+    from media_servers.instances import ConnectionSnapshot
+    return [ConnectionSnapshot(IDS[kind], kind, kind.capitalize(), True,
+                               getattr(settings.general, 'use_' + kind),
+                               getattr(settings, kind).url, getattr(settings, kind).apikey,
+                               getattr(settings, kind).verify_ssl,
+                               tuple(tuple(sorted(row.items())) for row in getattr(settings, kind).path_mappings))
+            for kind in ('emby', 'silo')]
+
+
+def apply_settings(configuration, settings):
+    configuration.publish_masters(settings)
+    for snapshot in native_snapshots(settings):
+        current = configuration.read(snapshot.id)[1]
+        if replace(snapshot, revision=current.revision) != current:
+            configuration.publish(snapshot)
+
+
+@pytest.fixture
+def dispatch():
+    from media_servers.dispatcher import NativeConfiguration, RefreshDispatcher
+    configuration = NativeConfiguration(native_settings(), snapshots=native_snapshots(native_settings()))
+    calls = {"emby": [], "silo": []}
+    started, release = Event(), Event()
+    failures = set()
+    failed_paths = set()
+    libraries = [{"id": "7", "type": "movies", "paths": ["/media"]}]
+
+    class Client:
+        def __init__(self, server, snapshot):
+            self.server = server
+            self.snapshot = snapshot
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            pass
+
+        def get_libraries(self):
+            return libraries
+
+        def refresh_movie(self, path, *, ensure_current):
+            return self.refresh_file(None, path, ensure_current=ensure_current)
+
+        def refresh_file(self, library_id, path, *, ensure_current):
+            from media_servers.http import MediaServerError
+            calls[self.server].append((path, self.snapshot))
+            if self.server == "silo" and len(calls["silo"]) == 1:
+                started.set()
+                assert release.wait(3)
+            ensure_current()
+            if self.server in failures or path in failed_paths:
+                raise MediaServerError("scan_incomplete")
+            return {"status": "confirmed" if self.server == "silo" else "requested"}
+
+    dispatcher = RefreshDispatcher(configuration, client_factory=Client)
+    yield SimpleNamespace(dispatcher=dispatcher, config=configuration, calls=calls, started=started,
+                          release=release, failures=failures, libraries=libraries, failed_paths=failed_paths)
+    release.set()
+    assert dispatcher.wait_idle(3)
+
+
+def movie_event(**overrides):
+    from media_servers.events import SubtitleMutation
+    return replace(SubtitleMutation("movie", "/movies/A.mkv", "/movies/A.en.srt", "upload", 2), **overrides)
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+def test_second_write_requires_followup_and_servers_are_independent(dispatch, media_type):
+    dispatch.libraries[0]['type'] = 'movies' if media_type == 'movie' else 'series'
+    dispatch.dispatcher.notify(movie_event(media_type=media_type))
+    assert dispatch.started.wait(3)
+    assert dispatch.dispatcher.wait_idle(3, server=IDS["emby"])
+    assert len(dispatch.calls["emby"]) == (1 if media_type == 'movie' else 0)
+    dispatch.dispatcher.notify(movie_event(media_type=media_type))
+    dispatch.release.set()
+    assert dispatch.dispatcher.wait_idle(3)
+    assert len(dispatch.calls["silo"]) == 2
+    assert dispatch.dispatcher.status(IDS["silo"]) == {"pending": 0, "state": "confirmed", "error_code": None}
+
+
+def test_failed_latest_target_retained_until_explicit_retry(dispatch):
+    dispatch.failures.add("silo")
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.dispatcher.status(IDS["silo"]) == {
+        "pending": 1, "state": "unconfirmed", "error_code": "scan_incomplete"}
+    assert len(dispatch.calls["silo"]) == 1
+    dispatch.failures.clear()
+    assert dispatch.dispatcher.retry(IDS["silo"]) == 1
+    assert dispatch.dispatcher.wait_idle(3)
+    assert len(dispatch.calls["silo"]) == 2
+    assert dispatch.dispatcher.status(IDS["silo"])["pending"] == 0
+
+
+def test_overflow_is_sticky_and_preserves_existing_targets(dispatch):
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.started.wait(3)
+    for number in range(1, 140):
+        dispatch.dispatcher.notify(movie_event(video_path=f"/movies/{number}.mkv"))
+    assert dispatch.dispatcher.status(IDS["silo"])["pending"] == 128
+    assert dispatch.dispatcher.status(IDS["silo"])["error_code"] == "queue_overflow"
+    dispatch.release.set()
+    assert dispatch.dispatcher.wait_idle(3)
+    assert len(dispatch.calls["silo"]) == 128
+    assert dispatch.dispatcher.status(IDS["silo"])["error_code"] == "queue_overflow"
+
+
+def test_configuration_change_invalidates_inflight_and_retry_uses_complete_snapshot(dispatch):
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.started.wait(3)
+    new_settings = native_settings()
+    new_settings.silo.url = "http://new.example"
+    new_settings.silo.apikey = "synthetic-new-key"
+    new_settings.silo.verify_ssl = False
+    apply_settings(dispatch.config, new_settings)
+    dispatch.release.set()
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.dispatcher.status(IDS["silo"])["error_code"] == "configuration_changed"
+    assert dispatch.dispatcher.retry(IDS["silo"]) == 1
+    assert dispatch.dispatcher.wait_idle(3)
+    snapshot = dispatch.calls["silo"][-1][1]
+    assert (snapshot.url, snapshot.apikey, snapshot.verify_ssl) == (
+        "http://new.example", "synthetic-new-key", False)
+
+
+def test_disabled_connection_retains_pending_without_new_requests(dispatch):
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.started.wait(3)
+    settings = native_settings()
+    settings.general.use_silo = False
+    apply_settings(dispatch.config, settings)
+    dispatch.release.set()
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.dispatcher.retry(IDS["silo"]) == 0
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.dispatcher.status(IDS["silo"])["pending"] == 1
+    assert len(dispatch.calls["silo"]) == 1
+
+
+@pytest.mark.parametrize("event", [movie_event(operation="delete"), movie_event(media_type="episode")])
+def test_emby_only_consumes_movie_download_and_upload(dispatch, event):
+    dispatch.release.set()
+    dispatch.dispatcher.notify(event)
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.calls["emby"] == []
+
+
+@pytest.mark.parametrize(("event", "code"), [
+    (movie_event(subtitle_path="/elsewhere/A.en.srt"), "sidecar_unsupported"),
+])
+def test_invalid_silo_target_retained_without_request(dispatch, event, code):
+    dispatch.release.set()
+    dispatch.dispatcher.notify(event)
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.calls["silo"] == []
+    assert dispatch.dispatcher.status(IDS["silo"])["error_code"] == code
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+@pytest.mark.parametrize('timing', ['already_unconfirmed', 'coalesced'])
+def test_supported_scan_keeps_unsupported_publication_pending(dispatch, media_type, timing):
+    dispatcher = dispatch.dispatcher
+    dispatch.libraries[0]['type'] = 'movies' if media_type == 'movie' else 'series'
+    dispatch.release.set()
+    unsupported = movie_event(media_type=media_type, subtitle_path='/movies/subtitles/A.hu.srt')
+    supported = movie_event(media_type=media_type)
+    warning = {'pending': 1, 'state': 'unconfirmed', 'error_code': 'sidecar_unsupported'}
+
+    if timing == 'already_unconfirmed':
+        dispatcher.notify(unsupported)
+        assert dispatcher.wait_idle(10)
+        assert dispatcher.status(IDS['silo']) == warning
+        dispatcher.notify(supported)
+    else:
+        # Hold selection until both actual publication callbacks have returned.
+        with dispatcher.condition:
+            dispatcher.notify(unsupported)
+            dispatcher.notify(supported)
+    assert dispatcher.wait_idle(10)
+    assert [path for path, _snapshot in dispatch.calls['silo']] == ['/media/A.mkv']
+    assert dispatcher.status(IDS['silo']) == warning
+
+    assert dispatcher.retry(IDS['silo']) == 1
+    assert dispatcher.wait_idle(10)
+    assert len(dispatch.calls['silo']) == 1
+    assert dispatcher.status(IDS['silo']) == warning
+
+    dispatcher.notify(replace(supported, subtitle_path='/movies/A.fr.srt'))
+    assert dispatcher.wait_idle(10)
+    assert len(dispatch.calls['silo']) == 2
+    assert dispatcher.status(IDS['silo']) == warning
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+def test_coalesced_unsupported_publication_keeps_queued_supported_work(dispatch, media_type):
+    dispatcher = dispatch.dispatcher
+    dispatch.libraries[0]['type'] = 'movies' if media_type == 'movie' else 'series'
+    dispatch.release.set()
+    with dispatcher.condition:
+        dispatcher.notify(movie_event(media_type=media_type))
+        dispatcher.notify(movie_event(media_type=media_type, subtitle_path='/movies/subtitles/A.hu.srt'))
+    assert dispatcher.wait_idle(10)
+    assert [path for path, _snapshot in dispatch.calls['silo']] == ['/media/A.mkv']
+    assert dispatcher.status(IDS['silo']) == {
+        'pending': 1, 'state': 'unconfirmed', 'error_code': 'sidecar_unsupported'}
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+@pytest.mark.parametrize('later_supported', [False, True])
+def test_unsupported_warning_survives_inflight_supported_generations(dispatch, media_type, later_supported):
+    dispatcher = dispatch.dispatcher
+    dispatch.libraries[0]['type'] = 'movies' if media_type == 'movie' else 'series'
+    dispatcher.notify(movie_event(media_type=media_type))
+    assert dispatch.started.wait(10)
+    dispatcher.notify(movie_event(media_type=media_type, subtitle_path='/movies/subtitles/A.hu.srt'))
+    if later_supported:
+        dispatcher.notify(movie_event(media_type=media_type, subtitle_path='/movies/A.fr.srt'))
+    assert dispatcher.status(IDS['silo'])['error_code'] == 'sidecar_unsupported'
+    dispatch.release.set()
+    assert dispatcher.wait_idle(10)
+    assert len(dispatch.calls['silo']) == (2 if later_supported else 1)
+    assert dispatcher.status(IDS['silo']) == {
+        'pending': 1, 'state': 'unconfirmed', 'error_code': 'sidecar_unsupported'}
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+def test_unsupported_warning_keeps_failed_supported_work_retryable(dispatch, media_type):
+    dispatcher = dispatch.dispatcher
+    dispatch.libraries[0]['type'] = 'movies' if media_type == 'movie' else 'series'
+    dispatch.failures.add('silo')
+    dispatcher.notify(movie_event(media_type=media_type))
+    assert dispatch.started.wait(10)
+    dispatcher.notify(movie_event(media_type=media_type, subtitle_path='/movies/subtitles/A.hu.srt'))
+    dispatch.release.set()
+    assert dispatcher.wait_idle(10)
+    assert dispatcher.status(IDS['silo']) == {
+        'pending': 1, 'state': 'unconfirmed', 'error_code': 'scan_incomplete'}
+    dispatch.failures.clear()
+    assert dispatcher.retry(IDS['silo']) == 1
+    assert dispatcher.wait_idle(10)
+    assert len(dispatch.calls['silo']) == 2
+    warning = {'pending': 1, 'state': 'unconfirmed', 'error_code': 'sidecar_unsupported'}
+    assert dispatcher.status(IDS['silo']) == warning
+    assert dispatcher.retry(IDS['silo']) == 1
+    assert dispatcher.wait_idle(10)
+    assert len(dispatch.calls['silo']) == 2
+    assert dispatcher.status(IDS['silo']) == warning
+
+
+def test_unsupported_warning_capacity_counts_distinct_video_and_arr_owner_targets(dispatch):
+    dispatcher = dispatch.dispatcher
+    dispatch.release.set()
+    with dispatcher.condition:
+        for owner in range(128):
+            dispatcher.notify(movie_event(arr_instance_id=owner, subtitle_path='/movies/subtitles/A.hu.srt'))
+        # Many subtitle paths on one target must neither consume extra capacity
+        # nor replace the warning associated with another source owner.
+        for number in range(200):
+            dispatcher.notify(movie_event(arr_instance_id=0, subtitle_path=f'/movies/subtitles/A.{number}.srt'))
+    assert dispatcher.wait_idle(10)
+    assert dispatcher.status(IDS['silo']) == {
+        'pending': 128, 'state': 'unconfirmed', 'error_code': 'sidecar_unsupported'}
+    assert dispatch.calls['silo'] == []
+    with dispatcher.condition:
+        for owner in range(128):
+            dispatcher.notify(movie_event(arr_instance_id=owner))
+        dispatcher.notify(movie_event(arr_instance_id=128))
+    assert dispatcher.wait_idle(10)
+    assert len(dispatch.calls['silo']) == 128
+    assert dispatcher.status(IDS['silo']) == {
+        'pending': 128, 'state': 'unconfirmed', 'error_code': 'queue_overflow'}
+    assert dispatcher.retry(IDS['silo']) == 128
+    assert dispatcher.wait_idle(10)
+    assert len(dispatch.calls['silo']) == 128
+    assert dispatcher.status(IDS['silo'])['pending'] == 128
+    assert dispatcher.status(IDS['silo'])['error_code'] == 'queue_overflow'
+
+
+def test_read_only_status_and_invalid_selection_never_start_worker(dispatch):
+    from media_servers.http import MediaServerError
+    assert dispatch.dispatcher.status(IDS["silo"]) == {"pending": 0, "state": "idle", "error_code": None}
+    assert dispatch.dispatcher.retry(IDS["silo"]) == 0
+    assert dispatch.dispatcher.worker_count == 0
+    with pytest.raises(MediaServerError, match="not_found"):
+        dispatch.dispatcher.status("jellyfin")
+    with pytest.raises(MediaServerError, match="not_found"):
+        dispatch.dispatcher.retry("jellyfin")
+
+
+@pytest.mark.parametrize('operation', ['download', 'upload', 'delete', 'sync', 'translate', 'combine', 'edit'])
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+def test_silo_accepts_each_supported_publication_for_movies_and_episodes(dispatch, operation, media_type):
+    dispatch.libraries[0]['type'] = 'movies' if media_type == 'movie' else 'series'
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event(media_type=media_type, operation=operation))
+    assert dispatch.dispatcher.wait_idle(3)
+    assert len(dispatch.calls['silo']) == 1
+    assert dispatch.dispatcher.status(IDS['silo'])['state'] == 'confirmed'
+
+
+@pytest.mark.parametrize('library', [
+    {'id': '7', 'type': 'movies', 'paths': ['/media-other']},
+    {'id': '8', 'type': 'movies', 'paths': ['/media']},
+    {'id': '7', 'type': 'series', 'paths': ['/media']},
+])
+def test_silo_requires_matching_library_type_and_root(dispatch, library):
+    dispatch.libraries[:] = [library]
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.calls['silo'] == []
+    assert dispatch.dispatcher.status(IDS['silo'])['error_code'] == 'library_invalid'
+
+
+def test_later_success_does_not_hide_retained_failure(dispatch):
+    dispatch.failed_paths.add('/media/A.mkv')
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.started.wait(3)
+    dispatch.dispatcher.notify(movie_event(video_path='/movies/B.mkv', subtitle_path='/movies/B.en.srt'))
+    dispatch.release.set()
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.dispatcher.status(IDS['silo']) == {
+        'pending': 1, 'state': 'unconfirmed', 'error_code': 'scan_incomplete'}
+
+
+def test_saved_configuration_does_not_inherit_old_confirmation(dispatch):
+    dispatch.release.set()
+    dispatch.dispatcher.notify(movie_event())
+    assert dispatch.dispatcher.wait_idle(3)
+    assert dispatch.dispatcher.status(IDS['silo'])['state'] == 'confirmed'
+    settings = native_settings()
+    settings.silo.url = 'http://different.example'
+    apply_settings(dispatch.config, settings)
+    assert dispatch.dispatcher.status(IDS['silo']) == {'pending': 0, 'state': 'idle', 'error_code': None}
+
+
+def test_remote_refresh_waits_for_local_publication_cleanup(dispatch, tmp_path, monkeypatch):
+    from subtitles.tools import subsync_engines
+    from threading import current_thread
+    settings = native_settings()
+    settings.general.use_emby = False
+    settings.silo.path_mappings[0]['local_path'] = str(tmp_path)
+    apply_settings(dispatch.config, settings)
+    event = movie_event(video_path=str(tmp_path / 'Video.mkv'), subtitle_path=str(tmp_path / 'Video.en.srt'))
+    cleanup_started, worker_waiting, finish_cleanup = Event(), Event(), Event()
+    original_locks = subsync_engines.subtitle_write_locks
+
+    @contextmanager
+    def observed_locks(*args):
+        if current_thread().name == 'silo-subtitle-refresh':
+            worker_waiting.set()
+        with original_locks(*args) as state:
+            yield state
+
+    monkeypatch.setattr(subsync_engines, 'subtitle_write_locks', observed_locks)
+
+    def cleanup():
+        cleanup_started.set()
+        assert finish_cleanup.wait(10)
+
+    def publish():
+        with subsync_engines.staged_subtitle_write(
+                event.video_path, event.subtitle_path, on_publish=lambda path: dispatch.dispatcher.notify(event),
+                after_publish=cleanup) as temporary:
+            from pathlib import Path
+            Path(temporary).write_text('Published')
+
+    writer = Thread(target=publish)
+    writer.start()
+    try:
+        assert cleanup_started.wait(3)
+        assert worker_waiting.wait(3)
+        assert dispatch.calls['silo'] == []
+    finally:
+        finish_cleanup.set()
+        dispatch.release.set()
+        writer.join(3)
+    assert dispatch.dispatcher.wait_idle(3)
+    assert len(dispatch.calls['silo']) == 1
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_incomplete_connection_still_excludes_disjoint_publications(kind):
+    from media_servers.dispatcher import NativeConfiguration, RefreshDispatcher
+    settings = native_settings()
+    snapshot = next(item for item in native_snapshots(settings) if item.kind == kind)
+    snapshot = replace(snapshot, url='', configuration_error='invalid_url')
+    configuration = NativeConfiguration(settings, snapshots=[snapshot])
+    dispatcher = RefreshDispatcher(configuration, client_factory=lambda *args: pytest.fail('invalid connection requested'))
+    dispatcher.notify(movie_event(video_path='/unrelated/A.mkv', subtitle_path='/unrelated/A.en.srt'))
+    assert dispatcher.wait_idle(3)
+    assert dispatcher.status(snapshot.id) == {'pending': 0, 'state': 'unconfirmed', 'error_code': 'invalid_url'}
+    assert dispatcher.worker_count == 0
+    dispatcher.notify(movie_event())
+    assert dispatcher.wait_idle(3)
+    assert dispatcher.status(snapshot.id) == {'pending': 1, 'state': 'unconfirmed', 'error_code': 'invalid_url'}

--- a/tests/bazarr/test_media_server_http.py
+++ b/tests/bazarr/test_media_server_http.py
@@ -1,0 +1,144 @@
+"""Local protocol fixtures use synthetic keys only."""
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+import requests
+
+
+@pytest.fixture
+def http_fixture():
+    servers = []
+
+    def start(replies, *, body_delay=0):
+        records = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *_args):
+                pass
+
+            def handle_request(self):
+                records.append({"method": self.command, "path": self.path,
+                                "headers": dict(self.headers),
+                                "body": self.rfile.read(int(self.headers.get("Content-Length", "0")))})
+                status, body, headers = replies.pop(0)
+                if isinstance(body, (dict, list)):
+                    body = json.dumps(body).encode()
+                self.send_response(status)
+                for key, value in headers.items():
+                    self.send_header(key, value)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                if body_delay:
+                    time.sleep(body_delay)
+                try:
+                    self.wfile.write(body)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+
+            do_GET = handle_request
+            do_POST = handle_request
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, kwargs={"poll_interval": 0.01}, daemon=True)
+        thread.start()
+        servers.append((server, thread))
+        return f"http://127.0.0.1:{server.server_port}", records
+
+    yield start
+    for server, thread in servers:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def test_base_prefix_proxy_bypass_and_authenticated_request(http_fixture, monkeypatch):
+    from media_servers.http import MediaServerHTTP
+    base, records = http_fixture([(200, {"ok": True}, {})])
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:1")
+    monkeypatch.setenv("NO_PROXY", "")
+    client = MediaServerHTTP(base + "/proxy/emby/", headers={"X-Emby-Token": "synthetic-key"})
+    assert client.request_json("GET", "/System/Info") == {"ok": True}
+    assert records[0]["path"] == "/proxy/emby/System/Info"
+    assert records[0]["headers"]["X-Emby-Token"] == "synthetic-key"
+    assert records[0]["body"] == b""
+    client.close()
+
+
+def test_redirect_fails_closed_without_contacting_target(http_fixture):
+    from media_servers.http import MediaServerError, MediaServerHTTP
+    target, target_records = http_fixture([])
+    base, records = http_fixture([(302, b"", {"Location": target + "/stolen"})])
+    with MediaServerHTTP(base, headers={"X-Emby-Token": "synthetic-key"}) as client:
+        with pytest.raises(MediaServerError, match="redirect_denied"):
+            client.request_json("GET", "/System/Info")
+    assert len(records) == 1
+    assert target_records == []
+
+
+@pytest.mark.parametrize("url", ["ftp://server", "http://user:synthetic-key@server", "http://server?x=1",
+                                 "http://server#fragment", "http://", "http://server:invalid", "http://server/\npath"])
+def test_unsafe_base_urls_are_rejected(url):
+    from media_servers.http import MediaServerError, MediaServerHTTP
+    with pytest.raises(MediaServerError, match="invalid_url"):
+        MediaServerHTTP(url)
+
+
+@pytest.mark.parametrize(("status", "body", "code"), [
+    (401, b"sensitive server response", "unauthorized"), (403, b"", "forbidden"),
+    (500, b"", "server_error"), (200, b"not json", "invalid_response"),
+    (200, b"x" * (2 * 1024 * 1024 + 1), "response_too_large"),
+], ids=["unauthorized", "forbidden", "server-error", "malformed", "oversized"])
+def test_response_classification(http_fixture, status, body, code):
+    from media_servers.http import MediaServerError, MediaServerHTTP
+    base, _records = http_fixture([(status, body, {})])
+    with MediaServerHTTP(base) as client, pytest.raises(MediaServerError) as error:
+        client.request_json("GET", "/System/Info")
+    assert str(error.value) == code
+
+
+@pytest.mark.parametrize("verify_ssl", [True, False])
+def test_tls_timeouts_and_streaming_are_propagated(monkeypatch, verify_ssl):
+    from media_servers.http import MediaServerError, MediaServerHTTP
+    observed = []
+
+    def request(_session, method, url, **kwargs):
+        observed.append(kwargs)
+        raise requests.Timeout("synthetic-secret-must-not-escape")
+
+    monkeypatch.setattr(requests.Session, "request", request)
+    with MediaServerHTTP("https://server", verify_ssl=verify_ssl) as client:
+        with pytest.raises(MediaServerError) as error:
+            client.request_json("GET", "/System/Info")
+    assert str(error.value) == "timeout"
+    assert observed[0]["verify"] is verify_ssl
+    assert observed[0]["timeout"] == (3, 10)
+    assert observed[0]["stream"] is True
+    assert observed[0]["allow_redirects"] is False
+
+
+def test_stream_limit_applies_without_content_length(monkeypatch):
+    from media_servers.http import MediaServerError, MediaServerHTTP
+    response = requests.Response()
+    response.status_code = 200
+    closed = []
+    response.close = lambda: closed.append(True)
+    response.iter_content = lambda chunk_size: iter([b"x" * chunk_size] * 400)
+    monkeypatch.setattr(requests.Session, "request", lambda *_args, **_kwargs: response)
+    with MediaServerHTTP("http://server") as client, pytest.raises(MediaServerError, match="response_too_large"):
+        client.request_json("GET", "/System/Info")
+    assert closed == [True]
+
+
+def test_real_stream_read_timeout_is_categorized(http_fixture):
+    from media_servers.http import MediaServerError, MediaServerHTTP
+    base, records = http_fixture([(200, {"ok": True}, {})], body_delay=11)
+    started = time.monotonic()
+    with MediaServerHTTP(base) as client, pytest.raises(MediaServerError) as error:
+        client.request_json("GET", "/System/Info")
+    assert str(error.value) == "timeout"
+    assert len(records) == 1
+    assert time.monotonic() - started < 13

--- a/tests/bazarr/test_media_server_instance_migration.py
+++ b/tests/bazarr/test_media_server_instance_migration.py
@@ -1,0 +1,138 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.orm import sessionmaker
+
+
+def legacy(**overrides):
+    rows = {kind: SimpleNamespace(url='', apikey='', verify_ssl=True, path_mappings=[])
+            for kind in ('emby', 'silo')}
+    return SimpleNamespace(general=SimpleNamespace(use_emby=False, use_silo=False), **(rows | overrides))
+
+
+@pytest.fixture
+def autocommit_session(tmp_path):
+    from app.database import Base
+    engine = create_engine(f'sqlite:///{tmp_path / "migration.db"}', isolation_level='AUTOCOMMIT')
+    Base.metadata.create_all(engine)
+    with sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)() as session:
+        yield session
+    engine.dispose()
+
+
+def migration():
+    path = Path(__file__).parents[2] / 'migrations/versions/c2e7a4d9f810_media_server_instances.py'
+    spec = importlib.util.spec_from_file_location('media_destination_migration', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize('create_all', [False, True])
+def test_migration_guarded_for_upgrade_and_create_all(tmp_path, create_all):
+    from app.database import Base
+    engine = create_engine(f'sqlite:///{tmp_path / "schema.db"}')
+    if create_all:
+        Base.metadata.create_all(engine)
+    with engine.begin() as connection:
+        migration().create_media_server_tables(connection)
+        migration().create_media_server_tables(connection)
+        assert {'media_server_instances', 'media_server_imports'} <= set(inspect(connection).get_table_names())
+    engine.dispose()
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_disabled_incomplete_scalar_preserved_once_even_after_deletion(autocommit_session, kind):
+    from app.database import TableMediaServerImports
+    from media_servers.backfill import backfill_instances
+    from media_servers.repository import MediaServerInstanceRepository
+    config = legacy(**{kind: SimpleNamespace(url='', apikey='000123', verify_ssl=False, path_mappings=[])})
+    assert backfill_instances(autocommit_session, config)[kind]['created'] is True
+    repo = MediaServerInstanceRepository(autocommit_session)
+    row, = repo.list()
+    assert (row.enabled, row.url, row.verify_ssl) == (0, '', 0)
+    assert repo.get_decrypted_api_key(row.id) == '000123'
+    assert autocommit_session.get(TableMediaServerImports, kind) is not None
+    repo.delete(row.id)
+    backfill_instances(autocommit_session, config)
+    assert repo.list() == []
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_row_and_import_marker_are_atomic_and_retryable(autocommit_session, monkeypatch, kind):
+    from app.database import TableMediaServerImports
+    from media_servers import backfill
+    from media_servers.repository import MediaServerInstanceRepository
+    config = legacy(**{kind: SimpleNamespace(url='http://legacy.example/base', apikey='key',
+                                            verify_ssl=True, path_mappings=[])})
+    original = backfill._record_import
+    def fail(session, target):
+        if target == kind:
+            raise RuntimeError('sensitive synthetic data')
+        original(session, target)
+    monkeypatch.setattr(backfill, '_record_import', fail)
+    result = backfill.backfill_instances(autocommit_session, config)
+    assert result[kind] == {'created': False, 'error_code': 'migration_failed'}
+    assert MediaServerInstanceRepository(autocommit_session).list(kind) == []
+    assert autocommit_session.get(TableMediaServerImports, kind) is None
+    monkeypatch.setattr(backfill, '_record_import', original)
+    assert backfill.backfill_instances(autocommit_session, config)[kind]['created'] is True
+    assert len(MediaServerInstanceRepository(autocommit_session).list(kind)) == 1
+
+
+def test_empty_scalar_stamped_without_dummy_and_never_imports_later(autocommit_session):
+    from app.database import TableMediaServerImports
+    from media_servers.backfill import backfill_instances
+    from media_servers.repository import MediaServerInstanceRepository
+    config = legacy()
+    backfill_instances(autocommit_session, config)
+    assert all(autocommit_session.get(TableMediaServerImports, kind) for kind in ('emby', 'silo'))
+    config.emby.url = 'http://stale.example'
+    backfill_instances(autocommit_session, config)
+    assert MediaServerInstanceRepository(autocommit_session).list() == []
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_import_preserves_existing_rows_and_enabled_incomplete_draft(autocommit_session, kind):
+    from media_servers.backfill import backfill_instances
+    from media_servers.repository import MediaServerInstanceRepository
+    from test_media_server_instances import payload
+    repo = MediaServerInstanceRepository(autocommit_session)
+    existing = repo.create(**payload(kind))
+    config = legacy(**{kind: SimpleNamespace(url='', apikey='000123', verify_ssl=False, path_mappings=[])})
+    setattr(config.general, 'use_' + kind, True)
+    assert backfill_instances(autocommit_session, config)[kind]['created'] is True
+    imported, = [row for row in repo.list(kind) if row.id != existing.id]
+    assert imported.enabled == 1 and imported.url == '' and imported.verify_ssl == 0
+    assert repo.get_decrypted_api_key(imported.id) == '000123'
+    assert repo.get_decrypted_api_key(existing.id) == 'opaque-A'
+    assert repo.snapshot(imported.id, config).configuration_error == 'invalid_url'
+    backfill_instances(autocommit_session, config)
+    assert len(repo.list(kind)) == 2
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_malformed_import_is_sanitized_and_does_not_activate_kind(autocommit_session, caplog, monkeypatch, kind):
+    from media_servers.backfill import backfill_instances
+    from media_servers import dispatcher
+    from app import config as app_config, database as app_database
+    config = legacy(**{kind: SimpleNamespace(url='http://private.example', apikey=['private-key'],
+                                            verify_ssl=True, path_mappings=[])})
+    setattr(config.general, 'use_' + kind, True)
+    assert backfill_instances(autocommit_session, config)[kind]['error_code'] == 'migration_failed'
+    config.general.secrets_encryption_key = 'synthetic-durable-key'
+    monkeypatch.setattr(app_config, 'settings', config)
+    monkeypatch.setattr(app_database, 'database', autocommit_session)
+    monkeypatch.setattr(dispatcher, '_configuration', None)
+    native = dispatcher.get_native_configuration()
+    assert native.list() == ()
+    from media_servers.repository import MediaServerInstanceRepository
+    from test_media_server_instances import payload
+    repo = MediaServerInstanceRepository(autocommit_session)
+    created = repo.create(**payload(kind))
+    native.publish(repo.snapshot(created.id, config))
+    assert native.list() == ()
+    assert 'private.example' not in caplog.text and 'private-key' not in caplog.text

--- a/tests/bazarr/test_media_server_instances.py
+++ b/tests/bazarr/test_media_server_instances.py
@@ -60,7 +60,7 @@ def test_same_path_fanout_and_failure_retry_are_destination_scoped(schema_sessio
         def get_libraries(self):
             return [{'id': '7' if self.snapshot.id == first.id else '8', 'type': 'movies',
                      'paths': [f'/media/{"A" if self.snapshot.id == first.id else "B"}']}]
-        def refresh_movie(self, path, *, ensure_current):
+        def refresh_item(self, _media_type, path, *, ensure_current):
             return self.refresh_file(None, path, ensure_current=ensure_current)
         def refresh_file(self, library_id, path, *, ensure_current):
             ensure_current()
@@ -107,7 +107,7 @@ def blocked_pair(schema_session, monkeypatch, request):
         def get_libraries(self):
             return [{'id': '7', 'type': 'movies', 'paths': ['/media/A']},
                     {'id': '8', 'type': 'movies', 'paths': ['/media/B']}]
-        def refresh_movie(self, path, *, ensure_current):
+        def refresh_item(self, _media_type, path, *, ensure_current):
             return self.refresh_file(None, path, ensure_current=ensure_current)
         def refresh_file(self, library_id, path, *, ensure_current):
             if self.snapshot.id == first_id and not started.is_set():

--- a/tests/bazarr/test_media_server_instances.py
+++ b/tests/bazarr/test_media_server_instances.py
@@ -40,6 +40,7 @@ def test_two_same_kind_destinations_keep_uuid_on_rename_and_safe_keys(schema_ses
 
 @pytest.mark.parametrize('kind', ['emby', 'silo'])
 def test_same_path_fanout_and_failure_retry_are_destination_scoped(schema_session, kind):
+    from media_servers import resolution
     from media_servers.repository import MediaServerInstanceRepository
     from media_servers.dispatcher import NativeConfiguration, RefreshDispatcher
     from media_servers.events import SubtitleMutation
@@ -51,6 +52,9 @@ def test_same_path_fanout_and_failure_retry_are_destination_scoped(schema_sessio
     calls, failures = [], {first.id}
 
     class Client:
+        # These fakes are about destination isolation, not about resolution, so
+        # they declare only the rung they implement: the exact path.
+        REFRESH_STEPS = (resolution.PATH,)
         def __init__(self, _kind, snapshot):
             self.snapshot = snapshot
         def __enter__(self):
@@ -86,7 +90,7 @@ def test_same_path_fanout_and_failure_retry_are_destination_scoped(schema_sessio
 @pytest.fixture
 def blocked_pair(schema_session, monkeypatch, request):
     from threading import Event
-    from media_servers import dispatcher as module
+    from media_servers import dispatcher as module, resolution
     from media_servers.repository import MediaServerInstanceRepository
     from app import config
     kind = request.param
@@ -98,6 +102,9 @@ def blocked_pair(schema_session, monkeypatch, request):
     first_id = first.id
     calls, started, release = [], Event(), Event()
     class Client:
+        # These fakes are about destination isolation, not about resolution, so
+        # they declare only the rung they implement: the exact path.
+        REFRESH_STEPS = (resolution.PATH,)
         def __init__(self, _kind, snapshot):
             self.snapshot = snapshot
         def __enter__(self):

--- a/tests/bazarr/test_media_server_instances.py
+++ b/tests/bazarr/test_media_server_instances.py
@@ -1,0 +1,351 @@
+from dataclasses import FrozenInstanceError
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+
+def settings():
+    return SimpleNamespace(general=SimpleNamespace(use_emby=True, use_silo=True))
+
+
+def payload(kind, name='A', **overrides):
+    values = dict(kind=kind, name=name, url=f'http://{name.lower()}.example/prefix',
+                  api_key=f'opaque-{name}', enabled=True, verify_ssl=True,
+                  path_mappings=[{'local_path': '/movies', 'remote_path': f'/media/{name}',
+                                  **({'library_id': '7' if name == 'A' else '8'} if kind == 'silo' else {})}])
+    return values | overrides
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_two_same_kind_destinations_keep_uuid_on_rename_and_safe_keys(schema_session, kind):
+    from media_servers.repository import MediaServerInstanceRepository, to_safe_dict
+    repo = MediaServerInstanceRepository(schema_session)
+    first = repo.create(**payload(kind))
+    second = repo.create(**payload(kind, 'B'))
+    first_id, second_id = first.id, second.id
+    assert str(UUID(first_id)) == first_id
+    repo.update(first_id, name='Renamed')
+    rows = [to_safe_dict(row) for row in repo.list()]
+    assert {row['id'] for row in rows} == {first_id, second_id}
+    assert first_id != second_id
+    assert all('api_key' not in row and 'apikey' not in row for row in rows)
+    assert repo.get_decrypted_api_key(first_id) == 'opaque-A'
+    assert repo.get_decrypted_api_key(second_id) == 'opaque-B'
+    assert repo.get(first_id).api_key != 'opaque-A'
+    snapshot = repo.snapshot(first_id, settings())
+    with pytest.raises(FrozenInstanceError):
+        snapshot.url = 'http://wrong.example'
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_same_path_fanout_and_failure_retry_are_destination_scoped(schema_session, kind):
+    from media_servers.repository import MediaServerInstanceRepository
+    from media_servers.dispatcher import NativeConfiguration, RefreshDispatcher
+    from media_servers.events import SubtitleMutation
+    from media_servers.http import MediaServerError
+    repo = MediaServerInstanceRepository(schema_session)
+    first = repo.create(**payload(kind))
+    second = repo.create(**payload(kind, 'B'))
+    configuration = NativeConfiguration(settings(), snapshots=repo.snapshots(settings()))
+    calls, failures = [], {first.id}
+
+    class Client:
+        def __init__(self, _kind, snapshot):
+            self.snapshot = snapshot
+        def __enter__(self):
+            return self
+        def __exit__(self, *_args):
+            pass
+        def get_libraries(self):
+            return [{'id': '7' if self.snapshot.id == first.id else '8', 'type': 'movies',
+                     'paths': [f'/media/{"A" if self.snapshot.id == first.id else "B"}']}]
+        def refresh_movie(self, path, *, ensure_current):
+            return self.refresh_file(None, path, ensure_current=ensure_current)
+        def refresh_file(self, library_id, path, *, ensure_current):
+            ensure_current()
+            calls.append((self.snapshot.id, self.snapshot.url, self.snapshot.apikey, library_id, path))
+            if self.snapshot.id in failures:
+                raise MediaServerError('timeout')
+            return {'status': 'requested' if kind == 'emby' else 'confirmed'}
+
+    dispatcher = RefreshDispatcher(configuration, client_factory=Client)
+    dispatcher.notify(SubtitleMutation('movie', '/movies/A.mkv', '/movies/A.en.srt', 'upload', 29))
+    assert dispatcher.wait_idle(3)
+    assert set(calls) == {(first.id, first.url, 'opaque-A', '7' if kind == 'silo' else None, '/media/A/A.mkv'),
+                          (second.id, second.url, 'opaque-B', '8' if kind == 'silo' else None, '/media/B/A.mkv')}
+    assert dispatcher.status(first.id) == {'pending': 1, 'state': 'unconfirmed', 'error_code': 'timeout'}
+    assert dispatcher.status(second.id)['pending'] == 0
+    failures.clear()
+    assert dispatcher.retry(first.id) == 1
+    assert dispatcher.wait_idle(3)
+    assert len([row for row in calls if row[0] == second.id]) == 1
+    assert dispatcher.status(first.id)['pending'] == 0
+
+
+@pytest.fixture
+def blocked_pair(schema_session, monkeypatch, request):
+    from threading import Event
+    from media_servers import dispatcher as module
+    from media_servers.repository import MediaServerInstanceRepository
+    from app import config
+    kind = request.param
+    repo = MediaServerInstanceRepository(schema_session)
+    first, second = repo.create(**payload(kind)), repo.create(**payload(kind, 'B'))
+    monkeypatch.setitem(config.settings.general, 'use_' + kind, True)
+    configuration = module.NativeConfiguration(settings(), snapshots=repo.snapshots(settings()))
+    monkeypatch.setattr(module, '_configuration', configuration)
+    first_id = first.id
+    calls, started, release = [], Event(), Event()
+    class Client:
+        def __init__(self, _kind, snapshot):
+            self.snapshot = snapshot
+        def __enter__(self):
+            return self
+        def __exit__(self, *_args):
+            pass
+        def get_libraries(self):
+            return [{'id': '7', 'type': 'movies', 'paths': ['/media/A']},
+                    {'id': '8', 'type': 'movies', 'paths': ['/media/B']}]
+        def refresh_movie(self, path, *, ensure_current):
+            return self.refresh_file(None, path, ensure_current=ensure_current)
+        def refresh_file(self, library_id, path, *, ensure_current):
+            if self.snapshot.id == first_id and not started.is_set():
+                started.set()
+                assert release.wait(5)
+            ensure_current()
+            calls.append((self.snapshot.id, self.snapshot.apikey, path, library_id))
+            return {'status': 'requested' if kind == 'emby' else 'confirmed'}
+    dispatch = module.RefreshDispatcher(configuration, client_factory=Client)
+    yield SimpleNamespace(repo=repo, config=configuration, dispatcher=dispatch, calls=calls,
+                          first=first.id, second=second.id, started=started, release=release, kind=kind)
+    release.set()
+    assert dispatch.wait_idle(5)
+
+
+def event(owner=29, **changes):
+    from dataclasses import replace
+    from media_servers.events import SubtitleMutation
+    return replace(SubtitleMutation('movie', '/movies/A.mkv', '/movies/A.en.srt', 'upload', owner), **changes)
+
+
+@pytest.mark.parametrize('blocked_pair', ['emby', 'silo'], indirect=True)
+@pytest.mark.parametrize('operation', ['edit', 'disable', 'delete'])
+def test_blocked_destination_edit_disable_delete_preserves_working_sibling(blocked_pair, schema_session, operation):
+    from media_servers import service
+    pair = blocked_pair
+    pair.dispatcher.notify(event())
+    assert pair.started.wait(3)
+    assert pair.dispatcher.wait_idle(3, server=pair.second)
+    assert len(pair.calls) == 1 and pair.calls[0][0] == pair.second
+    sibling_revision = pair.config.read(pair.second)[0]
+    if operation == 'delete':
+        assert service.delete_instance(schema_session, pair.first)[1] == 204
+        replacement, status = service.create_instance(schema_session, payload(pair.kind))
+        assert status == 201 and replacement['id'] != pair.first
+    else:
+        changes = {'api_key': 'new-key', 'url': 'http://edited.example/base'} if operation == 'edit' else {'enabled': False}
+        assert service.update_instance(schema_session, pair.first, changes)[1] == 200
+    assert pair.config.read(pair.second)[0] == sibling_revision
+    pair.release.set()
+    assert pair.dispatcher.wait_idle(3)
+    assert len(pair.calls) == 1
+    if operation == 'delete':
+        from media_servers.http import MediaServerError
+        with pytest.raises(MediaServerError, match='not_found'):
+            pair.dispatcher.status(pair.first)
+        assert pair.first not in pair.dispatcher.servers
+        assert pair.dispatcher.status(replacement['id'])['pending'] == 0
+    else:
+        assert pair.dispatcher.status(pair.first)['pending'] == 1
+        if operation == 'disable':
+            assert pair.dispatcher.retry(pair.first) == 0
+            assert service.update_instance(schema_session, pair.first, {'enabled': True})[1] == 200
+        assert pair.dispatcher.retry(pair.first) == 1
+        assert pair.dispatcher.wait_idle(3)
+        assert [call[0] for call in pair.calls] == [pair.second, pair.first]
+        if operation == 'edit':
+            assert pair.calls[-1][1] == 'new-key'
+
+
+@pytest.mark.parametrize('blocked_pair', ['emby', 'silo'], indirect=True)
+def test_later_publication_and_arr_owners_remain_independent(blocked_pair):
+    pair = blocked_pair
+    pair.dispatcher.notify(event(29))
+    assert pair.started.wait(3)
+    assert pair.dispatcher.wait_idle(3, server=pair.second)
+    pair.dispatcher.notify(event(29))
+    pair.dispatcher.notify(event(30))
+    pair.release.set()
+    assert pair.dispatcher.wait_idle(3)
+    assert len([call for call in pair.calls if call[0] == pair.first]) == 3
+    assert len([call for call in pair.calls if call[0] == pair.second]) >= 2
+    assert pair.dispatcher.status(pair.first)['pending'] == pair.dispatcher.status(pair.second)['pending'] == 0
+
+
+@pytest.mark.parametrize('blocked_pair', ['silo'], indirect=True)
+def test_unsupported_warning_retry_and_deletion_are_destination_scoped(blocked_pair, schema_session):
+    from media_servers import service
+    from media_servers.http import MediaServerError
+    pair = blocked_pair
+    pair.release.set()
+    assert service.update_instance(schema_session, pair.second, {'enabled': False})[1] == 200
+    pair.dispatcher.notify(event(subtitle_path='/movies/subtitles/A.hu.srt'))
+    assert pair.dispatcher.wait_idle(3)
+    assert pair.calls == []
+    warning = {'pending': 1, 'state': 'unconfirmed', 'error_code': 'sidecar_unsupported'}
+    assert pair.dispatcher.status(pair.first) == warning
+
+    assert service.update_instance(schema_session, pair.second, {'enabled': True})[1] == 200
+    pair.dispatcher.notify(event(owner=30))
+    assert pair.dispatcher.wait_idle(3)
+    assert pair.dispatcher.status(pair.first) == warning
+    pair.dispatcher.notify(event())
+    assert pair.dispatcher.wait_idle(3)
+    assert pair.dispatcher.status(pair.first) == warning
+    confirmed = {'pending': 0, 'state': 'confirmed', 'error_code': None}
+    assert pair.dispatcher.status(pair.second) == confirmed
+    assert [row[0] for row in pair.calls].count(pair.first) == 2
+    assert [row[0] for row in pair.calls].count(pair.second) == 2
+    before = list(pair.calls)
+    assert pair.dispatcher.retry(pair.first) == 1
+    assert pair.dispatcher.retry(pair.second) == 0
+    assert pair.dispatcher.wait_idle(3)
+    assert pair.calls == before
+    assert pair.dispatcher.status(pair.first) == warning
+    assert pair.dispatcher.status(pair.second) == confirmed
+
+    assert service.delete_instance(schema_session, pair.first)[1] == 204
+    replacement, status = service.create_instance(schema_session, payload('silo'))
+    assert status == 201 and replacement['id'] != pair.first
+    for operation in (pair.dispatcher.status, pair.dispatcher.retry):
+        with pytest.raises(MediaServerError, match='not_found'):
+            operation(pair.first)
+    assert pair.dispatcher.status(replacement['id']) == {'pending': 0, 'state': 'idle', 'error_code': None}
+    assert pair.dispatcher.retry(replacement['id']) == 0
+    pair.dispatcher.notify(event())
+    assert pair.dispatcher.wait_idle(3)
+    assert pair.first not in pair.dispatcher.servers
+    assert pair.dispatcher.status(replacement['id']) == confirmed
+    assert pair.dispatcher.status(pair.second) == confirmed
+
+
+@pytest.mark.parametrize('blocked_pair', ['silo'], indirect=True)
+def test_deleted_inflight_destination_cannot_restore_unsupported_warning(blocked_pair, schema_session):
+    from media_servers import service
+    from media_servers.http import MediaServerError
+    pair = blocked_pair
+    pair.dispatcher.notify(event())
+    assert pair.started.wait(10)
+    assert pair.dispatcher.wait_idle(10, server=pair.second)
+    pair.dispatcher.notify(event(subtitle_path='/movies/subtitles/A.hu.srt'))
+    assert pair.dispatcher.wait_idle(10, server=pair.second)
+    assert pair.dispatcher.status(pair.first)['error_code'] == 'sidecar_unsupported'
+    warning = {'pending': 1, 'state': 'unconfirmed', 'error_code': 'sidecar_unsupported'}
+    assert pair.dispatcher.status(pair.second) == warning
+    assert service.delete_instance(schema_session, pair.first)[1] == 204
+    replacement, status = service.create_instance(schema_session, payload('silo'))
+    assert status == 201 and replacement['id'] != pair.first
+    pair.release.set()
+    assert pair.dispatcher.wait_idle(10)
+    assert pair.first not in pair.dispatcher.servers
+    assert all(row[0] != pair.first for row in pair.calls)
+    with pytest.raises(MediaServerError, match='not_found'):
+        pair.dispatcher.retry(pair.first)
+    assert pair.dispatcher.retry(replacement['id']) == 0
+    assert pair.dispatcher.status(replacement['id']) == {'pending': 0, 'state': 'idle', 'error_code': None}
+    assert pair.dispatcher.status(pair.second) == warning
+
+
+@pytest.mark.parametrize('blocked_pair', ['emby', 'silo'], indirect=True)
+def test_disjoint_root_is_not_work_and_ambiguous_matching_instance_is_isolated(blocked_pair):
+    pair = blocked_pair
+    pair.release.set()
+    row = pair.repo.get(pair.first)
+    mappings = pair.repo.values(row)['path_mappings']
+    mappings.append(dict(mappings[0]))
+    pair.repo.update(pair.first, path_mappings=mappings)
+    pair.config.publish(pair.repo.snapshot(pair.first, settings()))
+    pair.dispatcher.notify(event())
+    assert pair.dispatcher.wait_idle(3)
+    assert [call[0] for call in pair.calls] == [pair.second]
+    assert pair.dispatcher.status(pair.first)['error_code'] == 'mapping_ambiguous'
+    before = tuple(pair.calls)
+    pair.dispatcher.notify(event(video_path='/unrelated/A.mkv'))
+    assert pair.dispatcher.wait_idle(3)
+    assert tuple(pair.calls) == before
+    assert pair.dispatcher.status(pair.first)['pending'] == 1
+
+
+@pytest.mark.parametrize('blocked_pair', ['emby', 'silo'], indirect=True)
+def test_failed_database_update_keeps_both_authorized_snapshots(blocked_pair, schema_session, monkeypatch):
+    from sqlalchemy import event as sql_event
+    from media_servers import service
+    pair = blocked_pair
+    before = pair.config.read(pair.first)
+    sibling = pair.config.read(pair.second)
+    session = schema_session()
+    def fail_after_flush(_session, _context):
+        raise RuntimeError('sensitive synthetic text')
+    sql_event.listen(session, 'after_flush', fail_after_flush)
+    try:
+        body, status = service.update_instance(schema_session, pair.first, {'url': 'http://staged.example',
+                                                                           'api_key': 'staged-key'})
+    finally:
+        sql_event.remove(session, 'after_flush', fail_after_flush)
+    assert status == 500 and body == {'error_code': 'persistence_failed'}
+    assert pair.config.read(pair.first) == before and pair.config.read(pair.second) == sibling
+    assert pair.repo.get(pair.first).url == before[1].url
+    assert pair.repo.get_decrypted_api_key(pair.first) == before[1].apikey
+    pair.config.ensure_current(pair.first, before[0])
+    pair.release.set()
+    pair.dispatcher.notify(event())
+    assert pair.dispatcher.wait_idle(3)
+    assert {call[0] for call in pair.calls} == {pair.first, pair.second}
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_enabled_incomplete_legacy_values_are_retained_but_never_requested(schema_session, kind):
+    from media_servers.repository import MediaServerInstanceRepository
+    from media_servers.dispatcher import NativeConfiguration, RefreshDispatcher
+    repo = MediaServerInstanceRepository(schema_session)
+    row = repo.import_values(payload(kind, url='', path_mappings=[]))
+    configuration = NativeConfiguration(settings(), snapshots=repo.snapshots(settings()))
+    dispatcher = RefreshDispatcher(configuration, client_factory=lambda *args: pytest.fail('invalid config requested'))
+    assert dispatcher.status(row.id) == {'pending': 0, 'state': 'unconfirmed', 'error_code': 'invalid_url'}
+    dispatcher.notify(event())
+    assert dispatcher.wait_idle(3)
+    assert dispatcher.status(row.id) == {'pending': 0, 'state': 'unconfirmed', 'error_code': 'invalid_url'}
+    assert repo.get_decrypted_api_key(row.id) == 'opaque-A'
+
+
+def test_replacement_key_recovers_unreadable_saved_ciphertext(schema_session):
+    from media_servers.repository import MediaServerInstanceRepository
+    from secret_store import encrypt_secret
+    repo = MediaServerInstanceRepository(schema_session)
+    row = repo.create(**payload('emby'))
+    row.api_key = encrypt_secret('old-key', master_key='different-test-master')
+    schema_session.flush()
+    assert repo.snapshot(row.id, settings()).configuration_error == 'missing_credentials'
+    repo.update(row.id, api_key='replacement-key')
+    assert repo.get_decrypted_api_key(row.id) == 'replacement-key'
+    assert repo.snapshot(row.id, settings()).configuration_error is None
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_invalid_imported_destination_preserves_capacity_for_its_configured_root(schema_session, kind):
+    from media_servers.repository import MediaServerInstanceRepository
+    from media_servers.dispatcher import NativeConfiguration, RefreshDispatcher
+    repo = MediaServerInstanceRepository(schema_session)
+    row = repo.import_values(payload(kind, url=''))
+    configuration = NativeConfiguration(settings(), snapshots=repo.snapshots(settings()))
+    dispatcher = RefreshDispatcher(configuration, client_factory=lambda *args: pytest.fail('invalid connection requested'))
+    for number in range(dispatcher.PENDING_LIMIT + 2):
+        dispatcher.notify(event(video_path=f'/unrelated/{number}.mkv',
+                                subtitle_path=f'/unrelated/{number}.en.srt'))
+    assert dispatcher.wait_idle(3)
+    assert dispatcher.status(row.id) == {'pending': 0, 'state': 'unconfirmed', 'error_code': 'invalid_url'}
+    dispatcher.notify(event())
+    assert dispatcher.wait_idle(3)
+    assert dispatcher.status(row.id) == {'pending': 1, 'state': 'unconfirmed', 'error_code': 'invalid_url'}
+    assert repo.get_decrypted_api_key(row.id) == 'opaque-A'

--- a/tests/bazarr/test_media_server_instances_api.py
+++ b/tests/bazarr/test_media_server_instances_api.py
@@ -167,3 +167,40 @@ def test_silo_mapping_ids_are_positive_decimal_strings(instance_api, library_id)
     data = payload('silo', path_mappings=[{'local_path': '/movies', 'remote_path': '/media', 'library_id': library_id}])
     assert instance_api.post(ROOT, json=data, headers=HEADERS).status_code == 400
     assert instance_api.get(ROOT, headers=HEADERS).json == {'data': []}
+
+
+@pytest.mark.parametrize('broken', ['unreadable_key', 'legacy_missing_url'])
+def test_a_broken_destination_can_still_be_turned_off(instance_api, schema_session, broken):
+    """The card's disable action submits ``{'enabled': False}`` and nothing else.
+
+    A saved key that no longer decrypts (a database restored without its master
+    key) and a legacy import that never had a URL are both destinations whose
+    retained values cannot pass validation. Refusing the edit leaves them
+    enabled and accumulating failed refresh targets with no way out short of
+    deleting the instance, so turning one off must not depend on reading or
+    re-validating whatever it retains.
+    """
+    from media_servers.repository import MediaServerInstanceRepository
+    from secret_store import encrypt_secret
+    created = instance_api.post(ROOT, json=payload('emby'), headers=HEADERS).json
+    path = ROOT + '/' + created['id']
+    repo = MediaServerInstanceRepository(schema_session)
+    row = repo.get(created['id'])
+    if broken == 'unreadable_key':
+        row.api_key = encrypt_secret('old-key', master_key='different-test-master')
+    else:
+        row.url = ''
+    retained_key, retained_url = row.api_key, row.url
+    schema_session.flush()
+
+    response = instance_api.patch(path, json={'enabled': False}, headers=HEADERS)
+    assert response.status_code == 200, response.json
+    assert response.json['enabled'] is False
+
+    # Nothing the destination retains was rewritten, so restoring the master key
+    # (or filling the URL back in) still recovers it.
+    saved = repo.get(created['id'])
+    assert (saved.api_key, saved.url) == (retained_key, retained_url)
+    assert bool(saved.enabled) is False
+    # Turning it back on has no usable connection and must still be refused.
+    assert instance_api.patch(path, json={'enabled': True}, headers=HEADERS).status_code == 400

--- a/tests/bazarr/test_media_server_instances_api.py
+++ b/tests/bazarr/test_media_server_instances_api.py
@@ -1,0 +1,169 @@
+import pytest
+from flask import Flask
+
+from test_media_server_instances import payload, settings
+from test_media_server_http import http_fixture as http_fixture
+
+
+@pytest.fixture
+def instance_api(schema_session, monkeypatch):
+    from api import api_bp
+    from app.config import settings as app_settings
+    from api import system
+    media_server_instances = getattr(system, "media_server_instances", None)
+    from media_servers import dispatcher
+    monkeypatch.setitem(app_settings.auth, 'apikey', 'synthetic-bazarr-key')
+    if media_server_instances is not None:
+        monkeypatch.setattr(media_server_instances, 'database', schema_session)
+    configuration = dispatcher.NativeConfiguration(settings())
+    monkeypatch.setattr(dispatcher, '_configuration', configuration)
+    monkeypatch.setattr(dispatcher, '_dispatcher', dispatcher.RefreshDispatcher(configuration))
+    app = Flask(__name__)
+    app.register_blueprint(api_bp)
+    return app.test_client()
+
+
+HEADERS = {'X-API-KEY': 'synthetic-bazarr-key'}
+ROOT = '/api/system/media-server-instances'
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_authenticated_crud_uuid_safe_key_and_status(instance_api, kind):
+    assert instance_api.get(ROOT).status_code == 401
+    first = instance_api.post(ROOT, json=payload(kind), headers=HEADERS)
+    second = instance_api.post(ROOT, json=payload(kind, 'B'), headers=HEADERS)
+    assert first.status_code == second.status_code == 201
+    assert first.json['id'] != second.json['id']
+    path = ROOT + '/' + first.json['id']
+    response = instance_api.patch(path, json={'name': 'Renamed', 'api_key': ''}, headers=HEADERS)
+    assert response.status_code == 200
+    assert response.json['id'] == first.json['id']
+    assert response.json['api_key_set'] is True
+    listed = instance_api.get(ROOT + '?kind=' + kind, headers=HEADERS)
+    assert len(listed.json['data']) == 2
+    assert all('api_key' not in row and 'apikey' not in row for row in listed.json['data'])
+    assert instance_api.get(path + '/status', headers=HEADERS).json['pending'] == 0
+    assert instance_api.post(path + '/retry-pending', headers=HEADERS).json == {'queued': 0}
+    assert instance_api.delete(path, headers=HEADERS).status_code == 204
+    assert instance_api.get(path, headers=HEADERS).status_code == 404
+    assert instance_api.get(path + '/status', headers=HEADERS).status_code == 404
+
+
+@pytest.mark.parametrize('patch', [{'id': '4'}, {'kind': 'silo'}, {'enabled': 1}, {'api_key': 123},
+                                  {'verify_ssl': 'false'}, {'url': 'http://user:secret@host'},
+                                  {'clear_api_key': True, 'api_key': 'new'}, {'unknown': 'x'}])
+def test_invalid_edit_never_mutates(instance_api, patch):
+    first = instance_api.post(ROOT, json=payload('emby'), headers=HEADERS).json
+    path = ROOT + '/' + first['id']
+    assert instance_api.patch(path, json=patch, headers=HEADERS).status_code == 400
+    assert instance_api.get(path, headers=HEADERS).json == first
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_default_disabled_create_and_explicit_key_clear(instance_api, schema_session, kind):
+    from media_servers.repository import MediaServerInstanceRepository
+    created = instance_api.post(ROOT, json={'kind': kind, 'name': 'Draft', 'url': 'http://[::1]:8096/base',
+                                           'api_key': '000123'}, headers=HEADERS)
+    assert created.status_code == 201
+    first = created.json
+    assert first['enabled'] is False and first['verify_ssl'] is True and first['path_mappings'] == []
+    path = ROOT + '/' + first['id']
+    assert instance_api.patch(path, json={'api_key': ''}, headers=HEADERS).json['api_key_set'] is True
+    assert MediaServerInstanceRepository(schema_session).get_decrypted_api_key(first['id']) == '000123'
+    assert instance_api.patch(path, json={'clear_api_key': True}, headers=HEADERS).json['api_key_set'] is False
+    assert instance_api.patch(path, json={'enabled': True}, headers=HEADERS).status_code == 400
+
+
+@pytest.mark.parametrize('body', [None, [], {}, {'kind': 'emby'}, {'kind': 'emby', 'name': 'A'},
+                                 payload('emby', api_key=''), payload('silo', path_mappings=[]),
+                                 payload('emby', name=' '), payload('silo', path_mappings=[
+                                     {'local_path': '/movies', 'remote_path': '/media', 'library_id': '0'}])])
+def test_invalid_create_fails_without_rows(instance_api, body):
+    response = instance_api.post(ROOT, json=body, headers=HEADERS)
+    assert response.status_code == 400
+    assert instance_api.get(ROOT, headers=HEADERS).json == {'data': []}
+
+
+@pytest.mark.parametrize('method,suffix', [('get', ''), ('patch', ''), ('delete', ''),
+                                         ('post', '/test-connection'), ('post', '/libraries'),
+                                         ('get', '/status'), ('post', '/retry-pending')])
+def test_all_item_operations_require_authentication(instance_api, method, suffix):
+    path = ROOT + '/01f0e1bc-68fe-4013-84b1-d4becad3e8fb' + suffix
+    assert getattr(instance_api, method)(path).status_code == 401
+    assert getattr(instance_api, method)(path, json={}, headers=HEADERS).status_code == 404
+
+
+def test_invalid_filters_and_numerical_ids_are_not_coerced(instance_api):
+    assert instance_api.get(ROOT + '?kind=jellyfin', headers=HEADERS).status_code == 400
+    assert instance_api.get(ROOT + '/1', headers=HEADERS).status_code == 404
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+@pytest.mark.parametrize('override', [False, True])
+def test_saved_probe_resolves_only_its_own_key_and_never_saves(instance_api, http_fixture, kind, override):
+    from test_silo_client import HEALTH, LIBRARIES
+    def replies():
+        return [(200, {'ServerName': 'Test', 'Version': '4.9.5.0'}, {})] if kind == 'emby' else [
+            (200, HEALTH, {}), (200, LIBRARIES, {})]
+    targets = [http_fixture(replies()) for _ in range(2)]
+    if override:
+        targets.append(http_fixture(replies()))
+    for index, name in enumerate(('A', 'B')):
+        created = instance_api.post(ROOT, json=payload(kind, name, url=targets[index][0] + '/saved'),
+                                    headers=HEADERS).json
+        path = ROOT + '/' + created['id']
+        body = {'url': targets[2][0] + '/override', 'api_key': 'unsaved', 'verify_ssl': False} if override and index == 0 else {}
+        response = instance_api.post(path + '/test-connection?api_key=wrong', json=body, headers=HEADERS)
+        assert response.status_code == 200 and response.json['success'] is True
+        target = targets[2] if override and index == 0 else targets[index]
+        expected_key = 'unsaved' if override and index == 0 else 'opaque-' + name
+        expected_header = expected_key if kind == 'emby' else 'Bearer ' + expected_key
+        assert target[1][0]['headers']['X-Emby-Token' if kind == 'emby' else 'Authorization'] == expected_header
+        assert all(row['method'] == 'GET' for row in target[1])
+        assert instance_api.get(path, headers=HEADERS).json == created
+
+
+@pytest.mark.parametrize('body', [{'verify_ssl': 'false'}, {'api_key': 1}, {'clear_api_key': True},
+                                 {'unknown': 'x'}, {'url': 'ftp://bad'}, {'api_key': 'x', 'clear_api_key': True}])
+def test_invalid_saved_probe_never_requests(instance_api, http_fixture, body):
+    base, records = http_fixture([])
+    first = instance_api.post(ROOT, json=payload('emby', url=base), headers=HEADERS).json
+    response = instance_api.post(ROOT + '/' + first['id'] + '/test-connection', json=body, headers=HEADERS)
+    assert response.status_code == 400
+    assert records == []
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_unknown_new_probe_fields_fail_before_network(instance_api, http_fixture, kind):
+    base, records = http_fixture([])
+    response = instance_api.post('/api/' + kind + '/test-connection', headers=HEADERS,
+                                 json={'url': base, 'apikey': 'synthetic', 'unexpected': 'field'})
+    assert response.status_code == 400
+    assert records == []
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_saved_probe_unknown_body_type_fails(instance_api, kind):
+    first = instance_api.post(ROOT, json=payload(kind), headers=HEADERS).json
+    assert instance_api.post(ROOT + '/' + first['id'] + '/test-connection', json=[], headers=HEADERS).status_code == 400
+
+
+def test_silo_saved_library_probes_keep_destination_credentials_and_library_ids(instance_api, http_fixture):
+    targets = [http_fixture([(200, [{'id': index, 'name': name, 'type': 'movies',
+                                    'paths': [f'/media/{name}'], 'enabled': True}], {})])
+               for index, name in ((7, 'A'), (8, 'B'))]
+    for (base, records), name, library in zip(targets, ('A', 'B'), ('7', '8')):
+        created = instance_api.post(ROOT, json=payload('silo', name, url=base), headers=HEADERS).json
+        response = instance_api.post(ROOT + '/' + created['id'] + '/libraries', json={}, headers=HEADERS)
+        assert response.status_code == 200
+        assert response.json['data'][0]['id'] == library
+        assert response.json['error_code'] is None
+        assert records[0]['headers']['Authorization'] == 'Bearer opaque-' + name
+        assert [(row['method'], row['path']) for row in records] == [('GET', '/api/v1/libraries')]
+
+
+@pytest.mark.parametrize('library_id', [0, 7, '', '0', '0000', '-1', '1.0', 'one', ' 7'])
+def test_silo_mapping_ids_are_positive_decimal_strings(instance_api, library_id):
+    data = payload('silo', path_mappings=[{'local_path': '/movies', 'remote_path': '/media', 'library_id': library_id}])
+    assert instance_api.post(ROOT, json=data, headers=HEADERS).status_code == 400
+    assert instance_api.get(ROOT, headers=HEADERS).json == {'data': []}

--- a/tests/bazarr/test_media_server_instances_pg.py
+++ b/tests/bazarr/test_media_server_instances_pg.py
@@ -1,0 +1,107 @@
+"""Real PostgreSQL coverage in an isolated, disposable schema."""
+
+import os
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+
+from test_media_server_instance_migration import legacy, migration
+from test_media_server_instances import payload
+
+
+@pytest.fixture
+def pg_engine():
+    url = os.environ.get('BAZARR_PG_TEST_URL')
+    if not url:
+        pytest.skip('BAZARR_PG_TEST_URL is required for real PostgreSQL coverage')
+    schema = 'media_instances_' + uuid4().hex
+    admin = sa.create_engine(url, isolation_level='AUTOCOMMIT', hide_parameters=True)
+    try:
+        with admin.connect() as connection:
+            connection.exec_driver_sql(f'CREATE SCHEMA {schema}')
+    except Exception:
+        admin.dispose()
+        pytest.fail('Could not create isolated PostgreSQL test schema', pytrace=False)
+    engine = sa.create_engine(url, isolation_level='AUTOCOMMIT', hide_parameters=True,
+                              connect_args={'options': f'-csearch_path={schema}'})
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+        with admin.connect() as connection:
+            connection.exec_driver_sql(f'DROP SCHEMA {schema} CASCADE')
+        admin.dispose()
+
+
+@pytest.fixture
+def pg_session(pg_engine):
+    with pg_engine.connect() as connection:
+        migration().create_media_server_tables(connection)
+    with sessionmaker(bind=pg_engine, autoflush=False, expire_on_commit=False)() as session:
+        yield session
+
+
+@pytest.mark.parametrize('fresh', [False, True])
+def test_pg_upgrade_and_create_all_have_same_columns_and_constraints(pg_engine, fresh):
+    from app.database import Base, TableMediaServerImports, TableMediaServerInstances
+    with pg_engine.connect() as connection:
+        if fresh:
+            Base.metadata.create_all(connection, tables=[TableMediaServerInstances.__table__,
+                                                         TableMediaServerImports.__table__])
+        migration().create_media_server_tables(connection)
+        migration().create_media_server_tables(connection)
+        inspector = sa.inspect(connection)
+        columns = {column['name']: column for column in inspector.get_columns('media_server_instances')}
+        assert set(columns) == {'id', 'kind', 'name', 'enabled', 'url', 'api_key', 'verify_ssl', 'path_mappings', 'revision'}
+        assert all(column['nullable'] is False for column in columns.values())
+        assert {row['name'] for row in inspector.get_check_constraints('media_server_instances')} == {
+            'ck_media_server_kind', 'ck_media_server_enabled', 'ck_media_server_verify_ssl'}
+        assert inspector.get_pk_constraint('media_server_instances')['constrained_columns'] == ['id']
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_pg_encrypted_crud_restart_and_no_import_resurrection(pg_session, pg_engine, kind):
+    from types import SimpleNamespace
+    from media_servers.backfill import backfill_instances
+    from media_servers.repository import MediaServerInstanceRepository
+    config = legacy(**{kind: SimpleNamespace(url='', apikey='000123', verify_ssl=False, path_mappings=[])})
+    assert backfill_instances(pg_session, config)[kind]['created'] is True
+    repo = MediaServerInstanceRepository(pg_session)
+    imported, = repo.list(kind)
+    original_id = imported.id
+    sibling = repo.create(**payload(kind, 'B'))
+    repo.update(sibling.id, name='Renamed')
+    with sessionmaker(bind=pg_engine)() as restarted:
+        rows = MediaServerInstanceRepository(restarted)
+        assert rows.get_decrypted_api_key(original_id) == '000123'
+        assert rows.get(original_id).api_key.startswith('enc:v1:')
+        assert rows.get(sibling.id).name == 'Renamed'
+        assert rows.get(sibling.id).id != original_id
+    repo.delete(original_id)
+    backfill_instances(pg_session, config)
+    assert [row.id for row in repo.list(kind)] == [sibling.id]
+
+
+@pytest.mark.parametrize('kind', ['emby', 'silo'])
+def test_pg_import_failure_rolls_back_both_structures_then_retries(pg_session, pg_engine, monkeypatch, kind):
+    from types import SimpleNamespace
+    from app.database import TableMediaServerImports
+    from media_servers import backfill
+    from media_servers.repository import MediaServerInstanceRepository
+    config = legacy(**{kind: SimpleNamespace(url='http://legacy/base', apikey='000123',
+                                            verify_ssl=True, path_mappings=[])})
+    record = backfill._record_import
+    def fail(session, candidate):
+        if candidate == kind:
+            raise RuntimeError('synthetic private detail')
+        record(session, candidate)
+    monkeypatch.setattr(backfill, '_record_import', fail)
+    result = backfill.backfill_instances(pg_session, config)
+    assert result[kind]['error_code'] == 'migration_failed'
+    with sessionmaker(bind=pg_engine)() as restarted:
+        assert MediaServerInstanceRepository(restarted).list(kind) == []
+        assert restarted.get(TableMediaServerImports, kind) is None
+    monkeypatch.setattr(backfill, '_record_import', record)
+    assert backfill.backfill_instances(pg_session, config)[kind]['created'] is True

--- a/tests/bazarr/test_media_server_mutation_hooks.py
+++ b/tests/bazarr/test_media_server_mutation_hooks.py
@@ -672,3 +672,91 @@ def test_combine_cleanup_notifies_each_successful_removal(tmp_path, mutations):
     _remove_stale_combined_siblings(str(destination), str(video), callback)
     assert not stale.exists()
     assert len(mutations) == 1 and mutations[0].subtitle_path == str(stale)
+
+
+SRT = '1\n00:00:01,000 --> 00:00:02,000\nOriginal\n'
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+@pytest.mark.parametrize('relocates', [False, True])
+def test_mod_edits_publish_the_file_they_leave_behind(upload_flow, mutations, monkeypatch, media_type, relocates):
+    """Remove HI and the other mods rewrite, and sometimes rename, the subtitle.
+
+    The mod implementation deletes the old file and writes the modified one, so
+    a destination that is not told about it serves the pre-mod subtitle until
+    some later scan happens to notice.
+    """
+    from subtitles.tools import mods
+    flow = upload_flow
+    source = flow.video.with_suffix('.en.hi.srt' if relocates else '.en.srt')
+    source.write_text(SRT)
+    monkeypatch.setattr(mods.Subtitle, 'get_modified_content', lambda self, **kwargs: b'Modified')
+    mods.subtitles_apply_mods('en', str(source), ['remove_HI'] if relocates else ['OCR_fixes'],
+                              str(flow.video), media_type=media_type, arr_instance_id=7)
+    survivor = next(path for path in flow.video.parent.glob('*.srt') if path.read_text() == 'Modified')
+    # Remove HI drops the .hi tag, so the published path is not the one the
+    # request named; every other mod rewrites the file in place.
+    assert (survivor != source) is relocates and not (relocates and source.exists())
+    assert len(mutations) == 1
+    assert (mutations[0].media_type, mutations[0].operation, mutations[0].video_path,
+            mutations[0].subtitle_path, mutations[0].arr_instance_id) == (
+        media_type, 'edit', str(flow.video), str(survivor), 7)
+
+
+def test_an_invalid_subtitle_the_mod_never_rewrites_publishes_nothing(upload_flow, mutations, monkeypatch):
+    from subtitles.tools import mods
+    source = upload_flow.video.with_suffix('.en.srt')
+    source.write_text('not a subtitle at all')
+    mods.subtitles_apply_mods('en', str(source), ['OCR_fixes'], str(upload_flow.video),
+                              media_type='movie', arr_instance_id=7)
+    assert source.read_text() == 'not a subtitle at all'
+    assert mutations == []
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+def test_the_subtitle_tools_endpoint_publishes_its_mod_action(upload_flow, mutations, monkeypatch, media_type):
+    """The finding's path: PATCH /api/subtitles with a mod action.
+
+    It applies the mod and post-processes it, and used to publish nothing at
+    all, so Remove HI or OCR fixes from the toolbar reached no destination.
+    """
+    from api.subtitles import subtitles as api_mod
+    from subtitles.tools import mods
+    flow = upload_flow
+    source = flow.video.with_suffix('.en.srt')
+    source.write_text(SRT)
+    monkeypatch.setattr(mods.Subtitle, 'get_modified_content', lambda self, **kwargs: b'Modified')
+    monkeypatch.setattr(api_mod, 'postprocess_subtitles', lambda *args, **kwargs: None)
+    metadata = SimpleNamespace(path='/upstream/Video.mkv', sonarrSeriesId=10, subtitles=None,
+                               season=1, episode=1, imdbId='tt1', tvdbId=1, tmdbId=1)
+    monkeypatch.setattr(api_mod, 'database',
+                        Mock(execute=Mock(return_value=Mock(first=Mock(return_value=metadata)))))
+    monkeypatch.setattr(api_mod.path_mappings, 'path_replace_instance',
+                        lambda path, owner, kind: str(flow.video))
+    args = {'action': 'OCR_fixes', 'language': 'en', 'path': str(source), 'type': media_type,
+            'id': 42, 'arr_instance_id': 7, 'forced': 'False', 'hi': 'False'}
+    stub = SimpleNamespace(patch_request_parser=SimpleNamespace(parse_args=lambda: args))
+
+    assert api_mod.Subtitles.patch.__wrapped__(stub) == ('', 204)
+
+    assert source.read_text() == 'Modified'
+    assert len(mutations) == 1
+    assert (mutations[0].media_type, mutations[0].operation, mutations[0].video_path,
+            mutations[0].subtitle_path, mutations[0].arr_instance_id) == (
+        media_type, 'edit', str(flow.video), str(source), 7)
+
+
+def test_bulk_mod_action_reaches_the_publication_hook(upload_flow, mutations, monkeypatch):
+    from subtitles.mass_operations import _process_subtitle_item
+    from subtitles.tools import mods
+    flow = upload_flow
+    source = flow.video.with_suffix('.en.srt')
+    source.write_text(SRT)
+    monkeypatch.setattr(mods.Subtitle, 'get_modified_content', lambda self, **kwargs: b'Modified')
+    item = dict(video_path=str(flow.video), srt_path=str(source), srt_lang='en', forced=False, hi=False,
+                sonarr_series_id=None, sonarr_episode_id=None, radarrId=None, radarr_id=30,
+                arr_instance_id=7, metadata=None)
+    assert _process_subtitle_item(item, 'OCR_fixes', {}, 'bulk')
+    assert len(mutations) == 1
+    assert (mutations[0].media_type, mutations[0].operation, mutations[0].arr_instance_id) == (
+        'movie', 'edit', 7)

--- a/tests/bazarr/test_media_server_mutation_hooks.py
+++ b/tests/bazarr/test_media_server_mutation_hooks.py
@@ -1,0 +1,674 @@
+"""Native notifications follow real file publication, not secondary callbacks."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from flask import Flask
+import pytest
+
+from test_upload_background_sync import upload_flow as upload_flow, review_translator as review_translator
+
+
+@pytest.fixture
+def mutations(monkeypatch):
+    from media_servers import dispatcher
+    events = []
+    monkeypatch.setattr(dispatcher, 'notify_subtitle_mutation', events.append)
+    return events
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'series'])
+def test_upload_and_later_background_sync_are_two_publications(upload_flow, mutations, media_type):
+    flow = upload_flow
+    flow.submit(media_type, job_id='upload')
+    assert len(mutations) == 1
+    assert mutations[0].operation == 'upload'
+    flow.release_engine.set()
+    job, thread = flow.start()
+    thread.join(3)
+    assert job.status == 'completed'
+    assert [event.operation for event in mutations] == ['upload', 'sync']
+    assert all(event.video_path == str(flow.video) and event.arr_instance_id == 7 for event in mutations)
+    assert all(event.media_type == ('episode' if media_type == 'series' else 'movie') for event in mutations)
+
+
+@pytest.mark.parametrize('failure', ['write', 'index'])
+def test_upload_requires_write_but_survives_later_index_failure(upload_flow, mutations, monkeypatch, failure):
+    from subtitles import upload
+    from subtitles.tools import subsync_engines
+    if failure == 'write':
+        monkeypatch.setattr(subsync_engines.os, 'replace', Mock(side_effect=OSError('controlled write failure')))
+        upload_flow.submit('movie', job_id='upload')
+        assert mutations == []
+    else:
+        monkeypatch.setattr(upload, '_refresh_uploaded_subtitles', Mock(side_effect=RuntimeError('controlled index failure')))
+        with pytest.raises(RuntimeError, match='controlled index failure'):
+            upload_flow.submit('movie', job_id='upload')
+        assert len(mutations) == 1
+        assert mutations[0].operation == 'upload'
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'series'])
+def test_delete_notifies_once_only_when_removed_before_index(upload_flow, mutations, monkeypatch, media_type):
+    from subtitles.tools import delete
+    target = upload_flow.video.with_suffix('.en.srt')
+    target.write_text('Original')
+    name = 'store_subtitles' if media_type == 'series' else 'store_subtitles_movie'
+    monkeypatch.setattr(delete, name, Mock(side_effect=RuntimeError('controlled index failure')))
+    with pytest.raises(RuntimeError):
+        upload_flow.remove(media_type)
+    assert not target.exists()
+    assert len(mutations) == 1
+    assert mutations[0].operation == 'delete'
+    with pytest.raises(RuntimeError):
+        upload_flow.remove(media_type)
+    assert len(mutations) == 1
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+@pytest.mark.parametrize('later_failure', [False, True])
+def test_sync_uses_video_not_explicit_subtitle_reference(upload_flow, mutations, monkeypatch, media_type, later_failure):
+    from subtitles import sync
+    flow = upload_flow
+    source = flow.video.with_suffix('.en.srt')
+    source.write_text('Original')
+    reference = flow.video.parent / 'reference.srt'
+    reference.write_text('Distinct subtitle reference')
+    flow.release_engine.set()
+    callback = Mock(side_effect=RuntimeError('controlled callback failure') if later_failure else None)
+    sync.sync_subtitles(video_path=str(flow.video), srt_path=str(source), srt_lang='en', forced=False, hi=False,
+                        percent_score=0, job_id='sync', reference=str(reference), force_sync=True,
+                        sonarr_episode_id=20 if media_type == 'episode' else None,
+                        radarr_id=30 if media_type == 'movie' else None, arr_instance_id=7,
+                        track_job_progress=False, callback=callback)
+    assert 'Synced' in source.read_text()
+    assert len(mutations) == 1
+    assert (mutations[0].video_path, mutations[0].subtitle_path, mutations[0].arr_instance_id) == (
+        str(flow.video), str(source), 7)
+
+
+@pytest.mark.parametrize('cancel_after_publish', [False, True])
+def test_sync_cancellation_retains_each_already_published_output(upload_flow, mutations, monkeypatch,
+                                                              cancel_after_publish):
+    from app.config import settings
+    from app.jobs_queue import JobCancelled
+    from subtitles.tools import subsyncer
+    flow = upload_flow
+    monkeypatch.setattr(settings.subsync, 'output_mode', 'keep_all')
+    monkeypatch.setattr(settings.subsync, 'enabled_engines', ['ffsubsync', 'alass'])
+
+    def cancel(self, **kwargs):
+        flow.queue.cancel_running_job(self.job_id)
+        raise JobCancelled()
+
+    monkeypatch.setattr(subsyncer.SubSyncer, '_run_external_engine' if cancel_after_publish else '_run_ffsubsync_engine',
+                        cancel)
+    flow.submit('movie', job_id='upload')
+    flow.release_engine.set()
+    _job, thread = flow.start()
+    thread.join(3)
+    assert [event.operation for event in mutations] == (['upload', 'sync'] if cancel_after_publish else ['upload'])
+    if cancel_after_publish:
+        assert mutations[-1].subtitle_path.endswith('.ffsubsync.srt')
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+def test_bulk_sync_reaches_publication_hook(upload_flow, mutations, media_type):
+    from subtitles.mass_operations import _process_subtitle_item
+    flow = upload_flow
+    source = flow.video.with_suffix('.en.srt')
+    source.write_text('Original')
+    flow.release_engine.set()
+    item = dict(video_path=str(flow.video), srt_path=str(source), srt_lang='en', forced=False, hi=False,
+                sonarr_series_id=10 if media_type == 'episode' else None,
+                sonarr_episode_id=20 if media_type == 'episode' else None,
+                radarr_id=30 if media_type == 'movie' else None, max_offset_seconds=60,
+                no_fix_framerate=True, gss=False, arr_instance_id=7)
+    assert _process_subtitle_item(item, 'sync', {}, 'bulk')
+    assert len(mutations) == 1 and mutations[0].operation == 'sync'
+
+
+@pytest.mark.parametrize('review_translator', ['google', 'lingarr', 'gemini', 'openrouter'], indirect=True)
+def test_translation_service_publishes_before_later_history_failure(review_translator, mutations, monkeypatch):
+    import sys
+    run = review_translator
+    module = sys.modules[type(run.service).__module__]
+    run.service.arr_instance_id = 7
+    monkeypatch.setattr(module, 'history_log_movie', Mock(side_effect=RuntimeError('controlled history failure')))
+    run.release.set()
+    run.worker.join(3)
+    assert 'Translated text' in run.destination.read_text()
+    assert len(mutations) == 1
+    assert (mutations[0].operation, mutations[0].video_path, mutations[0].arr_instance_id) == (
+        'translate', str(run.flow.video), 7)
+
+
+@pytest.mark.parametrize('operation', ['edit', 'create', 'promote'])
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+def test_content_publication_precedes_chmod_failure(tmp_path, monkeypatch, mutations, operation, media_type):
+    from api.subtitles import content
+    video = tmp_path / 'Actual.mkv'
+    video.touch()
+    subtitle = video.with_suffix('.en.srt')
+    source = video.with_suffix('.en.ffsubsync.srt')
+    source.write_text('Aligned')
+    if operation != 'create':
+        subtitle.write_text('Original')
+    metadata = {'mediaPath': '/upstream/Actual.mkv', 'arrInstanceId': 7}
+    monkeypatch.setattr(content.path_mappings, 'path_replace_instance', lambda path, owner, kind: str(video))
+    monkeypatch.setattr(content, 'resolve_subtitle_path', lambda kind, ident, language, **kwargs:
+                        (str(source if ':sync-' in language else subtitle), metadata))
+    monkeypatch.setattr(content, '_apply_subtitle_chmod', Mock(side_effect=RuntimeError('controlled chmod failure')))
+    monkeypatch.setattr(content, 'get_target_folder', lambda path: None)
+    row = Mock(path='/upstream/Actual.mkv', id=4, arr_instance_id=7)
+    monkeypatch.setattr(content, 'database', Mock(execute=Mock(return_value=Mock(first=Mock(return_value=row)))))
+    app = Flask(__name__)
+    with app.test_request_context(json={'content': 'Aligned', 'language': 'en', 'format': 'srt'}):
+        with pytest.raises(RuntimeError, match='controlled chmod failure'):
+            if operation == 'edit':
+                content._save_subtitle_content(media_type, 42, 'en', arr_instance_id=7)
+            elif operation == 'create':
+                content._create_subtitle(media_type, 42, arr_instance_id=7)
+            else:
+                content.promote_sync_subtitle(media_type, 42, 'en', 'en:sync-ffsubsync', arr_instance_id=7)
+    assert subtitle.read_text() == 'Aligned'
+    assert len(mutations) == 1
+    assert (mutations[0].video_path, mutations[0].subtitle_path, mutations[0].arr_instance_id,
+            mutations[0].operation) == (str(video), str(subtitle), 7, 'sync' if operation == 'promote' else 'edit')
+
+
+def test_runner_publishes_before_failure_store_and_never_replays_callback(tmp_path, mutations):
+    from media_servers.events import publication_callback
+    from subtitles.tools.subsync_engines import InMemorySubsyncFailureStore, SubsyncEngineRunner
+    subtitle = tmp_path / 'Movie.en.srt'
+    subtitle.write_text('Original')
+    store = InMemorySubsyncFailureStore()
+    store.record_success = Mock(side_effect=RuntimeError('controlled accounting failure'))
+    runner = SubsyncEngineRunner(store)
+    runner.run(str(subtitle), 'overwrite', ['ffsubsync'],
+               lambda engine, path: path.write_text('Aligned'),
+               on_publish=publication_callback('movie', str(tmp_path / 'Movie.mkv'), 'sync', 7))
+    assert subtitle.read_text() == 'Aligned'
+    assert len(mutations) == 1
+
+
+@pytest.fixture
+def colliding_media(schema_session, tmp_path, monkeypatch):
+    from app.database import TableEpisodes, TableShows, TableMovies, TableLanguagesProfiles
+    from utilities.path_mappings import path_mappings
+    roots = {owner: tmp_path / str(owner) for owner in (1, 2)}
+    for owner, root in roots.items():
+        root.mkdir()
+        (root / 'Video.mkv').touch()
+        schema_session.add(TableLanguagesProfiles(profileId=owner * 11, name=f'Profile {owner}', items='[]'))
+    schema_session.flush()
+    for owner in roots:
+        schema_session.add(TableMovies(id=owner, arr_instance_id=owner, radarrId=42, path='/upstream/Video.mkv',
+                                       title='Movie', year=2025, tmdbId=str(owner), profileId=owner * 11,
+                                       subtitles='[]', missing_subtitles="['en']", monitored=True, tags='[]'))
+        schema_session.add(TableShows(id=100 + owner, arr_instance_id=owner, sonarrSeriesId=99,
+                                      title='Show', path='/upstream', profileId=owner * 11, tags='[]'))
+    schema_session.flush()
+    for owner in roots:
+        schema_session.add(TableEpisodes(id=200 + owner, arr_instance_id=owner, series_id=100 + owner,
+                                         sonarrEpisodeId=42, sonarrSeriesId=99, title='Episode',
+                                         path='/upstream/Video.mkv', season=1, episode=1, subtitles='[]',
+                                         missing_subtitles="['en']", monitored=True))
+    schema_session.flush()
+    monkeypatch.setattr(path_mappings, 'path_replace_instance',
+                        lambda path, owner, kind: path.replace('/upstream', str(roots[owner or 1])))
+    monkeypatch.setattr(path_mappings, 'path_replace_reverse_instance',
+                        lambda path, owner, kind: path.replace(str(roots[owner or 1]), '/upstream'))
+    monkeypatch.setattr(path_mappings, 'path_replace_movie', lambda path: path.replace('/upstream', str(roots[1])))
+    monkeypatch.setattr(path_mappings, 'path_replace', lambda path: path.replace('/upstream', str(roots[1])))
+    return SimpleNamespace(db=schema_session, roots=roots, video=str(roots[2] / 'Video.mkv'))
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+@pytest.mark.parametrize('entry', ['manual', 'specific', 'missing'])
+def test_download_adapters_preserve_distinct_owner_path_and_profile(colliding_media, monkeypatch, media_type, entry):
+    from subtitles import manual
+    from subtitles.mass_download import movies, series
+    state = colliding_media
+    module = manual if entry == 'manual' else movies if media_type == 'movie' else series
+    monkeypatch.setattr(module, 'database', state.db)
+    monkeypatch.setattr(module, 'get_audio_profile_languages', lambda value: [])
+    monkeypatch.setattr(module, 'jobs_queue', Mock())
+    seen = []
+
+    def download(*args, **kwargs):
+        seen.append((args, kwargs))
+        return []
+
+    if entry == 'manual':
+        monkeypatch.setattr(module, 'manual_download_subtitle', download)
+        if media_type == 'movie':
+            module.movie_manually_download_specific_subtitle(42, False, False, False, 'fixture', 'subtitle',
+                                                             job_id='download', arr_instance_id=2)
+        else:
+            module.episode_manually_download_specific_subtitle(99, 42, False, False, False, 'fixture', 'subtitle',
+                                                               job_id='download', arr_instance_id=2)
+    else:
+        monkeypatch.setattr(module, 'generate_subtitles', download)
+        monkeypatch.setattr(module, 'event_stream', Mock())
+        monkeypatch.setattr(module, 'get_exclusion_clause', lambda kind: [])
+        monkeypatch.setattr(module, 'get_providers', lambda: ['fixture'])
+        if entry == 'specific' and media_type == 'movie':
+            module.movie_download_specific_subtitles(42, 'en', 'False', 'False', job_id='download', arr_instance_id=2)
+        elif entry == 'specific':
+            module.episode_download_specific_subtitles(99, 42, 'en', 'False', 'False', job_id='download', arr_instance_id=2)
+        elif media_type == 'movie':
+            module.movies_download_subtitles(42, job_id='download', arr_instance_id=2)
+        else:
+            module.episode_download_subtitles(42, job_id='download', arr_instance_id=2)
+    assert len(seen) == 1
+    args, kwargs = seen[0]
+    assert args[0] == state.video
+    assert kwargs['arr_instance_id'] == 2
+    assert (args[6] if entry == 'missing' else kwargs['profile_id']) == 22
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+def test_combine_create_and_rebuild_use_exact_owner_and_file(colliding_media, monkeypatch, mutations, media_type):
+    from subtitles.tools.combine import main
+    from app import database
+    from api.subtitles import subtitles
+    state = colliding_media
+    monkeypatch.setattr(database, 'database', state.db)
+    monkeypatch.setattr(database, 'get_profiles_list', lambda profile_id:
+                        {'profileId': profile_id, 'items': [{'language': 'en'}, {'language': 'hu'}],
+                         'combine': {'languages': ['en', 'hu'], 'format': 'srt'}} if profile_id == 22 else None)
+    postprocess = Mock()
+    monkeypatch.setattr(subtitles, 'postprocess_subtitles', postprocess)
+    for language in ('en', 'hu'):
+        Path(state.video).with_suffix(f'.{language}.srt').write_text(
+            f'1\n00:00:01,000 --> 00:00:02,000\n{language}\n')
+    for _attempt in range(2):
+        result = main.try_combine_for_video(state.video, media_type, sonarr_series_id=99,
+                                            sonarr_episode_id=42, radarr_id=42, arr_instance_id=2)
+        assert result.status == 'built', result
+    assert len(mutations) == 2
+    assert all(event.operation == 'combine' and event.arr_instance_id == 2 and event.video_path == state.video
+               for event in mutations)
+    assert postprocess.call_count == 2
+    assert postprocess.call_args.kwargs['arr_instance_id'] == 2
+    assert postprocess.call_args.args[3].profileId == 22
+    assert not list(state.roots[1].glob('*.srt'))
+
+
+def test_editor_alignment_is_temporary_until_real_content_save(upload_flow, mutations, monkeypatch):
+    from api.editor import editor
+    from api.subtitles import content
+    flow = upload_flow
+    library_subtitle = flow.video.with_suffix('.en.srt')
+    library_subtitle.write_text('Original library subtitle')
+    temporary = flow.video.parent / 'bazarr_sync_fixture.srt'
+    temporary.write_text('Editor input')
+    reference = flow.video.parent / 'reference.srt'
+    reference.write_text('Separate reference')
+    flow.release_engine.set()
+    monkeypatch.setattr('threading.Timer', Mock())
+    key = 'native-publication-test'
+    editor._editor_sync_jobs[key] = {'status': 'running'}
+    try:
+        editor.run_editor_sync(key, str(flow.video), str(temporary), str(temporary.with_suffix('.synced.srt')),
+                               'utf-8', '60', False, str(reference), enabled_engines=['ffsubsync'], output_mode='overwrite')
+        result = editor._editor_sync_jobs[key]
+        assert result['status'] == 'completed', result
+        assert mutations == []
+        assert library_subtitle.read_text() == 'Original library subtitle'
+        monkeypatch.setattr(content, 'resolve_subtitle_path', lambda *args, **kwargs:
+                            (str(library_subtitle), {'mediaPath': str(flow.video), 'arrInstanceId': 7}))
+        monkeypatch.setattr(content, '_refresh_media_subtitles', Mock())
+        app = Flask(__name__)
+        with app.test_request_context(json={'content': result['content']},
+                                      headers={'If-Match': content.generate_etag(str(library_subtitle))}):
+            assert content._save_subtitle_content('movie', 30, 'en', arr_instance_id=7).status_code == 204
+        assert len(mutations) == 1 and mutations[0].operation == 'edit'
+        assert mutations[0].video_path == str(flow.video)
+    finally:
+        editor._editor_sync_jobs.pop(key, None)
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+def test_download_missing_language_gate_uses_actual_owner(colliding_media, monkeypatch, media_type):
+    from app.database import TableEpisodes, TableMovies
+    from subtitles import download
+    from subzero.language import Language
+    state = colliding_media
+    table = TableMovies if media_type == 'movie' else TableEpisodes
+    state.db.query(table).filter(table.arr_instance_id == 1).update({'missing_subtitles': '[]'})
+    state.db.flush()
+    monkeypatch.setattr(download, 'database', state.db)
+    monkeypatch.setattr(download, '_get_language_obj', lambda languages: {Language('eng')} if languages else set())
+    kind = 'series' if media_type == 'episode' else 'movie'
+    assert download.check_missing_languages(state.video, kind, 2) == {Language('eng')}
+    assert download.check_missing_languages(str(state.roots[1] / 'Video.mkv'), kind, 1) == set()
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'episode'])
+@pytest.mark.parametrize('automatic_sync', [False, True])
+@pytest.mark.parametrize('entrypoint', ['manual', 'automatic'])
+def test_actual_manual_download_and_autosync_writes_each_notify_once(colliding_media, upload_flow,
+                                                                   monkeypatch, mutations, media_type, automatic_sync,
+                                                                   entrypoint):
+    from subtitles import manual, processing, download, pool
+    from subzero.language import Language
+    from subliminal_patch.subtitle import Subtitle
+    from subtitles.tools import mods
+    state = colliding_media
+    flow = upload_flow
+
+    class DownloadedSubtitle(Subtitle):
+        provider_name = 'fixture'
+        id = 'subtitle'
+
+    subtitle = DownloadedSubtitle(Language('eng'))
+    subtitle.content = b'1\n00:00:01,000 --> 00:00:02,000\nDownloaded\n'
+    subtitle.format = 'srt'
+    subtitle.score = 100
+    subtitle.matches = set()
+    monkeypatch.setattr(mods, 'get_subzero_mods', lambda owner: [])
+    monkeypatch.setattr(manual.subtitle_cache, 'get', lambda key: subtitle)
+    monkeypatch.setattr(manual, 'get_video', lambda path, *args, **kwargs: SimpleNamespace(original_path=path))
+    monkeypatch.setattr(manual, 'download_subtitles', lambda *args: None)
+    monkeypatch.setattr(manual, '_get_pool', lambda *args: None)
+    monkeypatch.setattr(manual, 'get_target_folder', lambda path: None)
+    monkeypatch.setattr(processing, 'database', state.db)
+    monkeypatch.setattr(processing, '_defaul_sync_checker', lambda subtitle: automatic_sync)
+    monkeypatch.setattr(processing, '_trigger_auto_translation', Mock())
+    monkeypatch.setattr(processing, '_trigger_combine', Mock())
+    monkeypatch.setattr(processing, 'notify_radarr', Mock())
+    monkeypatch.setattr(processing, 'notify_sonarr', Mock())
+    monkeypatch.setattr(processing, 'client_for_instance', Mock())
+    monkeypatch.setattr(processing, 'event_stream', Mock())
+    monkeypatch.setattr(processing, 'call_external_webhook', Mock())
+    # upload_flow has its own identity mapping; restore the two distinct owners
+    # for this real processing lookup and publication.
+    monkeypatch.setattr(processing.path_mappings, 'path_replace_reverse_instance',
+                        lambda path, owner, kind: path.replace(str(state.roots[owner]), '/upstream'))
+    flow.release_engine.set()
+    if entrypoint == 'manual':
+        result = manual.manual_download_subtitle(state.video, 'English', 'False', 'False', 'cached', 'fixture',
+                                                 'None', 'Video', 'series' if media_type == 'episode' else 'movie',
+                                                 False, 22, job_id='download', arr_instance_id=2)
+    else:
+        video = type('Video', (), {'original_path': state.video})()
+        monkeypatch.setattr(pool, '_update_pool', lambda *args, **kwargs: False)
+        monkeypatch.setattr(download, 'get_video', lambda *args, **kwargs: video)
+        monkeypatch.setattr(download, '_get_pool', lambda *args: SimpleNamespace(
+            providers=['fixture'], discarded_providers=[]))
+        monkeypatch.setattr(download, 'get_profiles_list', lambda profile_id: {'originalFormat': False})
+        monkeypatch.setattr(download, '_get_language_obj', lambda languages: {Language('eng')})
+        monkeypatch.setattr(download, 'database', state.db)
+        monkeypatch.setattr(download, 'download_best_subtitles', lambda **kwargs: {video: [subtitle]})
+        monkeypatch.setattr(download, 'clear_mismatch_for_video', Mock())
+        monkeypatch.setattr(download.subliminal, 'region', Mock())
+        result = list(download.generate_subtitles(
+            state.video, [('en', 'False', 'False')], 'English', 'None', 'Video',
+            'series' if media_type == 'episode' else 'movie', 22, job_id='download', arr_instance_id=2,
+            check_if_still_required=True))
+    assert result
+    assert [event.operation for event in mutations] == ['download'] * (2 if automatic_sync else 1)
+    assert all(event.video_path == state.video and event.arr_instance_id == 2 and event.media_type == media_type
+               for event in mutations)
+    actual = Path(state.video).with_suffix('.en.srt')
+    assert ('Synced' if automatic_sync else 'Downloaded') in actual.read_text()
+
+
+@pytest.mark.parametrize('review_translator', ['openrouter'], indirect=True)
+def test_saved_partial_translation_is_a_publication(review_translator, mutations):
+    run = review_translator
+    run.service.partial_error = 'One remote batch did not finish'
+    run.release.set()
+    run.worker.join(3)
+    assert run.service.partial_error
+    assert 'Translated text' in run.destination.read_text()
+    assert len(mutations) == 1 and mutations[0].operation == 'translate'
+
+
+def test_publication_callback_failure_cannot_replay_or_undo_saved_output(tmp_path):
+    from subtitles.tools.subsync_engines import staged_subtitle_write
+    destination = tmp_path / 'Video.en.srt'
+    calls = []
+
+    def callback(path):
+        calls.append(path)
+        raise RuntimeError('controlled publication callback failure')
+
+    with staged_subtitle_write(str(tmp_path / 'Video.mkv'), str(destination), on_publish=callback) as temporary:
+        Path(temporary).write_text('Published')
+    assert destination.read_text() == 'Published'
+    assert calls == [str(destination)]
+
+
+@pytest.mark.parametrize('changed', [False, True])
+def test_upload_postprocessing_change_survives_later_failure(upload_flow, mutations, monkeypatch, changed):
+    from subtitles import upload, processing
+    flow = upload_flow
+    monkeypatch.setattr(processing, '_postprocessing_config', lambda *args: (True, 'fixture', False, 0))
+    monkeypatch.setattr(upload, 'pp_replace', lambda *args: 'fixture')
+
+    def postprocess(command, path, subtitle_path):
+        if changed:
+            import os
+            original = Path(subtitle_path).read_bytes()
+            before = os.stat(subtitle_path)
+            Path(subtitle_path).write_bytes(original.replace(b'Uploaded', b'Modified'))
+            os.utime(subtitle_path, ns=(before.st_atime_ns, before.st_mtime_ns))
+            assert os.stat(subtitle_path).st_size == before.st_size
+        raise RuntimeError('controlled postprocessing failure')
+
+    monkeypatch.setattr(upload, 'postprocessing', postprocess)
+    with pytest.raises(RuntimeError, match='controlled postprocessing failure'):
+        flow.submit('movie', job_id='upload')
+    assert len(mutations) == (2 if changed else 1)
+    assert all(event.operation == 'upload' for event in mutations)
+
+
+@pytest.fixture
+def download_postprocessing(colliding_media, upload_flow, monkeypatch):
+    from app.config import settings
+    from subtitles import processing
+    from subzero.language import Language
+
+    state = colliding_media
+    destination = state.roots[2].parent / '0-configured-destination'
+    destination.mkdir()
+    subtitle_folder = state.roots[2].parent / '3-subtitles'
+    subtitle_folder.mkdir()
+    sidecar = subtitle_folder / 'Video.en.srt'
+    sidecar.write_bytes(b'Original')
+    monkeypatch.setattr(settings.general, 'subfolder', 'absolute')
+    monkeypatch.setattr(settings.general, 'subfolder_custom', str(destination))
+    monkeypatch.setattr(processing, 'database', state.db)
+    monkeypatch.setattr(processing, '_defaul_sync_checker', lambda subtitle: False)
+    monkeypatch.setattr(processing, '_postprocessing_config', lambda *args: (True, 'fixture', False, 0))
+    monkeypatch.setattr(processing, 'pp_replace', lambda *args: 'fixture')
+    monkeypatch.setattr(processing, 'set_chmod', lambda **kwargs: None)
+    monkeypatch.setattr(processing.path_mappings, 'path_replace_reverse_instance',
+                        lambda path, owner, kind: path.replace(str(state.roots[owner]), '/upstream'))
+    for name in ('_trigger_auto_translation', '_trigger_combine', 'notify_radarr', 'notify_sonarr',
+                 'client_for_instance', 'event_stream', 'call_external_webhook'):
+        monkeypatch.setattr(processing, name, Mock())
+    subtitle = SimpleNamespace(provider_name='fixture', uploader='', release_info='', language=Language('eng'),
+                               storage_path=str(sidecar), id='fixture', score=100, matches=set())
+
+    def process(media_type='movie'):
+        return processing.process_subtitle(subtitle, media_type, 'English', state.video, 100, arr_instance_id=2)
+
+    return SimpleNamespace(video=state.video, sidecar=sidecar, process=process)
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'series'])
+def test_download_noop_postprocessing_does_not_duplicate_concurrent_publication(
+        download_postprocessing, mutations, monkeypatch, media_type):
+    from threading import Event, Thread, current_thread
+    from subtitles import post_processing
+    from subtitles.tools import subsync_engines
+    from media_servers.events import publication_callback
+
+    run = download_postprocessing
+    held, observer_waiting = Event(), Event()
+    failures = []
+    observer = current_thread()
+    original_lock = subsync_engines.subtitle_write_lock
+
+    def observed_lock(*args):
+        if current_thread() is observer:
+            observer_waiting.set()
+        return original_lock(*args)
+
+    monkeypatch.setattr(subsync_engines, 'subtitle_write_lock', observed_lock)
+    monkeypatch.setattr(post_processing, '_postprocessing_locked', lambda command, path: None)
+
+    def publish():
+        try:
+            with subsync_engines.subtitle_write_locks(run.video, str(run.sidecar)):
+                held.set()
+                assert observer_waiting.wait(5)
+                subsync_engines.write_subtitle_file(
+                    run.video, str(run.sidecar), b'Published concurrently',
+                    on_publish=publication_callback(media_type, run.video, 'download', 2))
+        except BaseException as error:
+            failures.append(error)
+
+    writer = Thread(target=publish)
+    writer.start()
+    try:
+        assert held.wait(5)
+        assert run.process(media_type)
+    finally:
+        observer_waiting.set()
+        writer.join(5)
+    assert not writer.is_alive() and not failures
+    assert run.sidecar.read_bytes() == b'Published concurrently'
+    assert len(mutations) == 1
+    assert mutations[0].operation == 'download' and mutations[0].arr_instance_id == 2
+    assert mutations[0].video_path == run.video and mutations[0].subtitle_path == str(run.sidecar)
+
+
+@pytest.mark.parametrize('media_type', ['movie', 'series'])
+def test_download_keeps_resolved_postprocessing_directories_when_settings_change(
+        download_postprocessing, mutations, monkeypatch, media_type):
+    from contextlib import contextmanager
+    from threading import Event, Thread, current_thread
+    from app.config import settings
+    from media_servers.events import publication_callback
+    from subtitles import processing, post_processing
+    from subtitles.tools import subsync_engines
+
+    run = download_postprocessing
+    new_destination = Path(run.video).parent.parent / '1-new-destination'
+    new_destination.mkdir()
+    writer_owns_destination, writer_waits_video = Event(), Event()
+    download_thread = current_thread()
+    original_lock = subsync_engines.subtitle_write_lock
+    original_observer = processing.observe_subtitle_change
+    failures = []
+
+    @contextmanager
+    def tracked_lock(video_path, directory):
+        state = original_lock(video_path, directory)
+        if current_thread() is download_thread and directory == str(new_destination):
+            # Detect the actual cycle without leaving deadlocked test threads.
+            assert state.lock.acquire(blocking=False), 'nested destination resolution would deadlock the download'
+        else:
+            if current_thread() is writer and directory == str(Path(run.video).parent):
+                writer_waits_video.set()
+            state.lock.acquire()
+        try:
+            if current_thread() is writer and directory == str(new_destination):
+                writer_owns_destination.set()
+            yield state
+        finally:
+            state.lock.release()
+
+    def command(command, path):
+        if current_thread() is writer:
+            subsync_engines.write_subtitle_file(
+                run.video, str(run.sidecar), b'Published under new destination settings',
+                on_publish=publication_callback(media_type, run.video, 'download', 2))
+
+    def publish():
+        try:
+            # A legacy caller resolves the newly configured destination once.
+            post_processing.postprocessing('write', run.video, subtitle_path=str(run.sidecar))
+        except BaseException as error:
+            failures.append(error)
+
+    writer = Thread(target=publish)
+
+    @contextmanager
+    def change_destination(*args):
+        settings.general.subfolder_custom = str(new_destination)
+        writer.start()
+        assert writer_owns_destination.wait(5) and writer_waits_video.wait(5)
+        with original_observer(*args):
+            yield
+
+    monkeypatch.setattr(subsync_engines, 'subtitle_write_lock', tracked_lock)
+    monkeypatch.setattr(post_processing, '_postprocessing_locked', command)
+    monkeypatch.setattr(processing, 'observe_subtitle_change', change_destination)
+    try:
+        assert run.process(media_type)
+    finally:
+        if writer.ident is not None:
+            writer.join(5)
+    assert not writer.is_alive() and not failures
+    assert run.sidecar.read_bytes() == b'Published under new destination settings'
+    assert len(mutations) == 1
+    assert mutations[0].video_path == run.video and mutations[0].arr_instance_id == 2
+
+
+@pytest.mark.parametrize('change', ['none', 'bytes', 'restored_mtime'])
+@pytest.mark.parametrize('later_failure', [False, True])
+def test_download_postprocessing_reports_only_its_actual_change(
+        download_postprocessing, mutations, monkeypatch, change, later_failure):
+    import os
+    from subtitles import processing, post_processing
+
+    run = download_postprocessing
+
+    def command(command, path):
+        if change == 'bytes':
+            run.sidecar.write_bytes(b'Changed subtitle bytes')
+        elif change == 'restored_mtime':
+            before = run.sidecar.stat()
+            run.sidecar.write_bytes(b'Modified')
+            os.utime(run.sidecar, ns=(before.st_atime_ns, before.st_mtime_ns))
+            assert run.sidecar.stat().st_size == before.st_size
+
+    def chmod(**kwargs):
+        if later_failure:
+            raise OSError('controlled chmod failure after postprocessing')
+
+    monkeypatch.setattr(post_processing, '_postprocessing_locked', command)
+    monkeypatch.setattr(processing, 'set_chmod', chmod)
+    if later_failure:
+        with pytest.raises(OSError, match='controlled chmod failure'):
+            run.process()
+    else:
+        assert run.process()
+    assert len(mutations) == (0 if change == 'none' else 1)
+    assert all(event.operation == 'download' and event.arr_instance_id == 2 and event.video_path == run.video
+               for event in mutations)
+    assert run.sidecar.read_bytes() == {
+        'none': b'Original', 'bytes': b'Changed subtitle bytes', 'restored_mtime': b'Modified'}[change]
+
+
+def test_combine_cleanup_notifies_each_successful_removal(tmp_path, mutations):
+    from subtitles.tools.combine.main import _remove_stale_combined_siblings
+    from media_servers.events import publication_callback
+    video = tmp_path / 'Video.mkv'
+    video.touch()
+    destination = tmp_path / 'Video.en.combined-hu.srt'
+    destination.write_text('New')
+    stale = destination.with_suffix('.ass')
+    stale.write_text('Old')
+    callback = publication_callback('movie', str(video), 'combine', 7)
+    _remove_stale_combined_siblings(str(destination), str(video), callback)
+    _remove_stale_combined_siblings(str(destination), str(video), callback)
+    assert not stale.exists()
+    assert len(mutations) == 1 and mutations[0].subtitle_path == str(stale)

--- a/tests/bazarr/test_media_server_paths.py
+++ b/tests/bazarr/test_media_server_paths.py
@@ -1,0 +1,94 @@
+import pytest
+
+
+def map_path(path, rows, **kwargs):
+    from media_servers.paths import map_media_path
+    return map_media_path(path, rows, **kwargs)
+
+
+def test_mapping_uses_segment_boundary():
+    from media_servers.http import MediaServerError
+    rows = [{"local_path": "/movies", "remote_path": "/media"}]
+    with pytest.raises(MediaServerError, match="mapping_missing"):
+        map_path("/movies-old/A.mkv", rows)
+    assert map_path("/movies/A.mkv", rows) == {"path": "/media/A.mkv", "library_id": None}
+
+
+def test_longest_prefix_and_trailing_separators():
+    rows = [
+        {"local_path": "/movies/", "remote_path": "/media/"},
+        {"local_path": "/movies/4k/", "remote_path": "/uhd/"},
+    ]
+    assert map_path("/movies/4k/A.mkv", rows)["path"] == "/uhd/A.mkv"
+
+
+def test_numeric_ids_are_not_coerced():
+    rows = [{"local_path": "/tv", "remote_path": "/media/tv", "library_id": "0007"}]
+    assert map_path("/tv/A.mkv", rows, require_library=True)["library_id"] == "0007"
+
+
+def test_windows_drive_paths_keep_remote_separator_style():
+    rows = [{"local_path": "C:\\Movies\\", "remote_path": "D:\\Library\\"}]
+    assert map_path("c:\\movies\\A\\A.mkv", rows)["path"] == "D:\\Library\\A\\A.mkv"
+    rows[0]["remote_path"] = "/media"
+    assert map_path("C:\\Movies\\A\\A.mkv", rows)["path"] == "/media/A/A.mkv"
+
+
+@pytest.mark.parametrize("path", [
+    "/movies/D:/A.mkv",
+    "/movies/C:/A.mkv",
+    "/movies/d:/A.mkv",
+    "/movies/D:A.mkv",
+    "/movies/C:A.mkv",
+    "/movies/Edition/D:/A.mkv",
+    "/movies/Edition/C:/A.mkv",
+    "/movies/\\root/A.mkv",
+    "/movies/folder\\A.mkv",
+], ids=["same-drive", "other-drive", "same-drive-lowercase", "same-drive-filename", "other-drive-filename",
+        "nested-same-drive", "nested-other-drive", "rooted-component", "split-component"])
+def test_posix_components_cannot_acquire_windows_path_semantics(path):
+    from media_servers.http import MediaServerError
+    rows = [{"local_path": "/movies", "remote_path": "D:\\Library"}]
+    with pytest.raises(MediaServerError, match="path_invalid"):
+        map_path(path, rows)
+
+
+def test_posix_to_windows_mapping_preserves_ordinary_relative_components():
+    rows = [{"local_path": "/movies", "remote_path": "D:\\Library"}]
+    assert map_path("/movies/Edition/A.mkv", rows)["path"] == "D:\\Library\\Edition\\A.mkv"
+
+
+def test_posix_destination_keeps_literal_drive_like_filename_components():
+    rows = [{"local_path": "/movies", "remote_path": "/media"}]
+    assert map_path("/movies/D:/A.mkv", rows)["path"] == "/media/D:/A.mkv"
+
+
+@pytest.mark.parametrize("path", ["/movies/../private/A.mkv", "C:\\Movies\\..\\A.mkv", "relative/A.mkv", "", None])
+def test_invalid_video_paths_fail_closed(path):
+    from media_servers.http import MediaServerError
+    with pytest.raises(MediaServerError, match="path_invalid"):
+        map_path(path, [{"local_path": "/movies", "remote_path": "/media"}])
+
+
+@pytest.mark.parametrize("rows", [None, {}, [None], [["/movies", "/media"]],
+                                  [{"local_path": "/movies"}],
+                                  [{"local_path": "/movies", "remote_path": "relative"}],
+                                  [{"local_path": "/movies", "remote_path": "/media", "library_id": 7}],
+                                  [{"local_path": "/movies/../", "remote_path": "/media"}]])
+def test_malformed_mappings_fail_closed(rows):
+    from media_servers.http import MediaServerError
+    with pytest.raises(MediaServerError, match="mapping_invalid"):
+        map_path("/movies/A.mkv", rows)
+
+
+def test_equal_specificity_is_ambiguous_even_for_duplicate_rows():
+    from media_servers.http import MediaServerError
+    row = {"local_path": "/movies", "remote_path": "/media"}
+    with pytest.raises(MediaServerError, match="mapping_ambiguous"):
+        map_path("/movies/A.mkv", [row, row])
+
+
+def test_library_id_is_required_for_silo():
+    from media_servers.http import MediaServerError
+    with pytest.raises(MediaServerError, match="library_missing"):
+        map_path("/movies/A.mkv", [{"local_path": "/movies", "remote_path": "/media"}], require_library=True)

--- a/tests/bazarr/test_media_server_resolution.py
+++ b/tests/bazarr/test_media_server_resolution.py
@@ -92,10 +92,15 @@ def test_a_rung_that_resolves_hands_back_what_it_promised_for_checking():
     assert log == [resolution.PATH, resolution.PATH]
 
 
-def test_ladder_order_is_identifiers_then_path_then_library():
+def test_the_exact_path_outranks_the_weak_title_rung():
+    """A provider id identifies the item on its own, so it stays first.
+
+    A title and a year do not: they are a guess narrowed by two fields, and a
+    guess must never pre-empt the one rung that proves which file this is.
+    """
     from media_servers import resolution
-    assert resolution.CHAIN == (resolution.PROVIDER_ID, resolution.TITLE_YEAR,
-                                resolution.PATH, resolution.LIBRARY)
+    assert resolution.CHAIN == (resolution.PROVIDER_ID, resolution.PATH,
+                                resolution.TITLE_YEAR, resolution.LIBRARY)
 
 
 @pytest.mark.parametrize(("media_type", "expected"), [

--- a/tests/bazarr/test_media_server_resolution.py
+++ b/tests/bazarr/test_media_server_resolution.py
@@ -1,0 +1,190 @@
+# coding=utf-8
+"""The shared resolution ladder and the metadata it reads for itself."""
+
+from contextlib import nullcontext
+
+import pytest
+
+import app.database  # noqa: F401
+
+
+def rung(name, result, *, expected="requested", log=None):
+    def call():
+        if log is not None:
+            log.append(name)
+        if isinstance(result, Exception):
+            raise result
+        return result
+    return (name, call, expected)
+
+
+def test_first_resolving_rung_wins_and_no_later_rung_is_reached():
+    from media_servers import resolution
+    log = []
+    assert resolution.walk([
+        rung(resolution.PROVIDER_ID, {"status": "requested"}, log=log),
+        rung(resolution.TITLE_YEAR, {"status": "requested"}, log=log),
+        rung(resolution.PATH, {"status": "requested"}, log=log),
+        rung(resolution.LIBRARY, {"status": "requested"}, log=log),
+    ]) == (resolution.PROVIDER_ID, {"status": "requested"}, "requested")
+    assert log == [resolution.PROVIDER_ID]
+
+
+def test_returned_none_is_a_miss_that_falls_through_in_order():
+    from media_servers import resolution
+    log = []
+    name, _result, _expected = resolution.walk([
+        rung(resolution.PROVIDER_ID, None, log=log),
+        rung(resolution.TITLE_YEAR, None, log=log),
+        rung(resolution.PATH, {"status": "requested"}, log=log),
+        rung(resolution.LIBRARY, {"status": "requested"}, log=log),
+    ])
+    assert name == resolution.PATH
+    assert log == [resolution.PROVIDER_ID, resolution.TITLE_YEAR, resolution.PATH]
+
+
+def test_a_failure_stops_the_walk_instead_of_reaching_for_something_broader():
+    from media_servers import resolution
+    from media_servers.http import MediaServerError
+    log = []
+    with pytest.raises(MediaServerError, match="item_ambiguous"):
+        resolution.walk([
+            rung(resolution.PATH, MediaServerError("item_ambiguous"), log=log),
+            rung(resolution.LIBRARY, {"status": "requested"}, log=log),
+        ])
+    assert log == [resolution.PATH]
+
+
+def test_a_refusal_the_adapter_calls_a_miss_falls_through_but_no_other_does():
+    from media_servers.dispatcher import _misses_on
+    from media_servers.http import MediaServerError
+
+    def refuse(code):
+        def call():
+            raise MediaServerError(code)
+        return call
+
+    assert _misses_on(refuse("item_missing"), ("item_missing",))() is None
+    assert _misses_on(refuse("request_rejected"), ("request_rejected",))() is None
+    with pytest.raises(MediaServerError, match="item_ambiguous"):
+        _misses_on(refuse("item_ambiguous"), ("item_missing",))()
+    assert _misses_on(lambda: {"status": "confirmed"}, ("item_missing",))() == {"status": "confirmed"}
+
+
+def test_a_ladder_with_nothing_left_to_try_resolves_to_nothing():
+    from media_servers import resolution
+    assert resolution.walk([rung(resolution.PATH, None), rung(resolution.LIBRARY, None)]) is None
+    assert resolution.walk([]) is None
+
+
+def test_a_rung_that_resolves_hands_back_what_it_promised_for_checking():
+    from media_servers import resolution
+    log = []
+    assert resolution.walk([
+        rung(resolution.PATH, {"status": "confirmed"}, expected="confirmed", log=log)]) == (
+        resolution.PATH, {"status": "confirmed"}, "confirmed")
+    # A rung that answered at all ends the walk, right or wrong; judging the
+    # answer is the caller's, so a later rung is still never reached.
+    assert resolution.walk([
+        rung(resolution.PATH, {"status": "requested"}, expected="confirmed", log=log),
+        rung(resolution.LIBRARY, {"status": "requested"}, log=log),
+    ]) == (resolution.PATH, {"status": "requested"}, "confirmed")
+    assert log == [resolution.PATH, resolution.PATH]
+
+
+def test_ladder_order_is_identifiers_then_path_then_library():
+    from media_servers import resolution
+    assert resolution.CHAIN == (resolution.PROVIDER_ID, resolution.TITLE_YEAR,
+                                resolution.PATH, resolution.LIBRARY)
+
+
+@pytest.mark.parametrize(("media_type", "expected"), [
+    ("movie", [("imdb", "tt0017136"), ("tmdb", "19")]),
+    ("episode", [("imdb", "tt0303461"), ("tvdb", "78874")]),
+])
+def test_provider_pairs_keep_jellyfins_precedence_per_media_type(media_type, expected):
+    from media_servers.resolution import MediaMetadata
+    metadata = MediaMetadata(imdb_id=expected[0][1], tmdb_id="19", tvdb_id=78874, season=1, episode=1)
+    assert metadata.provider_ids(media_type) == expected
+
+
+@pytest.mark.parametrize("metadata", [
+    {}, {"imdb_id": ""}, {"tmdb_id": None},
+])
+def test_absent_identifiers_produce_no_pairs(metadata):
+    from media_servers.resolution import MediaMetadata
+    assert MediaMetadata(**metadata).provider_ids("movie") == []
+
+
+def test_an_episode_is_only_locatable_once_the_numbers_are_known():
+    from media_servers.resolution import MediaMetadata
+    assert MediaMetadata(imdb_id="tt1").locatable("movie") is True
+    assert MediaMetadata(imdb_id="tt1").locatable("episode") is False
+    assert MediaMetadata(imdb_id="tt1", season=0, episode=0).locatable("episode") is True
+
+
+# ----------------------------------------------------------- metadata lookup
+
+
+@pytest.fixture
+def stored(schema_session, monkeypatch):
+    from app.database import TableEpisodes, TableMovies, TableShows
+    from media_servers import resolution
+    from utilities.path_mappings import path_mappings
+
+    monkeypatch.setattr(resolution, "_reader", lambda: nullcontext(schema_session))
+    monkeypatch.setattr(path_mappings, "path_mapping_series", [["/remote/shows", "/movies"]])
+    monkeypatch.setattr(path_mappings, "path_mapping_movies", [["/remote/movies", "/movies"]])
+    schema_session.add(TableMovies(
+        id=1, arr_instance_id=2, radarrId=11, path="/remote/movies/A.mkv", title="Metropolis",
+        year="1927", imdbId="tt0017136", tmdbId="19", subtitles="[]", tags="[]"))
+    schema_session.add(TableShows(
+        id=5, arr_instance_id=2, sonarrSeriesId=21, path="/remote/shows/Firefly", title="Firefly",
+        year="2002", imdbId="tt0303461", tvdbId=78874, tags="[]"))
+    schema_session.flush()
+    schema_session.add(TableEpisodes(
+        id=9, series_id=5, arr_instance_id=2, sonarrSeriesId=21, sonarrEpisodeId=31,
+        path="/remote/shows/Firefly/S01E02.mkv", title="The Train Job", season=1, episode=2,
+        monitored="True", subtitles="[]"))
+    schema_session.flush()
+    return schema_session
+
+
+def test_movie_identifiers_are_read_from_the_row_bazarr_already_wrote(stored):
+    from media_servers.resolution import media_metadata
+    metadata = media_metadata("movie", "/movies/A.mkv", 2)
+    assert (metadata.imdb_id, metadata.tmdb_id, metadata.title, metadata.year) == (
+        "tt0017136", "19", "Metropolis", 1927)
+
+
+def test_episode_identifiers_come_from_the_show_with_the_episode_numbers(stored):
+    from media_servers.resolution import media_metadata
+    metadata = media_metadata("episode", "/movies/Firefly/S01E02.mkv", 2)
+    assert (metadata.imdb_id, metadata.tvdb_id, metadata.title, metadata.year) == (
+        "tt0303461", 78874, "Firefly", 2002)
+    assert (metadata.season, metadata.episode) == (1, 2)
+
+
+def test_lookup_is_scoped_to_the_owning_arr_instance(stored):
+    from media_servers.resolution import media_metadata
+    assert media_metadata("movie", "/movies/A.mkv", 3) is None
+    assert media_metadata("episode", "/movies/Firefly/S01E02.mkv", 3) is None
+
+
+def test_unknown_path_and_colliding_rows_resolve_to_nothing(stored):
+    from app.database import TableMovies
+    from media_servers.resolution import media_metadata
+    assert media_metadata("movie", "/movies/Missing.mkv", 2) is None
+    # Two owners sharing one path cannot identify a single item, so an
+    # unscoped publication must not guess between them.
+    stored.add(TableMovies(id=2, arr_instance_id=4, radarrId=12, path="/remote/movies/A.mkv",
+                           title="Other", year="1927", imdbId="tt9", tmdbId="20",
+                           subtitles="[]", tags="[]"))
+    stored.flush()
+    assert media_metadata("movie", "/movies/A.mkv", None) is None
+
+
+def test_a_broken_database_read_is_never_fatal_to_a_refresh(monkeypatch):
+    from media_servers import resolution
+    monkeypatch.setattr(resolution, "_reader", lambda: (_ for _ in ()).throw(RuntimeError("no database")))
+    assert resolution.media_metadata("movie", "/movies/A.mkv", 2) is None

--- a/tests/bazarr/test_silo_api.py
+++ b/tests/bazarr/test_silo_api.py
@@ -1,0 +1,42 @@
+import pytest
+
+from test_emby_api import api_client as api_client
+from test_media_server_http import http_fixture as http_fixture
+from test_silo_client import HEALTH, LIBRARIES
+
+
+@pytest.mark.parametrize("route", ["test-connection", "libraries"])
+@pytest.mark.parametrize("encoding", ["json", "data"])
+def test_silo_endpoints_use_unsaved_body_only(api_client, http_fixture, route, encoding):
+    replies = [(200, HEALTH, {}), (200, LIBRARIES, {})] if route == "test-connection" else [(200, LIBRARIES, {})]
+    base, records = http_fixture(replies)
+    response = api_client.post(f"/api/silo/{route}?url=http://wrong&apikey=wrong&verify_ssl=wrong",
+                               headers={"X-API-KEY": "synthetic-bazarr-key"}, **{encoding: {
+                                   "url": base + "/unsaved", "apikey": "synthetic-unsaved-key", "verify_ssl": "false"}})
+    assert response.status_code == 200
+    assert response.json.get("success", True) is True
+    assert response.json.get("error_code") is None
+    assert records[-1]["path"] == "/unsaved/api/v1/libraries"
+    assert records[-1]["headers"]["Authorization"] == "Bearer synthetic-unsaved-key"
+
+
+@pytest.mark.parametrize("route", ["test-connection", "libraries"])
+def test_bazarr_authentication_required_for_both_native_routes(api_client, route):
+    response = api_client.post(f"/api/silo/{route}", json={"url": "http://server", "apikey": "synthetic-key"})
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize("route", ["test-connection", "libraries"])
+@pytest.mark.parametrize("body", [{}, [], {"url": "http://server"}, {"url": "", "apikey": "synthetic-key"},
+                                 {"url": "http://server", "apikey": 7},
+                                 {"url": "http://server", "apikey": "synthetic-key", "verify_ssl": "maybe"},
+                                 {"url": "http://server", "apikey": "synthetic-key", "verify_ssl": 0}])
+def test_invalid_body_cannot_fall_back_to_query_or_saved_values(api_client, route, body):
+    response = api_client.post(f"/api/silo/{route}?url=http://server&apikey=synthetic-key",
+                               headers={"X-API-KEY": "synthetic-bazarr-key"}, json=body)
+    assert response.status_code == 400
+    assert response.json["error_code"] in {"missing_credentials", "invalid_verify_ssl"}
+    if route == "libraries":
+        assert response.json["data"] == []
+    else:
+        assert response.json["success"] is False

--- a/tests/bazarr/test_silo_client.py
+++ b/tests/bazarr/test_silo_client.py
@@ -105,6 +105,25 @@ def test_library_rung_submits_one_whole_library_scan(http_fixture):
     assert records[0]["headers"]["Authorization"] == "Bearer synthetic-key"
 
 
+def test_a_library_already_scanned_in_this_pass_is_not_scanned_again(http_fixture):
+    """Silo's library scan is the same broad request for every file in it."""
+    from silo.client import SiloClient
+    base, records = http_fixture([(202, ACCEPTED, {}), (202, {**ACCEPTED, "library_id": 8}, {})])
+    scanned = set()
+
+    def coalesce(library):
+        seen = library in scanned
+        scanned.add(library)
+        return seen
+
+    with SiloClient(base, "synthetic-key") as client:
+        assert client.refresh_library("0007", coalesce=coalesce) == {"status": "requested"}
+        assert client.refresh_library("7", coalesce=coalesce) == {"status": "requested"}
+        assert client.refresh_library("8", coalesce=coalesce) == {"status": "requested"}
+    from json import loads
+    assert [loads(record["body"]) for record in records] == [{"library_id": 7}, {"library_id": 8}]
+
+
 @pytest.mark.parametrize("body", [
     {**ACCEPTED, "status": "queued"}, {**ACCEPTED, "mode": "file"}, {**ACCEPTED, "library_id": 8},
     {**ACCEPTED, "library_id": "7"}, [ACCEPTED],

--- a/tests/bazarr/test_silo_client.py
+++ b/tests/bazarr/test_silo_client.py
@@ -78,3 +78,79 @@ def test_library_errors_and_redirects_are_sanitized_without_following(http_fixtu
     assert silo_get_libraries(base, "synthetic-key") == {"data": [], "error_code": "redirect_denied"}
     assert silo_get_libraries(base, "synthetic-key") == {"data": [], "error_code": "server_error"}
     assert target_records == []
+
+
+# ------------------------------------------------------------- library rung
+
+ACCEPTED = {"status": "accepted", "mode": "library", "library_id": 7}
+
+
+def test_declared_rungs_stop_at_the_path_because_silo_publishes_no_identifiers():
+    from media_servers import resolution
+    from silo.client import SiloClient
+    assert SiloClient.REFRESH_STEPS == (resolution.PATH, resolution.LIBRARY)
+    assert resolution.PROVIDER_ID not in SiloClient.REFRESH_STEPS
+    assert resolution.TITLE_YEAR not in SiloClient.REFRESH_STEPS
+
+
+def test_library_rung_submits_one_whole_library_scan(http_fixture):
+    import json
+    from silo.client import SiloClient
+    base, records = http_fixture([(202, ACCEPTED, {})])
+    with SiloClient(base + "/silo", "synthetic-key") as client:
+        assert client.refresh_library("0007") == {"status": "requested"}
+    assert records[0]["method"] == "POST"
+    assert records[0]["path"] == "/silo/api/v1/scan"
+    assert json.loads(records[0]["body"]) == {"library_id": 7}
+    assert records[0]["headers"]["Authorization"] == "Bearer synthetic-key"
+
+
+@pytest.mark.parametrize("body", [
+    {**ACCEPTED, "status": "queued"}, {**ACCEPTED, "mode": "file"}, {**ACCEPTED, "library_id": 8},
+    {**ACCEPTED, "library_id": "7"}, [ACCEPTED],
+], ids=["status", "mode", "other-library", "string-id", "shape"])
+def test_a_scan_this_did_not_ask_for_is_never_accepted(http_fixture, body):
+    from media_servers.http import MediaServerError
+    from silo.client import SiloClient
+    base, records = http_fixture([(202, body, {})])
+    with SiloClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match="invalid_response"):
+        client.refresh_library("7")
+    assert len(records) == 1
+
+
+@pytest.mark.parametrize(("status", "code"), [
+    (200, "request_rejected"), (400, "request_rejected"), (401, "unauthorized"),
+    (404, "not_found"), (500, "server_error"), (307, "redirect_denied"),
+])
+def test_library_scan_rejections_are_sanitized_codes(http_fixture, status, code):
+    from media_servers.http import MediaServerError
+    from silo.client import SiloClient
+    base, _records = http_fixture([(status, b"synthetic-private-detail", {"Location": "http://elsewhere/"})])
+    with SiloClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match=code):
+        client.refresh_library("7")
+
+
+@pytest.mark.parametrize("library_id", ["", "0", "0000", "7a", " 7", "7.0", None, 7, "9" * 20])
+def test_an_unusable_library_id_never_reaches_the_server(http_fixture, library_id):
+    from media_servers.http import MediaServerError
+    from silo.client import SiloClient
+    base, records = http_fixture([])
+    with SiloClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match="library_invalid"):
+        client.refresh_library(library_id)
+    assert records == []
+
+
+def test_library_scan_is_bracketed_by_the_revision_guard(http_fixture):
+    from media_servers.http import MediaServerError
+    from silo.client import SiloClient
+    calls = []
+    base, records = http_fixture([(202, ACCEPTED, {})])
+
+    def guard():
+        calls.append(len(records))
+        if len(calls) > 1:
+            raise MediaServerError("configuration_changed")
+
+    with SiloClient(base, "synthetic-key") as client, pytest.raises(MediaServerError, match="configuration_changed"):
+        client.refresh_library("7", ensure_current=guard)
+    assert calls == [0, 1]

--- a/tests/bazarr/test_silo_client.py
+++ b/tests/bazarr/test_silo_client.py
@@ -1,0 +1,80 @@
+"""Native Silo connection contracts with synthetic credentials."""
+
+import pytest
+
+from test_media_server_http import http_fixture as http_fixture
+
+
+HEALTH = {"server_id": "synthetic-server", "server_name": "Native Silo", "status": "ok"}
+LIBRARIES = [
+    {"id": 7, "name": "Movies", "type": "movies", "paths": ["/media/movies"], "enabled": True},
+    {"id": 8, "name": "Shows", "type": "series", "paths": ["/media/shows"], "enabled": True},
+    {"id": 9, "name": "Music", "type": "music", "paths": ["/media/music"], "enabled": True},
+    {"id": 10, "name": "Offline", "type": "movies", "paths": ["/offline"], "enabled": False},
+]
+
+
+def test_native_test_requires_authenticated_libraries_and_omits_absent_version(http_fixture, monkeypatch):
+    from silo.operations import silo_test_connection
+    base, records = http_fixture([(200, HEALTH, {}), (200, LIBRARIES, {})])
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:1")
+    monkeypatch.setenv("NO_PROXY", "")
+    result = silo_test_connection(base + "/reverse/silo/", "synthetic-key")
+    assert result == {"success": True, "server_id": "synthetic-server", "server_name": "Native Silo"}
+    assert [record["path"] for record in records] == [
+        "/reverse/silo/api/v1/health", "/reverse/silo/api/v1/libraries"]
+    assert records[1]["headers"]["Authorization"] == "Bearer synthetic-key"
+
+
+@pytest.mark.parametrize(("status", "code"), [(401, "unauthorized"), (403, "forbidden")])
+def test_public_health_does_not_prove_key_or_admin_scope(http_fixture, status, code):
+    from silo.operations import silo_test_connection
+    base, records = http_fixture([(200, HEALTH, {}), (status, b"synthetic-sensitive-detail", {})])
+    assert silo_test_connection(base, "synthetic-key") == {"success": False, "error_code": code}
+    assert len(records) == 2
+
+
+def test_library_selector_uses_native_shapes_string_ids_and_enabled_media_types(http_fixture):
+    from silo.operations import silo_get_libraries
+    base, _records = http_fixture([(200, LIBRARIES, {})])
+    assert silo_get_libraries(base, "synthetic-key") == {"data": [
+        {"id": "7", "name": "Movies", "type": "movies", "paths": ["/media/movies"]},
+        {"id": "8", "name": "Shows", "type": "series", "paths": ["/media/shows"]},
+    ], "error_code": None}
+
+
+@pytest.mark.parametrize("body", [[], {}, {**HEALTH, "status": "unhealthy"},
+                                 {**HEALTH, "server_id": 7}, {"status": "ok", "server_name": "Name"}])
+def test_invalid_health_is_rejected(http_fixture, body):
+    from silo.operations import silo_test_connection
+    base, _records = http_fixture([(200, body, {})])
+    assert silo_test_connection(base, "synthetic-key") == {"success": False, "error_code": "invalid_response"}
+
+
+@pytest.mark.parametrize("body", [{"libraries": LIBRARIES}, None, [None],
+                                 [{**LIBRARIES[0], "id": "7"}], [{**LIBRARIES[0], "id": True}],
+                                 [{**LIBRARIES[0], "paths": "/media"}],
+                                 [{**LIBRARIES[0], "paths": [3]}], [{**LIBRARIES[0], "enabled": "true"}],
+                                 [{**LIBRARIES[0], "type": None}], [LIBRARIES[0], LIBRARIES[0]]])
+def test_invalid_native_libraries_are_not_success_or_partial_data(http_fixture, body):
+    from silo.operations import silo_get_libraries, silo_test_connection
+    body = b"null" if body is None else body
+    base, _records = http_fixture([(200, body, {}), (200, HEALTH, {}), (200, body, {})])
+    assert silo_get_libraries(base, "synthetic-key") == {"data": [], "error_code": "invalid_response"}
+    assert silo_test_connection(base, "synthetic-key") == {"success": False, "error_code": "invalid_response"}
+
+
+@pytest.mark.parametrize("apikey", [None, 123, "", " ", "synthetic\nkey"])
+def test_invalid_credentials_are_sanitized(apikey):
+    from silo.operations import silo_test_connection
+    assert silo_test_connection("http://server", apikey) == {"success": False, "error_code": "missing_credentials"}
+
+
+def test_library_errors_and_redirects_are_sanitized_without_following(http_fixture):
+    from silo.operations import silo_get_libraries
+    target, target_records = http_fixture([])
+    base, _records = http_fixture([(307, b"", {"Location": target + "/capture"}),
+                                  (500, b"synthetic-private-response", {})])
+    assert silo_get_libraries(base, "synthetic-key") == {"data": [], "error_code": "redirect_denied"}
+    assert silo_get_libraries(base, "synthetic-key") == {"data": [], "error_code": "server_error"}
+    assert target_records == []

--- a/tests/bazarr/test_silo_scans.py
+++ b/tests/bazarr/test_silo_scans.py
@@ -435,6 +435,38 @@ def test_invalid_http_acceptance_cannot_confirm_even_with_clean_events(silo_fixt
     assert error.value.code in {"invalid_response", "request_rejected"}
 
 
+def test_the_documented_refusal_of_a_path_is_a_miss_not_a_failure(silo_fixture):
+    """Silo answers 400 for a path it cannot place and for a container its
+    scanner does not read. Retrying that scan cannot change the answer, so the
+    file rung has nothing left to say and the ladder climbs on."""
+    server = silo_fixture(post_reply=(400, {"error": "bad_request"}))
+    assert refresh(server) is None
+
+
+@pytest.mark.parametrize("status", [409, 422, 429])
+def test_a_rejected_scan_request_is_a_failure_not_a_path_silo_cannot_place(silo_fixture, status):
+    """A conflict, an unprocessable body or a rate limit are all the server
+    refusing this request, not the server saying it holds no such file. Reading
+    them as a miss escalates a working destination to whole-library scans and
+    reports every one of them as a success."""
+    from media_servers.http import MediaServerError
+    server = silo_fixture(post_reply=(status, {}))
+    with pytest.raises(MediaServerError) as error:
+        refresh(server)
+    assert str(error.value) == "request_rejected"
+
+
+def test_a_refused_event_stream_handshake_is_never_a_missing_file(silo_fixture):
+    """The file scan is observed over /api/v1/events/ws. A handshake the server
+    refuses breaks every per-file refresh, and it has to surface as one."""
+    from media_servers.http import MediaServerError
+    server = silo_fixture(ws_status=400)
+    with pytest.raises(MediaServerError) as error:
+        refresh(server)
+    assert str(error.value) == "request_rejected"
+    assert all("/api/v1/scan" not in record["path"] for record in server.records)
+
+
 @pytest.mark.parametrize("endpoint", ["ws", "post"])
 @pytest.mark.parametrize(("status", "code"), [(302, "redirect_denied"), (307, "redirect_denied"),
                                             (401, "unauthorized"), (403, "forbidden"), (500, "server_error")])

--- a/tests/bazarr/test_silo_scans.py
+++ b/tests/bazarr/test_silo_scans.py
@@ -1,0 +1,995 @@
+"""Real HTTP/WebSocket protocol tests for causal native file scans."""
+
+import asyncio
+import copy
+from datetime import datetime, timedelta, timezone
+import ipaddress
+import socket
+import ssl
+import threading
+import time
+
+import pytest
+from aiohttp import ClientConnectionError, web
+
+
+PATH = "/media/Movie.mkv"
+STAMP = "automatic fixture timestamp"
+CLEAN_RESULT = {"new": 0, "updated": 0, "unchanged": 0, "missing": 0, "missing_skipped_protected": 0,
+                "files_deleted": 0, "memberships_removed": 0, "items_deleted": 0, "matched_files": 0,
+                "retried_items": 1, "still_unmatched_warnings": 1, "skipped": 0, "errors": 0}
+
+
+def run_row(run_id="fresh", *, library=7, mode="file", path=PATH, status="accepted", result=None):
+    row = {"id": run_id, "library_id": library, "mode": mode, "trigger": "path", "status": status}
+    if mode != "library":
+        row["path"] = path
+    if status != "accepted":
+        row["started_at"] = STAMP
+    if status in {"completed", "failed", "cancelled"}:
+        row["completed_at"] = STAMP
+        row["result"] = copy.deepcopy(CLEAN_RESULT if result is None else result)
+    return row
+
+
+def scan_event(row, *, event_id=None, event=None, timestamp=STAMP):
+    suffix = "started" if row["status"] == "running" else row["status"]
+    return {"type": "event", "channel": "scans", "event": event or "scan." + suffix,
+            "event_id": event_id or f"event-{row['id']}-{suffix}", "timestamp": timestamp, "data": row}
+
+
+class NativeService:
+    """A threaded local service with explicit event gates, never real credentials."""
+
+    def __init__(self, *, snapshot=(), handshake=None, after_snapshot=None, on_post=None,
+                 ws_status=None, post_reply=None, prefix="", tls_context=None, before_ws=None, listen_host="127.0.0.1"):
+        self.snapshot = list(snapshot)
+        self.handshake = handshake
+        self.after_snapshot = after_snapshot
+        self.on_post = on_post
+        self.ws_status = ws_status
+        self.post_reply = post_reply
+        self.prefix = prefix
+        self.tls_context = tls_context
+        self.before_ws = before_ws
+        self.listen_host = listen_host
+        self.clock = datetime(2026, 9, 8, tzinfo=timezone.utc)
+        self.run_starts = {}
+        self.records = []
+        self.sequence = []
+        self.posts = []
+        self.ws_closed = threading.Event()
+        self.ready = threading.Event()
+        self.started = threading.Event()
+        self.thread = threading.Thread(target=lambda: asyncio.run(self.serve()), daemon=True)
+        self.thread.start()
+        assert self.ready.wait(3), "native fixture did not start"
+        if hasattr(self, "startup_error"):
+            raise self.startup_error
+
+    async def serve(self):
+        self.loop = asyncio.get_running_loop()
+        self.stop = asyncio.Event()
+        self.release = asyncio.Event()
+        app = web.Application()
+        app.router.add_route("*", "/{tail:.*}", self.handle)
+        runner = web.AppRunner(app, access_log=None, shutdown_timeout=0.1)
+        await runner.setup()
+        site = web.TCPSite(runner, self.listen_host, 0, ssl_context=self.tls_context)
+        try:
+            await site.start()
+        except Exception as error:
+            self.startup_error = error
+            self.ready.set()
+            await runner.cleanup()
+            return
+        port = site._server.sockets[0].getsockname()[1]
+        host = f"[{self.listen_host}]" if ":" in self.listen_host else self.listen_host
+        self.url = f"{'https' if self.tls_context else 'http'}://{host}:{port}{self.prefix}"
+        self.ready.set()
+        try:
+            await self.stop.wait()
+        finally:
+            self.release.set()
+            await runner.cleanup()
+
+    def close(self):
+        if self.thread.is_alive():
+            self.loop.call_soon_threadsafe(self.stop.set)
+            self.thread.join(3)
+        assert not self.thread.is_alive(), "native fixture leaked its server thread"
+
+    async def send(self, payload):
+        # The native hub drops events when the observer disconnects. Scan HTTP
+        # acceptance still succeeds independently of that subscriber's socket.
+        payload = copy.deepcopy(payload)
+        rows = payload.get("data") if payload.get("type") == "snapshot" else [payload.get("data")]
+        if isinstance(rows, list):
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                if row.get("started_at") == STAMP:
+                    row["started_at"] = self.run_starts.setdefault(row["id"], self.tick())
+                if row.get("completed_at") == STAMP:
+                    row["completed_at"] = self.tick()
+                for key in ("started_at", "completed_at"):
+                    self.observe_time(row.get(key))
+        if payload.get("timestamp") == STAMP:
+            payload["timestamp"] = self.tick()
+        else:
+            self.observe_time(payload.get("timestamp"))
+        try:
+            await self.ws.send_json(payload)
+        except ClientConnectionError:
+            pass
+
+    def observe_time(self, value):
+        if isinstance(value, str):
+            try:
+                stamp = datetime.fromisoformat(value)
+                if stamp.tzinfo:
+                    self.clock = max(self.clock, stamp)
+            except ValueError:
+                pass
+
+    def tick(self):
+        self.clock += timedelta(microseconds=100)
+        return self.clock.isoformat().replace("+00:00", "Z")
+
+    async def complete(self, run_id="fresh", **kwargs):
+        self.sequence.append(f"completed:{run_id}")
+        await self.send(scan_event(run_row(run_id, status="completed", **kwargs)))
+
+    async def handle(self, request):
+        record = {"method": request.method, "path": request.path_qs, "headers": dict(request.headers)}
+        self.records.append(record)
+        path = request.path.removeprefix(self.prefix)
+        if path == "/capture":
+            return web.Response(status=500)
+        if request.headers.get("Authorization") != "Bearer synthetic-key":
+            return web.Response(status=401)
+        if path == "/api/v1/events/ws":
+            if self.before_ws:
+                self.started.set()
+                await self.before_ws(self)
+            if self.ws_status:
+                return web.Response(status=self.ws_status, headers={"Location": self.url + "/capture"})
+            self.ws = web.WebSocketResponse(autoping=False)
+            await self.ws.prepare(request)
+            frames = self.handshake if self.handshake is not None else [
+                {"type": "hello", "schema_version": 1, "connection_id": "synthetic-connection",
+                 "available_channels": ["scans"], "required_action": "none"},
+                {"type": "subscribed", "channels": ["scans"]},
+                {"type": "snapshot", "channel": "scans", "timestamp": STAMP, "data": self.snapshot}]
+            try:
+                for frame in frames:
+                    await self.send(frame)
+                self.sequence.append("snapshot")
+                if self.after_snapshot:
+                    await self.after_snapshot(self)
+                async for message in self.ws:
+                    if message.type.name == "PONG":
+                        self.sequence.append("pong")
+                        self.release.set()
+            finally:
+                self.ws_closed.set()
+            return self.ws
+        if path == "/api/v1/scan":
+            record["json"] = await request.json()
+            self.posts.append(record["json"])
+            self.sequence.append("post")
+            self.started.set()
+            if self.on_post:
+                await self.on_post(self)
+            elif not self.post_reply:
+                await self.send(scan_event(run_row()))
+                await self.complete()
+            if self.post_reply:
+                if callable(self.post_reply):
+                    return await self.post_reply(request, self)
+                status, body = self.post_reply
+                if status in {301, 302, 307, 308}:
+                    return web.Response(status=status, headers={"Location": self.url + "/capture"})
+                if isinstance(body, bytes):
+                    return web.Response(status=status, body=body)
+                return web.json_response(body, status=status)
+            return web.json_response({"status": "accepted", "mode": "file", "library_id": 7}, status=202)
+        return web.Response(status=404)
+
+
+@pytest.fixture
+def silo_fixture():
+    servers = []
+
+    def start(**kwargs):
+        server = NativeService(**kwargs)
+        servers.append(server)
+        return server
+
+    yield start
+    for server in servers:
+        server.close()
+
+
+def refresh(server, *, timeout=0.5, library="0007", path=PATH, verify_ssl=True):
+    from silo.client import SiloClient
+    with SiloClient(server.url, "synthetic-key", verify_ssl) as client:
+        return client.refresh_file(library, path, timeout=timeout)
+
+
+@pytest.mark.parametrize('phase', ['connection', 'initial_barrier', 'trailing_barrier', 'completion'])
+def test_revision_invalidation_prevents_initial_or_trailing_scan(silo_fixture, phase):
+    from silo.client import SiloClient
+    from media_servers.http import MediaServerError
+    valid = phase != 'connection'
+
+    def guard():
+        if not valid:
+            raise MediaServerError('configuration_changed')
+
+    async def initial(server):
+        nonlocal valid
+        valid = False
+        await server.complete('old')
+
+    async def on_post(server):
+        nonlocal valid
+        if phase == 'trailing_barrier':
+            # The initial request reused an observed run. Its completion only
+            # clears a barrier and must not authorize another POST after a save.
+            await server.send(scan_event(run_row('reused', status='running')))
+            valid = False
+            await server.complete('reused')
+        else:
+            await server.send(scan_event(run_row()))
+            valid = False
+            await server.complete()
+
+    server = silo_fixture(snapshot=[run_row('old', status='running')] if phase == 'initial_barrier' else (),
+                          after_snapshot=initial if phase == 'initial_barrier' else None, on_post=on_post)
+    with SiloClient(server.url, 'synthetic-key') as client:
+        with pytest.raises(MediaServerError, match='^configuration_changed$'):
+            client.refresh_file('7', PATH, timeout=1, ensure_current=guard)
+    assert len(server.posts) == (1 if phase in {'trailing_barrier', 'completion'} else 0)
+    if phase == 'connection':
+        assert server.records == []
+    else:
+        assert server.ws_closed.wait(1)
+
+
+def test_fresh_clean_scan_confirms_even_with_zero_metadata_updates(silo_fixture, monkeypatch):
+    server = silo_fixture(prefix="/reverse/silo")
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:1")
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:1")
+    monkeypatch.setenv("NO_PROXY", "")
+    assert refresh(server) == {"status": "confirmed"}
+    assert server.posts == [{"library_id": 7, "path": "/media/Movie.mkv"}]
+    assert [r["path"] for r in server.records] == [
+        "/reverse/silo/api/v1/events/ws?channels=scans", "/reverse/silo/api/v1/scan"]
+    assert server.ws_closed.wait(1)
+
+
+@pytest.mark.parametrize(("mode", "path"), [("file", PATH), ("subtree", "/media"), ("library", None)])
+def test_preexisting_overlapping_run_must_finish_before_trailing_scan(silo_fixture, mode, path):
+    async def finish_old(server):
+        await server.complete("old", mode=mode, path=path, result={**CLEAN_RESULT, "skipped": 1})
+
+    server = silo_fixture(snapshot=[run_row("old", mode=mode, path=path, status="running")],
+                          after_snapshot=finish_old)
+    assert refresh(server) == {"status": "confirmed"}
+    assert server.sequence.index("completed:old") < server.sequence.index("post")
+    assert len(server.posts) == 1
+
+
+@pytest.mark.parametrize(("library", "mode", "path"), [(8, "library", None), (7, "file", "/media/Other.mkv"),
+                                                       (7, "subtree", "/media2")])
+def test_unrelated_active_runs_do_not_block_target(silo_fixture, library, mode, path):
+    server = silo_fixture(snapshot=[run_row("unrelated", library=library, mode=mode, path=path)])
+    assert refresh(server) == {"status": "confirmed"}
+
+
+@pytest.mark.parametrize("counter", ["skipped", "errors", "missing", "missing_skipped_protected"])
+def test_completed_with_unclean_work_never_confirms(silo_fixture, counter):
+    from media_servers.http import MediaServerError
+
+    async def unclean(server):
+        await server.send(scan_event(run_row()))
+        await server.complete(result={**CLEAN_RESULT, counter: 1})
+
+    server = silo_fixture(on_post=unclean)
+    with pytest.raises(MediaServerError, match="^scan_incomplete$"):
+        refresh(server)
+    assert server.ws_closed.wait(1)
+
+
+@pytest.mark.parametrize("status", ["failed", "cancelled"])
+def test_failed_or_cancelled_run_never_confirms_or_exposes_error_text(silo_fixture, status):
+    from media_servers.http import MediaServerError
+
+    async def fail(server):
+        await server.send(scan_event(run_row()))
+        row = run_row(status=status)
+        row["error_message"] = "synthetic-private-server-detail"
+        await server.send(scan_event(row))
+
+    server = silo_fixture(on_post=fail)
+    with pytest.raises(MediaServerError) as error:
+        refresh(server)
+    assert str(error.value) == f"scan_{status}"
+    assert server.ws_closed.wait(1)
+
+
+@pytest.mark.parametrize("result", [{}, {**CLEAN_RESULT, "errors": False}, {**CLEAN_RESULT, "missing": -1}])
+def test_absent_or_invalid_clean_counters_are_not_completion_proof(silo_fixture, result):
+    from media_servers.http import MediaServerError
+
+    async def malformed(server):
+        await server.send(scan_event(run_row()))
+        await server.complete(result=result)
+
+    server = silo_fixture(on_post=malformed)
+    with pytest.raises(MediaServerError, match="^invalid_response$"):
+        refresh(server)
+
+
+def test_reused_run_without_fresh_acceptance_requires_another_post(silo_fixture):
+    async def reuse_then_fresh(server):
+        if len(server.posts) == 1:
+            await server.send(scan_event(run_row("reused", status="running")))
+            await server.complete("reused")
+        else:
+            await server.send(scan_event(run_row("trailing")))
+            await server.complete("trailing")
+
+    server = silo_fixture(on_post=reuse_then_fresh)
+    assert refresh(server) == {"status": "confirmed"}
+    assert len(server.posts) == 2
+    assert server.sequence.index("completed:reused") < len(server.sequence) - 1
+
+
+def test_new_overlapping_full_scan_requires_trailing_scan(silo_fixture):
+    async def conflict_then_fresh(server):
+        if len(server.posts) == 1:
+            await server.send(scan_event(run_row()))
+            await server.send(scan_event(run_row("full", mode="library")))
+            await server.complete()
+            await server.complete("full", mode="library")
+        else:
+            await server.send(scan_event(run_row("trailing")))
+            await server.complete("trailing")
+
+    server = silo_fixture(on_post=conflict_then_fresh)
+    assert refresh(server) == {"status": "confirmed"}
+    assert len(server.posts) == 2
+    assert server.sequence.index("completed:full") < len(server.sequence) - 1
+
+
+def test_event_envelope_ids_cannot_substitute_for_matching_run_ids(silo_fixture):
+    from media_servers.http import MediaServerError
+
+    async def unrelated(server):
+        await server.send(scan_event(run_row("target"), event_id="same-envelope"))
+        await server.send(scan_event(run_row("other", status="completed", path="/media/Other.mkv"),
+                                     event_id="same-envelope"))
+
+    server = silo_fixture(on_post=unrelated)
+    with pytest.raises(MediaServerError, match="^timeout$"):
+        refresh(server, timeout=0.08)
+
+
+@pytest.mark.parametrize("fault", ["disconnect", "oversized", "invalid_json"])
+def test_stream_loss_or_invalid_frames_never_confirms_and_releases_socket(silo_fixture, fault):
+    from media_servers.http import MediaServerError
+
+    async def broken(server):
+        if fault == "disconnect":
+            await server.ws.close()
+        elif fault == "oversized":
+            await server.ws.send_str("x" * (2 * 1024 * 1024 + 1))
+        else:
+            await server.ws.send_str("not-json")
+
+    server = silo_fixture(after_snapshot=broken)
+    with pytest.raises(MediaServerError) as error:
+        refresh(server)
+    assert error.value.code == {"disconnect": "stream_disconnected", "oversized": "response_too_large",
+                                "invalid_json": "invalid_response"}[fault]
+    assert server.ws_closed.wait(1)
+
+
+@pytest.mark.parametrize("handshake", [[], [{"type": "subscribed", "channels": []}],
+                                      [{"type": "snapshot", "channel": "scans", "data": []}]])
+def test_missing_handshake_never_submits_a_scan(silo_fixture, handshake):
+    from media_servers.http import MediaServerError
+    server = silo_fixture(handshake=handshake)
+    with pytest.raises(MediaServerError) as error:
+        refresh(server, timeout=0.08)
+    assert error.value.code in {"timeout", "observation_incomplete"}
+    assert server.posts == []
+    assert server.ws_closed.wait(1)
+
+
+def test_capped_500_row_snapshot_is_unknown_even_when_rows_are_unrelated(silo_fixture):
+    from media_servers.http import MediaServerError
+    server = silo_fixture(snapshot=[run_row(f"other-{i}", library=8) for i in range(500)])
+    with pytest.raises(MediaServerError, match="^observation_incomplete$"):
+        refresh(server)
+    assert server.posts == []
+
+
+@pytest.mark.parametrize(("status", "body"), [(200, {"status": "accepted", "mode": "file", "library_id": 7}),
+                                            (202, {"status": "accepted", "mode": "library", "library_id": 7}),
+                                            (202, {"status": "accepted", "mode": "file", "library_id": 8}),
+                                            (202, {"status": "accepted", "mode": "file", "library_id": "7"}),
+                                            (202, b"not-json")])
+def test_invalid_http_acceptance_cannot_confirm_even_with_clean_events(silo_fixture, status, body):
+    from media_servers.http import MediaServerError
+
+    async def clean(server):
+        await server.send(scan_event(run_row()))
+        await server.complete()
+
+    server = silo_fixture(on_post=clean, post_reply=(status, body))
+    with pytest.raises(MediaServerError) as error:
+        refresh(server)
+    assert error.value.code in {"invalid_response", "request_rejected"}
+
+
+@pytest.mark.parametrize("endpoint", ["ws", "post"])
+@pytest.mark.parametrize(("status", "code"), [(302, "redirect_denied"), (307, "redirect_denied"),
+                                            (401, "unauthorized"), (403, "forbidden"), (500, "server_error")])
+def test_http_and_ws_failures_are_sanitized_and_redirects_never_reach_target(silo_fixture, endpoint, status, code):
+    from media_servers.http import MediaServerError
+    server = silo_fixture(**({"ws_status": status} if endpoint == "ws" else {"post_reply": (status, {})}))
+    with pytest.raises(MediaServerError) as error:
+        refresh(server)
+    assert str(error.value) == code
+    assert all("/capture" not in record["path"] for record in server.records)
+
+
+def test_socket_is_read_during_post_to_answer_pings(silo_fixture):
+    async def ping_during_post(server):
+        await server.ws.ping(b"synthetic-ping")
+        await server.release.wait()
+        await server.send(scan_event(run_row()))
+        await server.complete()
+
+    server = silo_fixture(on_post=ping_during_post)
+    assert refresh(server) == {"status": "confirmed"}
+    assert "pong" in server.sequence
+
+
+@pytest.mark.parametrize("phase", ["barrier", "post", "terminal"])
+def test_total_deadline_covers_active_runs_requests_and_terminal_wait(silo_fixture, phase):
+    from media_servers.http import MediaServerError
+
+    async def held_post(server):
+        if phase == "post":
+            await server.release.wait()
+        else:
+            await server.send(scan_event(run_row()))
+
+    server = silo_fixture(snapshot=[run_row("old")] if phase == "barrier" else [], on_post=held_post)
+    started = time.monotonic()
+    with pytest.raises(MediaServerError, match="^timeout$"):
+        refresh(server, timeout=0.08)
+    assert time.monotonic() - started < 0.4
+    assert server.ws_closed.wait(1)
+    assert len(server.posts) == (0 if phase == "barrier" else 1)
+
+
+@pytest.mark.parametrize("library", [7, True, "", "0", "-7", "7.0", " 7", "٧", "9" * 100])
+def test_invalid_native_library_id_sends_nothing(silo_fixture, library):
+    from media_servers.http import MediaServerError
+    server = silo_fixture()
+    with pytest.raises(MediaServerError, match="^library_invalid$"):
+        refresh(server, library=library)
+    assert server.records == []
+
+
+@pytest.mark.parametrize("path", ["relative.mkv", "/media/../Movie.mkv", "", "/media/\nMovie.mkv"])
+def test_invalid_video_path_sends_nothing(silo_fixture, path):
+    from media_servers.http import MediaServerError
+    server = silo_fixture()
+    with pytest.raises(MediaServerError, match="^path_invalid$"):
+        refresh(server, path=path)
+    assert server.records == []
+
+
+@pytest.mark.parametrize("field", ["status", "mode", "event"])
+def test_non_string_event_discriminators_fail_closed_as_invalid_response(silo_fixture, field):
+    from media_servers.http import MediaServerError
+
+    async def malformed(server):
+        payload = scan_event(run_row())
+        if field == "event":
+            payload["event"] = []
+        else:
+            payload["data"][field] = []
+        await server.send(payload)
+
+    server = silo_fixture(on_post=malformed)
+    with pytest.raises(MediaServerError, match="^invalid_response$"):
+        refresh(server, timeout=0.08)
+
+
+def test_same_run_id_with_changed_target_cannot_confirm(silo_fixture):
+    from media_servers.http import MediaServerError
+
+    async def substituted(server):
+        await server.send(scan_event(run_row()))
+        await server.complete(path="/media/Other.mkv")
+
+    server = silo_fixture(on_post=substituted)
+    with pytest.raises(MediaServerError, match="^invalid_response$"):
+        refresh(server)
+
+
+def test_repeated_reuse_is_bounded_to_three_posts(silo_fixture):
+    from media_servers.http import MediaServerError
+
+    async def always_reuse(server):
+        run_id = f"reused-{len(server.posts)}"
+        await server.send(scan_event(run_row(run_id, status="running")))
+        await server.complete(run_id)
+
+    server = silo_fixture(on_post=always_reuse)
+    with pytest.raises(MediaServerError, match="^observation_incomplete$"):
+        refresh(server)
+    assert len(server.posts) == 3
+
+
+@pytest.mark.parametrize("missing", ["subscribed", "snapshot"])
+def test_missing_subscription_or_snapshot_after_hello_never_posts(silo_fixture, missing):
+    from media_servers.http import MediaServerError
+    frames = [{"type": "hello", "schema_version": 1, "connection_id": "synthetic-connection",
+               "available_channels": ["scans"], "required_action": "none"}]
+    if missing == "snapshot":
+        frames.append({"type": "subscribed", "channels": ["scans"]})
+    server = silo_fixture(handshake=frames)
+    with pytest.raises(MediaServerError, match="^timeout$"):
+        refresh(server, timeout=0.08)
+    assert server.posts == []
+    assert server.ws_closed.wait(1)
+
+
+def test_upgrade_http_request_is_inside_total_deadline(silo_fixture):
+    from media_servers.http import MediaServerError
+
+    async def held_upgrade(server):
+        await server.release.wait()
+
+    server = silo_fixture(before_ws=held_upgrade)
+    started = time.monotonic()
+    with pytest.raises(MediaServerError, match="^timeout$"):
+        refresh(server, timeout=0.08)
+    assert time.monotonic() - started < 0.4
+    assert server.posts == []
+
+
+def test_http_response_body_wait_is_inside_total_deadline(silo_fixture):
+    from media_servers.http import MediaServerError
+
+    async def held_body(request, server):
+        response = web.StreamResponse(status=202)
+        await response.prepare(request)
+        await response.write(b'{"status":')
+        await server.release.wait()
+        return response
+
+    server = silo_fixture(post_reply=held_body)
+    started = time.monotonic()
+    with pytest.raises(MediaServerError, match="^timeout$"):
+        refresh(server, timeout=0.08)
+    assert time.monotonic() - started < 0.4
+    assert server.ws_closed.wait(1)
+
+
+def test_http_stream_without_content_length_is_size_bounded(silo_fixture):
+    from media_servers.http import MediaServerError
+
+    async def oversized_body(request, _server):
+        response = web.StreamResponse(status=202)
+        await response.prepare(request)
+        try:
+            for _chunk in range(257):
+                await response.write(b" " * 8192)
+        except ClientConnectionError:
+            pass
+        return response
+
+    server = silo_fixture(post_reply=oversized_body)
+    with pytest.raises(MediaServerError, match="^response_too_large$"):
+        refresh(server)
+
+
+@pytest.fixture
+def native_tls_context(tmp_path):
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    now = datetime.now(timezone.utc)
+    certificate = (x509.CertificateBuilder().subject_name(name).issuer_name(name).public_key(key.public_key())
+                   .serial_number(x509.random_serial_number()).not_valid_before(now - timedelta(minutes=1))
+                   .not_valid_after(now + timedelta(days=1))
+                   .add_extension(x509.SubjectAlternativeName([x509.IPAddress(ipaddress.ip_address("127.0.0.1"))]),
+                                  critical=False).sign(key, hashes.SHA256()))
+    cert_path, key_path = tmp_path / "certificate.pem", tmp_path / "key.pem"
+    cert_path.write_bytes(certificate.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(key.private_bytes(serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8,
+                                         serialization.NoEncryption()))
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(cert_path, key_path)
+    return context
+
+
+def test_tls_verification_applies_to_ws_and_post(silo_fixture, native_tls_context):
+    from media_servers.http import MediaServerError
+    server = silo_fixture(tls_context=native_tls_context)
+    with pytest.raises(MediaServerError, match="^tls_error$"):
+        refresh(server)
+    assert server.records == []
+    assert refresh(server, verify_ssl=False) == {"status": "confirmed"}
+    assert server.posts == [{"library_id": 7, "path": "/media/Movie.mkv"}]
+
+
+@pytest.mark.parametrize("timeout", [True, None, "90", 0, -1, float("nan"), float("inf"), 10**500],
+                         ids=["boolean", "null", "string", "zero", "negative", "nan", "infinite", "huge"])
+def test_invalid_deadline_values_send_nothing(silo_fixture, timeout):
+    from media_servers.http import MediaServerError
+    server = silo_fixture()
+    with pytest.raises(MediaServerError, match="^invalid_timeout$"):
+        refresh(server, timeout=timeout)
+    assert server.records == []
+
+
+def test_observer_cannot_retain_unbounded_target_text(silo_fixture):
+    from media_servers.http import MediaServerError
+
+    async def many_large_targets(server):
+        for index in range(25):
+            await server.send(scan_event(run_row(f"other-{index}", library=8, path="/other/" + "x" * 100000)))
+        await server.send(scan_event(run_row()))
+        await server.complete()
+
+    server = silo_fixture(on_post=many_large_targets)
+    with pytest.raises(MediaServerError, match="^observation_incomplete$"):
+        refresh(server)
+
+
+@pytest.fixture
+def native_dns(monkeypatch, tmp_path):
+    import dns.asyncresolver
+    import dns.flags
+    import dns.message
+    import dns.rrset
+
+    transports = []
+
+    def configure(server, *, stalled=False):
+        queries, peers = [], []
+
+        class Responder(asyncio.DatagramProtocol):
+            def connection_made(self, transport):
+                self.transport = transport
+
+            def datagram_received(self, packet, peer):
+                query = dns.message.from_wire(packet)
+                name, record_type = query.question[0].name.to_text(), query.question[0].rdtype
+                queries.append((name, record_type))
+                peers.append(peer)
+                if stalled:
+                    return
+                response = dns.message.make_response(query)
+                response.flags |= dns.flags.AA
+                if record_type == 1 and name == "native-silo.fixture.test.":
+                    response.answer.append(dns.rrset.from_text(name, 30, "IN", "A", "127.0.0.1"))
+                self.transport.sendto(response.to_wire(), peer)
+
+        async def start():
+            transport, _protocol = await server.loop.create_datagram_endpoint(Responder, local_addr=("127.0.0.1", 0))
+            return transport
+
+        transport = asyncio.run_coroutine_threadsafe(start(), server.loop).result(1)
+        transports.append((server, transport))
+        resolver_file = tmp_path / "resolv.conf"
+        resolver_file.write_text("nameserver 127.0.0.1\nsearch fixture.test\noptions ndots:1\n")
+        resolver_type = dns.asyncresolver.Resolver
+
+        def configured_resolver():
+            resolver = resolver_type(filename=str(resolver_file))
+            resolver.nameserver_ports["127.0.0.1"] = transport.get_extra_info("sockname")[1]
+            return resolver
+
+        monkeypatch.setattr(dns.asyncresolver, "Resolver", configured_resolver)
+
+        def forbid_threaded_lookup(*_args, **_kwargs):
+            raise AssertionError("blocking resolver must not run")
+
+        monkeypatch.setattr(socket, "getaddrinfo", forbid_threaded_lookup)
+        return queries, peers
+
+    yield configure
+    for server, transport in transports:
+        if server.thread.is_alive():
+            server.loop.call_soon_threadsafe(transport.close)
+
+
+def test_native_hostname_uses_configured_async_dns_and_search_domains(silo_fixture, native_dns):
+    server = silo_fixture()
+    queries, _peers = native_dns(server)
+    server.url = server.url.replace("127.0.0.1", "native-silo")
+    assert refresh(server) == {"status": "confirmed"}
+    assert ("native-silo.fixture.test.", 1) in queries
+    assert server.posts == [{"library_id": 7, "path": "/media/Movie.mkv"}]
+
+
+def test_stalled_async_dns_obeys_deadline_and_closes_its_socket(silo_fixture, native_dns):
+    from media_servers.http import MediaServerError
+    server = silo_fixture()
+    queries, peers = native_dns(server, stalled=True)
+    server.url = server.url.replace("127.0.0.1", "native-silo")
+    started = time.monotonic()
+    with pytest.raises(MediaServerError, match="^timeout$"):
+        refresh(server, timeout=0.08)
+    assert time.monotonic() - started < 0.4
+    assert queries
+    assert server.records == []
+    for peer in set(peers):
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as probe:
+            probe.bind(peer)
+
+
+def test_hosts_file_name_does_not_require_dns_or_an_executor(silo_fixture, monkeypatch):
+    server = silo_fixture()
+
+    def forbid_threaded_lookup(*_args, **_kwargs):
+        raise AssertionError("blocking resolver must not run")
+
+    monkeypatch.setattr(socket, "getaddrinfo", forbid_threaded_lookup)
+    server.url = server.url.replace("127.0.0.1", "localhost")
+    assert refresh(server) == {"status": "confirmed"}
+
+
+def test_ipv6_literal_connects_without_dns_or_an_executor(silo_fixture, monkeypatch):
+    if not socket.has_ipv6:
+        pytest.skip("IPv6 is unavailable on this host")
+    server = silo_fixture(listen_host="::1")
+
+    def forbid_threaded_lookup(*_args, **_kwargs):
+        raise AssertionError("blocking resolver must not run")
+
+    monkeypatch.setattr(socket, "getaddrinfo", forbid_threaded_lookup)
+    assert refresh(server) == {"status": "confirmed"}
+    assert server.posts == [{"library_id": 7, "path": "/media/Movie.mkv"}]
+
+
+def test_barrier_time_is_not_reset_when_the_http_post_starts(silo_fixture):
+    from media_servers.http import MediaServerError
+
+    async def release_barrier(server):
+        gate = asyncio.Event()
+        server.loop.call_later(0.2, gate.set)
+        await gate.wait()
+        await server.complete("old")
+
+    async def hold_post(server):
+        await server.release.wait()
+
+    server = silo_fixture(snapshot=[run_row("old")], after_snapshot=release_barrier, on_post=hold_post)
+    started = time.monotonic()
+    with pytest.raises(MediaServerError, match="^timeout$"):
+        refresh(server, timeout=0.3)
+    assert time.monotonic() - started < 0.45
+    assert server.posts == [{"library_id": 7, "path": "/media/Movie.mkv"}]
+    assert server.ws_closed.wait(1)
+
+
+def buffered_handshake(*frames, timestamp="2026-09-08T00:00:01Z"):
+    return [{"type": "hello", "schema_version": 1, "connection_id": "synthetic-connection",
+             "available_channels": ["scans"], "required_action": "none"},
+            {"type": "subscribed", "channels": ["scans"]},
+            {"type": "snapshot", "channel": "scans", "timestamp": timestamp, "data": []}, *frames]
+
+
+@pytest.mark.parametrize("fault", ["older_acceptance", "equal_acceptance", "missing_acceptance_time",
+                                  "old_start", "equal_start", "missing_start", "missing_completion",
+                                  "missing_terminal_time"])
+def test_snapshot_buffered_events_require_a_trailing_fresh_completion(silo_fixture, fault):
+    accepted_time = "2026-09-08T00:00:02Z"
+    completed = run_row("buffered", status="completed")
+    completed.update(started_at="2026-09-08T00:00:03Z", completed_at="2026-09-08T00:00:04Z")
+    terminal_time = "2026-09-08T00:00:05Z"
+    if fault == "older_acceptance":
+        accepted_time = "2026-09-08T00:00:00Z"
+    elif fault == "equal_acceptance":
+        accepted_time = "2026-09-08T00:00:01Z"
+    elif fault == "missing_acceptance_time":
+        accepted_time = None
+    elif fault == "old_start":
+        completed["started_at"] = "2026-09-08T00:00:00Z"
+    elif fault == "equal_start":
+        completed["started_at"] = "2026-09-08T00:00:01Z"
+    elif fault == "missing_start":
+        completed.pop("started_at")
+    elif fault == "missing_completion":
+        completed.pop("completed_at")
+    else:
+        terminal_time = None
+    frames = buffered_handshake(scan_event(run_row("buffered"), timestamp=accepted_time),
+                                scan_event(completed, timestamp=terminal_time))
+
+    async def accept_then_fresh(server):
+        if len(server.posts) == 2:
+            await server.send(scan_event(run_row("trailing")))
+            await server.complete("trailing")
+
+    server = silo_fixture(handshake=frames, on_post=accept_then_fresh)
+    assert refresh(server) == {"status": "confirmed"}
+    assert len(server.posts) == 2
+    assert "completed:trailing" in server.sequence
+    assert server.ws_closed.wait(1)
+
+
+def test_old_buffered_completion_never_confirms_an_unobserved_new_run(silo_fixture):
+    from media_servers.http import MediaServerError
+    old = run_row("old", status="completed")
+    old.update(started_at="2026-09-08T00:00:00Z", completed_at="2026-09-08T00:00:00.2Z")
+    frames = buffered_handshake(scan_event(run_row("old"), timestamp="2026-09-08T00:00:00Z"),
+                                scan_event(old, timestamp="2026-09-08T00:00:00.3Z"))
+    server = silo_fixture(handshake=frames, post_reply=(202, {"status": "accepted", "mode": "file", "library_id": 7}))
+    with pytest.raises(MediaServerError, match="^timeout$"):
+        refresh(server, timeout=0.08)
+    assert len(server.posts) == 2
+    assert server.ws_closed.wait(1)
+
+
+@pytest.mark.parametrize("timestamp", [None, "", "not a timestamp", "2026-09-08", "2026-09-08T00:00:00"])
+def test_missing_or_invalid_snapshot_time_never_submits(silo_fixture, timestamp):
+    from media_servers.http import MediaServerError
+    server = silo_fixture(handshake=buffered_handshake(timestamp=timestamp))
+    with pytest.raises(MediaServerError, match="^observation_incomplete$"):
+        refresh(server)
+    assert server.posts == []
+    assert server.ws_closed.wait(1)
+
+
+@pytest.mark.parametrize("value", ["x" * 131072, ["x" * 131072], {"detail": "x" * 131072}, True, 2**256],
+                         ids=["string", "list", "object", "boolean", "oversized-integer"])
+@pytest.mark.parametrize("counter", ["skipped", "errors", "missing", "missing_skipped_protected"])
+def test_unrelated_malformed_counters_fail_before_retention(silo_fixture, value, counter):
+    from media_servers.http import MediaServerError
+
+    async def unrelated(server):
+        await server.send(scan_event(run_row("other", library=8, status="completed",
+                                            result={**CLEAN_RESULT, counter: value})))
+        await server.send(scan_event(run_row()))
+        await server.complete()
+
+    server = silo_fixture(on_post=unrelated)
+    with pytest.raises(MediaServerError, match="^invalid_response$"):
+        refresh(server)
+    assert server.ws_closed.wait(1)
+
+
+def test_equivalent_replacement_paths_are_charged_to_the_retention_budget(silo_fixture):
+    from media_servers.http import MediaServerError
+
+    async def replacements(server):
+        for index in range(10):
+            await server.send(scan_event(run_row(f"other-{index}", library=8, path="/other/file.mkv")))
+            await server.send(scan_event(run_row(f"other-{index}", library=8, status="running",
+                                                path="/other/" + "./" * 32768 + "file.mkv")))
+        await server.send(scan_event(run_row()))
+        await server.complete()
+
+    server = silo_fixture(on_post=replacements)
+    with pytest.raises(MediaServerError, match="^observation_incomplete$"):
+        refresh(server, timeout=2)
+    assert server.ws_closed.wait(1)
+
+
+def test_shorter_replacements_release_the_previous_path_charge(silo_fixture):
+    async def replace_repeatedly(server):
+        for _index in range(20):
+            await server.send(scan_event(run_row("other", library=8, status="running",
+                                                path="/other/" + "./" * 16384 + "file.mkv")))
+            await server.send(scan_event(run_row("other", library=8, status="running", path="/other/file.mkv")))
+        await server.send(scan_event(run_row()))
+        await server.complete()
+
+    server = silo_fixture(on_post=replace_repeatedly)
+    assert refresh(server, timeout=2) == {"status": "confirmed"}
+    assert server.ws_closed.wait(1)
+
+
+@pytest.mark.parametrize("path", [1, True, [], {}, None, "relative/path"])
+def test_malformed_library_snapshot_is_categorized_and_closes_resources(silo_fixture, monkeypatch, path):
+    import aiohttp
+    from media_servers.http import MediaServerError
+    sessions = []
+    original = aiohttp.ClientSession.__init__
+
+    def record_session(session, *args, **kwargs):
+        original(session, *args, **kwargs)
+        sessions.append(session)
+
+    monkeypatch.setattr(aiohttp.ClientSession, "__init__", record_session)
+    row = run_row("library", mode="library")
+    row["path"] = path
+    server = silo_fixture(snapshot=[row])
+    with pytest.raises(MediaServerError, match="^invalid_response$"):
+        refresh(server, timeout=0.08)
+    assert sessions and all(session.closed for session in sessions)
+    assert server.ws_closed.wait(1)
+    assert server.posts == []
+
+
+@pytest.mark.parametrize("fault", ["counter", "library_id"])
+def test_unrelated_snapshot_scalars_are_validated_before_storage(silo_fixture, fault):
+    from media_servers.http import MediaServerError
+    row = run_row("other", library=8, status="running")
+    if fault == "counter":
+        row["result"] = {**CLEAN_RESULT, "missing": ["x" * 131072]}
+    else:
+        row["library_id"] = 2**256
+    server = silo_fixture(snapshot=[row])
+    with pytest.raises(MediaServerError, match="^invalid_response$"):
+        refresh(server)
+    assert server.posts == []
+    assert server.ws_closed.wait(1)
+
+
+def test_completed_barrier_advances_the_timestamp_boundary_for_the_next_post(silo_fixture):
+    async def stale_then_fresh(server):
+        if len(server.posts) == 1:
+            row = run_row("reused", status="completed")
+            row.update(started_at="2026-09-08T00:00:01Z", completed_at="2026-09-08T00:00:02Z")
+            await server.send(scan_event(row, timestamp="2026-09-08T00:00:03Z"))
+        elif len(server.posts) == 2:
+            row = run_row("delayed", status="completed")
+            row.update(started_at="2026-09-08T00:00:01.5Z", completed_at="2026-09-08T00:00:02.5Z")
+            await server.send(scan_event(run_row("delayed"), timestamp="2026-09-08T00:00:01.1Z"))
+            await server.send(scan_event(row, timestamp="2026-09-08T00:00:02.9Z"))
+        else:
+            await server.send(scan_event(run_row("trailing")))
+            await server.complete("trailing")
+
+    server = silo_fixture(on_post=stale_then_fresh,
+                          handshake=buffered_handshake(timestamp="2026-09-08T00:00:00Z"))
+    assert refresh(server) == {"status": "confirmed"}
+    assert len(server.posts) == 3
+    assert "completed:trailing" in server.sequence
+
+
+def test_native_nanosecond_times_preserve_a_strict_freshness_boundary(silo_fixture):
+    async def fresh(server):
+        await server.send(scan_event(run_row(), timestamp="2026-09-08T00:00:00.123456781Z"))
+        row = run_row(status="completed")
+        row.update(started_at="2026-09-08T00:00:00.123456782Z", completed_at="2026-09-08T00:00:00.123456783Z")
+        await server.send(scan_event(row, timestamp="2026-09-08T00:00:00.123456784Z"))
+
+    server = silo_fixture(handshake=buffered_handshake(timestamp="2026-09-08T00:00:00.123456780Z"), on_post=fresh)
+    assert refresh(server) == {"status": "confirmed"}
+    assert len(server.posts) == 1
+
+
+def test_equal_times_in_different_offsets_are_ambiguous(silo_fixture):
+    row = run_row("old", status="completed")
+    row.update(started_at="2026-09-08T00:00:01Z", completed_at="2026-09-08T00:00:02Z")
+    frames = buffered_handshake(scan_event(run_row("old"), timestamp="2026-09-08T00:00:01Z"),
+                                scan_event(row, timestamp="2026-09-08T00:00:03Z"),
+                                timestamp="2026-09-08T01:00:01+01:00")
+
+    async def trailing(server):
+        if len(server.posts) == 2:
+            await server.send(scan_event(run_row("trailing")))
+            await server.complete("trailing")
+
+    server = silo_fixture(handshake=frames, on_post=trailing)
+    assert refresh(server) == {"status": "confirmed"}
+    assert len(server.posts) == 2

--- a/tests/bazarr/test_upload_background_sync.py
+++ b/tests/bazarr/test_upload_background_sync.py
@@ -1062,7 +1062,7 @@ def test_review_create_cannot_overwrite_a_later_upload(upload_flow, monkeypatch)
     flow = upload_flow
     monkeypatch.setattr(settings.subsync, "use_subsync", False)
     monkeypatch.setattr(content, "database", Mock(execute=Mock(return_value=Mock(
-        first=Mock(return_value=SimpleNamespace(path=str(flow.video), id=30))))))
+        first=Mock(return_value=SimpleNamespace(path=str(flow.video), id=30, arr_instance_id=7))))))
     monkeypatch.setattr(content, "get_target_folder", lambda *args: None)
     monkeypatch.setattr(content, "store_subtitles_movie", lambda *args, **kwargs: None)
     monkeypatch.setattr(content, "event_stream", lambda **kwargs: None)
@@ -1111,7 +1111,7 @@ def test_review_combine_waits_for_an_existing_publication(upload_flow, monkeypat
     first.write_text("1\n00:00:01,000 --> 00:00:02,000\nFirst\n")
     second.write_text("1\n00:00:01,000 --> 00:00:02,000\nSecond\n")
     monkeypatch.setattr(main, "resolve_source_paths", lambda **kwargs: SourcePaths(str(first), [str(second)]))
-    monkeypatch.setattr(main, "_post_write", lambda *args: None)
+    monkeypatch.setattr(main, "_post_write", lambda *args, **kwargs: None)
     output = flow.video.with_suffix(".en.combined-hu.srt")
     results = []
     finished = Event()
@@ -1234,7 +1234,8 @@ def review_translator(upload_flow, monkeypatch, request):
     service = getattr(module, class_name)(
         source_srt_file=str(source), dest_srt_file=str(destination), lang_obj=None,
         to_lang="eng", from_lang="en", media_type="movie", video_path=str(flow.video),
-        orig_to_lang="en", forced=False, hi=False, sonarr_series_id=None, sonarr_episode_id=None, radarr_id=30)
+        orig_to_lang="en", forced=False, hi=False, sonarr_series_id=None, sonarr_episode_id=None, radarr_id=30,
+        arr_instance_id=7)
     monkeypatch.setattr(module, "jobs_queue", flow.queue)
     monkeypatch.setattr(module, "history_log_movie", Mock())
     monkeypatch.setattr(module, "create_process_result", Mock())
@@ -1401,7 +1402,7 @@ def review_combine(upload_flow, monkeypatch):
     primary.write_text("1\n00:00:01,000 --> 00:00:02,000\nFirst\n")
     secondary.write_text("1\n00:00:01,000 --> 00:00:02,000\nSecond\n")
     monkeypatch.setattr(main, "resolve_source_paths", lambda **kwargs: SourcePaths(str(primary), [str(secondary)]))
-    monkeypatch.setattr(main, "_post_write", lambda *args: None)
+    monkeypatch.setattr(main, "_post_write", lambda *args, **kwargs: None)
     return SimpleNamespace(flow=flow, module=main, output=flow.video.with_suffix(".en.combined-hu.srt"),
                            run=lambda format="srt": main.try_combine_for_video(
                                str(flow.video), "movie", languages=["en", "hu"], format=format))
@@ -1423,11 +1424,11 @@ def test_review_combine_format_rebuilds_cannot_delete_each_other(review_combine,
     original = run.module._remove_stale_combined_siblings
     results = []
 
-    def cleanup(path, video):
+    def cleanup(path, video, on_publish=None):
         mine, other = (first_cleanup, second_cleanup) if path.endswith(".srt") else (second_cleanup, first_cleanup)
         mine.set()
         other.wait(0.3)
-        original(path, video)
+        original(path, video, on_publish)
 
     monkeypatch.setattr(run.module, "_remove_stale_combined_siblings", cleanup)
     workers = [Thread(target=lambda fmt=fmt: results.append(run.run(fmt))) for fmt in ("srt", "ass")]


### PR DESCRIPTION
## What this adds

Bazarr can now talk to **multiple Emby and multiple Silo servers** instead of one of each, the way it already supports multiple Sonarr and Radarr instances.

When a subtitle is downloaded or uploaded, Bazarr asks every enabled destination whose local path mappings cover that file to rescan the item, so the subtitle actually appears in the server. Destinations outside the mappings are skipped silently rather than reported as errors.

Each instance owns its enabled state, URL, encrypted API key, TLS verification, path mappings, Silo library choices, pending targets, status and retry action.

## How it works

- `bazarr/media_servers/` holds the shared layer: dispatcher, repository, instance model, path mapping, HTTP and the one-time import of any previous single-server configuration.
- `bazarr/emby/` and `bazarr/silo/` are the per-server clients. Silo additionally observes its scan to completion, so a Silo refresh is confirmed rather than merely requested.
- Refreshes run on a background worker per server with pending targets, generation tracking and retry. One unreachable server does not block the others.
- Settings live under **Settings > Connections**, with named instance cards, per-instance enable, Test against the saved key, Edit, Delete and per-instance status with Retry pending.
- Existing single-server Emby and Silo configuration is imported once into an instance, guarded by a durable marker so it cannot run twice.

## Verification

Exercised end to end against a real stack: two Emby servers, two Silo servers each with its own PostgreSQL and Redis, plus real Radarr and Sonarr feeding a real library, with subtitles fetched from real providers rather than fixtures. Each server mounted the same media at a **different** container path, so a path-mapping mistake could not accidentally pass.

Confirmed, with evidence taken from the destination servers themselves rather than from Bazarr's own UI:

- Fan out: one subtitle write produced a refresh on all four destinations, each at its own path, and both Emby servers then listed the new sidecar as a subtitle stream.
- Path-mapping scope: a write outside an instance's mappings left that instance idle with zero requests reaching it.
- Isolation: pausing one server and, separately, stopping another confined the failure to that instance while the rest refreshed. Retry pending drained the queue afterwards, corroborated by the destination's own logs and database.
- Per-instance independence: disabling one instance left its sibling untouched, and a deliberately miswired mapping failed only on the instance that was miswired.

The Connections UI was driven through a browser for all of its scenarios, including instance CRUD with API key keep/replace/clear semantics, test against a saved key, failed save recovery, library loading, independent enable, delayed editor isolation and live retry.

Backend and frontend suites pass, including new coverage for the dispatcher, the native clients, path mapping, the instance API and the settings screens.

## Notes for review

- Database migration adds the instance tables. Both SQLite and PostgreSQL paths are covered.
- API keys are stored encrypted and never returned by the API.
- The second commit only rewrites user-facing copy in the Connections screens and updates the tests that assert it, after the original wording proved unreadable in use.


## Resolution parity with Jellyfin

Emby and Silo now resolve a refresh target the way the existing Jellyfin integration does, instead of by file path alone. The shared layer walks a ladder and stops at the first rung an adapter supports and resolves: **provider ID, then title and year, then exact path, then a library refresh.** The path rung is one Jellyfin never had, and it stays because it is the only proof of a single file.

| | Jellyfin | Emby | Silo |
| --- | --- | --- | --- |
| Provider-ID match | yes | yes | no, see below |
| Title/year fallback | yes | yes | no, see below |
| Exact path match | no | yes | yes |
| Library refresh fallback | yes | yes | yes |
| Movies and episodes | yes | yes | yes |
| Operations | download, upload, delete | all seven | all seven |

Emby previously refreshed movies only, and only on download and upload. Both restrictions are gone: it now handles episodes and every publication type Silo does.

Silo cannot match on identifiers. Its Jellyfin-compatible API returns items with no `ProviderIds` field at all, confirmed against Silo 10.12.0, so there is nothing to match against. It uses the path rung with a library-scan fallback, and the limitation is recorded where the capability is declared.

Verified against real servers rather than fixtures:

- Provider-ID rung: setting an IMDB id on an Emby item and querying `AnyProviderIdEquals` returns exactly that item.
- Library rung: a recursive `ValidationOnly` refresh made Emby discover a newly written sidecar, taking the item from three subtitle streams to four.
- Silo library scan returns 202 for a library-scoped request.
- Episode refresh: uploading a subtitle for an episode through the API took that episode from zero to two subtitle streams in Emby.

Rung ordering is asserted in tests over every rung and both media types, proving a resolved rung never falls through to a later one.

## Related requests

Delivers the two inbound feature requests:

- Fixes https://github.com/LavX/bazarr/issues/296
- Fixes https://github.com/LavX/bazarr/issues/390

These will not auto-close from this pull request, because it targets `development` rather than the default branch. Close them at the release cut.

